### PR TITLE
fix: remove personal information from examples and tests

### DIFF
--- a/examples/ai/memory_long_term_ollama.py
+++ b/examples/ai/memory_long_term_ollama.py
@@ -37,7 +37,7 @@ async def memory_long_term(ctx: ExecutionContext[dict[str, Any]]):
         initial_input = json.loads(initial_input)
     message = initial_input.get(
         "message",
-        "Hi! My name is Eduardo and I work as a VP of Engineering.",
+        "Hi! My name is Alice and I work as a software developer.",
     )
     response = await assistant(message)
     return response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.13.0"
+version = "0.13.2"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/tasks/ai/memory/test_long_term_memory.py
+++ b/tests/flux/tasks/ai/memory/test_long_term_memory.py
@@ -25,9 +25,9 @@ async def test_ltm_memorize_and_recall():
     try:
         provider = InMemoryProvider()
         ltm = LongTermMemory(provider=provider, scope="user:1")
-        await ltm.memorize("name", "Eduardo")
+        await ltm.memorize("name", "Alice")
         result = await ltm.recall("name")
-        assert result == "Eduardo"
+        assert result == "Alice"
     finally:
         ExecutionContext.reset(token)
 
@@ -40,10 +40,10 @@ async def test_ltm_recall_all():
     try:
         provider = InMemoryProvider()
         ltm = LongTermMemory(provider=provider, scope="user:1")
-        await ltm.memorize("name", "Eduardo")
-        await ltm.memorize("role", "VP")
+        await ltm.memorize("name", "Alice")
+        await ltm.memorize("role", "developer")
         result = await ltm.recall()
-        assert result == {"name": "Eduardo", "role": "VP"}
+        assert result == {"name": "Alice", "role": "developer"}
     finally:
         ExecutionContext.reset(token)
 
@@ -56,7 +56,7 @@ async def test_ltm_forget():
     try:
         provider = InMemoryProvider()
         ltm = LongTermMemory(provider=provider, scope="user:1")
-        await ltm.memorize("name", "Eduardo")
+        await ltm.memorize("name", "Alice")
         await ltm.forget("name")
         result = await ltm.recall("name")
         assert result is None
@@ -72,8 +72,8 @@ async def test_ltm_keys():
     try:
         provider = InMemoryProvider()
         ltm = LongTermMemory(provider=provider, scope="user:1")
-        await ltm.memorize("name", "Eduardo")
-        await ltm.memorize("role", "VP")
+        await ltm.memorize("name", "Alice")
+        await ltm.memorize("role", "developer")
         keys = await ltm.keys()
         assert sorted(keys) == ["name", "role"]
     finally:
@@ -89,8 +89,8 @@ async def test_ltm_scopes():
         provider = InMemoryProvider()
         ltm1 = LongTermMemory(provider=provider, scope="user:1")
         ltm2 = LongTermMemory(provider=provider, scope="user:2")
-        await ltm1.memorize("name", "Eduardo")
-        await ltm2.memorize("name", "Alice")
+        await ltm1.memorize("name", "Alice")
+        await ltm2.memorize("name", "Bob")
         scopes = await ltm1.scopes()
         assert sorted(scopes) == ["user:1", "user:2"]
     finally:
@@ -106,9 +106,9 @@ async def test_ltm_workflow_auto_scoping():
     try:
         provider = InMemoryProvider()
         ltm = LongTermMemory(provider=provider, scope="user:1")
-        await ltm.memorize("name", "Eduardo")
+        await ltm.memorize("name", "Alice")
         result = await provider.recall("my_workflow", "user:1", "name")
-        assert result == "Eduardo"
+        assert result == "Alice"
     finally:
         ExecutionContext.reset(token)
 

--- a/tests/flux/tasks/ai/memory/test_providers.py
+++ b/tests/flux/tasks/ai/memory/test_providers.py
@@ -12,9 +12,9 @@ async def test_provider_memorize_and_recall():
     from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
 
     provider = InMemoryProvider()
-    await provider.memorize("wf", "user:1", "name", "Eduardo")
+    await provider.memorize("wf", "user:1", "name", "Alice")
     result = await provider.recall("wf", "user:1", "name")
-    assert result == "Eduardo"
+    assert result == "Alice"
 
 
 @pytest.mark.asyncio
@@ -23,10 +23,10 @@ async def test_provider_recall_all_in_scope():
     from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
 
     provider = InMemoryProvider()
-    await provider.memorize("wf", "user:1", "name", "Eduardo")
-    await provider.memorize("wf", "user:1", "role", "VP")
+    await provider.memorize("wf", "user:1", "name", "Alice")
+    await provider.memorize("wf", "user:1", "role", "developer")
     result = await provider.recall("wf", "user:1")
