### PR TITLE
Add missing MCP server tools to align with REST API and CLI

### DIFF
--- a/flux/mcp_server.py
+++ b/flux/mcp_server.py
@@ -538,7 +538,7 @@ class MCPServer:
         async def list_executions(
             workflow_name: str | None = None,
             state: str | None = None,
-            limit: int = 100,
+            limit: int = 50,
             offset: int = 0,
         ) -> dict[str, any]:
             """List workflow executions with optional filtering.
@@ -622,7 +622,7 @@ class MCPServer:
         async def list_workflow_executions(
             workflow_name: str,
             state: str | None = None,
-            limit: int = 100,
+            limit: int = 50,
             offset: int = 0,
         ) -> dict[str, any]:
             """List executions for a specific workflow.
@@ -764,7 +764,7 @@ class MCPServer:
                     }
                     if description:
                         body["description"] = description
-                    if parsed_input:
+                    if parsed_input is not None:
                         body["input_data"] = parsed_input
 
                     response = await client.post(
@@ -791,7 +791,7 @@ class MCPServer:
         @self.mcp.tool()
         async def list_schedules(
             workflow_name: str | None = None,
-            active_only: bool = False,
+            active_only: bool = True,
             limit: int | None = None,
             offset: int | None = None,
         ) -> dict[str, any]:
@@ -1002,7 +1002,7 @@ class MCPServer:
         @self.mcp.tool()
         async def get_schedule_history(
             schedule_id: str,
-            limit: int = 100,
+            limit: int = 50,
             offset: int = 0,
         ) -> dict[str, any]:
             """Get execution history for a schedule.

--- a/flux/mcp_server.py
+++ b/flux/mcp_server.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import httpx
 
-from typing import Literal
+from typing import Any, Literal
 from fastmcp import FastMCP
 
 from flux.config import Configuration
@@ -484,7 +484,7 @@ class MCPServer:
             try:
                 async with httpx.AsyncClient(timeout=30.0) as client:
                     response = await client.get(
-                        f"{self.server_url}/workflows/{workflow_name}/versions"
+                        f"{self.server_url}/workflows/{workflow_name}/versions",
                     )
                     response.raise_for_status()
                     versions = response.json()
@@ -514,7 +514,7 @@ class MCPServer:
             try:
                 async with httpx.AsyncClient(timeout=30.0) as client:
                     response = await client.get(
-                        f"{self.server_url}/workflows/{workflow_name}/versions/{version}"
+                        f"{self.server_url}/workflows/{workflow_name}/versions/{version}",
                     )
                     response.raise_for_status()
                     workflow = response.json()
@@ -551,7 +551,7 @@ class MCPServer:
             """
             try:
                 async with httpx.AsyncClient(timeout=30.0) as client:
-                    params = {"limit": limit, "offset": offset}
+                    params: dict[str, Any] = {"limit": limit, "offset": offset}
                     if workflow_name:
                         params["workflow_name"] = workflow_name
                     if state:
@@ -635,7 +635,7 @@ class MCPServer:
             """
             try:
                 async with httpx.AsyncClient(timeout=30.0) as client:
-                    params = {"limit": limit, "offset": offset}
+                    params: dict[str, Any] = {"limit": limit, "offset": offset}
                     if state:
                         params["state"] = state
 
@@ -649,7 +649,7 @@ class MCPServer:
                     executions = result.get("executions", [])
                     total = result.get("total", len(executions))
                     logger.info(
-                        f"Retrieved {len(executions)} executions for workflow {workflow_name}"
+                        f"Retrieved {len(executions)} executions for workflow {workflow_name}",
                     )
                     return {
                         "success": True,
@@ -805,7 +805,7 @@ class MCPServer:
             """
             try:
                 async with httpx.AsyncClient(timeout=30.0) as client:
-                    params = {"active_only": active_only}
+                    params: dict[str, Any] = {"active_only": active_only}
                     if workflow_name:
                         params["workflow_name"] = workflow_name
                     if limit is not None:
@@ -925,9 +925,7 @@ class MCPServer:
             """
             try:
                 async with httpx.AsyncClient(timeout=30.0) as client:
-                    response = await client.post(
-                        f"{self.server_url}/schedules/{schedule_id}/pause"
-                    )
+                    response = await client.post(f"{self.server_url}/schedules/{schedule_id}/pause")
                     response.raise_for_status()
                     schedule = response.json()
 
@@ -955,7 +953,7 @@ class MCPServer:
             try:
                 async with httpx.AsyncClient(timeout=30.0) as client:
                     response = await client.post(
-                        f"{self.server_url}/schedules/{schedule_id}/resume"
+                        f"{self.server_url}/schedules/{schedule_id}/resume",
                     )
                     response.raise_for_status()
                     schedule = response.json()
@@ -983,9 +981,7 @@ class MCPServer:
             """
             try:
                 async with httpx.AsyncClient(timeout=30.0) as client:
-                    response = await client.delete(
-                        f"{self.server_url}/schedules/{schedule_id}"
-                    )
+                    response = await client.delete(f"{self.server_url}/schedules/{schedule_id}")
                     response.raise_for_status()
                     result = response.json()
 
@@ -1027,7 +1023,7 @@ class MCPServer:
 
                     entries = result.get("entries", [])
                     logger.info(
-                        f"Retrieved {len(entries)} history entries for schedule {schedule_id}"
+                        f"Retrieved {len(entries)} history entries for schedule {schedule_id}",
                     )
                     return {
                         "success": True,

--- a/flux/mcp_server.py
+++ b/flux/mcp_server.py
@@ -438,6 +438,643 @@ class MCPServer:
                 logger.error(error_msg)
                 return {"success": False, "error": error_msg}
 
+        @self.mcp.tool()
+        async def delete_workflow(
+            workflow_name: str,
+            version: int | None = None,
+        ) -> dict[str, any]:
+            """Delete a workflow from the Flux system.
+
+            Args:
+                workflow_name: Name of the workflow to delete
+                version: Optional specific version to delete. If not provided, deletes all versions.
+            """
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    params = {"version": version} if version is not None else {}
+                    response = await client.delete(
+                        f"{self.server_url}/workflows/{workflow_name}",
+                        params=params,
+                    )
+                    response.raise_for_status()
+                    result = response.json()
+
+                    version_info = f" version {version}" if version else " (all versions)"
+                    logger.info(f"Deleted workflow: {workflow_name}{version_info}")
+                    return {"success": True, "message": result.get("message", "Workflow deleted")}
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    error_msg = f"Workflow '{workflow_name}' not found"
+                else:
+                    error_msg = f"HTTP error: {e.response.status_code} - {e.response.text}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+            except Exception as e:
+                error_msg = f"Error deleting workflow: {str(e)}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+
+        @self.mcp.tool()
+        async def list_workflow_versions(workflow_name: str) -> dict[str, any]:
+            """List all versions of a specific workflow.
+
+            Args:
+                workflow_name: Name of the workflow to list versions for
+            """
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    response = await client.get(
+                        f"{self.server_url}/workflows/{workflow_name}/versions"
+                    )
+                    response.raise_for_status()
+                    versions = response.json()
+
+                    logger.info(f"Retrieved {len(versions)} versions for workflow: {workflow_name}")
+                    return {"success": True, "versions": versions, "count": len(versions)}
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    error_msg = f"Workflow '{workflow_name}' not found"
+                else:
+                    error_msg = f"HTTP error: {e.response.status_code} - {e.response.text}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+            except Exception as e:
+                error_msg = f"Error listing workflow versions: {str(e)}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+
+        @self.mcp.tool()
+        async def get_workflow_version(workflow_name: str, version: int) -> dict[str, any]:
+            """Get details of a specific workflow version.
+
+            Args:
+                workflow_name: Name of the workflow
+                version: Version number to retrieve
+            """
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    response = await client.get(
+                        f"{self.server_url}/workflows/{workflow_name}/versions/{version}"
+                    )
+                    response.raise_for_status()
+                    workflow = response.json()
+
+                    logger.info(f"Retrieved workflow {workflow_name} version {version}")
+                    return {"success": True, "workflow": workflow}
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    error_msg = f"Workflow '{workflow_name}' version {version} not found"
+                else:
+                    error_msg = f"HTTP error: {e.response.status_code} - {e.response.text}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+            except Exception as e:
+                error_msg = f"Error retrieving workflow version: {str(e)}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+
+        # Execution Management Tools
+        @self.mcp.tool()
+        async def list_executions(
+            workflow_name: str | None = None,
+            state: str | None = None,
+            limit: int = 100,
+            offset: int = 0,
+        ) -> dict[str, any]:
+            """List workflow executions with optional filtering.
+
+            Args:
+                workflow_name: Optional workflow name to filter by
+                state: Optional execution state to filter by (e.g., 'running', 'completed', 'failed')
+                limit: Maximum number of executions to return
+                offset: Number of executions to skip for pagination
+            """
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    params = {"limit": limit, "offset": offset}
+                    if workflow_name:
+                        params["workflow_name"] = workflow_name
+                    if state:
+                        params["state"] = state
+
+                    response = await client.get(
+                        f"{self.server_url}/executions",
+                        params=params,
+                    )
+                    response.raise_for_status()
+                    result = response.json()
+
+                    executions = result.get("executions", [])
+                    total = result.get("total", len(executions))
+                    logger.info(f"Retrieved {len(executions)} executions (total: {total})")
+                    return {
+                        "success": True,
+                        "executions": executions,
+                        "total": total,
+                        "limit": limit,
+                        "offset": offset,
+                    }
+            except httpx.HTTPStatusError as e:
+                error_msg = f"HTTP error: {e.response.status_code} - {e.response.text}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+            except Exception as e:
+                error_msg = f"Error listing executions: {str(e)}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+
+        @self.mcp.tool()
+        async def get_execution(
+            execution_id: str,
+            detailed: bool = False,
+        ) -> dict[str, any]:
+            """Get details of a specific execution by ID.
+
+            Args:
+                execution_id: ID of the execution to retrieve
+                detailed: Whether to return detailed execution information
+            """
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    response = await client.get(
+                        f"{self.server_url}/executions/{execution_id}",
+                        params={"detailed": detailed},
+                    )
+                    response.raise_for_status()
+                    result = response.json()
+                    context = ExecutionContext.from_dict(result)
+
+                    logger.info(f"Retrieved execution: {execution_id}")
+                    return context if detailed else context.summary()
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    error_msg = f"Execution '{execution_id}' not found"
+                else:
+                    error_msg = f"HTTP error: {e.response.status_code} - {e.response.text}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+            except Exception as e:
+                error_msg = f"Error retrieving execution: {str(e)}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+
+        @self.mcp.tool()
+        async def list_workflow_executions(
+            workflow_name: str,
+            state: str | None = None,
+            limit: int = 100,
+            offset: int = 0,
+        ) -> dict[str, any]:
+            """List executions for a specific workflow.
+
+            Args:
+                workflow_name: Name of the workflow to list executions for
+                state: Optional execution state to filter by
+                limit: Maximum number of executions to return
+                offset: Number of executions to skip for pagination
+            """
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    params = {"limit": limit, "offset": offset}
+                    if state:
+                        params["state"] = state
+
+                    response = await client.get(
+                        f"{self.server_url}/workflows/{workflow_name}/executions",
+                        params=params,
+                    )
+                    response.raise_for_status()
+                    result = response.json()
+
+                    executions = result.get("executions", [])
+                    total = result.get("total", len(executions))
+                    logger.info(
+                        f"Retrieved {len(executions)} executions for workflow {workflow_name}"
+                    )
+                    return {
+                        "success": True,
+                        "workflow_name": workflow_name,
+                        "executions": executions,
+                        "total": total,
+                        "limit": limit,
+                        "offset": offset,
+                    }
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    error_msg = f"Workflow '{workflow_name}' not found"
+                else:
+                    error_msg = f"HTTP error: {e.response.status_code} - {e.response.text}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+            except Exception as e:
+                error_msg = f"Error listing workflow executions: {str(e)}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+
+        # Worker Management Tools
+        @self.mcp.tool()
+        async def list_workers() -> dict[str, any]:
+            """List all workers in the Flux system."""
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    response = await client.get(f"{self.server_url}/workers")
+                    response.raise_for_status()
+                    workers = response.json()
+
+                    logger.info(f"Retrieved {len(workers)} workers")
+                    return {"success": True, "workers": workers, "count": len(workers)}
+            except httpx.ConnectError:
+                error_msg = f"Could not connect to Flux server at {self.server_url}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+            except httpx.HTTPStatusError as e:
+                error_msg = f"HTTP error: {e.response.status_code} - {e.response.text}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+            except Exception as e:
+                error_msg = f"Unexpected error: {str(e)}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+
+        @self.mcp.tool()
+        async def get_worker(worker_name: str) -> dict[str, any]:
+            """Get details of a specific worker.
+
+            Args:
+                worker_name: Name of the worker to retrieve
+            """
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    response = await client.get(f"{self.server_url}/workers/{worker_name}")
+                    response.raise_for_status()
+                    worker = response.json()
+
+                    logger.info(f"Retrieved worker: {worker_name}")
+                    return {"success": True, "worker": worker}
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    error_msg = f"Worker '{worker_name}' not found"
+                else:
+                    error_msg = f"HTTP error: {e.response.status_code} - {e.response.text}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+            except Exception as e:
+                error_msg = f"Error retrieving worker: {str(e)}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+
+        # Schedule Management Tools
+        @self.mcp.tool()
+        async def create_schedule(
+            workflow_name: str,
+            name: str,
+            schedule_config: str,
+            description: str | None = None,
+            input_data: str | None = None,
+        ) -> dict[str, any]:
+            """Create a new schedule for a workflow.
+
+            Args:
+                workflow_name: Name of the workflow to schedule
+                name: Name for the schedule
+                schedule_config: JSON string with schedule configuration (cron, interval, etc.)
+                description: Optional description for the schedule
+                input_data: Optional JSON string of input data for scheduled executions
+            """
+            try:
+                # Parse schedule config
+                try:
+                    parsed_config = json.loads(schedule_config)
+                except json.JSONDecodeError:
+                    return {"success": False, "error": "Invalid JSON in schedule_config"}
+
+                # Parse input data if provided
+                parsed_input = None
+                if input_data:
+                    try:
+                        parsed_input = json.loads(input_data)
+                    except json.JSONDecodeError:
+                        parsed_input = input_data
+
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    body = {
+                        "workflow_name": workflow_name,
+                        "name": name,
+                        "schedule_config": parsed_config,
+                    }
+                    if description:
+                        body["description"] = description
+                    if parsed_input:
+                        body["input_data"] = parsed_input
+
+                    response = await client.post(
+                        f"{self.server_url}/schedules",
+                        json=body,
+                    )
+                    response.raise_for_status()
+                    schedule = response.json()
+
+                    logger.info(f"Created schedule '{name}' for workflow {workflow_name}")
+                    return {"success": True, "schedule": schedule}
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    error_msg = f"Workflow '{workflow_name}' not found"
+                else:
+                    error_msg = f"HTTP error: {e.response.status_code} - {e.response.text}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+            except Exception as e:
+                error_msg = f"Error creating schedule: {str(e)}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+
+        @self.mcp.tool()
+        async def list_schedules(
+            workflow_name: str | None = None,
+            active_only: bool = False,
+            limit: int | None = None,
+            offset: int | None = None,
+        ) -> dict[str, any]:
+            """List schedules with optional filtering.
+
+            Args:
+                workflow_name: Optional workflow name to filter by
+                active_only: If True, only return active schedules
+                limit: Maximum number of schedules to return
+                offset: Number of schedules to skip for pagination
+            """
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    params = {"active_only": active_only}
+                    if workflow_name:
+                        params["workflow_name"] = workflow_name
+                    if limit is not None:
+                        params["limit"] = limit
+                    if offset is not None:
+                        params["offset"] = offset
+
+                    response = await client.get(
+                        f"{self.server_url}/schedules",
+                        params=params,
+                    )
+                    response.raise_for_status()
+                    schedules = response.json()
+
+                    logger.info(f"Retrieved {len(schedules)} schedules")
+                    return {"success": True, "schedules": schedules, "count": len(schedules)}
+            except httpx.HTTPStatusError as e:
+                error_msg = f"HTTP error: {e.response.status_code} - {e.response.text}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+            except Exception as e:
+                error_msg = f"Error listing schedules: {str(e)}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+
+        @self.mcp.tool()
+        async def get_schedule(schedule_id: str) -> dict[str, any]:
+            """Get details of a specific schedule.
+
+            Args:
+                schedule_id: ID or name of the schedule to retrieve
+            """
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    response = await client.get(f"{self.server_url}/schedules/{schedule_id}")
+                    response.raise_for_status()
+                    schedule = response.json()
+
+                    logger.info(f"Retrieved schedule: {schedule_id}")
+                    return {"success": True, "schedule": schedule}
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    error_msg = f"Schedule '{schedule_id}' not found"
+                else:
+                    error_msg = f"HTTP error: {e.response.status_code} - {e.response.text}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+            except Exception as e:
+                error_msg = f"Error retrieving schedule: {str(e)}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+
+        @self.mcp.tool()
+        async def update_schedule(
+            schedule_id: str,
+            schedule_config: str | None = None,
+            description: str | None = None,
+            input_data: str | None = None,
+        ) -> dict[str, any]:
+            """Update an existing schedule.
+
+            Args:
+                schedule_id: ID or name of the schedule to update
+                schedule_config: Optional JSON string with new schedule configuration
+                description: Optional new description
+                input_data: Optional JSON string of new input data
+            """
+            try:
+                body = {}
+
+                if schedule_config:
+                    try:
+                        body["schedule_config"] = json.loads(schedule_config)
+                    except json.JSONDecodeError:
+                        return {"success": False, "error": "Invalid JSON in schedule_config"}
+
+                if description is not None:
+                    body["description"] = description
+
+                if input_data:
+                    try:
+                        body["input_data"] = json.loads(input_data)
+                    except json.JSONDecodeError:
+                        body["input_data"] = input_data
+
+                if not body:
+                    return {"success": False, "error": "No update parameters provided"}
+
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    response = await client.put(
+                        f"{self.server_url}/schedules/{schedule_id}",
+                        json=body,
+                    )
+                    response.raise_for_status()
+                    schedule = response.json()
+
+                    logger.info(f"Updated schedule: {schedule_id}")
+                    return {"success": True, "schedule": schedule}
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    error_msg = f"Schedule '{schedule_id}' not found"
+                else:
+                    error_msg = f"HTTP error: {e.response.status_code} - {e.response.text}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+            except Exception as e:
+                error_msg = f"Error updating schedule: {str(e)}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+
+        @self.mcp.tool()
+        async def pause_schedule(schedule_id: str) -> dict[str, any]:
+            """Pause a schedule.
+
+            Args:
+                schedule_id: ID or name of the schedule to pause
+            """
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    response = await client.post(
+                        f"{self.server_url}/schedules/{schedule_id}/pause"
+                    )
+                    response.raise_for_status()
+                    schedule = response.json()
+
+                    logger.info(f"Paused schedule: {schedule_id}")
+                    return {"success": True, "schedule": schedule}
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    error_msg = f"Schedule '{schedule_id}' not found"
+                else:
+                    error_msg = f"HTTP error: {e.response.status_code} - {e.response.text}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+            except Exception as e:
+                error_msg = f"Error pausing schedule: {str(e)}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+
+        @self.mcp.tool()
+        async def resume_schedule(schedule_id: str) -> dict[str, any]:
+            """Resume a paused schedule.
+
+            Args:
+                schedule_id: ID or name of the schedule to resume
+            """
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    response = await client.post(
+                        f"{self.server_url}/schedules/{schedule_id}/resume"
+                    )
+                    response.raise_for_status()
+                    schedule = response.json()
+
+                    logger.info(f"Resumed schedule: {schedule_id}")
+                    return {"success": True, "schedule": schedule}
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    error_msg = f"Schedule '{schedule_id}' not found"
+                else:
+                    error_msg = f"HTTP error: {e.response.status_code} - {e.response.text}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+            except Exception as e:
+                error_msg = f"Error resuming schedule: {str(e)}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+
+        @self.mcp.tool()
+        async def delete_schedule(schedule_id: str) -> dict[str, any]:
+            """Delete a schedule.
+
+            Args:
+                schedule_id: ID or name of the schedule to delete
+            """
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    response = await client.delete(
+                        f"{self.server_url}/schedules/{schedule_id}"
+                    )
+                    response.raise_for_status()
+                    result = response.json()
+
+                    logger.info(f"Deleted schedule: {schedule_id}")
+                    return {"success": True, "message": result.get("message", "Schedule deleted")}
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    error_msg = f"Schedule '{schedule_id}' not found"
+                else:
+                    error_msg = f"HTTP error: {e.response.status_code} - {e.response.text}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+            except Exception as e:
+                error_msg = f"Error deleting schedule: {str(e)}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+
+        @self.mcp.tool()
+        async def get_schedule_history(
+            schedule_id: str,
+            limit: int = 100,
+            offset: int = 0,
+        ) -> dict[str, any]:
+            """Get execution history for a schedule.
+
+            Args:
+                schedule_id: ID or name of the schedule
+                limit: Maximum number of history entries to return
+                offset: Number of entries to skip for pagination
+            """
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    response = await client.get(
+                        f"{self.server_url}/schedules/{schedule_id}/history",
+                        params={"limit": limit, "offset": offset},
+                    )
+                    response.raise_for_status()
+                    result = response.json()
+
+                    entries = result.get("entries", [])
+                    logger.info(
+                        f"Retrieved {len(entries)} history entries for schedule {schedule_id}"
+                    )
+                    return {
+                        "success": True,
+                        "schedule_id": result.get("schedule_id"),
+                        "workflow_name": result.get("workflow_name"),
+                        "entries": entries,
+                        "total": result.get("total", len(entries)),
+                        "limit": limit,
+                        "offset": offset,
+                    }
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    error_msg = f"Schedule '{schedule_id}' not found"
+                else:
+                    error_msg = f"HTTP error: {e.response.status_code} - {e.response.text}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+            except Exception as e:
+                error_msg = f"Error retrieving schedule history: {str(e)}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+
+        # Health Check Tool
+        @self.mcp.tool()
+        async def health_check() -> dict[str, any]:
+            """Check the health status of the Flux server."""
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    response = await client.get(f"{self.server_url}/health")
+                    response.raise_for_status()
+                    health = response.json()
+
+                    logger.info(f"Health check: {health.get('status', 'unknown')}")
+                    return {"success": True, "health": health}
+            except httpx.ConnectError:
+                error_msg = f"Could not connect to Flux server at {self.server_url}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+            except httpx.HTTPStatusError as e:
+                error_msg = f"HTTP error: {e.response.status_code} - {e.response.text}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+            except Exception as e:
+                error_msg = f"Unexpected error: {str(e)}"
+                logger.error(error_msg)
+                return {"success": False, "error": error_msg}
+
 
 if __name__ == "__main__":
     config = Configuration.get().settings.mcp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.6.3"
+version = "0.6.4"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"


### PR DESCRIPTION
## Summary
- Add MCP server tools that were missing compared to the REST API and CLI: `delete_workflow`, `list_workflow_versions`, `get_workflow_version`, `list_executions`, `get_execution`, `list_workflow_executions`, `list_workers`, `get_worker`, `create_schedule`, `list_schedules`, `get_schedule`, `update_schedule`, `pause_schedule`, `resume_schedule`, `delete_schedule`, `get_schedule_history`, and `health_check`
- Ensures full feature parity between MCP server, REST API, and CLI interfaces

## Test plan
- [ ] Verify MCP server starts without errors
- [ ] Test each new tool against a running Flux server
- [ ] Confirm tool responses match REST API equivalents

🤖 Generated with [Claude Code](https://claude.com/claude-code)