### PR TITLE
Fix output storage replay by always using storage providers

### DIFF
--- a/examples/dataframe_with_pause.py
+++ b/examples/dataframe_with_pause.py
@@ -1,0 +1,97 @@
+"""
+Example workflow demonstrating DataFrame serialization with pause/resume.
+
+This example shows how to use LocalFileStorage to properly serialize
+pandas DataFrames across workflow pause/resume cycles, ensuring data
+integrity is maintained.
+
+Usage:
+    flux workflow run dataframe_with_pause '{"file_path": "path/to/data.csv"}'
+    flux workflow resume dataframe_with_pause <execution_id> '{}'
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from flux import ExecutionContext, task, workflow
+from flux.output_storage import LocalFileStorage
+from flux.tasks import pause
+
+file_storage = LocalFileStorage()
+
+
+@task.with_options(output_storage=file_storage)
+async def load_csv(file_path: str) -> pd.DataFrame:
+    """Load CSV file into a DataFrame."""
+    return pd.read_csv(file_path)
+
+
+@task.with_options(output_storage=file_storage)
+async def process_dataframe(df: pd.DataFrame) -> dict[str, Any]:
+    """Process the DataFrame and return summary statistics."""
+    return {
+        "row_count": len(df),
+        "column_count": len(df.columns),
+        "columns": list(df.columns),
+        "first_row": df.head(1).to_dict(orient="records")[0] if len(df) > 0 else {},
+    }
+
+
+@workflow.with_options(name="dataframe_with_pause")
+async def dataframe_with_pause(ctx: ExecutionContext[dict[str, str]]):
+    """
+    Workflow that validates DataFrame integrity across pause/resume.
+
+    This workflow demonstrates that DataFrames are properly preserved
+    when using LocalFileStorage with pause/resume functionality.
+    """
+    file_path = ctx.input.get("file_path")
+
+    # Load CSV
+    df = await load_csv(file_path)
+
+    # Capture values before pause to validate integrity after resume
+    before_pause_values = {
+        "shape": df.shape,
+        "first_row_product": df.iloc[0]["product"],
+        "first_row_revenue": float(df.iloc[0]["revenue"]),
+        "first_row_quantity": int(df.iloc[0]["quantity"]),
+        "total_rows": len(df),
+        "column_count": len(df.columns),
+        "sum_revenue": float(df["revenue"].sum()),
+    }
+
+    # Pause here - DataFrame needs to be preserved
+    resume_input = await pause("after_load")
+
+    # Validate DataFrame was correctly restored
+    after_pause_values = {
+        "shape": df.shape,
+        "first_row_product": df.iloc[0]["product"],
+        "first_row_revenue": float(df.iloc[0]["revenue"]),
+        "first_row_quantity": int(df.iloc[0]["quantity"]),
+        "total_rows": len(df),
+        "column_count": len(df.columns),
+        "sum_revenue": float(df["revenue"].sum()),
+    }
+
+    # Verify all values match
+    integrity_check = all(
+        before_pause_values[k] == after_pause_values[k] for k in before_pause_values.keys()
+    )
+
+    # Process it after resume
+    result = await process_dataframe(df)
+
+    return {
+        "status": "success" if integrity_check else "data_integrity_failed",
+        "result": result,
+        "before_pause": before_pause_values,
+        "after_pause": after_pause_values,
+        "integrity_check": integrity_check,
+        "execution_id": ctx.execution_id,
+        "resumed_with": resume_input,
+    }

--- a/examples/dataframe_with_pause.py
+++ b/examples/dataframe_with_pause.py
@@ -53,6 +53,12 @@ async def dataframe_with_pause(ctx: ExecutionContext[dict[str, str]]):
     # Load CSV
     df = await load_csv(file_path)
 
+    # Validate required columns exist
+    required_columns = {"product", "quantity", "revenue"}
+    if not required_columns.issubset(df.columns):
+        missing = required_columns - set(df.columns)
+        raise ValueError(f"Missing required columns: {missing}")
+
     # Capture values before pause to validate integrity after resume
     before_pause_values = {
         "shape": df.shape,

--- a/flux/task.py
+++ b/flux/task.py
@@ -118,7 +118,8 @@ class task:
                 reference = value
             else:
                 assert isinstance(
-                    value, dict,
+                    value,
+                    dict,
                 ), f"Expected dict or OutputStorageReference, got {type(value)}"
                 reference = OutputStorageReference.from_dict(value)
             return self.output_storage.retrieve(reference)

--- a/flux/task.py
+++ b/flux/task.py
@@ -4,7 +4,7 @@ from flux import ExecutionContext
 from flux.cache import CacheManager
 from flux.domain.events import ExecutionEvent, ExecutionEventType
 from flux.errors import ExecutionError, ExecutionTimeoutError, PauseRequested, RetryError
-from flux.output_storage import OutputStorage
+from flux.output_storage import InlineOutputStorage, OutputStorage, OutputStorageReference
 from flux.secret_managers import SecretManager
 from flux.utils import get_func_args, make_hashable, maybe_awaitable
 
@@ -82,7 +82,7 @@ class task:
         self.retry_backoff = retry_backoff
         self.timeout = timeout
         self.secret_requests = secret_requests
-        self.output_storage = output_storage
+        self.output_storage = output_storage if output_storage else InlineOutputStorage()
         self.cache = cache
         self.metadata = metadata
         wraps(func)(self)
@@ -113,7 +113,15 @@ class task:
         ]
 
         if len(finished) > 0:
-            return finished[0].value
+            value = finished[0].value
+            if isinstance(value, OutputStorageReference):
+                reference = value
+            else:
+                assert isinstance(
+                    value, dict,
+                ), f"Expected dict or OutputStorageReference, got {type(value)}"
+                reference = OutputStorageReference.from_dict(value)
+            return self.output_storage.retrieve(reference)
 
         if not ctx.is_resuming and not ctx.has_resumed:
             ctx.events.append(
@@ -173,7 +181,7 @@ class task:
                 type=ExecutionEventType.TASK_COMPLETED,
                 source_id=task_id,
                 name=full_name,
-                value=self.output_storage.store(task_id, output) if self.output_storage else output,
+                value=self.output_storage.store(task_id, output),
             ),
         )
 
@@ -284,9 +292,7 @@ class task:
                         type=ExecutionEventType.TASK_FALLBACK_COMPLETED,
                         source_id=task_id,
                         name=task_full_name,
-                        value=self.output_storage.store(task_id, output)
-                        if self.output_storage
-                        else output,
+                        value=self.output_storage.store(task_id, output),
                     ),
                 )
             except Exception as ex:
@@ -329,9 +335,7 @@ class task:
                         type=ExecutionEventType.TASK_ROLLBACK_COMPLETED,
                         source_id=task_id,
                         name=task_full_name,
-                        value=self.output_storage.store(task_id, output)
-                        if self.output_storage
-                        else output,
+                        value=self.output_storage.store(task_id, output),
                     ),
                 )
                 return output
@@ -391,9 +395,7 @@ class task:
                             "max_attempts": self.retry_max_attempts,
                             "current_delay": current_delay,
                             "backoff": self.retry_backoff,
-                            "output": self.output_storage.store(task_id, output)
-                            if self.output_storage
-                            else output,
+                            "output": self.output_storage.store(task_id, output),
                         },
                     ),
                 )

--- a/flux/task.py
+++ b/flux/task.py
@@ -117,11 +117,19 @@ class task:
             if isinstance(value, OutputStorageReference):
                 reference = value
             else:
-                assert isinstance(
-                    value,
-                    dict,
-                ), f"Expected dict or OutputStorageReference, got {type(value)}"
-                reference = OutputStorageReference.from_dict(value)
+                if not isinstance(value, dict):
+                    raise ExecutionError(
+                        message=f"Failed to deserialize OutputStorageReference when resuming task '{full_name}' (task_id={task_id}). "
+                        f"Expected OutputStorageReference or dict, but got {type(value)}: {value!r}.",
+                    )
+                try:
+                    reference = OutputStorageReference.from_dict(value)
+                except Exception as ex:
+                    raise ExecutionError(
+                        ex,
+                        f"Failed to deserialize OutputStorageReference when resuming task '{full_name}' (task_id={task_id}). "
+                        f"Original error: {ex}",
+                    ) from ex
             return self.output_storage.retrieve(reference)
 
         if not ctx.is_resuming and not ctx.has_resumed:

--- a/flux/task.py
+++ b/flux/task.py
@@ -119,7 +119,7 @@ class task:
             else:
                 if not isinstance(value, dict):
                     raise ExecutionError(
-                        message=f"Failed to deserialize OutputStorageReference when resuming task '{full_name}' (task_id={task_id}). "
+                        message=f"Failed to deserialize OutputStorageReference when replaying task '{full_name}' (task_id={task_id}). "
                         f"Expected OutputStorageReference or dict, but got {type(value)}: {value!r}.",
                     )
                 try:
@@ -127,7 +127,7 @@ class task:
                 except Exception as ex:
                     raise ExecutionError(
                         ex,
-                        f"Failed to deserialize OutputStorageReference when resuming task '{full_name}' (task_id={task_id}). "
+                        f"Failed to deserialize OutputStorageReference when replaying task '{full_name}' (task_id={task_id}). "
                         f"Original error: {ex}",
                     ) from ex
             return self.output_storage.retrieve(reference)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.6.0"
+version = "0.6.1"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/examples/test_dataframe_with_pause.py
+++ b/tests/examples/test_dataframe_with_pause.py
@@ -11,9 +11,6 @@ import pandas as pd
 
 from examples.dataframe_with_pause import dataframe_with_pause
 
-# Expected sum of test data revenues
-EXPECTED_TOTAL_REVENUE = 11089.23
-
 
 def test_dataframe_integrity_across_pause():
     """Test that DataFrame values are preserved across pause/resume."""
@@ -49,8 +46,6 @@ def test_dataframe_integrity_across_pause():
         assert ctx.output["after_pause"]["shape"] == (3, 4)
         assert ctx.output["before_pause"]["first_row_product"] == "Monitor 27inch"
         assert ctx.output["after_pause"]["first_row_product"] == "Monitor 27inch"
-        assert abs(ctx.output["before_pause"]["sum_revenue"] - EXPECTED_TOTAL_REVENUE) < 0.01
-        assert abs(ctx.output["after_pause"]["sum_revenue"] - EXPECTED_TOTAL_REVENUE) < 0.01
 
     finally:
         # Clean up temp file

--- a/tests/examples/test_dataframe_with_pause.py
+++ b/tests/examples/test_dataframe_with_pause.py
@@ -1,0 +1,54 @@
+"""
+Tests for DataFrame serialization across pause/resume.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+
+from examples.dataframe_with_pause import dataframe_with_pause
+
+
+def test_dataframe_integrity_across_pause():
+    """Test that DataFrame values are preserved across pause/resume."""
+    # Create a temporary CSV file with test data
+    test_data = pd.DataFrame(
+        {
+            "product": ["Monitor 27inch", "HD Webcam", "Portable SSD 1TB"],
+            "quantity": [8, 27, 42],
+            "revenue": [3199.92, 2429.73, 5459.58],
+            "cost": [2000.0, 1215.0, 3360.0],
+        },
+    )
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        test_data.to_csv(f.name, index=False)
+        temp_file = f.name
+
+    try:
+        # Run workflow to pause
+        ctx = dataframe_with_pause.run({"file_path": temp_file})
+        assert ctx.is_paused, "Workflow should be paused"
+
+        # Resume workflow
+        ctx = dataframe_with_pause.run(execution_id=ctx.execution_id)
+        assert ctx.has_succeeded, "Workflow should have succeeded"
+
+        # Validate integrity
+        assert ctx.output["integrity_check"] is True, "DataFrame integrity check should pass"
+        assert ctx.output["status"] == "success", "Status should be success"
+
+        # Validate specific values
+        assert ctx.output["before_pause"]["shape"] == (3, 4)
+        assert ctx.output["after_pause"]["shape"] == (3, 4)
+        assert ctx.output["before_pause"]["first_row_product"] == "Monitor 27inch"
+        assert ctx.output["after_pause"]["first_row_product"] == "Monitor 27inch"
+        assert abs(ctx.output["before_pause"]["sum_revenue"] - 11089.23) < 0.01
+        assert abs(ctx.output["after_pause"]["sum_revenue"] - 11089.23) < 0.01
+
+    finally:
+        # Clean up temp file
+        Path(temp_file).unlink()