-    assert result == {"name": "Eduardo", "role": "VP"}
+    assert result == {"name": "Alice", "role": "developer"}
 
 
 @pytest.mark.asyncio
@@ -54,9 +54,9 @@ async def test_provider_memorize_overwrites():
 
     provider = InMemoryProvider()
     await provider.memorize("wf", "user:1", "role", "Engineer")
-    await provider.memorize("wf", "user:1", "role", "VP")
+    await provider.memorize("wf", "user:1", "role", "developer")
     result = await provider.recall("wf", "user:1", "role")
-    assert result == "VP"
+    assert result == "developer"
 
 
 @pytest.mark.asyncio
@@ -64,7 +64,7 @@ async def test_provider_forget_key():
     from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
 
     provider = InMemoryProvider()
-    await provider.memorize("wf", "user:1", "name", "Eduardo")
+    await provider.memorize("wf", "user:1", "name", "Alice")
     await provider.forget("wf", "user:1", "name")
     result = await provider.recall("wf", "user:1", "name")
     assert result is None
@@ -76,8 +76,8 @@ async def test_provider_forget_scope():
     from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
 
     provider = InMemoryProvider()
-    await provider.memorize("wf", "user:1", "name", "Eduardo")
-    await provider.memorize("wf", "user:1", "role", "VP")
+    await provider.memorize("wf", "user:1", "name", "Alice")
+    await provider.memorize("wf", "user:1", "role", "developer")
     await provider.forget("wf", "user:1")
     result = await provider.recall("wf", "user:1")
     assert result == {}
@@ -88,8 +88,8 @@ async def test_provider_keys():
     from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
 
     provider = InMemoryProvider()
-    await provider.memorize("wf", "user:1", "name", "Eduardo")
-    await provider.memorize("wf", "user:1", "role", "VP")
+    await provider.memorize("wf", "user:1", "name", "Alice")
+    await provider.memorize("wf", "user:1", "role", "developer")
     keys = await provider.keys("wf", "user:1")
     assert sorted(keys) == ["name", "role"]
 
@@ -99,8 +99,8 @@ async def test_provider_scopes():
     from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
 
     provider = InMemoryProvider()
-    await provider.memorize("wf", "user:1", "name", "Eduardo")
-    await provider.memorize("wf", "user:2", "name", "Alice")
+    await provider.memorize("wf", "user:1", "name", "Alice")
+    await provider.memorize("wf", "user:2", "name", "Bob")
     scopes = await provider.scopes("wf")
     assert sorted(scopes) == ["user:1", "user:2"]
 
@@ -111,10 +111,10 @@ async def test_provider_workflow_isolation():
     from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
 
     provider = InMemoryProvider()
-    await provider.memorize("wf_a", "user:1", "name", "Eduardo")
-    await provider.memorize("wf_b", "user:1", "name", "Alice")
-    assert await provider.recall("wf_a", "user:1", "name") == "Eduardo"
-    assert await provider.recall("wf_b", "user:1", "name") == "Alice"
+    await provider.memorize("wf_a", "user:1", "name", "Alice")
+    await provider.memorize("wf_b", "user:1", "name", "Bob")
+    assert await provider.recall("wf_a", "user:1", "name") == "Alice"
+    assert await provider.recall("wf_b", "user:1", "name") == "Bob"
 
 
 def test_in_memory_provider_conforms_to_protocol():
@@ -127,11 +127,11 @@ def test_in_memory_provider_conforms_to_protocol():
 def test_memory_entry_fields():
     from flux.tasks.ai.memory.types import MemoryEntry
 
-    entry = MemoryEntry(workflow="wf", scope="user:1", key="name", value="Eduardo")
+    entry = MemoryEntry(workflow="wf", scope="user:1", key="name", value="Alice")
     assert entry.workflow == "wf"
     assert entry.scope == "user:1"
     assert entry.key == "name"
-    assert entry.value == "Eduardo"
+    assert entry.value == "Alice"
 
 
 @pytest.mark.asyncio
@@ -141,9 +141,9 @@ async def test_sqlalchemy_provider_memorize_and_recall():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         provider = SqlAlchemyProvider(f"sqlite:///{db_path}")
-        await provider.memorize("wf", "user:1", "name", "Eduardo")
+        await provider.memorize("wf", "user:1", "name", "Alice")
         result = await provider.recall("wf", "user:1", "name")
-        assert result == "Eduardo"
+        assert result == "Alice"
 
 
 @pytest.mark.asyncio
