### PR TITLE
feat: Add Docker image publishing workflow with version extraction from pyproject.toml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,67 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  workflow_dispatch:  # Allow manual triggering
+
+env:
+  REGISTRY: docker.io
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ secrets.DOCKER_USERNAME }}/flux
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Build and push Docker image
+      id: build
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          FLUX_VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] || 'latest' }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Generate artifact attestation
+      uses: actions/attest-build-provenance@v1
+      with:
+        subject-name: ${{ env.REGISTRY }}/${{ secrets.DOCKER_USERNAME }}/flux
+        subject-digest: ${{ steps.build.outputs.digest }}
+        push-to-registry: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,6 +32,13 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_TOKEN }}
 
+    - name: Extract version from pyproject.toml
+      id: version
+      run: |
+        VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Extracted version: $VERSION"
+
     - name: Extract metadata
       id: meta
       uses: docker/metadata-action@v5
@@ -55,7 +62,7 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
-          FLUX_VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] || 'latest' }}
+          FLUX_VERSION=${{ steps.version.outputs.version }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.4.3"
+version = "0.4.4"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -150,6 +150,10 @@ def test_workflow(
         str(EVENT_FILES_DIR / f"{event}.json"),
         "--secret",
         "PYPI_API_TOKEN=fake-token",
+        "--secret",
+        "DOCKER_USERNAME=fake-user",
+        "--secret",
+        "DOCKER_TOKEN=fake-token",
     ]
 
     # Add dry-run flag if needed
@@ -182,6 +186,7 @@ def test_workflows() -> None:
     workflows_to_test = [
         ("pull-request.yml", "test", "pull_request"),
         ("build-publish.yml", "build", "push"),
+        ("docker-publish.yml", "build-and-publish", "push"),
         ("docs.yml", "deploy", "paths"),
     ]
 


### PR DESCRIPTION
This PR introduces automated Docker image publishing to Docker Hub with the following key features:

## 🚀 **New Features**
- **GitHub Actions workflow** for building and publishing multi-platform Docker images (linux/amd64, linux/arm64)
- **Automatic version extraction** from `pyproject.toml` instead of relying on git tags
- **Multi-trigger support**: Push to main, manual dispatch, and tag-based releases
- **Build attestation** for supply chain security using GitHub's artifact attestation

## 🔧 **Key Changes**
- **New file**: `.github/workflows/docker-publish.yml` - Complete CI/CD pipeline for Docker publishing
- **Version bump**: `pyproject.toml` updated from 0.4.3 → 0.4.4 
- **Enhanced CI testing**: Added Docker secrets to `scripts/ci.py` for workflow testing

## 📋 **Workflow Features**
- Builds for multiple architectures (AMD64 + ARM64)
- Uses GitHub Actions cache for faster builds
- Extracts version directly from Poetry configuration
- Publishes to Docker Hub with proper tagging strategy
- Generates signed build provenance attestations

## 🎯 **Benefits**
- Streamlines deployment process - no manual Docker builds needed
- Version consistency between Python package and Docker image
- Enhanced security through build attestations
- Multi-platform support for broader compatibility

The workflow will trigger on every push to `main` and use the version specified in `pyproject.toml` (currently 0.4.4) as the Docker image version, eliminating the need for manual version management in CI/CD.