--- a/tests/examples/test_dataframe_with_pause.py
+++ b/tests/examples/test_dataframe_with_pause.py
@@ -11,6 +11,9 @@ import pandas as pd
 
 from examples.dataframe_with_pause import dataframe_with_pause
 
+# Expected sum of test data revenues
+EXPECTED_TOTAL_REVENUE = 11089.23
+
 
 def test_dataframe_integrity_across_pause():
     """Test that DataFrame values are preserved across pause/resume."""
@@ -46,8 +49,8 @@ def test_dataframe_integrity_across_pause():
         assert ctx.output["after_pause"]["shape"] == (3, 4)
         assert ctx.output["before_pause"]["first_row_product"] == "Monitor 27inch"
         assert ctx.output["after_pause"]["first_row_product"] == "Monitor 27inch"
-        assert abs(ctx.output["before_pause"]["sum_revenue"] - 11089.23) < 0.01
-        assert abs(ctx.output["after_pause"]["sum_revenue"] - 11089.23) < 0.01
+        assert abs(ctx.output["before_pause"]["sum_revenue"] - EXPECTED_TOTAL_REVENUE) < 0.01
+        assert abs(ctx.output["after_pause"]["sum_revenue"] - EXPECTED_TOTAL_REVENUE) < 0.01
 
     finally:
         # Clean up temp file


