### PR TITLE
feat: Google Gemini provider support

### DIFF
--- a/docs/advanced-features/ai-agents.md
+++ b/docs/advanced-features/ai-agents.md
@@ -29,7 +29,13 @@ The returned value is a regular Flux `@task`. Call it with an instruction string
 | Anthropic | `anthropic/claude-sonnet-4-20250514` | `ANTHROPIC_API_KEY` | `anthropic` |
 | Google Gemini | `google/gemini-2.5-flash` | `GOOGLE_API_KEY` or `GEMINI_API_KEY` | `google-genai` |
 
-Install the SDK for the provider you want to use:
+Install all AI provider SDKs at once:
+
+```bash
+pip install flux-core[ai]
+```
+
+Or install only the provider you need:
 
 ```bash
 pip install ollama           # for Ollama models

--- a/docs/advanced-features/ai-agents.md
+++ b/docs/advanced-features/ai-agents.md
@@ -1,0 +1,333 @@
+# AI Agents
+
+`agent()` creates a Flux `@task` that calls an LLM. Like any other task, it can be awaited inside a workflow, retried, observed, and composed with other tasks. It handles the agentic loop — tool calling, streaming, structured output, and memory — so you can focus on the prompt and the tools.
+
+## Quick Start
+
+```python
+from flux import task, workflow, ExecutionContext
+from flux.tasks.ai import agent
+
+assistant = agent(
+    "You are a helpful assistant.",
+    model="ollama/llama3.2",
+)
+
+@workflow
+async def my_workflow(ctx: ExecutionContext):
+    return await assistant("What is the capital of France?")
+```
+
+The returned value is a regular Flux `@task`. Call it with an instruction string and, optionally, a `context` string for additional background.
+
+## Supported Providers
+
+| Provider | Model Format | Required Env Var | SDK Package |
+|----------|-------------|-----------------|-------------|
+| Ollama | `ollama/llama3` | (none, local) | `ollama` |
+| OpenAI | `openai/gpt-4o` | `OPENAI_API_KEY` | `openai` |
+| Anthropic | `anthropic/claude-sonnet-4-20250514` | `ANTHROPIC_API_KEY` | `anthropic` |
+| Google Gemini | `google/gemini-2.5-flash` | `GOOGLE_API_KEY` or `GEMINI_API_KEY` | `google-genai` |
+
+Install the SDK for the provider you want to use:
+
+```bash
+pip install flux-core[ollama]
+pip install flux-core[openai]
+pip install flux-core[anthropic]
+pip install flux-core[google]
+```
+
+## Quick Start by Provider
+
+### Ollama
+
+Ollama runs locally. No API key required. Start the Ollama server before running your workflow.
+
+```python
+assistant = agent(
+    "You are a helpful assistant.",
+    model="ollama/llama3.2",
+)
+```
+
+### OpenAI
+
+```python
+import os
+os.environ["OPENAI_API_KEY"] = "sk-..."
+
+assistant = agent(
+    "You are a helpful assistant.",
+    model="openai/gpt-4o",
+)
+```
+
+### Anthropic
+
+```python
+import os
+os.environ["ANTHROPIC_API_KEY"] = "sk-ant-..."
+
+assistant = agent(
+    "You are a helpful assistant.",
+    model="anthropic/claude-sonnet-4-20250514",
+)
+```
+
+### Google Gemini
+
+```python
+import os
+os.environ["GOOGLE_API_KEY"] = "AIza..."  # or GEMINI_API_KEY
+
+assistant = agent(
+    "You are a helpful assistant.",
+    model="google/gemini-2.5-flash",
+)
+```
+
+## Parameters
+
+```python
+def agent(
+    system_prompt: str,
+    *,
+    model: str,
+    name: str | None = None,
+    tools: list[task] | None = None,
+    skills: SkillCatalog | None = None,
+    response_format: type[BaseModel] | None = None,
+    working_memory: WorkingMemory | None = None,
+    long_term_memory: LongTermMemory | None = None,
+    max_tool_calls: int = 10,
+    max_tokens: int = 4096,
+    stream: bool = True,
+) -> task:
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `system_prompt` | `str` | required | The system prompt defining the agent's identity and behavior. |
+| `model` | `str` | required | Provider and model in `"provider/model_name"` format. |
+| `name` | `str \| None` | `None` | Task name used in events and traces. Defaults to `"agent_{provider}_{model}"`. |
+| `tools` | `list[task] \| None` | `None` | Flux `@task` functions the agent can call as tools. |
+| `skills` | `SkillCatalog \| None` | `None` | Skill catalog providing reusable instruction bundles the LLM can activate. |
+| `response_format` | `type[BaseModel] \| None` | `None` | Pydantic model class for structured JSON output. Disables streaming. |
+| `working_memory` | `WorkingMemory \| None` | `None` | Conversation history across invocations within the same workflow execution. |
+| `long_term_memory` | `LongTermMemory \| None` | `None` | Persistent fact storage across workflow executions. |
+| `max_tool_calls` | `int` | `10` | Maximum tool call iterations before forcing a final answer. |
+| `max_tokens` | `int` | `4096` | Maximum tokens in the LLM response. Used by Anthropic and Google; ignored by Ollama and OpenAI. |
+| `stream` | `bool` | `True` | Enable streaming responses. Automatically disabled when `response_format` is set. |
+
+The returned task has the signature:
+
+```python
+async def agent_task(instruction: str, *, context: str = "") -> str | BaseModel:
+```
+
+- `instruction` — the user message sent to the LLM.
+- `context` — optional background information prepended to the instruction.
+
+## Tool Calling
+
+Pass any Flux `@task` function via the `tools` parameter. The agent calls them autonomously during the agentic loop.
+
+```python
+from flux import task, workflow, ExecutionContext
+from flux.tasks.ai import agent
+
+@task
+async def get_weather(city: str) -> str:
+    """Return the current weather for a city."""
+    return f"Sunny, 22°C in {city}"
+
+@task
+async def search_web(query: str) -> str:
+    """Search the web and return relevant results."""
+    ...
+
+assistant = agent(
+    "You are a helpful assistant with access to real-time data.",
+    model="openai/gpt-4o",
+    tools=[get_weather, search_web],
+)
+
+@workflow
+async def my_workflow(ctx: ExecutionContext):
+    return await assistant("What's the weather like in Tokyo?")
+```
+
+Each tool call is recorded as a Flux task event, so tool invocations are fully observable, retryable, and replay-safe.
+
+### Tool Call Limit
+
+The `max_tool_calls` parameter (default `10`) caps the number of tool call iterations per agent invocation. When the limit is reached, the agent is forced to produce a final answer with whatever it has gathered.
+
+```python
+assistant = agent(
+    "You are a research assistant.",
+    model="openai/gpt-4o",
+    tools=[search_web],
+    max_tool_calls=20,
+)
+```
+
+## Structured Output
+
+Pass a Pydantic model class to `response_format` to get typed, structured output instead of a plain string.
+
+```python
+from pydantic import BaseModel
+from flux import workflow, ExecutionContext
+from flux.tasks.ai import agent
+
+class Sentiment(BaseModel):
+    label: str        # "positive", "negative", or "neutral"
+    confidence: float # 0.0 to 1.0
+    reason: str
+
+classifier = agent(
+    "You are a sentiment analysis assistant. Respond only with structured JSON.",
+    model="openai/gpt-4o",
+    response_format=Sentiment,
+)
+
+@workflow
+async def analyze(ctx: ExecutionContext):
+    result: Sentiment = await classifier(ctx.input["text"])
+    return {"label": result.label, "confidence": result.confidence}
+```
+
+When `response_format` is set:
+- The return type changes from `str` to the Pydantic model instance.
+- Streaming is automatically disabled (`stream=True` is ignored).
+
+## Streaming
+
+By default, `stream=True` and the agent emits progress events as the LLM produces tokens. These are surfaced as Flux task progress events and can be consumed by the workflow engine for real-time feedback.
+
+```python
+from flux import workflow, ExecutionContext
+from flux.tasks.ai import agent
+
+assistant = agent(
+    "You are a helpful assistant.",
+    model="anthropic/claude-sonnet-4-20250514",
+    stream=True,  # default, can be omitted
+)
+
+@workflow
+async def my_workflow(ctx: ExecutionContext):
+    return await assistant("Explain the theory of relativity.")
+```
+
+To disable streaming:
+
+```python
+assistant = agent(
+    "You are a helpful assistant.",
+    model="openai/gpt-4o",
+    stream=False,
+)
+```
+
+Streaming is automatically disabled when `response_format` is provided, regardless of the `stream` setting.
+
+See [Task Progress](task-progress.md) for how to consume progress events from workflows.
+
+## Memory
+
+### Working Memory
+
+Pass `working_memory()` to maintain conversation history across multiple agent calls within the same workflow execution:
+
+```python
+from flux.tasks.ai.memory import working_memory
+
+chatbot = agent(
+    "You are a helpful assistant.",
+    model="openai/gpt-4o",
+    working_memory=working_memory(),
+)
+
+@workflow
+async def conversation(ctx: ExecutionContext):
+    r1 = await chatbot("What is Python?")
+    r2 = await chatbot("What about asyncio?")  # aware of the Python context
+    return r2
+```
+
+### Long-term Memory
+
+Pass `long_term_memory()` to persist facts across workflow executions:
+
+```python
+from flux.tasks.ai.memory import long_term_memory, sqlite
+
+assistant = agent(
+    "You are a personal assistant. Remember important facts about the user.",
+    model="openai/gpt-4o",
+    long_term_memory=long_term_memory(
+        provider=sqlite("memory.db"),
+        scope="user:123",
+    ),
+)
+```
+
+See [AI Memory](ai-memory.md) for the full memory reference including windowed memory, pause/resume behavior, PostgreSQL and custom providers, and shared memory across multiple agents.
+
+## Skills
+
+Pass a `SkillCatalog` to give the agent reusable instruction bundles it can discover and activate on demand:
+
+```python
+from flux.tasks.ai import agent, SkillCatalog
+
+catalog = SkillCatalog.from_directory("./skills")
+
+assistant = agent(
+    "You are a research assistant.",
+    model="openai/gpt-4o",
+    tools=[search_web],
+    skills=catalog,
+)
+```
+
+See [Agent Skills](agent-skills.md) for the full skills reference including `SKILL.md` authoring, Python-defined skills, and multi-skill stacking.
+
+## Task Options
+
+Because `agent()` returns a Flux `@task`, you can chain `.with_options()` to configure retry, timeout, and other task-level settings:
+
+```python
+assistant = agent(
+    "You are a helpful assistant.",
+    model="openai/gpt-4o",
+    tools=[search_web],
+).with_options(
+    retry_max_attempts=3,
+    timeout=120,
+)
+```
+
+## `agent()` Reference
+
+```python
+from flux.tasks.ai import agent
+
+agent(
+    system_prompt: str,
+    *,
+    model: str,
+    name: str | None = None,
+    tools: list[task] | None = None,
+    skills: SkillCatalog | None = None,
+    response_format: type[BaseModel] | None = None,
+    working_memory: WorkingMemory | None = None,
+    long_term_memory: LongTermMemory | None = None,
+    max_tool_calls: int = 10,
+    max_tokens: int = 4096,
+    stream: bool = True,
+) -> task
+```

