### PR TITLE
docs: agent skills documentation and docs refresh

### DIFF
--- a/docs/advanced-features/agent-skills.md
+++ b/docs/advanced-features/agent-skills.md
@@ -1,0 +1,416 @@
+# Agent Skills
+
+Agent skills are reusable instruction bundles that agents can discover and activate on demand. Skills follow the [Agent Skills](https://agentskills.io) open standard — skills authored for Flux work with Claude Code, Cursor, GitHub Copilot, Gemini CLI, and 30+ other tools.
+
+## Basic Usage
+
+```python
+from flux import workflow, ExecutionContext
+from flux.tasks.ai import agent, SkillCatalog
+
+catalog = SkillCatalog.from_directory("./skills")
+
+assistant = agent(
+    "You are a helpful assistant.",
+    model="ollama/llama3.2",
+    tools=[search_web],
+    skills=catalog,
+)
+
+@workflow
+async def my_workflow(ctx: ExecutionContext):
+    return await assistant("Research quantum computing")
+```
+
+The agent sees skill descriptions in its system prompt, calls `use_skill` to load full instructions when relevant, then follows them using the available tools.
+
+## Defining Skills
+
+### SKILL.md Files
+
+A skill is a directory containing a `SKILL.md` file with YAML frontmatter and markdown instructions:
+
+```
+skills/
+├── researcher/
+│   └── SKILL.md
+├── summarizer/
+│   └── SKILL.md
+└── code-reviewer/
+    ├── SKILL.md
+    ├── references/
+    │   └── owasp-checklist.md
+    └── scripts/
+        └── lint.py
+```
+
+The `SKILL.md` format:
+
+```yaml
+---
+name: researcher
+description: Deep research on a topic using web sources. Use when the task requires gathering information from multiple sources and synthesizing findings.
+allowed-tools: search_web read_url
+metadata:
+  author: acme-corp
+  version: "1.0"
+---
+
+Research the given topic thoroughly.
+
+1. Use search_web to find relevant sources on the topic
+2. Use read_url to extract content from the most promising results
+3. Cross-reference findings across multiple sources
+4. Synthesize findings into a comprehensive summary with citations
+```
+
+### Frontmatter Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Skill identifier. Max 64 chars, lowercase letters, numbers, and hyphens. Must match the parent directory name. |
+| `description` | Yes | What the skill does and when to use it. Max 1024 chars. The LLM uses this to decide which skill to activate. |
+| `allowed-tools` | No | Space-delimited list of tool names the skill expects to use. Validated against the agent's tools at construction time. |
+| `license` | No | License name or reference to a bundled license file. |
+| `compatibility` | No | Environment requirements (max 500 chars). |
+| `metadata` | No | Arbitrary key-value mapping for additional metadata (author, version, etc.). |
+
+### Python-Defined Skills
+
+Skills can be constructed directly in Python without a `SKILL.md` file:
+
+```python
+from flux.tasks.ai import Skill
+
+security_reviewer = Skill(
+    name="security-reviewer",
+    description="Reviews code for security vulnerabilities including injection, "
+    "XSS, and OWASP Top 10 issues.",
+    instructions=(
+        "You are a security expert. Review the provided code.\n\n"
+        "Check for:\n"
+        "1. SQL injection vulnerabilities\n"
+        "2. Cross-site scripting (XSS)\n"
+        "3. Authentication and authorization flaws\n"
+        "4. Sensitive data exposure\n"
+        "5. Input validation issues\n\n"
+        "For each issue, provide severity, description, and a fix."
+    ),
+    allowed_tools=["run_linter"],
+)
+```
+
+Python skills are useful when:
+- You want IDE autocompletion and type checking
+- Skill instructions are generated dynamically
+- You don't need cross-tool portability
+
+### Name Validation
+
+Skill names follow the Agent Skills standard:
+
+- Lowercase letters, numbers, and hyphens only
+- Must not start or end with a hyphen
+- Must not contain consecutive hyphens (`--`)
+- Maximum 64 characters
+- Must match the parent directory name (for `SKILL.md` files; warns if mismatched)
+
+## SkillCatalog
+
+The `SkillCatalog` discovers, indexes, and provides access to skills.
+
+### From a Directory
+
+Scans immediate subdirectories for `SKILL.md` files:
+
+```python
+from flux.tasks.ai import SkillCatalog
+
+catalog = SkillCatalog.from_directory("./skills")
+# Finds: skills/researcher/SKILL.md, skills/summarizer/SKILL.md, etc.
+```
+
+Invalid skills (missing required fields, malformed YAML) are logged as warnings and skipped.
+
+### From a List
+
+Construct directly from `Skill` objects:
+
+```python
+from flux.tasks.ai import Skill, SkillCatalog
+
+catalog = SkillCatalog([
+    Skill(name="alpha", description="...", instructions="..."),
+    Skill(name="beta", description="...", instructions="..."),
+])
+```
+
+### Mixed Catalogs
+
+Directory discovery and explicit registration can be combined:
+
+```python
+catalog = SkillCatalog.from_directory("./skills")
+
+catalog.register(Skill(
+    name="custom-reviewer",
+    description="Custom review logic.",
+    instructions="Review using these criteria...",
+))
+```
+
+### Lookup
+
+```python
+skill = catalog.get("researcher")                       # by name, raises SkillNotFoundError if missing
+skills = catalog.find(["researcher", "code-reviewer"])   # multiple by name
+all_skills = catalog.list()                              # all registered skills
+```
+
+Name uniqueness is enforced — registering a skill with a duplicate name raises `SkillCatalogError`.
+
+## Agent Integration
+
+### Passing Skills to an Agent
+
+Pass a `SkillCatalog` to `agent()` via the `skills` parameter:
+
+```python
+assistant = agent(
+    "You are a helpful assistant.",
+    model="openai/gpt-4o",
+    tools=[search_web, read_url, lint_code],
+    skills=catalog,
+)
+```
+
+When `skills` is provided, `agent()` does three things:
+
+1. **Appends skill descriptions** to the system prompt (~20 tokens per skill)
+2. **Creates a `use_skill` tool** that the LLM can call to load a skill's full instructions
+3. **Validates `allowed_tools`** — warns if a skill declares tools not present in the agent's tool list
+
+No changes are needed in the provider builders (Ollama, OpenAI, Anthropic) — they receive an augmented system prompt and one additional tool.
+
+### How Skill Selection Works
+
+The LLM selects skills through a tool-calling mechanism:
+
+```
+1. System prompt includes:
+   "Available skills:
+    - researcher: Deep research on a topic using web sources.
+    - summarizer: Summarizes long content into concise bullet points."
+
+2. User instruction: "Research quantum computing"
+
+3. LLM decides "researcher" is relevant, calls:
+   use_skill(name="researcher")
+
+4. Tool returns the skill's full instructions:
+   "Research the given topic thoroughly.
+    1. Use search_web to find relevant sources..."
+
+5. LLM follows the instructions using available tools:
+   search_web(query="quantum computing advances 2026")
+
+6. LLM returns the final response
+```
+
+### Multi-Skill Stacking
+
+The LLM can activate multiple skills in a single run. Previously loaded instructions remain in the message history:
+
+```python
+# Agent has both "researcher" and "summarizer" skills
+result = await assistant("Research quantum computing and summarize the findings")
+
+# LLM flow:
+# 1. Calls use_skill("researcher") → gets research instructions
+# 2. Calls search_web(...) → gets results
+# 3. Calls use_skill("summarizer") → gets summarization instructions
+# 4. Returns summarized research findings
+```
+
+### Allowed Tools Validation
+
+Skills can declare which tools they expect via `allowed-tools` (SKILL.md) or `allowed_tools` (Python). At agent construction time, Flux validates these against the agent's actual tools and warns about any missing ones:
+
+```python
+# Skill declares: allowed-tools: search_web read_url
+# Agent has: tools=[search_web]
+# → Warning: "Skill 'researcher' declares allowed_tool 'read_url' which is not in the agent's tools list."
+```
+
+This is a warning, not an error — the skill may still work without all declared tools. Tool names are matched against `func.__name__` since that is what the tool executor uses for dispatch.
+
+## Event Tracking
+
+Skill activation appears in the Flux event log as regular task events:
+
+```
+TASK_STARTED    assistant         {"instruction": "Research quantum computing"}
+TASK_STARTED    use_skill         {}
+TASK_COMPLETED  use_skill         "Research the given topic thoroughly..."
+TASK_STARTED    search_web        {"query": "quantum computing"}
+TASK_COMPLETED  search_web        "Results: ..."
+TASK_COMPLETED  assistant         "Quantum computing is..."
+```
+
+The `use_skill` call is a regular `@task` — it gets full observability (events, OpenTelemetry spans, retry tracking) for free.
+
+## Error Handling
+
+### Skill Not Found
+
+If the LLM calls `use_skill` with an unknown name, `SkillNotFoundError` is raised. This extends Flux's `ExecutionError`, so it integrates with the agent's retry and error handling:
+
+```python
+assistant = agent(
+    "You are a helpful assistant.",
+    model="ollama/llama3.2",
+    skills=catalog,
+).with_options(retry_max_attempts=3)
+
+# If the LLM hallucinates a skill name, the task fails and retries
+```
+
+### Validation Errors
+
+Construction-time errors raise `SkillValidationError` (extends `ValueError`):
+
+```python
+# Missing required fields
+Skill(name="", description="test", instructions="test")
+# → SkillValidationError: Skill name must not be empty.
+
+# Invalid SKILL.md format
+Skill.from_file("bad-skill/SKILL.md")
+# → SkillValidationError: Skill file must contain YAML frontmatter delimited by '---'.
+```
+
+### Catalog Errors
+
+Duplicate names raise `SkillCatalogError` (extends `ValueError`):
+
+```python
+catalog = SkillCatalog([skill_a, skill_a])
+# → SkillCatalogError: Skill 'researcher' is already registered.
+```
+
+## Examples
+
+### Multi-Skill Research Agent
+
+```python
+from flux import task, workflow, ExecutionContext
+from flux.tasks.ai import agent, SkillCatalog
+
+@task
+async def search_web(query: str) -> str:
+    """Search the web and return relevant results."""
+    ...
+
+catalog = SkillCatalog.from_directory("./skills")
+
+assistant = agent(
+    "You are a research assistant.",
+    model="ollama/llama3.2",
+    tools=[search_web],
+    skills=catalog,
+).with_options(retry_max_attempts=3, timeout=120)
+
+@workflow
+async def research(ctx: ExecutionContext):
+    return await assistant(f"Research: {ctx.input['topic']}")
+```
+
+### Code Review Agent with Python Skills
+
+```python
+from flux import task, workflow, ExecutionContext
+from flux.tasks.ai import Skill, SkillCatalog, agent
+
+security = Skill(
+    name="security-reviewer",
+    description="Reviews code for security vulnerabilities.",
+    instructions="Check for SQL injection, XSS, auth flaws...",
+)
+
+performance = Skill(
+    name="performance-reviewer",
+    description="Reviews code for performance issues.",
+    instructions="Check for O(n^2), memory leaks, N+1 queries...",
+)
+
+@task
+async def run_linter(code: str) -> str:
+    """Run static analysis on the provided code."""
+    ...
+
+reviewer = agent(
+    "You are a code review assistant.",
+    model="openai/gpt-4o",
+    tools=[run_linter],
+    skills=SkillCatalog([security, performance]),
+).with_options(retry_max_attempts=3, timeout=120)
+
+@workflow
+async def review(ctx: ExecutionContext):
+    return await reviewer(f"Review this code:\n{ctx.input['code']}")
+```
+
+### Skills with MCP Tools
+
+Skills compose naturally with MCP-discovered tools:
+
+```python
+from flux.tasks.ai import agent, SkillCatalog
+from flux.tasks.mcp import mcp
+
+catalog = SkillCatalog.from_directory("./skills")
+
+async with mcp("http://localhost:8080/mcp", name="server") as client:
+    tools = await client.discover()
+
+    assistant = agent(
+        "You are a workflow assistant.",
+        model="ollama/llama3.2",
+        tools=list(tools),
+        skills=catalog,
+    )
+
+    result = await assistant("List available workflows and summarize them")
+```
+
+## `Skill` Reference
+
+```python
+class Skill:
+    def __init__(
+        self,
+        name: str,                              # required, validated
+        description: str,                       # required
+        instructions: str,                      # required
+        allowed_tools: list[str] | None = None, # optional, defaults to []
+        metadata: dict[str, str] | None = None, # optional, defaults to {}
+    ): ...
+
+    @classmethod
+    def from_file(cls, path: str) -> Skill: ...
+```
+
+## `SkillCatalog` Reference
+
+```python
+class SkillCatalog:
+    def __init__(self, skills: list[Skill] | None = None): ...
+
+    @classmethod
+    def from_directory(cls, path: str) -> SkillCatalog: ...
+
+    def register(self, skill: Skill) -> None: ...
+    def get(self, name: str) -> Skill: ...
+    def find(self, names: list[str]) -> list[Skill]: ...
+    def list(self) -> list[Skill]: ...
+```

--- a/docs/advanced-features/agent-skills.md
+++ b/docs/advanced-features/agent-skills.md
@@ -68,12 +68,12 @@ Research the given topic thoroughly.
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `name` | Yes | Skill identifier. Max 64 chars, lowercase letters, numbers, and hyphens. Must match the parent directory name. |
+| `name` | Yes | Skill identifier. Max 64 chars, lowercase letters, numbers, and hyphens. Should match the parent directory name (Flux warns on mismatch). |
 | `description` | Yes | What the skill does and when to use it. Max 1024 chars. The LLM uses this to decide which skill to activate. |
 | `allowed-tools` | No | Space-delimited list of tool names the skill expects to use. Validated against the agent's tools at construction time. |
-| `license` | No | License name or reference to a bundled license file. |
-| `compatibility` | No | Environment requirements (max 500 chars). |
 | `metadata` | No | Arbitrary key-value mapping for additional metadata (author, version, etc.). |
+| `license` | No | Part of the Agent Skills standard. Stored but not consumed by Flux. |
+| `compatibility` | No | Part of the Agent Skills standard. Stored but not consumed by Flux. |
 
 ### Python-Defined Skills
 

--- a/docs/advanced-features/task-patterns.md
+++ b/docs/advanced-features/task-patterns.md
@@ -331,14 +331,11 @@ researcher = agent(
 
 ### Agent Skills
 
-Skills are reusable instruction bundles that agents can discover and activate on demand, following the [Agent Skills](https://agentskills.io) open standard. Skills are defined as `SKILL.md` files with YAML frontmatter or constructed directly in Python.
-
-#### Loading Skills from SKILL.md Files
+Skills are reusable instruction bundles that agents can discover and activate on demand, following the [Agent Skills](https://agentskills.io) open standard:
 
 ```python
 from flux.tasks.ai import agent, SkillCatalog
 
-# Discover skills from a directory
 catalog = SkillCatalog.from_directory("./skills")
 
 assistant = agent(
@@ -349,65 +346,9 @@ assistant = agent(
 )
 ```
 
-A `SKILL.md` file follows the Agent Skills standard:
+Skills can be defined as `SKILL.md` files (portable across tools) or constructed in Python. The agent receives skill descriptions in its system prompt, and calls a `use_skill` tool to load full instructions on demand. Multiple skills can be activated sequentially in a single run.
 
-```yaml
----
-name: researcher
-description: Deep research on a topic using web sources.
-allowed-tools: search_web read_url
----
-
-Research the given topic thoroughly.
-
-1. Use search_web to find relevant sources
-2. Use read_url to extract content from promising results
-3. Synthesize findings into a comprehensive summary
-```
-
-#### Defining Skills in Python
-
-```python
-from flux.tasks.ai import Skill, SkillCatalog
-
-reviewer = Skill(
-    name="security-reviewer",
-    description="Reviews code for security vulnerabilities.",
-    instructions="Check for SQL injection, XSS, auth flaws...",
-    allowed_tools=["run_linter"],
-)
-
-catalog = SkillCatalog([reviewer])
-```
-
-#### How Skill Selection Works
-
-When `agent()` receives a `SkillCatalog`:
-
-1. Skill **descriptions** are appended to the system prompt (lightweight, ~20 tokens each)
-2. A `use_skill` tool is added to the agent's tool list
-3. The LLM reads the instruction and calls `use_skill(name="researcher")` to load a skill's full instructions
-4. The full instructions arrive as a tool result — the LLM follows them
-5. The LLM can activate **multiple skills** sequentially in a single run (stacking)
-
-```
-LLM turn 1:  → calls use_skill("researcher")  → gets full instructions
-LLM turn 2:  → calls search_web("AI agents")  → gets results (following skill instructions)
-LLM turn 3:  → returns synthesized response
-```
-
-#### Mixed Catalogs
-
-Directory discovery and explicit registration can be combined:
-
-```python
-catalog = SkillCatalog.from_directory("./skills")
-catalog.register(Skill(
-    name="custom-reviewer",
-    description="Custom review logic.",
-    instructions="Review using these criteria...",
-))
-```
+See [Agent Skills](agent-skills.md) for full documentation.
 
 ### Agent Composition
 

--- a/docs/core-concepts/tasks.md
+++ b/docs/core-concepts/tasks.md
@@ -301,6 +301,38 @@ graph = (
 - Guaranteed execution order
 - Built-in validation
 
+### AI Agent Tasks
+
+The `agent()` factory creates tasks that call LLMs. Each agent is a regular `@task` with retry, timeout, and observability support:
+
+```python
+from flux.tasks.ai import agent
+
+assistant = agent(
+    "You are a helpful assistant.",
+    model="ollama/llama3.2",
+    tools=[search_web, get_weather],
+)
+
+result = await assistant("What's the weather in London?")
+```
+
+Agents support tool calling, structured output, stateful conversations, and reusable skills. See [AI Agents](../advanced-features/task-patterns.md#ai-agents) and [Agent Skills](../advanced-features/agent-skills.md) for details.
+
+### MCP Client Tasks
+
+The `mcp()` task connects workflows to external MCP servers. Each discovered tool becomes a Flux `@task`:
+
+```python
+from flux.tasks.mcp import mcp
+
+async with mcp("http://localhost:8080/mcp") as client:
+    tools = await client.discover()
+    result = await tools.list_workflows()
+```
+
+See [MCP Client](../advanced-features/mcp-client.md) for full documentation.
+
 #### Error Handling in Graphs
 ```python
 def check_condition(result):

--- a/docs/getting-started/basic_concepts.md
+++ b/docs/getting-started/basic_concepts.md
@@ -81,6 +81,33 @@ Task features:
 - Can be composed and nested
 - Support for parallel execution and mapping operations
 
+## AI Agents
+
+The `agent()` factory creates Flux tasks that call LLMs. Agents are regular `@task` functions — they compose with `parallel()`, `Graph`, `pause()`, and all other Flux primitives.
+
+```python
+from flux.tasks.ai import agent
+
+researcher = agent(
+    "You are a research analyst.",
+    model="ollama/llama3.2",
+    name="researcher",
+)
+
+@workflow
+async def research_workflow(ctx: ExecutionContext):
+    return await researcher(ctx.input["topic"])
+```
+
+Agents support:
+- **Multiple providers**: `ollama/`, `openai/`, `anthropic/` model prefixes
+- **Tool use**: Pass `@task` functions as tools the LLM can call
+- **Structured output**: Return Pydantic models via `response_format`
+- **Skills**: Reusable instruction bundles via `SkillCatalog`
+- **Stateful conversations**: Accumulate message history with `stateful=True`
+
+See [AI Agents](../advanced-features/task-patterns.md#ai-agents), [Agent Skills](../advanced-features/agent-skills.md), and [MCP Client](../advanced-features/mcp-client.md) for full documentation.
+
 ## Execution Context
 
 The `ExecutionContext` is a container that maintains the state and information about a workflow execution.

--- a/docs/getting-started/basic_concepts.md
+++ b/docs/getting-started/basic_concepts.md
@@ -86,6 +86,7 @@ Task features:
 The `agent()` factory creates Flux tasks that call LLMs. Agents are regular `@task` functions — they compose with `parallel()`, `Graph`, `pause()`, and all other Flux primitives.
 
 ```python
+from flux import workflow, ExecutionContext
 from flux.tasks.ai import agent
 
 researcher = agent(

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,13 @@
    - [MCP Client](advanced-features/task-patterns.md#mcp-client)
    - [Performance Considerations](advanced-features/task-patterns.md#performance-considerations)
 
+### [Agent Skills](advanced-features/agent-skills.md)
+   - [Defining Skills](advanced-features/agent-skills.md#defining-skills)
+   - [SkillCatalog](advanced-features/agent-skills.md#skillcatalog)
+   - [Agent Integration](advanced-features/agent-skills.md#agent-integration)
+   - [Event Tracking](advanced-features/agent-skills.md#event-tracking)
+   - [Error Handling](advanced-features/agent-skills.md#error-handling)
+
 ### [MCP Client](advanced-features/mcp-client.md)
    - [Tool Discovery](advanced-features/mcp-client.md#tool-discovery)
    - [Task Options](advanced-features/mcp-client.md#task-options)
@@ -83,6 +90,15 @@
    - [Workflow Pause Points](advanced-features/workflow-controls.md#workflow-pause-points)
    - [Workflow Replay](advanced-features/workflow-controls.md#workflow-replay)
    - [Subworkflow Support](advanced-features/workflow-controls.md#subworkflows)
+
+### [Cancellation](advanced-features/cancellation.md)
+   - [Cancellation States](advanced-features/cancellation.md#cancellation-states)
+   - [API and CLI](advanced-features/cancellation.md#cancellation-api)
+
+### [Observability](advanced-features/observability.md)
+   - [OpenTelemetry Integration](advanced-features/observability.md#opentelemetry-integration)
+   - [Metrics](advanced-features/observability.md#metrics)
+   - [Distributed Tracing](advanced-features/observability.md#distributed-tracing)
 
 ## Appendix
 - [Examples in the Repository](https://github.com/flux-framework/flux/tree/main/examples)

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,10 +93,11 @@
 
 ### [Cancellation](advanced-features/cancellation.md)
    - [Cancellation States](advanced-features/cancellation.md#cancellation-states)
-   - [API and CLI](advanced-features/cancellation.md#cancellation-api)
+   - [API Endpoint](advanced-features/cancellation.md#api-endpoint)
+   - [Command Line Interface](advanced-features/cancellation.md#command-line-interface)
 
 ### [Observability](advanced-features/observability.md)
-   - [OpenTelemetry Integration](advanced-features/observability.md#opentelemetry-integration)
+   - [Configuration](advanced-features/observability.md#configuration)
    - [Metrics](advanced-features/observability.md#metrics)
    - [Distributed Tracing](advanced-features/observability.md#distributed-tracing)
 

--- a/docs/introduction/overview.md
+++ b/docs/introduction/overview.md
@@ -10,3 +10,6 @@ Flux is a Python-based workflow orchestration system that allows you to:
 - Handle failures and retries automatically
 - Maintain state across workflow executions
 - Scale from local development to distributed systems
+- Build AI-powered agents with LLM integration (Ollama, OpenAI, Anthropic)
+- Compose agents with reusable skills following the [Agent Skills](https://agentskills.io) open standard
+- Connect to external tools via the [Model Context Protocol](https://modelcontextprotocol.io) (MCP)

--- a/docs/introduction/use-cases.md
+++ b/docs/introduction/use-cases.md
@@ -25,3 +25,16 @@ Flux is particularly well-suited for:
    - Data preparation workflows
    - Feature engineering
    - Model deployment processes
+
+### **AI Agent Workflows**
+   - Multi-agent pipelines (research → write → edit)
+   - Conversational agents with stateful pause/resume
+   - Code review with specialized skills (security, performance)
+   - RAG (Retrieval Augmented Generation) systems
+   - Function-calling agents with real-time tool use
+
+### **MCP Tool Integration**
+   - Dynamic tool discovery from MCP servers
+   - LLM-driven workflow management assistants
+   - Multi-server tool orchestration
+   - Authenticated external service integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.11.0"
+version = "0.11.1"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"


### PR DESCRIPTION
## Summary

- Add dedicated `docs/advanced-features/agent-skills.md` documentation page with full coverage of the agent skills feature
- Update all foundational documentation pages to reflect AI agents, skills, and MCP capabilities
- Add missing Cancellation and Observability entries to the docs TOC
- Bump version to 0.11.1

### New documentation
- **`docs/advanced-features/agent-skills.md`** — Dedicated page covering: defining skills (SKILL.md + Python), SkillCatalog (directory discovery, list construction, mixed catalogs), agent integration (skill selection flow, multi-skill stacking, allowed_tools validation), event tracking, error handling, examples (research agent, code review, MCP tools), and API reference

### Updated pages
- **`docs/introduction/overview.md`** — Added AI agents, skills, and MCP to the "What is Flux?" list
- **`docs/introduction/use-cases.md`** — Added AI Agent Workflows and MCP Tool Integration use cases
- **`docs/getting-started/basic_concepts.md`** — Added AI Agents section with agent() overview and links to advanced docs
- **`docs/core-concepts/tasks.md`** — Added AI Agent Tasks and MCP Client Tasks to built-in task types
- **`docs/advanced-features/task-patterns.md`** — Simplified Agent Skills section to reference the dedicated page
- **`docs/index.md`** — Added Agent Skills page, Cancellation, and Observability to TOC navigation

## Test plan

- [x] All documentation links are valid (relative paths verified)
- [x] No code changes beyond version bump — existing tests unaffected


🤖 Generated with [Claude Code](https://claude.com/claude-code)