### PR DESCRIPTION
## Problem
When tasks with `output_storage` completed and workflow paused/resumed, the replay mechanism returned `OutputStorageReference` dict instead of retrieving actual data. This caused errors when trying to use DataFrame or other complex objects after resume.

## Solution
- Always use OutputStorage pattern (default to InlineOutputStorage)
- Always call `storage.retrieve()` when replaying completed tasks  
- Always call `storage.store()` when saving outputs
- Handle both dict and OutputStorageReference objects during retrieval

## Benefits
- ✅ Fixes DataFrame and complex object serialization across pause/resume
- ✅ Cleaner code with single code path for all tasks
- ✅ Maintains backwards compatibility (InlineOutputStorage preserves existing behavior)
- ✅ All existing tests pass (21/21)

## Example & Test Coverage
**Example:** `examples/dataframe_with_pause.py` demonstrates DataFrame preservation across pause/resume with LocalFileStorage

**Test:** `tests/examples/test_dataframe_with_pause.py` validates DataFrame integrity:
- Captures DataFrame values before pause (shape, first row data, sum of revenue)
- Resumes workflow and verifies all values match exactly
- Confirms `integrity_check: true`

## Testing
```bash
# Run the new test
poetry run pytest tests/examples/test_dataframe_with_pause.py -v

# Run all output storage and pause tests  
poetry run pytest tests/flux/output_storage/ tests/examples/test_output_storage.py tests/examples/test_pause.py tests/examples/test_dataframe_with_pause.py -v
```

All 21 tests pass with no regressions.