--- a/docs/advanced-features/ai-agents.md
+++ b/docs/advanced-features/ai-agents.md
@@ -32,10 +32,10 @@ The returned value is a regular Flux `@task`. Call it with an instruction string
 Install the SDK for the provider you want to use:
 
 ```bash
-pip install flux-core[ollama]
-pip install flux-core[openai]
-pip install flux-core[anthropic]
-pip install flux-core[google]
+pip install ollama           # for Ollama models
+pip install openai           # for OpenAI models
+pip install anthropic        # for Anthropic models
+pip install google-genai     # for Google Gemini models
 ```
 
 ## Quick Start by Provider

--- a/examples/ai/conversational_agent_gemini.py
+++ b/examples/ai/conversational_agent_gemini.py
@@ -1,0 +1,267 @@
+"""
+Conversational AI Agent using Google Gemini.
+
+This example uses Google's Gemini API which excels at:
+- Long-form conversations with extended context
+- Complex reasoning and analysis
+- Following detailed instructions
+
+Prerequisites:
+    1. Get a Gemini API key: https://aistudio.google.com/apikey
+    2. Set the API key as a secret:
+       flux secrets set GEMINI_API_KEY "your-api-key"
+
+Usage:
+    # Start a new conversation
+    flux workflow run conversational_agent_gemini '{"message": "Why is the sky blue?"}'
+
+    # Resume the conversation
+    flux workflow resume conversational_agent_gemini <execution_id> '{"message": "Why does the sky turn red and orange during sunset?"}'
+
+    # Specify the model explicitly (uses Gemini 2.5 Flash by default)
+    flux workflow run conversational_agent_gemini '{"message": "What color would the sky be on Mars?", "model": "gemini-2.5-pro"}'
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from google import genai
+from google.genai import types
+
+from flux import ExecutionContext, task, workflow
+from flux.tasks import pause
+
+
+@task.with_options(
+    secret_requests=["GEMINI_API_KEY"],
+    retry_max_attempts=3,
+    retry_delay=1,
+    retry_backoff=2,
+    timeout=60,
+)
+async def call_gemini_api(
+    messages: list[dict[str, str]],
+    system_prompt: str,
+    model: str,
+    max_tokens: int,
+    secrets: dict[str, Any] | None = None,
+) -> tuple[str, int, int]:
+    """
+    Call Gemini API to generate a response using the official SDK.
+
+    Args:
+        messages: Conversation history
+        system_prompt: System instructions for the model
+        model: The Gemini model to use
+        max_tokens: Maximum tokens in the response
+        secrets: Dictionary containing GEMINI_API_KEY
+
+    Returns:
+        Tuple of (assistant_response, input_tokens, output_tokens)
+    """
+    if not secrets or "GEMINI_API_KEY" not in secrets:
+        raise ValueError(
+            "GEMINI_API_KEY not found. Set it using: "
+            "flux secrets set GEMINI_API_KEY 'your-key'",
+        )
+
+    try:
+        client = genai.Client(api_key=secrets["GEMINI_API_KEY"])
+
+        contents = [
+            types.Content(
+                role="model" if msg["role"] == "assistant" else "user",
+                parts=[types.Part(text=msg["content"])],
+            )
+            for msg in messages
+        ]
+
+        config = types.GenerateContentConfig(
+            system_instruction=system_prompt,
+            max_output_tokens=max_tokens,
+        )
+
+        response = await client.aio.models.generate_content(
+            model=model,
+            contents=contents,
+            config=config,
+        )
+
+        assistant_message = response.text
+        input_tokens = response.usage_metadata.prompt_token_count
+        output_tokens = response.usage_metadata.candidates_token_count
+
+        return assistant_message, input_tokens, output_tokens
+
+    except Exception as e:
+        raise RuntimeError(f"Failed to call Gemini API: {str(e)}") from e
+
+
+@task
+async def conversation_turn(
+    messages: list[dict[str, str]],
+    user_message: str,
+    system_prompt: str,
+    model: str,
+    max_tokens: int,
+) -> tuple[list[dict[str, str]], str, int, int]:
+    """
+    Process one turn of the conversation.
+
+    Args:
+        messages: Current conversation history
+        user_message: The user's message
+        system_prompt: System prompt for the LLM
+        model: Gemini model to use
+        max_tokens: Maximum tokens per response
+
+    Returns:
+        Tuple of (updated messages, assistant response, input tokens, output tokens)
+    """
+    messages.append({"role": "user", "content": user_message})
+
+    assistant_response, input_tokens, output_tokens = await call_gemini_api(
+        messages=messages,
+        system_prompt=system_prompt,
+        model=model,
+        max_tokens=max_tokens,
+    )
+
+    messages.append({"role": "assistant", "content": assistant_response})
+
+    return messages, assistant_response, input_tokens, output_tokens
+
+
+@workflow
+async def conversational_agent_gemini(ctx: ExecutionContext[dict[str, Any]]):
+    """
+    A conversational AI agent using Google's Gemini models.
+
+    Initial Input format:
+    {
+        "message": "User's message",
+        "system_prompt": "Optional system prompt",
+        "model": "gemini-2.5-flash",  # Latest Gemini model
+        "max_tokens": 1024,           # Optional: max tokens per response
+        "max_turns": 10               # Optional: maximum conversation turns
+    }
+
+    Resume Input format:
+    {
+        "message": "User's next message"
+    }
+    """
+    initial_input = ctx.input or {}
+    system_prompt = initial_input.get(
+        "system_prompt",
+        "You are a helpful AI assistant. Be concise and informative.",
+    )
+    model = initial_input.get("model", "gemini-2.5-flash")
+    max_tokens = initial_input.get("max_tokens", 1024)
+    max_turns = initial_input.get("max_turns", 10)
+
+    messages: list[dict[str, str]] = []
+    total_input_tokens = 0
+    total_output_tokens = 0
+
+    first_message = initial_input.get("message", "")
+    if not first_message:
+        return {"error": "No message provided in initial input", "execution_id": ctx.execution_id}
+
+    messages, _, input_tokens, output_tokens = await conversation_turn(
+        messages,
+        first_message,
+        system_prompt,
+        model,
+        max_tokens,
+    )
+    total_input_tokens += input_tokens
+    total_output_tokens += output_tokens
+
+    for turn in range(1, max_turns):
+        resume_input = await pause(f"waiting_for_user_input_turn_{turn}")
+
+        next_message = resume_input.get("message", "") if resume_input else ""
+        if not next_message:
+            return {
+                "error": "No message provided in resume input",
+                "turn_count": len(messages) // 2,
+                "execution_id": ctx.execution_id,
+                "conversation_history": messages,
+                "total_input_tokens": total_input_tokens,
+                "total_output_tokens": total_output_tokens,
+                "total_tokens": total_input_tokens + total_output_tokens,
+            }
+
+        messages, _, input_tokens, output_tokens = await conversation_turn(
+            messages,
+            next_message,
+            system_prompt,
+            model,
+            max_tokens,
+        )
+        total_input_tokens += input_tokens
+        total_output_tokens += output_tokens
+
+    return {
+        "status": "conversation_ended",
+        "reason": f"Maximum turns ({max_turns}) reached",
+        "conversation_history": messages,
+        "turn_count": len(messages) // 2,
+        "total_input_tokens": total_input_tokens,
+        "total_output_tokens": total_output_tokens,
+        "total_tokens": total_input_tokens + total_output_tokens,
+        "model": model,
+        "execution_id": ctx.execution_id,
+    }
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import json
+    import os
+    from flux.secret_managers import SecretManager
+
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        print("Error: GEMINI_API_KEY not found in environment.")
+        print("Set it using: export GEMINI_API_KEY='your-key'")
+        exit(1)
+
+    secret_manager = SecretManager.current()
+    secret_manager.save("GEMINI_API_KEY", api_key)
+
+    initial_input = {
+        "message": "Why is the sky blue?",
+        "model": "gemini-2.5-flash",
+        "max_turns": 3,
+    }
+
+    try:
+        result = conversational_agent_gemini.run(initial_input)
+        if result.has_failed:
+            raise Exception(f"Workflow failed: {result.output}")
+
+        result = conversational_agent_gemini.resume(
+            result.execution_id,
+            {"message": "Why does the sky turn red and orange during sunset?"},
+        )
+        if result.has_failed:
+            raise Exception(f"Workflow failed: {result.output}")
+
+        result = conversational_agent_gemini.resume(
+            result.execution_id,
+            {"message": "What color would the sky be on Mars?"},
+        )
+        if result.has_failed:
+            raise Exception(f"Workflow failed: {result.output}")
+
+        print(
+            f"Total Tokens: {result.output.get('total_tokens', 0)} "
+            f"(in: {result.output.get('total_input_tokens', 0)}, "
+            f"out: {result.output.get('total_output_tokens', 0)})",
+        )
+        print(json.dumps(result.output.get("conversation_history", []), indent=2))
+
+    except Exception as e:
+        print(f"Error: {e}")

--- a/examples/ai/conversational_agent_gemini.py
+++ b/examples/ai/conversational_agent_gemini.py
@@ -62,8 +62,7 @@ async def call_gemini_api(
     """
     if not secrets or "GEMINI_API_KEY" not in secrets:
         raise ValueError(
-            "GEMINI_API_KEY not found. Set it using: "
-            "flux secrets set GEMINI_API_KEY 'your-key'",
+            "GEMINI_API_KEY not found. Set it using: " "flux secrets set GEMINI_API_KEY 'your-key'",
         )
 
     try:

