### PR TITLE
feat: Add Docker image publishing workflow with multi-architecture support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,67 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  workflow_dispatch:  # Allow manual triggering
+
+env:
+  REGISTRY: docker.io
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ secrets.DOCKER_USERNAME }}/flux
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Build and push Docker image
+      id: build
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          FLUX_VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] || 'latest' }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Generate artifact attestation
+      uses: actions/attest-build-provenance@v1
+      with:
+        subject-name: ${{ env.REGISTRY }}/${{ secrets.DOCKER_USERNAME }}/flux
+        subject-digest: ${{ steps.build.outputs.digest }}
+        push-to-registry: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.4.3"
+version = "0.4.4"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -150,6 +150,10 @@ def test_workflow(
         str(EVENT_FILES_DIR / f"{event}.json"),
         "--secret",
         "PYPI_API_TOKEN=fake-token",
+        "--secret",
+        "DOCKER_USERNAME=fake-user",
+        "--secret",
+        "DOCKER_TOKEN=fake-token",
     ]
 
     # Add dry-run flag if needed
@@ -182,6 +186,7 @@ def test_workflows() -> None:
     workflows_to_test = [
         ("pull-request.yml", "test", "pull_request"),
         ("build-publish.yml", "build", "push"),
+        ("docker-publish.yml", "build-and-publish", "push"),
         ("docs.yml", "deploy", "paths"),
     ]
 


### PR DESCRIPTION
## 🐳 **What This PR Does**
Adds automated Docker image publishing to Docker Hub with a new GitHub Actions workflow, making Flux easier to deploy in containerized environments.

## ✨ **Key Features**
- **🏗️ Multi-architecture builds**: Supports both `linux/amd64` and `linux/arm64` platforms
- **🏷️ Smart tagging**: Automatically tags images with `latest` (main branch) and version tags (e.g., `v0.4.4`)
- **🔒 Secure authentication**: Uses Docker Hub Personal Access Tokens via GitHub secrets
- **⚡ Optimized builds**: Includes Docker layer caching and build attestation
- **🧪 Integrated testing**: Added to existing CI test suite with local testing support

## 📋 **Changes Made**
1. **New workflow**: docker-publish.yml - Complete Docker publishing pipeline
2. **CI integration**: Updated ci.py to test Docker workflow alongside existing workflows  
3. **Version bump**: pyproject.toml updated to v0.4.4

## 🚀 **Usage**
Once merged and secrets are configured, Docker images will be available at:
```bash
docker pull yourusername/flux:latest
docker pull yourusername/flux:v0.4.4
```

## ⚙️ **Setup Required**
Repository maintainers need to add these GitHub secrets:
- `DOCKER_USERNAME`: Docker Hub username
- `DOCKER_TOKEN`: Docker Hub Personal Access Token

## 🎯 **Benefits**
- **Easier deployment**: Users can run Flux with a simple `docker run` command
- **Consistent releases**: Docker images automatically built and published alongside PyPI packages
- **Production ready**: Multi-architecture support for diverse deployment environments
- **Security focused**: Build attestation and token-based authentication

The workflow mirrors the existing PyPI publishing setup for consistency and follows GitHub Actions best practices.