@@ -153,10 +153,10 @@ async def test_sqlalchemy_provider_recall_all():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         provider = SqlAlchemyProvider(f"sqlite:///{db_path}")
-        await provider.memorize("wf", "user:1", "name", "Eduardo")
-        await provider.memorize("wf", "user:1", "role", "VP")
+        await provider.memorize("wf", "user:1", "name", "Alice")
+        await provider.memorize("wf", "user:1", "role", "developer")
         result = await provider.recall("wf", "user:1")
-        assert result == {"name": "Eduardo", "role": "VP"}
+        assert result == {"name": "Alice", "role": "developer"}
 
 
 @pytest.mark.asyncio
@@ -167,9 +167,9 @@ async def test_sqlalchemy_provider_upsert():
         db_path = os.path.join(tmpdir, "test.db")
         provider = SqlAlchemyProvider(f"sqlite:///{db_path}")
         await provider.memorize("wf", "user:1", "role", "Engineer")
-        await provider.memorize("wf", "user:1", "role", "VP")
+        await provider.memorize("wf", "user:1", "role", "developer")
         result = await provider.recall("wf", "user:1", "role")
-        assert result == "VP"
+        assert result == "developer"
 
 
 @pytest.mark.asyncio
@@ -179,7 +179,7 @@ async def test_sqlalchemy_provider_forget_key():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         provider = SqlAlchemyProvider(f"sqlite:///{db_path}")
-        await provider.memorize("wf", "user:1", "name", "Eduardo")
+        await provider.memorize("wf", "user:1", "name", "Alice")
         await provider.forget("wf", "user:1", "name")
         result = await provider.recall("wf", "user:1", "name")
         assert result is None
@@ -192,8 +192,8 @@ async def test_sqlalchemy_provider_forget_scope():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         provider = SqlAlchemyProvider(f"sqlite:///{db_path}")
-        await provider.memorize("wf", "user:1", "name", "Eduardo")
-        await provider.memorize("wf", "user:1", "role", "VP")
+        await provider.memorize("wf", "user:1", "name", "Alice")
+        await provider.memorize("wf", "user:1", "role", "developer")
         await provider.forget("wf", "user:1")
         result = await provider.recall("wf", "user:1")
         assert result == {}
@@ -206,8 +206,8 @@ async def test_sqlalchemy_provider_keys_and_scopes():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         provider = SqlAlchemyProvider(f"sqlite:///{db_path}")
-        await provider.memorize("wf", "user:1", "name", "Eduardo")
-        await provider.memorize("wf", "user:2", "name", "Alice")
+        await provider.memorize("wf", "user:1", "name", "Alice")
+        await provider.memorize("wf", "user:2", "name", "Bob")
         assert sorted(await provider.keys("wf", "user:1")) == ["name"]
         assert sorted(await provider.scopes("wf")) == ["user:1", "user:2"]
 
@@ -219,10 +219,10 @@ async def test_sqlalchemy_provider_workflow_isolation():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         provider = SqlAlchemyProvider(f"sqlite:///{db_path}")
-        await provider.memorize("wf_a", "user:1", "name", "Eduardo")
-        await provider.memorize("wf_b", "user:1", "name", "Alice")
-        assert await provider.recall("wf_a", "user:1", "name") == "Eduardo"
-        assert await provider.recall("wf_b", "user:1", "name") == "Alice"
+        await provider.memorize("wf_a", "user:1", "name", "Alice")
+        await provider.memorize("wf_b", "user:1", "name", "Bob")
+        assert await provider.recall("wf_a", "user:1", "name") == "Alice"
+        assert await provider.recall("wf_b", "user:1", "name") == "Bob"
 
 
 @pytest.mark.asyncio
@@ -233,7 +233,7 @@ async def test_sqlalchemy_provider_persists_across_instances():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         provider1 = SqlAlchemyProvider(f"sqlite:///{db_path}")
-        await provider1.memorize("wf", "user:1", "name", "Eduardo")
+        await provider1.memorize("wf", "user:1", "name", "Alice")
         provider2 = SqlAlchemyProvider(f"sqlite:///{db_path}")
         result = await provider2.recall("wf", "user:1", "name")
-        assert result == "Eduardo"
+        assert result == "Alice"


### PR DESCRIPTION
## Summary
- Replace personal name and title references with generic placeholders (`Alice`, `Bob`, `developer`) in memory example and test fixtures
- Bump patch version to 0.13.2

## Test plan
- [x] All 40 memory tests pass
- [x] Full test suite passes (711 passed, 38 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)