--- a/flux/task.py
+++ b/flux/task.py
@@ -348,6 +348,8 @@ class task:
                         value=ex,
                     ),
                 )
+                if isinstance(ex, RetryError):
+                    raise ExecutionError(ex)
                 if isinstance(ex, ExecutionError):
                     raise ex
                 raise ExecutionError(ex)

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -44,7 +44,7 @@ def agent(
         working_memory: WorkingMemory instance for conversation history across invocations.
         long_term_memory: LongTermMemory instance for persistent fact storage.
         max_tool_calls: Maximum tool call iterations before forcing a final answer.
-        max_tokens: Maximum tokens in the LLM response (used by Anthropic, ignored by others).
+        max_tokens: Maximum tokens in the LLM response (used by Anthropic and Google, ignored by others).
         stream: If True, enable streaming responses. Automatically disabled when response_format is set.
 
     Returns:
@@ -81,7 +81,8 @@ def agent(
     if "/" not in model:
         raise ValueError(
             f"Model must be in 'provider/model_name' format, got: '{model}'. "
-            "Examples: 'ollama/llama3', 'openai/gpt-4o', 'anthropic/claude-sonnet-4-20250514'",
+            "Examples: 'ollama/llama3', 'openai/gpt-4o', 'anthropic/claude-sonnet-4-20250514', "
+            "'google/gemini-2.5-flash'",
         )
 
     provider, model_name = model.split("/", 1)
@@ -126,7 +127,22 @@ def agent(
             max_tokens=max_tokens,
             stream=effective_stream,
         )
+    elif provider == "google":
+        from flux.tasks.ai.gemini import build_gemini_agent
+
+        return build_gemini_agent(
+            system_prompt=system_prompt,
+            model_name=model_name,
+            name=name,
+            tools=tools,
+            response_format=response_format,
+            working_memory=working_memory,
+            max_tool_calls=max_tool_calls,
+            max_tokens=max_tokens,
+            stream=effective_stream,
+        )
     else:
         raise ValueError(
-            f"Unknown provider: '{provider}'. " "Supported providers: ollama, openai, anthropic",
+            f"Unknown provider: '{provider}'. "
+            "Supported providers: ollama, openai, anthropic, google",
         )

--- a/flux/tasks/ai/gemini.py
+++ b/flux/tasks/ai/gemini.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+
+from flux.task import task
+from flux.tasks.ai.tool_executor import build_tool_schemas, execute_tools
+
+if TYPE_CHECKING:
+    from flux.tasks.ai.memory.working_memory import WorkingMemory
+
+try:
+    from google import genai
+    from google.genai import types
+except ImportError:
+    genai = None  # type: ignore[assignment,misc]
+    types = None  # type: ignore[assignment,misc]
+
+
+def build_gemini_agent(
+    system_prompt: str,
+    model_name: str,
+    name: str | None = None,
+    tools: list[Any] | None = None,
+    response_format: type[BaseModel] | None = None,
+    working_memory: WorkingMemory | None = None,
+    max_tool_calls: int = 10,
+    max_tokens: int = 4096,
+    stream: bool = True,
+) -> task:
+    """Build a Flux @task that calls Google Gemini's API."""
+    if genai is None:
+        raise ImportError(
+            "To use Google Gemini models, install the google-genai package: "
+            "pip install google-genai",
+        )
+
+    task_name = name or f"agent_google_{model_name.replace('-', '_').replace('.', '_')}"
+    tool_schemas = build_tool_schemas(tools) if tools else None
+    gemini_tools = _to_gemini_tools(tool_schemas) if tool_schemas else None
+
+    client = genai.Client()
+
+    @task.with_options(name=task_name)
+    async def gemini_agent_task(instruction: str, *, context: str = "") -> str | BaseModel:
+        from flux.tasks.progress import progress
+
+        user_content = instruction
+        if context:
+            user_content = f"{instruction}\n\nContext from previous work:\n\n{context}"
+
+        config = types.GenerateContentConfig(
+            system_instruction=system_prompt,
+            max_output_tokens=max_tokens,
+            tools=gemini_tools,
+            response_mime_type="application/json" if response_format else None,
+            response_schema=response_format if response_format else None,
+        )
+
+        if working_memory:
+            prior_messages = [
+                _to_content(m["role"], m["content"]) for m in working_memory.recall()
+            ]
+            contents = prior_messages + [_to_content("user", user_content)]
+        else:
+            contents = [_to_content("user", user_content)]
+
+        if stream and not gemini_tools:
+            content = ""
+            async for chunk in await client.aio.models.generate_content_stream(
+                model=model_name,
+                contents=contents,
+                config=config,
+            ):
+                token = chunk.text
+                if token:
+                    content += token
+                    await progress({"token": token})
+        else:
+            response = await client.aio.models.generate_content(
+                model=model_name,
+                contents=contents,
+                config=config,
+            )
+
+            tool_call_count = 0
+            tool_iteration = 0
+            while response.function_calls and tools and tool_call_count < max_tool_calls:
+                tool_calls = [
+                    {
+                        "id": fc.name,
+                        "name": fc.name,
+                        "arguments": fc.args,
+                    }
+                    for fc in response.function_calls
+                ]
+                tool_call_count += len(tool_calls)
+
+                contents.append(response.candidates[0].content)
+                results = await execute_tools(tool_calls, tools, iteration=tool_iteration)
+                tool_iteration += 1
+
+                function_response_parts = [
+                    types.Part(
+                        function_response=types.FunctionResponse(
+                            name=tc["name"],
+                            response={"output": result["output"]},
+                        ),
+                    )
+                    for tc, result in zip(tool_calls, results)
+                ]
+                contents.append(
+                    types.Content(role="user", parts=function_response_parts),
+                )
+
+                response = await client.aio.models.generate_content(
+                    model=model_name,
+                    contents=contents,
+                    config=config,
+                )
+
+            if response.function_calls and tool_call_count >= max_tool_calls:
+                contents.append(response.candidates[0].content)
+                contents.append(_to_content(
+                    "user",
+                    "You must provide your final answer now. Do not call any more tools.",
+                ))
+                config_no_tools = types.GenerateContentConfig(
+                    system_instruction=system_prompt,
+                    max_output_tokens=max_tokens,
+                )
+                response = await client.aio.models.generate_content(
+                    model=model_name,
+                    contents=contents,
+                    config=config_no_tools,
+                )
+
+            if stream and not (response.function_calls):
+                config_stream = types.GenerateContentConfig(
+                    system_instruction=system_prompt,
+                    max_output_tokens=max_tokens,
+                )
+                content = ""
+                async for chunk in await client.aio.models.generate_content_stream(
+                    model=model_name,
+                    contents=contents,
+                    config=config_stream,
+                ):
+                    token = chunk.text
+                    if token:
+                        content += token
+                        await progress({"token": token})
+            else:
+                content = response.text or ""
+
+        if working_memory:
+            await working_memory.memorize("user", user_content)
+            await working_memory.memorize("assistant", content)
+
+        if response_format:
+            return response_format.model_validate_json(content)
+
+        return content
+
+    return gemini_agent_task
+
+
+def _to_content(role: str, text: str) -> types.Content:
+    gemini_role = "model" if role == "assistant" else role
+    return types.Content(role=gemini_role, parts=[types.Part(text=text)])
+
+
+def _to_gemini_tools(schemas: list[dict[str, Any]]) -> list[types.Tool]:
+    declarations = [
+        types.FunctionDeclaration(
+            name=s["name"],
+            description=s["description"],
+            parameters_json_schema=s["parameters"],
+        )
+        for s in schemas
+    ]
+    return [types.Tool(function_declarations=declarations)]

--- a/flux/tasks/ai/gemini.py
+++ b/flux/tasks/ai/gemini.py
@@ -58,9 +58,7 @@ def build_gemini_agent(
         )
 
         if working_memory:
-            prior_messages = [
-                _to_content(m["role"], m["content"]) for m in working_memory.recall()
-            ]
+            prior_messages = [_to_content(m["role"], m["content"]) for m in working_memory.recall()]
             contents = prior_messages + [_to_content("user", user_content)]
         else:
             contents = [_to_content("user", user_content)]
@@ -121,10 +119,12 @@ def build_gemini_agent(
 
             if response.function_calls and tool_call_count >= max_tool_calls:
                 contents.append(response.candidates[0].content)
-                contents.append(_to_content(
-                    "user",
-                    "You must provide your final answer now. Do not call any more tools.",
-                ))
+                contents.append(
+                    _to_content(
+                        "user",
+                        "You must provide your final answer now. Do not call any more tools.",
+                    ),
+                )
                 config_no_tools = types.GenerateContentConfig(
                     system_instruction=system_prompt,
                     max_output_tokens=max_tokens,

--- a/flux/tasks/ai/gemini.py
+++ b/flux/tasks/ai/gemini.py
@@ -40,10 +40,9 @@ def build_gemini_agent(
     tool_schemas = build_tool_schemas(tools) if tools else None
     gemini_tools = _to_gemini_tools(tool_schemas) if tool_schemas else None
 
-    client = genai.Client()
-
     @task.with_options(name=task_name)
     async def gemini_agent_task(instruction: str, *, context: str = "") -> str | BaseModel:
+        client = genai.Client()
         from flux.tasks.progress import progress
 
         user_content = instruction

--- a/poetry.lock
+++ b/poetry.lock
@@ -180,7 +180,7 @@ description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
-markers = "implementation_name == \"pypy\""
+markers = "implementation_name == \"pypy\" or platform_python_implementation != \"PyPy\""
 files = [
     {file = "cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14"},
     {file = "cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67"},
@@ -510,6 +510,145 @@ files = [
 [package.dependencies]
 python-dateutil = "*"
 pytz = ">2021.1"
+
+[[package]]
+name = "cryptography"
+version = "45.0.7"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = false
+python-versions = "!=3.9.0,!=3.9.1,>=3.7"
+groups = ["dev"]
+markers = "python_full_version >= \"3.14.0\" and platform_python_implementation != \"PyPy\""
+files = [
+    {file = "cryptography-45.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3be4f21c6245930688bd9e162829480de027f8bf962ede33d4f8ba7d67a00cee"},
+    {file = "cryptography-45.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:67285f8a611b0ebc0857ced2081e30302909f571a46bfa7a3cc0ad303fe015c6"},
+    {file = "cryptography-45.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:577470e39e60a6cd7780793202e63536026d9b8641de011ed9d8174da9ca5339"},
+    {file = "cryptography-45.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4bd3e5c4b9682bc112d634f2c6ccc6736ed3635fc3319ac2bb11d768cc5a00d8"},
+    {file = "cryptography-45.0.7-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:465ccac9d70115cd4de7186e60cfe989de73f7bb23e8a7aa45af18f7412e75bf"},
+    {file = "cryptography-45.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:16ede8a4f7929b4b7ff3642eba2bf79aa1d71f24ab6ee443935c0d269b6bc513"},
+    {file = "cryptography-45.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8978132287a9d3ad6b54fcd1e08548033cc09dc6aacacb6c004c73c3eb5d3ac3"},
+    {file = "cryptography-45.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b6a0e535baec27b528cb07a119f321ac024592388c5681a5ced167ae98e9fff3"},
+    {file = "cryptography-45.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a24ee598d10befaec178efdff6054bc4d7e883f615bfbcd08126a0f4931c83a6"},
+    {file = "cryptography-45.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:fa26fa54c0a9384c27fcdc905a2fb7d60ac6e47d14bc2692145f2b3b1e2cfdbd"},
+    {file = "cryptography-45.0.7-cp311-abi3-win32.whl", hash = "sha256:bef32a5e327bd8e5af915d3416ffefdbe65ed975b646b3805be81b23580b57b8"},
+    {file = "cryptography-45.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:3808e6b2e5f0b46d981c24d79648e5c25c35e59902ea4391a0dcb3e667bf7443"},
+    {file = "cryptography-45.0.7-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bfb4c801f65dd61cedfc61a83732327fafbac55a47282e6f26f073ca7a41c3b2"},
+    {file = "cryptography-45.0.7-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:81823935e2f8d476707e85a78a405953a03ef7b7b4f55f93f7c2d9680e5e0691"},
+    {file = "cryptography-45.0.7-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3994c809c17fc570c2af12c9b840d7cea85a9fd3e5c0e0491f4fa3c029216d59"},
+    {file = "cryptography-45.0.7-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:dad43797959a74103cb59c5dac71409f9c27d34c8a05921341fb64ea8ccb1dd4"},
+    {file = "cryptography-45.0.7-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ce7a453385e4c4693985b4a4a3533e041558851eae061a58a5405363b098fcd3"},
+    {file = "cryptography-45.0.7-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b04f85ac3a90c227b6e5890acb0edbaf3140938dbecf07bff618bf3638578cf1"},
+    {file = "cryptography-45.0.7-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:48c41a44ef8b8c2e80ca4527ee81daa4c527df3ecbc9423c41a420a9559d0e27"},
+    {file = "cryptography-45.0.7-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f3df7b3d0f91b88b2106031fd995802a2e9ae13e02c36c1fc075b43f420f3a17"},
+    {file = "cryptography-45.0.7-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dd342f085542f6eb894ca00ef70236ea46070c8a13824c6bde0dfdcd36065b9b"},
+    {file = "cryptography-45.0.7-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1993a1bb7e4eccfb922b6cd414f072e08ff5816702a0bdb8941c247a6b1b287c"},
+    {file = "cryptography-45.0.7-cp37-abi3-win32.whl", hash = "sha256:18fcf70f243fe07252dcb1b268a687f2358025ce32f9f88028ca5c364b123ef5"},
+    {file = "cryptography-45.0.7-cp37-abi3-win_amd64.whl", hash = "sha256:7285a89df4900ed3bfaad5679b1e668cb4b38a8de1ccbfc84b05f34512da0a90"},
+    {file = "cryptography-45.0.7-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:de58755d723e86175756f463f2f0bddd45cc36fbd62601228a3f8761c9f58252"},
+    {file = "cryptography-45.0.7-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a20e442e917889d1a6b3c570c9e3fa2fdc398c20868abcea268ea33c024c4083"},
+    {file = "cryptography-45.0.7-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:258e0dff86d1d891169b5af222d362468a9570e2532923088658aa866eb11130"},
+    {file = "cryptography-45.0.7-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d97cf502abe2ab9eff8bd5e4aca274da8d06dd3ef08b759a8d6143f4ad65d4b4"},
+    {file = "cryptography-45.0.7-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:c987dad82e8c65ebc985f5dae5e74a3beda9d0a2a4daf8a1115f3772b59e5141"},
+    {file = "cryptography-45.0.7-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:c13b1e3afd29a5b3b2656257f14669ca8fa8d7956d509926f0b130b600b50ab7"},
+    {file = "cryptography-45.0.7-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:4a862753b36620af6fc54209264f92c716367f2f0ff4624952276a6bbd18cbde"},
+    {file = "cryptography-45.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:06ce84dc14df0bf6ea84666f958e6080cdb6fe1231be2a51f3fc1267d9f3fb34"},
+    {file = "cryptography-45.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d0c5c6bac22b177bf8da7435d9d27a6834ee130309749d162b26c3105c0795a9"},
+    {file = "cryptography-45.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:2f641b64acc00811da98df63df7d59fd4706c0df449da71cb7ac39a0732b40ae"},
+    {file = "cryptography-45.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:f5414a788ecc6ee6bc58560e85ca624258a55ca434884445440a810796ea0e0b"},
+    {file = "cryptography-45.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:1f3d56f73595376f4244646dd5c5870c14c196949807be39e79e7bd9bac3da63"},
+    {file = "cryptography-45.0.7.tar.gz", hash = "sha256:4b1654dfc64ea479c242508eb8c724044f1e964a47d1d1cacc5132292d851971"},
+]
+
+[package.dependencies]
+cffi = {version = ">=1.14", markers = "platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-inline-tabs ; python_full_version >= \"3.8.0\"", "sphinx-rtd-theme (>=3.0.0) ; python_full_version >= \"3.8.0\""]
+docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
+nox = ["nox (>=2024.4.15)", "nox[uv] (>=2024.3.2) ; python_full_version >= \"3.8.0\""]
+pep8test = ["check-sdist ; python_full_version >= \"3.8.0\"", "click (>=8.0.1)", "mypy (>=1.4)", "ruff (>=0.3.6)"]
+sdist = ["build (>=1.0.0)"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==45.0.7)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test-randomorder = ["pytest-randomly"]
+
+[[package]]
+name = "cryptography"
+version = "46.0.0"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = false
+python-versions = "!=3.9.0,!=3.9.1,>=3.8"
+groups = ["dev"]
+markers = "python_full_version < \"3.14.0\" or platform_python_implementation == \"PyPy\""
+files = [
+    {file = "cryptography-46.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:c9c4121f9a41cc3d02164541d986f59be31548ad355a5c96ac50703003c50fb7"},
+    {file = "cryptography-46.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4f70cbade61a16f5e238c4b0eb4e258d177a2fcb59aa0aae1236594f7b0ae338"},
+    {file = "cryptography-46.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d1eccae15d5c28c74b2bea228775c63ac5b6c36eedb574e002440c0bc28750d3"},
+    {file = "cryptography-46.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:1b4fba84166d906a22027f0d958e42f3a4dbbb19c28ea71f0fb7812380b04e3c"},
+    {file = "cryptography-46.0.0-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:523153480d7575a169933f083eb47b1edd5fef45d87b026737de74ffeb300f69"},
+    {file = "cryptography-46.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:f09a3a108223e319168b7557810596631a8cb864657b0c16ed7a6017f0be9433"},
+    {file = "cryptography-46.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c1f6ccd6f2eef3b2eb52837f0463e853501e45a916b3fc42e5d93cf244a4b97b"},
+    {file = "cryptography-46.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:80a548a5862d6912a45557a101092cd6c64ae1475b82cef50ee305d14a75f598"},
+    {file = "cryptography-46.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6c39fd5cd9b7526afa69d64b5e5645a06e1b904f342584b3885254400b63f1b3"},
+    {file = "cryptography-46.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:d5c0cbb2fb522f7e39b59a5482a1c9c5923b7c506cfe96a1b8e7368c31617ac0"},
+    {file = "cryptography-46.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6d8945bc120dcd90ae39aa841afddaeafc5f2e832809dc54fb906e3db829dfdc"},
+    {file = "cryptography-46.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:88c09da8a94ac27798f6b62de6968ac78bb94805b5d272dbcfd5fdc8c566999f"},
+    {file = "cryptography-46.0.0-cp311-abi3-win32.whl", hash = "sha256:3738f50215211cee1974193a1809348d33893696ce119968932ea117bcbc9b1d"},
+    {file = "cryptography-46.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:bbaa5eef3c19c66613317dc61e211b48d5f550db009c45e1c28b59d5a9b7812a"},
+    {file = "cryptography-46.0.0-cp311-abi3-win_arm64.whl", hash = "sha256:16b5ac72a965ec9d1e34d9417dbce235d45fa04dac28634384e3ce40dfc66495"},
+    {file = "cryptography-46.0.0-cp314-abi3-macosx_10_9_universal2.whl", hash = "sha256:91585fc9e696abd7b3e48a463a20dda1a5c0eeeca4ba60fa4205a79527694390"},
+    {file = "cryptography-46.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:65e9117ebed5b16b28154ed36b164c20021f3a480e9cbb4b4a2a59b95e74c25d"},
+    {file = "cryptography-46.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:da7f93551d39d462263b6b5c9056c49f780b9200bf9fc2656d7c88c7bdb9b363"},
+    {file = "cryptography-46.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:be7479f9504bfb46628544ec7cb4637fe6af8b70445d4455fbb9c395ad9b7290"},
+    {file = "cryptography-46.0.0-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f85e6a7d42ad60024fa1347b1d4ef82c4df517a4deb7f829d301f1a92ded038c"},
+    {file = "cryptography-46.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:d349af4d76a93562f1dce4d983a4a34d01cb22b48635b0d2a0b8372cdb4a8136"},
+    {file = "cryptography-46.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:35aa1a44bd3e0efc3ef09cf924b3a0e2a57eda84074556f4506af2d294076685"},
+    {file = "cryptography-46.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:c457ad3f151d5fb380be99425b286167b358f76d97ad18b188b68097193ed95a"},
+    {file = "cryptography-46.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:399ef4c9be67f3902e5ca1d80e64b04498f8b56c19e1bc8d0825050ea5290410"},
+    {file = "cryptography-46.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:378eff89b040cbce6169528f130ee75dceeb97eef396a801daec03b696434f06"},
+    {file = "cryptography-46.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c3648d6a5878fd1c9a22b1d43fa75efc069d5f54de12df95c638ae7ba88701d0"},
+    {file = "cryptography-46.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fc30be952dd4334801d345d134c9ef0e9ccbaa8c3e1bc18925cbc4247b3e29c"},
+    {file = "cryptography-46.0.0-cp314-cp314t-win32.whl", hash = "sha256:b8e7db4ce0b7297e88f3d02e6ee9a39382e0efaf1e8974ad353120a2b5a57ef7"},
+    {file = "cryptography-46.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:40ee4ce3c34acaa5bc347615ec452c74ae8ff7db973a98c97c62293120f668c6"},
+    {file = "cryptography-46.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:07a1be54f995ce14740bf8bbe1cc35f7a37760f992f73cf9f98a2a60b9b97419"},
+    {file = "cryptography-46.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:1d2073313324226fd846e6b5fc340ed02d43fd7478f584741bd6b791c33c9fee"},
+    {file = "cryptography-46.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83af84ebe7b6e9b6de05050c79f8cc0173c864ce747b53abce6a11e940efdc0d"},
+    {file = "cryptography-46.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c3cd09b1490c1509bf3892bde9cef729795fae4a2fee0621f19be3321beca7e4"},
+    {file = "cryptography-46.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d14eaf1569d6252280516bedaffdd65267428cdbc3a8c2d6de63753cf0863d5e"},
+    {file = "cryptography-46.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ab3a14cecc741c8c03ad0ad46dfbf18de25218551931a23bca2731d46c706d83"},
+    {file = "cryptography-46.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8e8b222eb54e3e7d3743a7c2b1f7fa7df7a9add790307bb34327c88ec85fe087"},
+    {file = "cryptography-46.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7f3f88df0c9b248dcc2e76124f9140621aca187ccc396b87bc363f890acf3a30"},
+    {file = "cryptography-46.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:9aa85222f03fdb30defabc7a9e1e3d4ec76eb74ea9fe1504b2800844f9c98440"},
+    {file = "cryptography-46.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f9aaf2a91302e1490c068d2f3af7df4137ac2b36600f5bd26e53d9ec320412d3"},
+    {file = "cryptography-46.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:32670ca085150ff36b438c17f2dfc54146fe4a074ebf0a76d72fb1b419a974bc"},
+    {file = "cryptography-46.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0f58183453032727a65e6605240e7a3824fd1d6a7e75d2b537e280286ab79a52"},
+    {file = "cryptography-46.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4bc257c2d5d865ed37d0bd7c500baa71f939a7952c424f28632298d80ccd5ec1"},
+    {file = "cryptography-46.0.0-cp38-abi3-win32.whl", hash = "sha256:df932ac70388be034b2e046e34d636245d5eeb8140db24a6b4c2268cd2073270"},
+    {file = "cryptography-46.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:274f8b2eb3616709f437326185eb563eb4e5813d01ebe2029b61bfe7d9995fbb"},
+    {file = "cryptography-46.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:249c41f2bbfa026615e7bdca47e4a66135baa81b08509ab240a2e666f6af5966"},
+    {file = "cryptography-46.0.0-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:fe9ff1139b2b1f59a5a0b538bbd950f8660a39624bbe10cf3640d17574f973bb"},
+    {file = "cryptography-46.0.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:77e3bd53c9c189cea361bc18ceb173959f8b2dd8f8d984ae118e9ac641410252"},
+    {file = "cryptography-46.0.0-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:75d2ddde8f1766ab2db48ed7f2aa3797aeb491ea8dfe9b4c074201aec00f5c16"},
+    {file = "cryptography-46.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:f9f85d9cf88e3ba2b2b6da3c2310d1cf75bdf04a5bc1a2e972603054f82c4dd5"},
+    {file = "cryptography-46.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:834af45296083d892e23430e3b11df77e2ac5c042caede1da29c9bf59016f4d2"},
+    {file = "cryptography-46.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:c39f0947d50f74b1b3523cec3931315072646286fb462995eb998f8136779319"},
+    {file = "cryptography-46.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:6460866a92143a24e3ed68eaeb6e98d0cedd85d7d9a8ab1fc293ec91850b1b38"},
+    {file = "cryptography-46.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bf1961037309ee0bdf874ccba9820b1c2f720c2016895c44d8eb2316226c1ad5"},
+    {file = "cryptography-46.0.0.tar.gz", hash = "sha256:99f64a6d15f19f3afd78720ad2978f6d8d4c68cd4eb600fab82ab1a7c2071dca"},
+]
+
+[package.dependencies]
+cffi = {version = ">=1.14", markers = "python_full_version < \"3.14.0\" and platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-inline-tabs", "sphinx-rtd-theme (>=3.0.0)"]
+docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
+nox = ["nox[uv] (>=2024.4.15)"]
+pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.14)", "ruff (>=0.11.11)"]
+sdist = ["build (>=1.0.0)"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==46.0.0)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "debugpy"
@@ -875,6 +1014,63 @@ gitdb = ">=4.0.1,<5"
 [package.extras]
 doc = ["sphinx (>=7.1.2,<7.2)", "sphinx-autodoc-typehints", "sphinx_rtd_theme"]
 test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock ; python_version < \"3.8\"", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions ; python_version < \"3.11\""]
+
+[[package]]
+name = "google-auth"
+version = "2.49.1"
+description = "Google Authentication Library"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "google_auth-2.49.1-py3-none-any.whl", hash = "sha256:195ebe3dca18eddd1b3db5edc5189b76c13e96f29e73043b923ebcf3f1a860f7"},
+    {file = "google_auth-2.49.1.tar.gz", hash = "sha256:16d40da1c3c5a0533f57d268fe72e0ebb0ae1cc3b567024122651c045d879b64"},
+]
+
+[package.dependencies]
+cryptography = ">=38.0.3"
+pyasn1-modules = ">=0.2.1"
+requests = {version = ">=2.20.0,<3.0.0", optional = true, markers = "extra == \"requests\""}
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.6.2,<4.0.0)", "requests (>=2.20.0,<3.0.0)"]
+cryptography = ["cryptography (>=38.0.3)"]
+enterprise-cert = ["pyopenssl"]
+pyjwt = ["pyjwt (>=2.0)"]
+pyopenssl = ["pyopenssl (>=20.0.0)"]
+reauth = ["pyu2f (>=0.1.5)"]
+requests = ["requests (>=2.20.0,<3.0.0)"]
+rsa = ["rsa (>=3.1.4,<5)"]
+testing = ["aiohttp (<3.10.0)", "aiohttp (>=3.6.2,<4.0.0)", "aioresponses", "flask", "freezegun", "grpcio", "packaging", "pyjwt (>=2.0)", "pyopenssl (<24.3.0)", "pyopenssl (>=20.0.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-localserver", "pyu2f (>=0.1.5)", "requests (>=2.20.0,<3.0.0)", "responses", "urllib3"]
+urllib3 = ["packaging", "urllib3"]
+
+[[package]]
+name = "google-genai"
+version = "1.67.0"
+description = "GenAI Python SDK"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "google_genai-1.67.0-py3-none-any.whl", hash = "sha256:58b0484ff2d4335fa53c724b489e9f807fcca8115d9cdbd8fdf341121fbd6d2d"},
+    {file = "google_genai-1.67.0.tar.gz", hash = "sha256:897195a6a9742deb6de240b99227189ada8b2d901d61bdfba836c3092021eab6"},
+]
+
+[package.dependencies]
+anyio = ">=4.8.0,<5.0.0"
+distro = ">=1.7.0,<2"
+google-auth = {version = ">=2.47.0,<3.0.0", extras = ["requests"]}
+httpx = ">=0.28.1,<1.0.0"
+pydantic = ">=2.9.0,<3.0.0"
+requests = ">=2.28.1,<3.0.0"
+sniffio = "*"
+tenacity = ">=8.2.3,<9.2.0"
+typing-extensions = ">=4.11.0,<5.0.0"
+websockets = ">=13.0.0,<17.0"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.10.11,<4.0.0)"]
+local-tokenizer = ["protobuf", "sentencepiece (>=0.2.0)"]
 
 [[package]]
 name = "googleapis-common-protos"
@@ -2704,6 +2900,33 @@ files = [
 tests = ["pytest"]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.3"
+description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+description = "A collection of ASN.1-based protocols modules"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a"},
+    {file = "pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6"},
+]
+
+[package.dependencies]
+pyasn1 = ">=0.6.1,<0.7.0"
+
+[[package]]
 name = "pycodestyle"
 version = "2.13.0"
 description = "Python style guide checker"
@@ -2722,7 +2945,7 @@ description = "C parser in Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
-markers = "implementation_name == \"pypy\""
+markers = "implementation_name == \"pypy\" or platform_python_implementation != \"PyPy\""
 files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
@@ -3824,6 +4047,22 @@ files = [
 pbr = ">=2.0.0"
 
 [[package]]
+name = "tenacity"
+version = "9.1.4"
+description = "Retry code until it succeeds"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55"},
+    {file = "tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a"},
+]
+
+[package.extras]
+doc = ["reno", "sphinx"]
+test = ["pytest", "tornado (>=4.5)", "typeguard"]
+
+[[package]]
 name = "textual"
 version = "1.0.0"
 description = "Modern Text User Interface framework"
@@ -4198,7 +4437,7 @@ version = "15.0.1"
 description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b"},
     {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205"},
@@ -4391,4 +4630,4 @@ postgresql = ["psycopg2-binary"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "e12995c38087bff3afbefb0ce436be3edebebe9363040636eb38bdd67a652400"
+content-hash = "d5fbde45d37b4a0f1375027e586fcf57ba8b12c77b0f2a9365a49a73f7800f18"

--- a/poetry.lock
+++ b/poetry.lock
@@ -18,11 +18,12 @@ version = "0.71.0"
 description = "The official Python library for the anthropic API"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "anthropic-0.71.0-py3-none-any.whl", hash = "sha256:85c5015fcdbdc728390f11b17642a65a4365d03b12b799b18b6cc57e71fdb327"},
     {file = "anthropic-0.71.0.tar.gz", hash = "sha256:eb8e6fa86d049061b3ef26eb4cbae0174ebbff21affa6de7b3098da857d8de6a"},
 ]
+markers = {main = "extra == \"ai\""}
 
 [package.dependencies]
 anyio = ">=3.5.0,<5"
@@ -179,8 +180,7 @@ version = "1.17.1"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
-markers = "implementation_name == \"pypy\" or platform_python_implementation != \"PyPy\""
+groups = ["main", "dev"]
 files = [
     {file = "cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14"},
     {file = "cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67"},
@@ -250,9 +250,108 @@ files = [
     {file = "cffi-1.17.1-cp39-cp39-win_amd64.whl", hash = "sha256:d016c76bdd850f3c626af19b0542c9677ba156e4ee4fccfdd7848803533ef662"},
     {file = "cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824"},
 ]
+markers = {main = "python_full_version < \"3.14.0\" and platform_python_implementation != \"PyPy\" and extra == \"ai\"", dev = "python_full_version < \"3.14.0\" and platform_python_implementation != \"PyPy\" or platform_python_implementation == \"PyPy\" and implementation_name == \"pypy\""}
 
 [package.dependencies]
 pycparser = "*"
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "dev"]
+files = [
+    {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
+    {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb"},
+    {file = "cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a"},
+    {file = "cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743"},
+    {file = "cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187"},
+    {file = "cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18"},
+    {file = "cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5"},
+    {file = "cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b"},
+    {file = "cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27"},
+    {file = "cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75"},
+    {file = "cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1"},
+    {file = "cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f"},
+    {file = "cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25"},
+    {file = "cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4"},
+    {file = "cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322"},
+    {file = "cffi-2.0.0-cp39-cp39-win32.whl", hash = "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a"},
+    {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
+    {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
+]
+markers = {main = "python_full_version >= \"3.14.0\" and platform_python_implementation != \"PyPy\" and extra == \"ai\"", dev = "python_full_version >= \"3.14.0\" and platform_python_implementation != \"PyPy\""}
+
+[package.dependencies]
+pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
 
 [[package]]
 name = "cfgv"
@@ -367,7 +466,7 @@ files = [
     {file = "charset_normalizer-3.4.2-py3-none-any.whl", hash = "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0"},
     {file = "charset_normalizer-3.4.2.tar.gz", hash = "sha256:5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63"},
 ]
-markers = {main = "extra == \"observability\""}
+markers = {main = "extra == \"observability\" or extra == \"ai\""}
 
 [[package]]
 name = "click"
@@ -513,73 +612,11 @@ pytz = ">2021.1"
 
 [[package]]
 name = "cryptography"
-version = "45.0.7"
-description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
-optional = false
-python-versions = "!=3.9.0,!=3.9.1,>=3.7"
-groups = ["dev"]
-markers = "python_full_version >= \"3.14.0\" and platform_python_implementation != \"PyPy\""
-files = [
-    {file = "cryptography-45.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3be4f21c6245930688bd9e162829480de027f8bf962ede33d4f8ba7d67a00cee"},
-    {file = "cryptography-45.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:67285f8a611b0ebc0857ced2081e30302909f571a46bfa7a3cc0ad303fe015c6"},
-    {file = "cryptography-45.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:577470e39e60a6cd7780793202e63536026d9b8641de011ed9d8174da9ca5339"},
-    {file = "cryptography-45.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4bd3e5c4b9682bc112d634f2c6ccc6736ed3635fc3319ac2bb11d768cc5a00d8"},
-    {file = "cryptography-45.0.7-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:465ccac9d70115cd4de7186e60cfe989de73f7bb23e8a7aa45af18f7412e75bf"},
-    {file = "cryptography-45.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:16ede8a4f7929b4b7ff3642eba2bf79aa1d71f24ab6ee443935c0d269b6bc513"},
-    {file = "cryptography-45.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8978132287a9d3ad6b54fcd1e08548033cc09dc6aacacb6c004c73c3eb5d3ac3"},
-    {file = "cryptography-45.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b6a0e535baec27b528cb07a119f321ac024592388c5681a5ced167ae98e9fff3"},
-    {file = "cryptography-45.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a24ee598d10befaec178efdff6054bc4d7e883f615bfbcd08126a0f4931c83a6"},
-    {file = "cryptography-45.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:fa26fa54c0a9384c27fcdc905a2fb7d60ac6e47d14bc2692145f2b3b1e2cfdbd"},
-    {file = "cryptography-45.0.7-cp311-abi3-win32.whl", hash = "sha256:bef32a5e327bd8e5af915d3416ffefdbe65ed975b646b3805be81b23580b57b8"},
-    {file = "cryptography-45.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:3808e6b2e5f0b46d981c24d79648e5c25c35e59902ea4391a0dcb3e667bf7443"},
-    {file = "cryptography-45.0.7-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bfb4c801f65dd61cedfc61a83732327fafbac55a47282e6f26f073ca7a41c3b2"},
-    {file = "cryptography-45.0.7-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:81823935e2f8d476707e85a78a405953a03ef7b7b4f55f93f7c2d9680e5e0691"},
-    {file = "cryptography-45.0.7-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3994c809c17fc570c2af12c9b840d7cea85a9fd3e5c0e0491f4fa3c029216d59"},
-    {file = "cryptography-45.0.7-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:dad43797959a74103cb59c5dac71409f9c27d34c8a05921341fb64ea8ccb1dd4"},
-    {file = "cryptography-45.0.7-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ce7a453385e4c4693985b4a4a3533e041558851eae061a58a5405363b098fcd3"},
-    {file = "cryptography-45.0.7-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b04f85ac3a90c227b6e5890acb0edbaf3140938dbecf07bff618bf3638578cf1"},
-    {file = "cryptography-45.0.7-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:48c41a44ef8b8c2e80ca4527ee81daa4c527df3ecbc9423c41a420a9559d0e27"},
-    {file = "cryptography-45.0.7-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f3df7b3d0f91b88b2106031fd995802a2e9ae13e02c36c1fc075b43f420f3a17"},
-    {file = "cryptography-45.0.7-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dd342f085542f6eb894ca00ef70236ea46070c8a13824c6bde0dfdcd36065b9b"},
-    {file = "cryptography-45.0.7-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1993a1bb7e4eccfb922b6cd414f072e08ff5816702a0bdb8941c247a6b1b287c"},
-    {file = "cryptography-45.0.7-cp37-abi3-win32.whl", hash = "sha256:18fcf70f243fe07252dcb1b268a687f2358025ce32f9f88028ca5c364b123ef5"},
-    {file = "cryptography-45.0.7-cp37-abi3-win_amd64.whl", hash = "sha256:7285a89df4900ed3bfaad5679b1e668cb4b38a8de1ccbfc84b05f34512da0a90"},
-    {file = "cryptography-45.0.7-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:de58755d723e86175756f463f2f0bddd45cc36fbd62601228a3f8761c9f58252"},
-    {file = "cryptography-45.0.7-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a20e442e917889d1a6b3c570c9e3fa2fdc398c20868abcea268ea33c024c4083"},
-    {file = "cryptography-45.0.7-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:258e0dff86d1d891169b5af222d362468a9570e2532923088658aa866eb11130"},
-    {file = "cryptography-45.0.7-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d97cf502abe2ab9eff8bd5e4aca274da8d06dd3ef08b759a8d6143f4ad65d4b4"},
-    {file = "cryptography-45.0.7-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:c987dad82e8c65ebc985f5dae5e74a3beda9d0a2a4daf8a1115f3772b59e5141"},
-    {file = "cryptography-45.0.7-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:c13b1e3afd29a5b3b2656257f14669ca8fa8d7956d509926f0b130b600b50ab7"},
-    {file = "cryptography-45.0.7-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:4a862753b36620af6fc54209264f92c716367f2f0ff4624952276a6bbd18cbde"},
-    {file = "cryptography-45.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:06ce84dc14df0bf6ea84666f958e6080cdb6fe1231be2a51f3fc1267d9f3fb34"},
-    {file = "cryptography-45.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d0c5c6bac22b177bf8da7435d9d27a6834ee130309749d162b26c3105c0795a9"},
-    {file = "cryptography-45.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:2f641b64acc00811da98df63df7d59fd4706c0df449da71cb7ac39a0732b40ae"},
-    {file = "cryptography-45.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:f5414a788ecc6ee6bc58560e85ca624258a55ca434884445440a810796ea0e0b"},
-    {file = "cryptography-45.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:1f3d56f73595376f4244646dd5c5870c14c196949807be39e79e7bd9bac3da63"},
-    {file = "cryptography-45.0.7.tar.gz", hash = "sha256:4b1654dfc64ea479c242508eb8c724044f1e964a47d1d1cacc5132292d851971"},
-]
-
-[package.dependencies]
-cffi = {version = ">=1.14", markers = "platform_python_implementation != \"PyPy\""}
-
-[package.extras]
-docs = ["sphinx (>=5.3.0)", "sphinx-inline-tabs ; python_full_version >= \"3.8.0\"", "sphinx-rtd-theme (>=3.0.0) ; python_full_version >= \"3.8.0\""]
-docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
-nox = ["nox (>=2024.4.15)", "nox[uv] (>=2024.3.2) ; python_full_version >= \"3.8.0\""]
-pep8test = ["check-sdist ; python_full_version >= \"3.8.0\"", "click (>=8.0.1)", "mypy (>=1.4)", "ruff (>=0.3.6)"]
-sdist = ["build (>=1.0.0)"]
-ssh = ["bcrypt (>=3.1.5)"]
-test = ["certifi (>=2024)", "cryptography-vectors (==45.0.7)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
-test-randomorder = ["pytest-randomly"]
-
-[[package]]
-name = "cryptography"
 version = "46.0.0"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.8"
-groups = ["dev"]
-markers = "python_full_version < \"3.14.0\" or platform_python_implementation == \"PyPy\""
+groups = ["main", "dev"]
 files = [
     {file = "cryptography-46.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:c9c4121f9a41cc3d02164541d986f59be31548ad355a5c96ac50703003c50fb7"},
     {file = "cryptography-46.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4f70cbade61a16f5e238c4b0eb4e258d177a2fcb59aa0aae1236594f7b0ae338"},
@@ -636,9 +673,13 @@ files = [
     {file = "cryptography-46.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bf1961037309ee0bdf874ccba9820b1c2f720c2016895c44d8eb2316226c1ad5"},
     {file = "cryptography-46.0.0.tar.gz", hash = "sha256:99f64a6d15f19f3afd78720ad2978f6d8d4c68cd4eb600fab82ab1a7c2071dca"},
 ]
+markers = {main = "extra == \"ai\""}
 
 [package.dependencies]
-cffi = {version = ">=1.14", markers = "python_full_version < \"3.14.0\" and platform_python_implementation != \"PyPy\""}
+cffi = [
+    {version = ">=1.14", markers = "python_full_version < \"3.14.0\" and platform_python_implementation != \"PyPy\""},
+    {version = ">=2.0.0", markers = "python_full_version >= \"3.14.0\" and platform_python_implementation != \"PyPy\""},
+]
 
 [package.extras]
 docs = ["sphinx (>=5.3.0)", "sphinx-inline-tabs", "sphinx-rtd-theme (>=3.0.0)"]
@@ -751,11 +792,12 @@ version = "1.9.0"
 description = "Distro - an OS platform information API"
 optional = false
 python-versions = ">=3.6"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
     {file = "distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"},
 ]
+markers = {main = "extra == \"ai\""}
 
 [[package]]
 name = "docstring-parser"
@@ -763,11 +805,12 @@ version = "0.17.0"
 description = "Parse Python docstrings in reST, Google and Numpydoc format"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708"},
     {file = "docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912"},
 ]
+markers = {main = "extra == \"ai\""}
 
 [package.extras]
 dev = ["pre-commit (>=2.16.0) ; python_version >= \"3.9\"", "pydoctor (>=25.4.0)", "pytest"]
@@ -1021,11 +1064,12 @@ version = "2.49.1"
 description = "Google Authentication Library"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "google_auth-2.49.1-py3-none-any.whl", hash = "sha256:195ebe3dca18eddd1b3db5edc5189b76c13e96f29e73043b923ebcf3f1a860f7"},
     {file = "google_auth-2.49.1.tar.gz", hash = "sha256:16d40da1c3c5a0533f57d268fe72e0ebb0ae1cc3b567024122651c045d879b64"},
 ]
+markers = {main = "extra == \"ai\""}
 
 [package.dependencies]
 cryptography = ">=38.0.3"
@@ -1050,11 +1094,12 @@ version = "1.67.0"
 description = "GenAI Python SDK"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "google_genai-1.67.0-py3-none-any.whl", hash = "sha256:58b0484ff2d4335fa53c724b489e9f807fcca8115d9cdbd8fdf341121fbd6d2d"},
     {file = "google_genai-1.67.0.tar.gz", hash = "sha256:897195a6a9742deb6de240b99227189ada8b2d901d61bdfba836c3092021eab6"},
 ]
+markers = {main = "extra == \"ai\""}
 
 [package.dependencies]
 anyio = ">=4.8.0,<5.0.0"
@@ -1544,7 +1589,7 @@ version = "0.11.1"
 description = "Fast iterable JSON parser."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "jiter-0.11.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:ed58841a491bbbf3f7c55a6b68fff568439ab73b2cce27ace0e169057b5851df"},
     {file = "jiter-0.11.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:499beb9b2d7e51d61095a8de39ebcab1d1778f2a74085f8305a969f6cee9f3e4"},
@@ -1649,6 +1694,7 @@ files = [
     {file = "jiter-0.11.1-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18c77aaa9117510d5bdc6a946baf21b1f0cfa58ef04d31c8d016f206f2118960"},
     {file = "jiter-0.11.1.tar.gz", hash = "sha256:849dcfc76481c0ea0099391235b7ca97d7279e0fa4c86005457ac7c88e8b76dc"},
 ]
+markers = {main = "extra == \"ai\""}
 
 [[package]]
 name = "jupyter-client"
@@ -2191,11 +2237,12 @@ version = "0.6.0"
 description = "The official Python client for Ollama."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "ollama-0.6.0-py3-none-any.whl", hash = "sha256:534511b3ccea2dff419ae06c3b58d7f217c55be7897c8ce5868dfb6b219cf7a0"},
     {file = "ollama-0.6.0.tar.gz", hash = "sha256:da2b2d846b5944cfbcee1ca1e6ee0585f6c9d45a2fe9467cbcd096a37383da2f"},
 ]
+markers = {main = "extra == \"ai\""}
 
 [package.dependencies]
 httpx = ">=0.27"
@@ -2207,11 +2254,12 @@ version = "2.6.0"
 description = "The official Python library for the openai API"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "openai-2.6.0-py3-none-any.whl", hash = "sha256:f33fa12070fe347b5787a7861c8dd397786a4a17e1c3186e239338dac7e2e743"},
     {file = "openai-2.6.0.tar.gz", hash = "sha256:f119faf7fc07d7e558c1e7c32c873e241439b01bd7480418234291ee8c8f4b9d"},
 ]
+markers = {main = "extra == \"ai\""}
 
 [package.dependencies]
 anyio = ">=3.5.0,<5"
@@ -2905,11 +2953,12 @@ version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
     {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
+markers = {main = "extra == \"ai\""}
 
 [[package]]
 name = "pyasn1-modules"
@@ -2917,11 +2966,12 @@ version = "0.4.2"
 description = "A collection of ASN.1-based protocols modules"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a"},
     {file = "pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6"},
 ]
+markers = {main = "extra == \"ai\""}
 
 [package.dependencies]
 pyasn1 = ">=0.6.1,<0.7.0"
@@ -2944,12 +2994,12 @@ version = "2.22"
 description = "C parser in Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
-markers = "implementation_name == \"pypy\" or platform_python_implementation != \"PyPy\""
+groups = ["main", "dev"]
 files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
 ]
+markers = {main = "platform_python_implementation != \"PyPy\" and extra == \"ai\" and (python_full_version < \"3.14.0\" or implementation_name != \"PyPy\")", dev = "(platform_python_implementation != \"PyPy\" or implementation_name == \"pypy\") and (python_full_version < \"3.14.0\" or implementation_name != \"PyPy\")"}
 
 [[package]]
 name = "pycryptodome"
@@ -3693,7 +3743,7 @@ files = [
     {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
     {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
 ]
-markers = {main = "extra == \"observability\""}
+markers = {main = "extra == \"observability\" or extra == \"ai\""}
 
 [package.dependencies]
 certifi = ">=2017.4.17"
@@ -4052,11 +4102,12 @@ version = "9.1.4"
 description = "Retry code until it succeeds"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55"},
     {file = "tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a"},
 ]
+markers = {main = "extra == \"ai\""}
 
 [package.extras]
 doc = ["reno", "sphinx"]
@@ -4177,11 +4228,12 @@ version = "4.67.1"
 description = "Fast, Extensible Progress Meter"
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2"},
     {file = "tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2"},
 ]
+markers = {main = "extra == \"ai\""}
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
@@ -4328,7 +4380,7 @@ files = [
     {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
     {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
 ]
-markers = {main = "extra == \"observability\""}
+markers = {main = "extra == \"observability\" or extra == \"ai\""}
 
 [package.extras]
 brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\""]
@@ -4624,10 +4676,11 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_it
 type = ["pytest-mypy"]
 
 [extras]
+ai = ["anthropic", "google-genai", "ollama", "openai"]
 observability = ["opentelemetry-api", "opentelemetry-exporter-otlp", "opentelemetry-exporter-prometheus", "opentelemetry-sdk", "prometheus-client"]
 postgresql = ["psycopg2-binary"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "d5fbde45d37b4a0f1375027e586fcf57ba8b12c77b0f2a9365a49a73f7800f18"
+content-hash = "a7645a7dc6aebe86d367406e95a31ce15b115bc0062223a01d4056308da57f0c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.13.2"
+version = "0.14.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"
@@ -62,6 +62,7 @@ poethepoet = "^0.34.0"
 openai = "^2.6.0"
 anthropic = "^0.71.0"
 ollama = "^0.6.0"
+google-genai = "^1.0.0"
 ruff = "^0.15.5"
 pytest-asyncio = "^1.3.0"
 types-pyyaml = "^6.0.12.20250915"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ opentelemetry-sdk = {version = "^1.28", optional = true}
 opentelemetry-exporter-otlp = {version = "^1.28", optional = true}
 opentelemetry-exporter-prometheus = {version = "^0.49b0", optional = true}
 prometheus-client = {version = ">=0.20", optional = true}
+ollama = {version = "^0.6.0", optional = true}
+openai = {version = "^2.6.0", optional = true}
+anthropic = {version = "^0.71.0", optional = true}
+google-genai = {version = "^1.0.0", optional = true}
 
 [tool.poetry.group.dev.dependencies]
 pandas = "^2.2.3"
@@ -131,6 +135,7 @@ observability = [
     "opentelemetry-exporter-prometheus",
     "prometheus-client",
 ]
+ai = ["ollama", "openai", "anthropic", "google-genai"]
 
 
 [tool.ruff]

--- a/tests/flux/tasks/ai/test_agent.py
+++ b/tests/flux/tasks/ai/test_agent.py
@@ -86,3 +86,13 @@ def test_agent_stream_disabled_with_response_format():
 
     a = agent("Extract info.", model="ollama/llama3", response_format=Info, stream=True)
     assert a is not None
+
+
+def test_agent_parses_google_model():
+    a = agent("You are a test agent.", model="google/gemini-2.5-flash")
+    assert a.name == "agent_google_gemini_2_5_flash"
+
+
+def test_agent_parses_google_model_with_version():
+    a = agent("You are a test agent.", model="google/gemini-2.5-pro")
+    assert a.name == "agent_google_gemini_2_5_pro"

--- a/tests/flux/tasks/ai/test_gemini_streaming.py
+++ b/tests/flux/tasks/ai/test_gemini_streaming.py
@@ -1,0 +1,89 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from flux.domain.execution_context import ExecutionContext
+
+
+def test_gemini_streaming_emits_progress():
+    captured_progress = []
+
+    def on_progress(execution_id, task_id, task_name, value):
+        captured_progress.append(value)
+
+    async def run():
+        from flux.tasks.ai.gemini import build_gemini_agent
+
+        async def mock_stream():
+            for token in ["Hello", " world", "!"]:
+                chunk = MagicMock()
+                chunk.text = token
+                yield chunk
+
+        with patch("flux.tasks.ai.gemini.genai") as mock_genai:
+            mock_client = MagicMock()
+            mock_client.aio.models.generate_content_stream = AsyncMock(
+                return_value=mock_stream(),
+            )
+            mock_genai.Client.return_value = mock_client
+
+            agent_task = build_gemini_agent(
+                system_prompt="Test",
+                model_name="gemini-2.5-flash",
+                stream=True,
+            )
+
+            ctx = ExecutionContext(workflow_id="wf1", workflow_name="test")
+            ctx.set_progress_callback(on_progress)
+            token = ExecutionContext.set(ctx)
+            try:
+                result = await agent_task("Say hello")
+            finally:
+                ExecutionContext.reset(token)
+
+            assert result == "Hello world!"
+            assert len(captured_progress) == 3
+            assert captured_progress[0] == {"token": "Hello"}
+            assert captured_progress[1] == {"token": " world"}
+            assert captured_progress[2] == {"token": "!"}
+
+    asyncio.run(run())
+
+
+def test_gemini_no_streaming_when_disabled():
+    captured_progress = []
+
+    def on_progress(execution_id, task_id, task_name, value):
+        captured_progress.append(value)
+
+    async def run():
+        from flux.tasks.ai.gemini import build_gemini_agent
+
+        mock_response = MagicMock()
+        mock_response.text = "Hello world!"
+        mock_response.function_calls = None
+
+        with patch("flux.tasks.ai.gemini.genai") as mock_genai:
+            mock_client = MagicMock()
+            mock_client.aio.models.generate_content = AsyncMock(
+                return_value=mock_response,
+            )
+            mock_genai.Client.return_value = mock_client
+
+            agent_task = build_gemini_agent(
+                system_prompt="Test",
+                model_name="gemini-2.5-flash",
+                stream=False,
+            )
+
+            ctx = ExecutionContext(workflow_id="wf1", workflow_name="test")
+            ctx.set_progress_callback(on_progress)
+            token = ExecutionContext.set(ctx)
+            try:
+                result = await agent_task("Say hello")
+            finally:
+                ExecutionContext.reset(token)
+
+            assert result == "Hello world!"
+            assert len(captured_progress) == 0
+
+    asyncio.run(run())

--- a/tests/flux/test_gemini_integration.py
+++ b/tests/flux/test_gemini_integration.py
@@ -17,7 +17,6 @@ class WeatherReport(BaseModel):
 
 
 class TestGeminiWorkflowIntegration:
-
     def test_gemini_agent_workflow_basic(self):
         mock_response = MagicMock()
         mock_response.text = "The sky is blue because of Rayleigh scattering."

--- a/tests/flux/test_gemini_integration.py
+++ b/tests/flux/test_gemini_integration.py
@@ -1,0 +1,124 @@
+"""Integration tests for Gemini provider: full workflow execution with mocked SDK."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pydantic import BaseModel
+
+from flux import ExecutionContext, task, workflow
+from flux.tasks.ai import agent
+
+
+class WeatherReport(BaseModel):
+    city: str
+    temperature: float
+    condition: str
+
+
+class TestGeminiWorkflowIntegration:
+
+    def test_gemini_agent_workflow_basic(self):
+        mock_response = MagicMock()
+        mock_response.text = "The sky is blue because of Rayleigh scattering."
+        mock_response.function_calls = None
+
+        with patch("flux.tasks.ai.gemini.genai") as mock_genai:
+            mock_client = MagicMock()
+            mock_client.aio.models.generate_content = AsyncMock(
+                return_value=mock_response,
+            )
+            mock_genai.Client.return_value = mock_client
+
+            assistant = agent(
+                system_prompt="You are a helpful assistant.",
+                model="google/gemini-2.5-flash",
+                stream=False,
+            )
+
+            @workflow
+            async def gemini_basic_workflow(ctx: ExecutionContext):
+                return await assistant(ctx.input["message"])
+
+            result = gemini_basic_workflow.run({"message": "Why is the sky blue?"})
+
+            assert result.has_succeeded
+            assert result.output == "The sky is blue because of Rayleigh scattering."
+
+    def test_gemini_agent_workflow_with_tools(self):
+        mock_fc = MagicMock()
+        mock_fc.name = "get_weather"
+        mock_fc.args = {"city": "London"}
+
+        mock_response_1 = MagicMock()
+        mock_response_1.function_calls = [mock_fc]
+        mock_response_1.candidates = [MagicMock()]
+        mock_response_1.candidates[0].content = MagicMock()
+
+        mock_response_2 = MagicMock()
+        mock_response_2.text = "The weather in London is 15°C and cloudy."
+        mock_response_2.function_calls = None
+        mock_response_2.candidates = [MagicMock()]
+        mock_response_2.candidates[0].content = MagicMock()
+
+        with patch("flux.tasks.ai.gemini.genai") as mock_genai:
+            mock_client = MagicMock()
+            mock_client.aio.models.generate_content = AsyncMock(
+                side_effect=[mock_response_1, mock_response_2],
+            )
+            mock_genai.Client.return_value = mock_client
+
+            @task
+            async def get_weather(city: str) -> str:
+                """Get weather for a city."""
+                return "15°C, cloudy"
+
+            assistant = agent(
+                system_prompt="You are a weather assistant.",
+                model="google/gemini-2.5-flash",
+                tools=[get_weather],
+                stream=False,
+            )
+
+            @workflow
+            async def gemini_tools_workflow(ctx: ExecutionContext):
+                return await assistant(ctx.input["message"])
+
+            result = gemini_tools_workflow.run(
+                {"message": "What's the weather in London?"},
+            )
+
+            assert result.has_succeeded
+            assert "15°C" in result.output
+
+    def test_gemini_agent_workflow_structured_output(self):
+        mock_response = MagicMock()
+        mock_response.text = '{"city": "London", "temperature": 15.0, "condition": "cloudy"}'
+        mock_response.function_calls = None
+
+        with patch("flux.tasks.ai.gemini.genai") as mock_genai:
+            mock_client = MagicMock()
+            mock_client.aio.models.generate_content = AsyncMock(
+                return_value=mock_response,
+            )
+            mock_genai.Client.return_value = mock_client
+
+            assistant = agent(
+                system_prompt="Return weather data as JSON.",
+                model="google/gemini-2.5-flash",
+                response_format=WeatherReport,
+                stream=False,
+            )
+
+            @workflow
+            async def gemini_structured_workflow(ctx: ExecutionContext):
+                return await assistant(ctx.input["message"])
+
+            result = gemini_structured_workflow.run(
+                {"message": "Weather in London?"},
+            )
+
+            assert result.has_succeeded
+            assert isinstance(result.output, WeatherReport)
+            assert result.output.city == "London"
+            assert result.output.temperature == 15.0


### PR DESCRIPTION
## Summary

Adds Google Gemini as a fourth LLM provider for the `agent()` task primitive, accessible via `model="google/gemini-2.5-flash"`.

- New provider `flux/tasks/ai/gemini.py` following the established provider pattern (streaming, tool calling, structured output, working memory, forced-final-answer on max_tool_calls exhaustion)
- Agent dispatcher routing via `"google/"` prefix (chosen over `"gemini/"` to allow future expansion to Vertex AI, etc.)
- `google-genai` SDK (^1.0.0) as dev dependency
- Version bump to 0.14.0
- Bugfix: pre-existing `RecursionError` in retry error handling (affected all providers)

## What's included

| File | What |
|---|---|
| `flux/tasks/ai/gemini.py` | Provider: `build_gemini_agent()`, `_to_content()`, `_to_gemini_tools()` |
| `flux/tasks/ai/agent.py` | `elif provider == "google"` routing branch, updated error messages and docstrings |
| `flux/task.py` | Fix: prevent `RecursionError` when `RetryError` propagates to parent task |
| `pyproject.toml` / `poetry.lock` | `google-genai ^1.0.0` dev dependency, version 0.14.0 |
| `tests/flux/tasks/ai/test_gemini_streaming.py` | Unit tests: streaming progress emission + non-streaming |
| `tests/flux/tasks/ai/test_agent.py` | Dispatcher routing tests for `google/` prefix |
| `tests/flux/test_gemini_integration.py` | Integration tests: basic workflow, tool calling, structured output |
| `examples/ai/conversational_agent_gemini.py` | Conversational agent example (mirrors OpenAI/Anthropic examples) |
| `docs/advanced-features/ai-agents.md` | AI agents documentation covering all four providers |

## Usage

```python
from flux.tasks.ai import agent

assistant = agent(
    "You are a helpful assistant.",
    model="google/gemini-2.5-flash",
)
```

Requires `GOOGLE_API_KEY` or `GEMINI_API_KEY` environment variable.

## Bugfix: RetryError recursion

E2E testing uncovered a pre-existing `RecursionError` affecting **all providers** when a retried task exhausts all attempts inside a parent task. Root cause: `__handle_exception` in `task.py` re-raised `RetryError` (an `ExecutionError` subclass) which was caught by the `except RetryError` handler, causing infinite recursion. Fix: wrap `RetryError` in `ExecutionError` before re-raising to break the cycle.

## Test plan

- [x] Unit tests: streaming and non-streaming (2 tests)
- [x] Dispatcher tests: model string parsing (2 tests)
- [x] Integration tests: basic, tools, structured output (3 tests)
- [x] Full test suite: 718 passed, 0 failures
- [x] Pre-commit: all checks pass (ruff, ruff-format, mypy)
- [x] E2E: server + worker + register + run — fails cleanly with `RetryError` (expected without API key, no more `RecursionError`)