### PR TITLE
feat: agent plans with streaming fix and plan continuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Flux is a distributed workflow orchestration engine written in Python that enables building stateful and fault-tolerant workflows. It provides an intuitive async programming model for creating complex, reliable distributed applications with built-in support for state management, error handling, and execution control.
 
-**Current Version**: 0.7.0
+**Current Version**: 0.15.0
 
 ## Key Features
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Flux is a distributed workflow orchestration engine written in Python that enabl
 - **High Performance**: Efficient parallel task execution and workflow processing
 - **Type Safety**: Leverages Python type hints for safer workflow development
 - **API Integration**: Built-in FastAPI server for HTTP-based workflow execution
+- **AI Agents**: LLM-powered tasks with tool use, structured output, streaming, and memory (Ollama, OpenAI, Anthropic, Gemini)
+- **Agent Plans**: Structured multi-step planning with dependency tracking, replanning, and plan approval
 - **Model Context Protocol (MCP) Support**: Integration with AI development workflows through MCP server capabilities
 - **Workflow Cancellation**: Cancel running workflows with both sync and async modes
 - **Resource Monitoring**: Worker system with CPU, memory, and resource tracking

--- a/docs/advanced-features/agent-plans.md
+++ b/docs/advanced-features/agent-plans.md
@@ -73,12 +73,8 @@ pending → in_progress → completed
 ### Plan Structure
 
 ```python
-# The LLM calls create_plan with steps like:
-create_plan(steps=[
-    {"name": "research", "description": "Search for competitor pricing data."},
-    {"name": "analyze", "description": "Analyze pricing trends.", "depends_on": ["research"]},
-    {"name": "report", "description": "Write the final report.", "depends_on": ["analyze"]},
-])
+# The LLM calls create_plan with a JSON string:
+create_plan(steps='[{"name": "research", "description": "Search for competitor pricing data."}, {"name": "analyze", "description": "Analyze pricing trends.", "depends_on": ["research"]}, {"name": "report", "description": "Write the final report.", "depends_on": ["analyze"]}]')
 ```
 
 - **Steps are goals, not tool calls.** A step like "Research competitor pricing" may involve multiple tool calls.

--- a/docs/advanced-features/agent-plans.md
+++ b/docs/advanced-features/agent-plans.md
@@ -9,7 +9,6 @@ Plans are guidance, not rigid execution. The agent decides when to plan, works t
 ## Quick Start
 
 ```python
-import asyncio
 from flux import task, workflow, ExecutionContext
 from flux.tasks.ai import agent
 
@@ -103,6 +102,12 @@ After each tool call, the agent sees a lightweight one-line reminder:
 ```
 
 This prevents the agent from losing track of the plan during long sequences of tool calls. When a step has dependency results, they are included inline so the agent has context without calling `get_plan`.
+
+### Plan Continuation
+
+If the LLM stops responding mid-plan (returns no content and no tool calls while steps remain incomplete), the framework automatically nudges it to continue by injecting a continuation prompt with the current plan summary. This prevents models — especially smaller local ones — from silently abandoning incomplete plans.
+
+The nudge is transparent: the agent receives a message like `"Continue working on your plan. [Plan: 1/3 done. Active: \"analyze\".]"` and resumes calling tools normally.
 
 ### Replanning
 

--- a/docs/advanced-features/agent-plans.md
+++ b/docs/advanced-features/agent-plans.md
@@ -1,12 +1,15 @@
 # Agent Plans
 
-Agent Plans let an agent create a structured roadmap before starting complex work. When `planning=True`, the agent gets three tools — `create_plan`, `mark_step_done`, and `get_plan` — that it uses to organize multi-step tasks with named steps and dependency tracking.
+Agent Plans let an agent create a structured roadmap before starting complex work. When `planning=True`, the agent gets six tools — `create_plan`, `start_step`, `mark_step_done`, `mark_step_failed`, `get_plan`, and `get_ready_steps` — that it uses to organize multi-step tasks with named steps and dependency tracking.
 
 Plans are guidance, not rigid execution. The agent decides when to plan, works through steps using its existing tools, skills, and sub-agents, and can replan at any time if circumstances change.
+
+> **Note:** `agent()` is now async and must be awaited. Create agents inside a workflow or with `asyncio.run`.
 
 ## Quick Start
 
 ```python
+import asyncio
 from flux import task, workflow, ExecutionContext
 from flux.tasks.ai import agent
 
@@ -20,36 +23,53 @@ async def write_report(content: str) -> str:
     """Write a formatted report."""
     return f"Report: {content}"
 
-analyst = agent(
-    "You are a market research analyst. Create a plan for complex research tasks.",
-    model="openai/gpt-4o",
-    tools=[search_web, write_report],
-    planning=True,
-)
-
 @workflow
 async def research(ctx: ExecutionContext):
+    analyst = await agent(
+        "You are a market research analyst. Create a plan for complex research tasks.",
+        model="openai/gpt-4o",
+        tools=[search_web, write_report],
+        planning=True,
+    )
     return await analyst(f"Research the competitive landscape for {ctx.input['product']}.")
 ```
 
 The agent will:
 1. Assess the task and decide to create a plan
 2. Call `create_plan` with named steps and dependencies
-3. Work through each step using `search_web`, `write_report`, etc.
-4. Call `mark_step_done` after each step to record results
-5. Return a final response when done
+3. Call `start_step` before working on each step
+4. Work through each step using `search_web`, `write_report`, etc.
+5. Call `mark_step_done` after each step to record results
+6. Return a final response when done
 
 ## How It Works
 
-### The Three Tools
+### The Six Tools
 
 When `planning=True`, the agent receives:
 
 | Tool | Purpose |
 |------|---------|
 | `create_plan(steps)` | Create or replace the plan. Each step has a `name`, `description`, and optional `depends_on` list. |
+| `start_step(step_name)` | Mark a step as in-progress before beginning work on it. |
 | `mark_step_done(step_name, result)` | Mark a step as completed and store its result for dependent steps. |
+| `mark_step_failed(step_name, reason)` | Mark a step as failed and store the reason. Failed steps block dependents. |
 | `get_plan()` | Return the current plan with all statuses and results. |
+| `get_ready_steps()` | Return steps whose dependencies are satisfied and can be started now, with dependency results included. |
+
+### Step Lifecycle
+
+Each step moves through a defined lifecycle:
+
+```
+pending → in_progress → completed
+                      → failed
+```
+
+- **pending**: Created but not yet started.
+- **in_progress**: The agent called `start_step`. Only one step can be in-progress at a time.
+- **completed**: `mark_step_done` was called with a result. Results are visible to dependent steps.
+- **failed**: `mark_step_failed` was called with a reason. Dependents cannot start until the plan is updated.
 
 ### Plan Structure
 
@@ -64,7 +84,7 @@ create_plan(steps=[
 
 - **Steps are goals, not tool calls.** A step like "Research competitor pricing" may involve multiple tool calls.
 - **Dependencies** declare which steps must complete first. The agent respects this ordering.
-- **Named results** from completed steps are visible via `get_plan()`, so dependent steps can reference prior outputs.
+- **Named results** from completed steps are visible via `get_plan()` and `get_ready_steps()`, so dependent steps can reference prior outputs.
 
 ### The LLM Stays in Control
 
@@ -79,41 +99,140 @@ The plan is guidance. The framework tracks state and stores results, but the LLM
 After each tool call, the agent sees a lightweight one-line reminder:
 
 ```
-[Plan: 2/5 steps completed. Ready: "analyze", "validate"]
+[Plan: 2/5 done. Active: "analyze". Ready: "validate" (from research: ...).]
 ```
 
-This prevents the agent from losing track of the plan during long sequences of tool calls.
+This prevents the agent from losing track of the plan during long sequences of tool calls. When a step has dependency results, they are included inline so the agent has context without calling `get_plan`.
 
 ### Replanning
 
-If results change the plan, the agent calls `create_plan` again with updated steps. Completed steps and their results are preserved automatically — only pending steps are replaced.
+If results change the plan, the agent calls `create_plan` again with updated steps. Completed steps and their results are preserved automatically — only pending and in-progress steps are replaced.
+
+If completed steps are dropped from the new plan, the agent receives a warning:
+
+```json
+{
+  "warning": "Completed steps dropped (not in new plan): ['old-step']. Their results are lost."
+}
+```
 
 ## Configuration
+
+```python
+analyst = await agent(
+    "You are a market research analyst.",
+    model="openai/gpt-4o",
+    tools=[search_web, write_report],
+    planning=True,
+    max_plan_steps=15,
+    strict_dependencies=True,
+    approve_plan=True,
+    max_tool_calls=30,
+)
+```
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `planning` | `False` | Enable planning tools. |
+| `max_plan_steps` | `20` | Maximum steps allowed in a plan. |
+| `strict_dependencies` | `False` | When `True`, `start_step` returns an error if dependencies are not completed. When `False`, it warns but proceeds. |
+| `approve_plan` | `False` | When `True`, `create_plan` pauses the workflow for human review before activating the plan. |
 | `max_tool_calls` | `10` | Plan tools count against this limit. Increase for planning agents (e.g., `30`). |
+
+### Dependency Enforcement
+
+By default (`strict_dependencies=False`), starting a step with unmet dependencies produces a warning but succeeds:
+
+```json
+{
+  "name": "analyze",
+  "status": "in_progress",
+  "warning": "Step 'analyze' has unsatisfied dependencies: ['research']. Proceeding anyway."
+}
+```
+
+With `strict_dependencies=True`, the same call returns an error and the step stays pending:
+
+```json
+{
+  "error": "Step 'analyze' has unsatisfied dependencies: ['research']. Complete them first."
+}
+```
+
+## Plan Approval
+
+When `approve_plan=True`, `create_plan` pauses the workflow and waits for a human to review the plan before it becomes active. Use Flux's resume mechanism to provide a decision.
+
+```python
+# Resume with the original plan (approve as-is)
+workflow.resume(execution_id, plan_dict)
+
+# Resume with a modified plan (change steps before activation)
+workflow.resume(execution_id, {
+    "steps": [
+        {"name": "research", "description": "Revised research scope."},
+        {"name": "report", "description": "Write the report.", "depends_on": ["research"]},
+    ]
+})
+
+# Reject the plan entirely
+workflow.resume(execution_id, {"rejected": True})
+```
+
+When rejected, `create_plan` returns `{"error": "Plan was rejected during review."}` and the agent must reconsider.
+
+## LTM Persistence
+
+When `long_term_memory` is provided alongside `planning=True`, plans are automatically saved after every state change and restored when the agent is next initialized. This allows plans to survive process restarts.
+
+```python
+from flux.tasks.ai.memory import LongTermMemory
+from flux.tasks.ai.memory.providers import InMemoryProvider, SqlAlchemyProvider
+
+# No LTM — plan exists only for the duration of the current agent() call (ephemeral)
+analyst = await agent("...", model="openai/gpt-4o", planning=True)
+
+# InMemoryProvider — plan survives multiple calls within the same process
+mem = LongTermMemory(InMemoryProvider(), scope="analyst")
+analyst = await agent("...", model="openai/gpt-4o", planning=True, long_term_memory=mem)
+
+# SqlAlchemyProvider — plan persists across process restarts
+engine_url = "sqlite:///agent_memory.db"
+mem = LongTermMemory(SqlAlchemyProvider(engine_url), scope="analyst")
+analyst = await agent("...", model="openai/gpt-4o", planning=True, long_term_memory=mem)
+```
+
+The three persistence tiers:
+
+| Tier | Provider | Survives restart? |
+|------|----------|-------------------|
+| Ephemeral | _(none)_ | No — plan is lost when agent() returns |
+| Process lifetime | `InMemoryProvider` | No — plan lives as long as the process |
+| Persistent | `SqlAlchemyProvider` | Yes — plan is saved to a database |
 
 ## Planning with Sub-Agents
 
 Planning composes with sub-agents. A manager agent can create a plan and delegate steps to specialist agents:
 
 ```python
-researcher = agent(
-    "You are a research specialist.",
-    model="ollama/llama3.2",
-    name="researcher",
-    description="Deep research using web sources.",
-    tools=[search_web],
-)
+@workflow
+async def managed_research(ctx: ExecutionContext):
+    researcher = await agent(
+        "You are a research specialist.",
+        model="ollama/llama3.2",
+        name="researcher",
+        description="Deep research using web sources.",
+        tools=[search_web],
+    )
 
-manager = agent(
-    "You are a project manager. Plan complex tasks and delegate to your team.",
-    model="openai/gpt-4o",
-    agents=[researcher],
-    planning=True,
-)
+    manager = await agent(
+        "You are a project manager. Plan complex tasks and delegate to your team.",
+        model="openai/gpt-4o",
+        agents=[researcher],
+        planning=True,
+    )
+
+    return await manager(ctx.input["task"])
 ```
 
 The manager creates a plan where steps use the `delegate` tool to assign work to sub-agents.
@@ -124,6 +243,7 @@ The manager creates a plan where steps use the `delegate` tool to assign work to
 - Multi-step research or analysis tasks
 - Workflows with data dependencies between steps
 - Tasks that benefit from upfront organization
+- Long-running tasks where failure recovery is important
 
 **Not needed:**
 - Simple question-answering
@@ -140,9 +260,24 @@ from flux.tasks.ai import AgentPlan, AgentStep
 step = AgentStep(name="research", description="Research the topic.")
 plan = AgentPlan(steps=[step])
 
-# Check status
+# Query by status
 plan.completed_steps()
 plan.pending_steps()
-plan.dependencies_satisfied(step)
+plan.in_progress_steps()
+plan.failed_steps()
+
+# Check readiness
+plan.ready_steps()                    # steps with satisfied dependencies
+plan.dependencies_satisfied(step)     # True/False
+plan.dependency_results(step)         # dict of dep_name -> result
+
+# Active step
+plan.active_step()                    # the in_progress step, or None
+
+# Summary (shown in status reminder)
 plan.summary()
+
+# Serialization
+plan.to_dict()
+AgentPlan.from_dict(data)
 ```

--- a/docs/advanced-features/agent-plans.md
+++ b/docs/advanced-features/agent-plans.md
@@ -1,0 +1,148 @@
+# Agent Plans
+
+Agent Plans let an agent create a structured roadmap before starting complex work. When `planning=True`, the agent gets three tools — `create_plan`, `mark_step_done`, and `get_plan` — that it uses to organize multi-step tasks with named steps and dependency tracking.
+
+Plans are guidance, not rigid execution. The agent decides when to plan, works through steps using its existing tools, skills, and sub-agents, and can replan at any time if circumstances change.
+
+## Quick Start
+
+```python
+from flux import task, workflow, ExecutionContext
+from flux.tasks.ai import agent
+
+@task
+async def search_web(query: str) -> str:
+    """Search the web for information."""
+    return f"Results for: {query}"
+
+@task
+async def write_report(content: str) -> str:
+    """Write a formatted report."""
+    return f"Report: {content}"
+
+analyst = agent(
+    "You are a market research analyst. Create a plan for complex research tasks.",
+    model="openai/gpt-4o",
+    tools=[search_web, write_report],
+    planning=True,
+)
+
+@workflow
+async def research(ctx: ExecutionContext):
+    return await analyst(f"Research the competitive landscape for {ctx.input['product']}.")
+```
+
+The agent will:
+1. Assess the task and decide to create a plan
+2. Call `create_plan` with named steps and dependencies
+3. Work through each step using `search_web`, `write_report`, etc.
+4. Call `mark_step_done` after each step to record results
+5. Return a final response when done
+
+## How It Works
+
+### The Three Tools
+
+When `planning=True`, the agent receives:
+
+| Tool | Purpose |
+|------|---------|
+| `create_plan(steps)` | Create or replace the plan. Each step has a `name`, `description`, and optional `depends_on` list. |
+| `mark_step_done(step_name, result)` | Mark a step as completed and store its result for dependent steps. |
+| `get_plan()` | Return the current plan with all statuses and results. |
+
+### Plan Structure
+
+```python
+# The LLM calls create_plan with steps like:
+create_plan(steps=[
+    {"name": "research", "description": "Search for competitor pricing data."},
+    {"name": "analyze", "description": "Analyze pricing trends.", "depends_on": ["research"]},
+    {"name": "report", "description": "Write the final report.", "depends_on": ["analyze"]},
+])
+```
+
+- **Steps are goals, not tool calls.** A step like "Research competitor pricing" may involve multiple tool calls.
+- **Dependencies** declare which steps must complete first. The agent respects this ordering.
+- **Named results** from completed steps are visible via `get_plan()`, so dependent steps can reference prior outputs.
+
+### The LLM Stays in Control
+
+The plan is guidance. The framework tracks state and stores results, but the LLM decides:
+- **When to plan** — simple tasks don't need a plan
+- **Which step to work on** — it picks the next step based on the plan
+- **When to replan** — call `create_plan` again if circumstances change
+- **When to abandon** — stop using plan tools and respond directly
+
+### Status Reminder
+
+After each tool call, the agent sees a lightweight one-line reminder:
+
+```
+[Plan: 2/5 steps completed. Ready: "analyze", "validate"]
+```
+
+This prevents the agent from losing track of the plan during long sequences of tool calls.
+
+### Replanning
+
+If results change the plan, the agent calls `create_plan` again with updated steps. Completed steps and their results are preserved automatically — only pending steps are replaced.
+
+## Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `planning` | `False` | Enable planning tools. |
+| `max_tool_calls` | `10` | Plan tools count against this limit. Increase for planning agents (e.g., `30`). |
+
+## Planning with Sub-Agents
+
+Planning composes with sub-agents. A manager agent can create a plan and delegate steps to specialist agents:
+
+```python
+researcher = agent(
+    "You are a research specialist.",
+    model="ollama/llama3.2",
+    name="researcher",
+    description="Deep research using web sources.",
+    tools=[search_web],
+)
+
+manager = agent(
+    "You are a project manager. Plan complex tasks and delegate to your team.",
+    model="openai/gpt-4o",
+    agents=[researcher],
+    planning=True,
+)
+```
+
+The manager creates a plan where steps use the `delegate` tool to assign work to sub-agents.
+
+## When to Use Planning
+
+**Good fit:**
+- Multi-step research or analysis tasks
+- Workflows with data dependencies between steps
+- Tasks that benefit from upfront organization
+
+**Not needed:**
+- Simple question-answering
+- Single tool call tasks
+- Purely exploratory work where the next step is unpredictable
+
+## Data Structures
+
+For programmatic access (e.g., in tests):
+
+```python
+from flux.tasks.ai import AgentPlan, AgentStep
+
+step = AgentStep(name="research", description="Research the topic.")
+plan = AgentPlan(steps=[step])
+
+# Check status
+plan.completed_steps()
+plan.pending_steps()
+plan.dependencies_satisfied(step)
+plan.summary()
+```

--- a/docs/advanced-features/ai-agents.md
+++ b/docs/advanced-features/ai-agents.md
@@ -5,20 +5,19 @@
 ## Quick Start
 
 ```python
-from flux import task, workflow, ExecutionContext
+from flux import workflow, ExecutionContext
 from flux.tasks.ai import agent
-
-assistant = agent(
-    "You are a helpful assistant.",
-    model="ollama/llama3.2",
-)
 
 @workflow
 async def my_workflow(ctx: ExecutionContext):
+    assistant = await agent(
+        "You are a helpful assistant.",
+        model="ollama/llama3.2",
+    )
     return await assistant("What is the capital of France?")
 ```
 
-The returned value is a regular Flux `@task`. Call it with an instruction string and, optionally, a `context` string for additional background.
+`agent()` is an async function that returns a Flux `@task`. Call it with an instruction string and, optionally, a `context` string for additional background.
 
 ## Supported Providers
 
@@ -51,7 +50,7 @@ pip install google-genai     # for Google Gemini models
 Ollama runs locally. No API key required. Start the Ollama server before running your workflow.
 
 ```python
-assistant = agent(
+assistant = await agent(
     "You are a helpful assistant.",
     model="ollama/llama3.2",
 )
@@ -63,7 +62,7 @@ assistant = agent(
 import os
 os.environ["OPENAI_API_KEY"] = "sk-..."
 
-assistant = agent(
+assistant = await agent(
     "You are a helpful assistant.",
     model="openai/gpt-4o",
 )
@@ -75,7 +74,7 @@ assistant = agent(
 import os
 os.environ["ANTHROPIC_API_KEY"] = "sk-ant-..."
 
-assistant = agent(
+assistant = await agent(
     "You are a helpful assistant.",
     model="anthropic/claude-sonnet-4-20250514",
 )
@@ -87,7 +86,7 @@ assistant = agent(
 import os
 os.environ["GOOGLE_API_KEY"] = "AIza..."  # or GEMINI_API_KEY
 
-assistant = agent(
+assistant = await agent(
     "You are a helpful assistant.",
     model="google/gemini-2.5-flash",
 )
@@ -96,7 +95,7 @@ assistant = agent(
 ## Parameters
 
 ```python
-def agent(
+async def agent(
     system_prompt: str,
     *,
     model: str,
@@ -153,14 +152,13 @@ async def search_web(query: str) -> str:
     """Search the web and return relevant results."""
     ...
 
-assistant = agent(
-    "You are a helpful assistant with access to real-time data.",
-    model="openai/gpt-4o",
-    tools=[get_weather, search_web],
-)
-
 @workflow
 async def my_workflow(ctx: ExecutionContext):
+    assistant = await agent(
+        "You are a helpful assistant with access to real-time data.",
+        model="openai/gpt-4o",
+        tools=[get_weather, search_web],
+    )
     return await assistant("What's the weather like in Tokyo?")
 ```
 
@@ -171,7 +169,7 @@ Each tool call is recorded as a Flux task event, so tool invocations are fully o
 The `max_tool_calls` parameter (default `10`) caps the number of tool call iterations per agent invocation. When the limit is reached, the agent is forced to produce a final answer with whatever it has gathered.
 
 ```python
-assistant = agent(
+assistant = await agent(
     "You are a research assistant.",
     model="openai/gpt-4o",
     tools=[search_web],
@@ -193,14 +191,13 @@ class Sentiment(BaseModel):
     confidence: float # 0.0 to 1.0
     reason: str
 
-classifier = agent(
-    "You are a sentiment analysis assistant. Respond only with structured JSON.",
-    model="openai/gpt-4o",
-    response_format=Sentiment,
-)
-
 @workflow
 async def analyze(ctx: ExecutionContext):
+    classifier = await agent(
+        "You are a sentiment analysis assistant. Respond only with structured JSON.",
+        model="openai/gpt-4o",
+        response_format=Sentiment,
+    )
     result: Sentiment = await classifier(ctx.input["text"])
     return {"label": result.label, "confidence": result.confidence}
 ```
@@ -217,21 +214,20 @@ By default, `stream=True` and the agent emits progress events as the LLM produce
 from flux import workflow, ExecutionContext
 from flux.tasks.ai import agent
 
-assistant = agent(
-    "You are a helpful assistant.",
-    model="anthropic/claude-sonnet-4-20250514",
-    stream=True,  # default, can be omitted
-)
-
 @workflow
 async def my_workflow(ctx: ExecutionContext):
+    assistant = await agent(
+        "You are a helpful assistant.",
+        model="anthropic/claude-sonnet-4-20250514",
+        stream=True,  # default, can be omitted
+    )
     return await assistant("Explain the theory of relativity.")
 ```
 
 To disable streaming:
 
 ```python
-assistant = agent(
+assistant = await agent(
     "You are a helpful assistant.",
     model="openai/gpt-4o",
     stream=False,
@@ -251,14 +247,13 @@ Pass `working_memory()` to maintain conversation history across multiple agent c
 ```python
 from flux.tasks.ai.memory import working_memory
 
-chatbot = agent(
-    "You are a helpful assistant.",
-    model="openai/gpt-4o",
-    working_memory=working_memory(),
-)
-
 @workflow
 async def conversation(ctx: ExecutionContext):
+    chatbot = await agent(
+        "You are a helpful assistant.",
+        model="openai/gpt-4o",
+        working_memory=working_memory(),
+    )
     r1 = await chatbot("What is Python?")
     r2 = await chatbot("What about asyncio?")  # aware of the Python context
     return r2
@@ -271,7 +266,7 @@ Pass `long_term_memory()` to persist facts across workflow executions:
 ```python
 from flux.tasks.ai.memory import long_term_memory, sqlite
 
-assistant = agent(
+assistant = await agent(
     "You are a personal assistant. Remember important facts about the user.",
     model="openai/gpt-4o",
     long_term_memory=long_term_memory(
@@ -292,7 +287,7 @@ from flux.tasks.ai import agent, SkillCatalog
 
 catalog = SkillCatalog.from_directory("./skills")
 
-assistant = agent(
+assistant = await agent(
     "You are a research assistant.",
     model="openai/gpt-4o",
     tools=[search_web],
@@ -307,11 +302,11 @@ See [Agent Skills](agent-skills.md) for the full skills reference including `SKI
 Because `agent()` returns a Flux `@task`, you can chain `.with_options()` to configure retry, timeout, and other task-level settings:
 
 ```python
-assistant = agent(
+assistant = (await agent(
     "You are a helpful assistant.",
     model="openai/gpt-4o",
     tools=[search_web],
-).with_options(
+)).with_options(
     retry_max_attempts=3,
     timeout=120,
 )
@@ -322,7 +317,7 @@ assistant = agent(
 ```python
 from flux.tasks.ai import agent
 
-agent(
+await agent(
     system_prompt: str,
     *,
     model: str,

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,20 @@
    - [MCP Client](advanced-features/task-patterns.md#mcp-client)
    - [Performance Considerations](advanced-features/task-patterns.md#performance-considerations)
 
+### [AI Agents](advanced-features/ai-agents.md)
+   - [Supported Providers](advanced-features/ai-agents.md#supported-providers)
+   - [Tool Calling](advanced-features/ai-agents.md#tool-calling)
+   - [Streaming](advanced-features/ai-agents.md#streaming)
+   - [Structured Output](advanced-features/ai-agents.md#structured-output)
+   - [Memory](advanced-features/ai-agents.md#memory)
+
+### [Agent Plans](advanced-features/agent-plans.md)
+   - [Plan Tools](advanced-features/agent-plans.md#the-six-tools)
+   - [Step Lifecycle](advanced-features/agent-plans.md#step-lifecycle)
+   - [Replanning](advanced-features/agent-plans.md#replanning)
+   - [Plan Approval](advanced-features/agent-plans.md#plan-approval)
+   - [Planning with Sub-Agents](advanced-features/agent-plans.md#planning-with-sub-agents)
+
 ### [Agent Skills](advanced-features/agent-skills.md)
    - [Defining Skills](advanced-features/agent-skills.md#defining-skills)
    - [SkillCatalog](advanced-features/agent-skills.md#skillcatalog)

--- a/docs/introduction/features.md
+++ b/docs/introduction/features.md
@@ -31,8 +31,10 @@
 
 ## AI & MCP Integration
 - **AI Agents**: LLM-powered tasks with tool use, structured output, and conversation history
+- **Agent Plans**: Structured multi-step planning with dependency tracking, replanning, and plan approval
+- **Agent Skills**: Reusable prompt-based capabilities that agents discover and invoke at runtime
 - **MCP Client**: Connect to external MCP servers, discover tools at runtime, and use them as Flux tasks
-- **Provider Support**: Ollama, OpenAI, and Anthropic for AI agents; any MCP-compliant server for tools
+- **Provider Support**: Ollama, OpenAI, Anthropic, and Google Gemini for AI agents; any MCP-compliant server for tools
 
 ## API Integration
 - **HTTP API**: Built-in FastAPI server for HTTP access

--- a/examples/ai/blog_post_writer_ollama.py
+++ b/examples/ai/blog_post_writer_ollama.py
@@ -31,34 +31,41 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from flux import ExecutionContext, workflow
 from flux.tasks.ai import agent
 
 
-researcher = agent(
-    "You are an experienced research analyst. Research topics thoroughly and produce "
-    "structured summaries with key findings, trends, perspectives, examples, and future outlook. "
-    "Organize your findings with clear headings and bullet points.",
-    model="ollama/llama3",
-    name="researcher",
+researcher = asyncio.run(
+    agent(
+        "You are an experienced research analyst. Research topics thoroughly and produce "
+        "structured summaries with key findings, trends, perspectives, examples, and future outlook. "
+        "Organize your findings with clear headings and bullet points.",
+        model="ollama/llama3",
+        name="researcher",
+    ),
 ).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=120)
 
-writer = agent(
-    "You are a skilled content writer. Transform research into compelling blog posts "
-    "with a title (as a markdown heading), an engaging introduction, well-organized body "
-    "sections with clear headings, and a strong conclusion. Target 800-1200 words.",
-    model="ollama/llama3",
-    name="writer",
+writer = asyncio.run(
+    agent(
+        "You are a skilled content writer. Transform research into compelling blog posts "
+        "with a title (as a markdown heading), an engaging introduction, well-organized body "
+        "sections with clear headings, and a strong conclusion. Target 800-1200 words.",
+        model="ollama/llama3",
+        name="writer",
+    ),
 ).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=120)
 
-editor = agent(
-    "You are an experienced content editor. Polish drafts for clarity, grammar, flow, "
-    "tone consistency, and argument strength. Return only the final polished post — "
-    "no editorial notes.",
-    model="ollama/llama3",
-    name="editor",
+editor = asyncio.run(
+    agent(
+        "You are an experienced content editor. Polish drafts for clarity, grammar, flow, "
+        "tone consistency, and argument strength. Return only the final polished post — "
+        "no editorial notes.",
+        model="ollama/llama3",
+        name="editor",
+    ),
 ).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=120)
 
 

--- a/examples/ai/blog_post_writer_ollama.py
+++ b/examples/ai/blog_post_writer_ollama.py
@@ -31,42 +31,10 @@ Usage:
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from flux import ExecutionContext, workflow
 from flux.tasks.ai import agent
-
-
-researcher = asyncio.run(
-    agent(
-        "You are an experienced research analyst. Research topics thoroughly and produce "
-        "structured summaries with key findings, trends, perspectives, examples, and future outlook. "
-        "Organize your findings with clear headings and bullet points.",
-        model="ollama/llama3",
-        name="researcher",
-    ),
-).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=120)
-
-writer = asyncio.run(
-    agent(
-        "You are a skilled content writer. Transform research into compelling blog posts "
-        "with a title (as a markdown heading), an engaging introduction, well-organized body "
-        "sections with clear headings, and a strong conclusion. Target 800-1200 words.",
-        model="ollama/llama3",
-        name="writer",
-    ),
-).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=120)
-
-editor = asyncio.run(
-    agent(
-        "You are an experienced content editor. Polish drafts for clarity, grammar, flow, "
-        "tone consistency, and argument strength. Return only the final polished post — "
-        "no editorial notes.",
-        model="ollama/llama3",
-        name="editor",
-    ),
-).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=120)
 
 
 @workflow
@@ -97,6 +65,30 @@ async def blog_post_writer_ollama(ctx: ExecutionContext[dict[str, Any]]):
             "error": "Missing required parameter 'topic'",
             "execution_id": ctx.execution_id,
         }
+
+    researcher = await agent(
+        "You are an experienced research analyst. Research topics thoroughly and produce "
+        "structured summaries with key findings, trends, perspectives, examples, and future outlook. "
+        "Organize your findings with clear headings and bullet points.",
+        model="ollama/llama3",
+        name="researcher",
+    )
+
+    writer = await agent(
+        "You are a skilled content writer. Transform research into compelling blog posts "
+        "with a title (as a markdown heading), an engaging introduction, well-organized body "
+        "sections with clear headings, and a strong conclusion. Target 800-1200 words.",
+        model="ollama/llama3",
+        name="writer",
+    )
+
+    editor = await agent(
+        "You are an experienced content editor. Polish drafts for clarity, grammar, flow, "
+        "tone consistency, and argument strength. Return only the final polished post — "
+        "no editorial notes.",
+        model="ollama/llama3",
+        name="editor",
+    )
 
     research = await researcher(f"Research this topic: {topic}")
     draft = await writer(f"Write a blog post about: {topic}", context=research)

--- a/examples/ai/memory_chatbot_ollama.py
+++ b/examples/ai/memory_chatbot_ollama.py
@@ -8,21 +8,12 @@ Usage:
 """
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from flux import workflow, ExecutionContext
 from flux.tasks.ai import agent
 from flux.tasks.ai.memory import working_memory
 from flux.tasks import pause
-
-chatbot = asyncio.run(
-    agent(
-        system_prompt="You are a friendly assistant. Keep responses concise.",
-        model="ollama/llama3.2",
-        working_memory=working_memory(),
-    ),
-)
 
 
 @workflow
@@ -33,6 +24,12 @@ async def memory_chatbot(ctx: ExecutionContext[dict[str, Any]]):
 
         initial_input = json.loads(initial_input)
     message = initial_input.get("message", "Hello!")
+
+    chatbot = await agent(
+        system_prompt="You are a friendly assistant. Keep responses concise.",
+        model="ollama/llama3.2",
+        working_memory=working_memory(),
+    )
 
     response = await chatbot(message)
     print(f"Assistant: {response}")

--- a/examples/ai/memory_chatbot_ollama.py
+++ b/examples/ai/memory_chatbot_ollama.py
@@ -8,6 +8,7 @@ Usage:
 """
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from flux import workflow, ExecutionContext
@@ -15,10 +16,12 @@ from flux.tasks.ai import agent
 from flux.tasks.ai.memory import working_memory
 from flux.tasks import pause
 
-chatbot = agent(
-    system_prompt="You are a friendly assistant. Keep responses concise.",
-    model="ollama/llama3.2",
-    working_memory=working_memory(),
+chatbot = asyncio.run(
+    agent(
+        system_prompt="You are a friendly assistant. Keep responses concise.",
+        model="ollama/llama3.2",
+        working_memory=working_memory(),
+    ),
 )
 
 

--- a/examples/ai/memory_long_term_ollama.py
+++ b/examples/ai/memory_long_term_ollama.py
@@ -8,27 +8,11 @@ Usage:
 """
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from flux import workflow, ExecutionContext
 from flux.tasks.ai import agent
 from flux.tasks.ai.memory import working_memory, long_term_memory, sqlite
-
-assistant = asyncio.run(
-    agent(
-        system_prompt=(
-            "You are a personal assistant. Remember important facts about the user "
-            "using your memory tools. Always check memory at the start of a conversation."
-        ),
-        model="ollama/llama3.2",
-        working_memory=working_memory(),
-        long_term_memory=long_term_memory(
-            provider=sqlite("memory_example.db"),
-            scope="user:default",
-        ),
-    ),
-)
 
 
 @workflow
@@ -41,6 +25,19 @@ async def memory_long_term(ctx: ExecutionContext[dict[str, Any]]):
     message = initial_input.get(
         "message",
         "Hi! My name is Alice and I work as a software developer.",
+    )
+
+    assistant = await agent(
+        system_prompt=(
+            "You are a personal assistant. Remember important facts about the user "
+            "using your memory tools. Always check memory at the start of a conversation."
+        ),
+        model="ollama/llama3.2",
+        working_memory=working_memory(),
+        long_term_memory=long_term_memory(
+            provider=sqlite("memory_example.db"),
+            scope="user:default",
+        ),
     )
     response = await assistant(message)
     return response

--- a/examples/ai/memory_long_term_ollama.py
+++ b/examples/ai/memory_long_term_ollama.py
@@ -8,22 +8,25 @@ Usage:
 """
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from flux import workflow, ExecutionContext
 from flux.tasks.ai import agent
 from flux.tasks.ai.memory import working_memory, long_term_memory, sqlite
 
-assistant = agent(
-    system_prompt=(
-        "You are a personal assistant. Remember important facts about the user "
-        "using your memory tools. Always check memory at the start of a conversation."
-    ),
-    model="ollama/llama3.2",
-    working_memory=working_memory(),
-    long_term_memory=long_term_memory(
-        provider=sqlite("memory_example.db"),
-        scope="user:default",
+assistant = asyncio.run(
+    agent(
+        system_prompt=(
+            "You are a personal assistant. Remember important facts about the user "
+            "using your memory tools. Always check memory at the start of a conversation."
+        ),
+        model="ollama/llama3.2",
+        working_memory=working_memory(),
+        long_term_memory=long_term_memory(
+            provider=sqlite("memory_example.db"),
+            scope="user:default",
+        ),
     ),
 )
 

--- a/examples/ai/memory_shared_agents_ollama.py
+++ b/examples/ai/memory_shared_agents_ollama.py
@@ -7,6 +7,7 @@ Usage:
 """
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from flux import workflow, ExecutionContext
@@ -15,22 +16,26 @@ from flux.tasks.ai.memory import long_term_memory, in_memory
 
 shared = long_term_memory(provider=in_memory(), scope="review:pr-42")
 
-reviewer = agent(
-    system_prompt=(
-        "You are a code reviewer. Analyze the code and store your findings "
-        "using store_memory. Organize findings by category (bugs, style, security)."
+reviewer = asyncio.run(
+    agent(
+        system_prompt=(
+            "You are a code reviewer. Analyze the code and store your findings "
+            "using store_memory. Organize findings by category (bugs, style, security)."
+        ),
+        model="ollama/llama3.2",
+        long_term_memory=shared,
     ),
-    model="ollama/llama3.2",
-    long_term_memory=shared,
 )
 
-summarizer = agent(
-    system_prompt=(
-        "You are a summary writer. Use recall_memory and list_memory_keys to read "
-        "the reviewer's findings, then write a concise summary."
+summarizer = asyncio.run(
+    agent(
+        system_prompt=(
+            "You are a summary writer. Use recall_memory and list_memory_keys to read "
+            "the reviewer's findings, then write a concise summary."
+        ),
+        model="ollama/llama3.2",
+        long_term_memory=shared,
     ),
-    model="ollama/llama3.2",
-    long_term_memory=shared,
 )
 
 

--- a/examples/ai/memory_shared_agents_ollama.py
+++ b/examples/ai/memory_shared_agents_ollama.py
@@ -7,7 +7,6 @@ Usage:
 """
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from flux import workflow, ExecutionContext
@@ -15,28 +14,6 @@ from flux.tasks.ai import agent
 from flux.tasks.ai.memory import long_term_memory, in_memory
 
 shared = long_term_memory(provider=in_memory(), scope="review:pr-42")
-
-reviewer = asyncio.run(
-    agent(
-        system_prompt=(
-            "You are a code reviewer. Analyze the code and store your findings "
-            "using store_memory. Organize findings by category (bugs, style, security)."
-        ),
-        model="ollama/llama3.2",
-        long_term_memory=shared,
-    ),
-)
-
-summarizer = asyncio.run(
-    agent(
-        system_prompt=(
-            "You are a summary writer. Use recall_memory and list_memory_keys to read "
-            "the reviewer's findings, then write a concise summary."
-        ),
-        model="ollama/llama3.2",
-        long_term_memory=shared,
-    ),
-)
 
 
 @workflow
@@ -47,6 +24,24 @@ async def memory_shared_agents(ctx: ExecutionContext[dict[str, Any]]):
 
         initial_input = json.loads(initial_input)
     code = initial_input.get("code", "def add(a, b): return a + b  # TODO: add validation")
+
+    reviewer = await agent(
+        system_prompt=(
+            "You are a code reviewer. Analyze the code and store your findings "
+            "using store_memory. Organize findings by category (bugs, style, security)."
+        ),
+        model="ollama/llama3.2",
+        long_term_memory=shared,
+    )
+
+    summarizer = await agent(
+        system_prompt=(
+            "You are a summary writer. Use recall_memory and list_memory_keys to read "
+            "the reviewer's findings, then write a concise summary."
+        ),
+        model="ollama/llama3.2",
+        long_term_memory=shared,
+    )
 
     await reviewer(f"Review this code:\n\n```python\n{code}\n```")
     summary = await summarizer("Summarize the code review findings.")

--- a/examples/ai/multi_agent_code_review_ollama.py
+++ b/examples/ai/multi_agent_code_review_ollama.py
@@ -34,6 +34,7 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 from datetime import datetime
@@ -65,39 +66,47 @@ Provide your suggestions as a JSON array. Each suggestion should have:
 Respond with ONLY the JSON array, no other text."""
 
 
-security_reviewer = agent(
-    "You are a security code reviewer with expertise in finding vulnerabilities. "
-    "Analyze code for: SQL injection, XSS, authentication issues, hardcoded secrets, "
-    "input validation, command injection, path traversal, insecure cryptography, "
-    "race conditions, and sensitive data exposure.",
-    model="ollama/llama3.2",
-    name="security_review",
+security_reviewer = asyncio.run(
+    agent(
+        "You are a security code reviewer with expertise in finding vulnerabilities. "
+        "Analyze code for: SQL injection, XSS, authentication issues, hardcoded secrets, "
+        "input validation, command injection, path traversal, insecure cryptography, "
+        "race conditions, and sensitive data exposure.",
+        model="ollama/llama3.2",
+        name="security_review",
+    ),
 ).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=60)
 
-performance_reviewer = agent(
-    "You are a performance optimization expert. "
-    "Review code for: algorithm efficiency, unnecessary loops, inefficient data structures, "
-    "memory leaks, database query optimization, missing caching, redundant computations, "
-    "I/O bottlenecks, and blocking operations.",
-    model="ollama/llama3.2",
-    name="performance_review",
+performance_reviewer = asyncio.run(
+    agent(
+        "You are a performance optimization expert. "
+        "Review code for: algorithm efficiency, unnecessary loops, inefficient data structures, "
+        "memory leaks, database query optimization, missing caching, redundant computations, "
+        "I/O bottlenecks, and blocking operations.",
+        model="ollama/llama3.2",
+        name="performance_review",
+    ),
 ).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=60)
 
-style_reviewer = agent(
-    "You are a code quality and style expert. "
-    "Review code for: readability, naming conventions, organization, documentation, "
-    "DRY violations, function complexity, magic numbers, error handling, type hints, "
-    "and PEP 8 compliance.",
-    model="ollama/llama3.2",
-    name="style_review",
+style_reviewer = asyncio.run(
+    agent(
+        "You are a code quality and style expert. "
+        "Review code for: readability, naming conventions, organization, documentation, "
+        "DRY violations, function complexity, magic numbers, error handling, type hints, "
+        "and PEP 8 compliance.",
+        model="ollama/llama3.2",
+        name="style_review",
+    ),
 ).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=60)
 
-testing_reviewer = agent(
-    "You are a testing and quality assurance expert. "
-    "Suggest: critical test cases, edge cases, error conditions, integration tests, "
-    "mock requirements, test data, missing coverage, and regression tests.",
-    model="ollama/llama3.2",
-    name="testing_review",
+testing_reviewer = asyncio.run(
+    agent(
+        "You are a testing and quality assurance expert. "
+        "Suggest: critical test cases, edge cases, error conditions, integration tests, "
+        "mock requirements, test data, missing coverage, and regression tests.",
+        model="ollama/llama3.2",
+        name="testing_review",
+    ),
 ).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=60)
 
 

--- a/examples/ai/multi_agent_code_review_ollama.py
+++ b/examples/ai/multi_agent_code_review_ollama.py
@@ -34,7 +34,6 @@ Usage:
 
 from __future__ import annotations
 
-import asyncio
 import json
 import re
 from datetime import datetime
@@ -64,50 +63,6 @@ Provide your suggestions as a JSON array. Each suggestion should have:
 - importance: string (why it matters)
 
 Respond with ONLY the JSON array, no other text."""
-
-
-security_reviewer = asyncio.run(
-    agent(
-        "You are a security code reviewer with expertise in finding vulnerabilities. "
-        "Analyze code for: SQL injection, XSS, authentication issues, hardcoded secrets, "
-        "input validation, command injection, path traversal, insecure cryptography, "
-        "race conditions, and sensitive data exposure.",
-        model="ollama/llama3.2",
-        name="security_review",
-    ),
-).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=60)
-
-performance_reviewer = asyncio.run(
-    agent(
-        "You are a performance optimization expert. "
-        "Review code for: algorithm efficiency, unnecessary loops, inefficient data structures, "
-        "memory leaks, database query optimization, missing caching, redundant computations, "
-        "I/O bottlenecks, and blocking operations.",
-        model="ollama/llama3.2",
-        name="performance_review",
-    ),
-).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=60)
-
-style_reviewer = asyncio.run(
-    agent(
-        "You are a code quality and style expert. "
-        "Review code for: readability, naming conventions, organization, documentation, "
-        "DRY violations, function complexity, magic numbers, error handling, type hints, "
-        "and PEP 8 compliance.",
-        model="ollama/llama3.2",
-        name="style_review",
-    ),
-).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=60)
-
-testing_reviewer = asyncio.run(
-    agent(
-        "You are a testing and quality assurance expert. "
-        "Suggest: critical test cases, edge cases, error conditions, integration tests, "
-        "mock requirements, test data, missing coverage, and regression tests.",
-        model="ollama/llama3.2",
-        name="testing_review",
-    ),
-).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=60)
 
 
 def parse_llm_json_response(content: str) -> list[dict[str, Any]]:
@@ -184,6 +139,14 @@ def _parse_review(agent_name: str, raw_output: str, key: str = "findings") -> di
 @task
 async def run_security(input_data: dict[str, Any]) -> dict[str, Any]:
     """Graph node: run security review agent."""
+    security_reviewer = await agent(
+        "You are a security code reviewer with expertise in finding vulnerabilities. "
+        "Analyze code for: SQL injection, XSS, authentication issues, hardcoded secrets, "
+        "input validation, command injection, path traversal, insecure cryptography, "
+        "race conditions, and sensitive data exposure.",
+        model="ollama/llama3.2",
+        name="security_review",
+    )
     prompt = _build_review_prompt(
         input_data["code"],
         input_data.get("file_path"),
@@ -197,6 +160,14 @@ async def run_security(input_data: dict[str, Any]) -> dict[str, Any]:
 @task
 async def run_performance(input_data: dict[str, Any]) -> dict[str, Any]:
     """Graph node: run performance review agent."""
+    performance_reviewer = await agent(
+        "You are a performance optimization expert. "
+        "Review code for: algorithm efficiency, unnecessary loops, inefficient data structures, "
+        "memory leaks, database query optimization, missing caching, redundant computations, "
+        "I/O bottlenecks, and blocking operations.",
+        model="ollama/llama3.2",
+        name="performance_review",
+    )
     prompt = _build_review_prompt(
         input_data["code"],
         input_data.get("file_path"),
@@ -210,6 +181,14 @@ async def run_performance(input_data: dict[str, Any]) -> dict[str, Any]:
 @task
 async def run_style(input_data: dict[str, Any]) -> dict[str, Any]:
     """Graph node: run style review agent."""
+    style_reviewer = await agent(
+        "You are a code quality and style expert. "
+        "Review code for: readability, naming conventions, organization, documentation, "
+        "DRY violations, function complexity, magic numbers, error handling, type hints, "
+        "and PEP 8 compliance.",
+        model="ollama/llama3.2",
+        name="style_review",
+    )
     prompt = _build_review_prompt(
         input_data["code"],
         input_data.get("file_path"),
@@ -223,6 +202,13 @@ async def run_style(input_data: dict[str, Any]) -> dict[str, Any]:
 @task
 async def run_testing(input_data: dict[str, Any]) -> dict[str, Any]:
     """Graph node: run testing review agent."""
+    testing_reviewer = await agent(
+        "You are a testing and quality assurance expert. "
+        "Suggest: critical test cases, edge cases, error conditions, integration tests, "
+        "mock requirements, test data, missing coverage, and regression tests.",
+        model="ollama/llama3.2",
+        name="testing_review",
+    )
     prompt = _build_review_prompt(
         input_data["code"],
         input_data.get("file_path"),

--- a/examples/ai/planning_agent_ollama.py
+++ b/examples/ai/planning_agent_ollama.py
@@ -14,7 +14,7 @@ Key Features:
 
 Prerequisites:
     1. Install Ollama: https://ollama.ai
-    2. Pull a model: ollama pull llama3.2
+    2. Pull a model: ollama pull mistral-small:24b
     3. Start Ollama service: ollama serve
 
 Usage:
@@ -23,6 +23,7 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from flux import ExecutionContext, task, workflow
@@ -63,15 +64,19 @@ async def write_report(topic: str, content: str) -> str:
     )
 
 
-analyst = agent(
-    "You are a thorough market research analyst. "
-    "For complex research tasks, create a plan to organize your work. "
-    "Use your tools to gather data, analyze it, and produce reports.",
-    model="ollama/mistral-small:24b",
-    name="planning-analyst",
-    tools=[search_web, analyze_data, write_report],
-    planning=True,
-    max_tool_calls=30,
+analyst = asyncio.run(
+    agent(
+        "You are a thorough market research analyst. "
+        "For complex research tasks, create a plan to organize your work. "
+        "Call start_step before working on each step. Mark steps done with mark_step_done, "
+        "or mark_step_failed if they cannot be completed. Use get_ready_steps to see what "
+        "can be started next. Use your tools to gather data, analyze it, and produce reports.",
+        model="ollama/mistral-small:24b",
+        name="planning-analyst",
+        tools=[search_web, analyze_data, write_report],
+        planning=True,
+        max_tool_calls=30,
+    ),
 ).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=600)
 
 
@@ -127,4 +132,4 @@ if __name__ == "__main__":  # pragma: no cover
         print(f"Error: {e}")
         print("\nMake sure:")
         print("1. Ollama is running: ollama serve")
-        print("2. Model is pulled: ollama pull llama3.2")
+        print("2. Model is pulled: ollama pull mistral-small:24b")

--- a/examples/ai/planning_agent_ollama.py
+++ b/examples/ai/planning_agent_ollama.py
@@ -23,7 +23,6 @@ Usage:
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from flux import ExecutionContext, task, workflow
@@ -64,22 +63,6 @@ async def write_report(topic: str, content: str) -> str:
     )
 
 
-analyst = asyncio.run(
-    agent(
-        "You are a thorough market research analyst. "
-        "For complex research tasks, create a plan to organize your work. "
-        "Call start_step before working on each step. Mark steps done with mark_step_done, "
-        "or mark_step_failed if they cannot be completed. Use get_ready_steps to see what "
-        "can be started next. Use your tools to gather data, analyze it, and produce reports.",
-        model="ollama/mistral-small:24b",
-        name="planning-analyst",
-        tools=[search_web, analyze_data, write_report],
-        planning=True,
-        max_tool_calls=30,
-    ),
-).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=600)
-
-
 @workflow
 async def planning_agent_ollama(ctx: ExecutionContext[dict[str, Any]]):
     """
@@ -92,6 +75,19 @@ async def planning_agent_ollama(ctx: ExecutionContext[dict[str, Any]]):
     """
     input_data = ctx.input or {}
     topic = input_data.get("topic", "AI agent frameworks")
+
+    analyst = await agent(
+        "You are a thorough market research analyst. "
+        "For complex research tasks, create a plan to organize your work. "
+        "Call start_step before working on each step. Mark steps done with mark_step_done, "
+        "or mark_step_failed if they cannot be completed. Use get_ready_steps to see what "
+        "can be started next. Use your tools to gather data, analyze it, and produce reports.",
+        model="ollama/mistral-small:24b",
+        name="planning-analyst",
+        tools=[search_web, analyze_data, write_report],
+        planning=True,
+        max_tool_calls=30,
+    )
 
     response = await analyst(
         f"Research the competitive landscape for '{topic}' and produce "

--- a/examples/ai/planning_agent_ollama.py
+++ b/examples/ai/planning_agent_ollama.py
@@ -1,0 +1,130 @@
+"""
+Planning Agent using Ollama.
+
+Demonstrates how to create an agent with planning capabilities. The agent
+creates a structured plan before tackling complex tasks, works through each
+step, and tracks progress with named results.
+
+Key Features:
+- LLM-driven plan creation (the agent decides when to plan)
+- Named steps with dependency tracking
+- Automatic result storage for dependent steps
+- Status tracking with plan summaries
+- Replanning when circumstances change
+
+Prerequisites:
+    1. Install Ollama: https://ollama.ai
+    2. Pull a model: ollama pull llama3.2
+    3. Start Ollama service: ollama serve
+
+Usage:
+    python examples/ai/planning_agent_ollama.py
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from flux import ExecutionContext, task, workflow
+from flux.tasks.ai import agent
+
+
+@task
+async def search_web(query: str) -> str:
+    """Search the web and return relevant results for a query."""
+    return (
+        f"Results for '{query}':\n"
+        f"1. Market analysis: {query} shows 15% growth in 2026\n"
+        f"2. Key players: Company A (35% share), Company B (28% share), Company C (20% share)\n"
+        f"3. Emerging trend: AI integration driving innovation in {query}"
+    )
+
+
+@task
+async def analyze_data(data: str) -> str:
+    """Analyze data and produce structured insights."""
+    return (
+        "Analysis of provided data:\n"
+        "- Primary finding: Strong market growth trajectory\n"
+        "- Key insight: Top 3 players control 83% of market\n"
+        "- Recommendation: Focus on AI-driven differentiation\n"
+        "- Risk factor: Market consolidation may limit new entrants"
+    )
+
+
+@task
+async def write_report(topic: str, content: str) -> str:
+    """Write a formatted report on a topic with the given content."""
+    return (
+        f"# Market Report: {topic}\n\n"
+        f"## Executive Summary\n{content}\n\n"
+        f"## Conclusion\nBased on our analysis, the market presents "
+        f"significant opportunities for AI-driven solutions.\n"
+    )
+
+
+analyst = agent(
+    "You are a thorough market research analyst. "
+    "For complex research tasks, create a plan to organize your work. "
+    "Use your tools to gather data, analyze it, and produce reports.",
+    model="ollama/mistral-small:24b",
+    name="planning-analyst",
+    tools=[search_web, analyze_data, write_report],
+    planning=True,
+    max_tool_calls=30,
+).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=600)
+
+
+@workflow
+async def planning_agent_ollama(ctx: ExecutionContext[dict[str, Any]]):
+    """
+    A planning agent that organizes complex research tasks.
+
+    Input format:
+    {
+        "topic": "cloud computing market"
+    }
+    """
+    input_data = ctx.input or {}
+    topic = input_data.get("topic", "AI agent frameworks")
+
+    response = await analyst(
+        f"Research the competitive landscape for '{topic}' and produce "
+        f"a comprehensive market report. This requires multiple steps: "
+        f"gathering data, analyzing trends, and writing a report.",
+    )
+
+    return {
+        "topic": topic,
+        "response": response,
+        "execution_id": ctx.execution_id,
+    }
+
+
+if __name__ == "__main__":  # pragma: no cover
+    topic = "AI Agent Frameworks"
+
+    try:
+        print("=" * 80)
+        print("Planning Agent Demo (Ollama)")
+        print(f"Topic: {topic}")
+        print("=" * 80 + "\n")
+
+        print("Running agent with planning enabled...\n")
+        result = planning_agent_ollama.run({"topic": topic})
+
+        if result.has_failed:
+            raise Exception(f"Workflow failed: {result.output}")
+
+        output = result.output
+        print(f"Topic: {output.get('topic')}")
+        print(f"Execution ID: {output.get('execution_id')}\n")
+        print("-" * 80)
+        print(output.get("response", ""))
+        print("-" * 80)
+
+    except Exception as e:
+        print(f"Error: {e}")
+        print("\nMake sure:")
+        print("1. Ollama is running: ollama serve")
+        print("2. Model is pulled: ollama pull llama3.2")

--- a/examples/ai/planning_agent_replan.py
+++ b/examples/ai/planning_agent_replan.py
@@ -20,7 +20,6 @@ Usage:
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from flux import ExecutionContext, task, workflow
@@ -84,8 +83,22 @@ async def generate_report(title: str, sections: str) -> str:
     )
 
 
-analyst = asyncio.run(
-    agent(
+@workflow
+async def planning_agent_replan(ctx: ExecutionContext[dict[str, Any]]):
+    """
+    A planning agent that handles failures and replans.
+
+    Input format:
+    {
+        "topic": "quarterly business review"
+    }
+    """
+    _call_count.clear()
+
+    input_data = ctx.input or {}
+    topic = input_data.get("topic", "quarterly business review")
+
+    analyst = await agent(
         "You are a business analyst. Always use your tools to accomplish tasks. "
         "Never describe what you would do — actually do it by calling tools. "
         "For multi-step tasks, create a plan first using create_plan, then "
@@ -97,25 +110,7 @@ analyst = asyncio.run(
         tools=[search_database, search_web, analyze_data, generate_report],
         planning=True,
         max_tool_calls=30,
-    ),
-).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=600)
-
-
-@workflow
-async def planning_agent_replan(ctx: ExecutionContext[dict[str, Any]]):
-    """
-    A planning agent that handles failures and replans.
-
-    Input format:
-    {
-        "topic": "quarterly business review"
-    }
-    """
-    # Reset call counts for each run
-    _call_count.clear()
-
-    input_data = ctx.input or {}
-    topic = input_data.get("topic", "quarterly business review")
+    )
 
     response = await analyst(
         f"Prepare a {topic} report. You need to: "

--- a/examples/ai/planning_agent_replan.py
+++ b/examples/ai/planning_agent_replan.py
@@ -11,7 +11,7 @@ Key scenarios tested:
 
 Prerequisites:
     1. Install Ollama: https://ollama.ai
-    2. Pull a model: ollama pull mistral-small:24b
+    2. Pull a model: ollama pull qwen3
     3. Start Ollama service: ollama serve
 
 Usage:
@@ -20,6 +20,7 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from flux import ExecutionContext, task, workflow
@@ -83,17 +84,20 @@ async def generate_report(title: str, sections: str) -> str:
     )
 
 
-analyst = agent(
-    "You are a business analyst. Always use your tools to accomplish tasks. "
-    "Never describe what you would do — actually do it by calling tools. "
-    "For multi-step tasks, create a plan first using create_plan, then "
-    "execute each step using your tools, and mark steps done with mark_step_done. "
-    "If a tool fails, retry it or adjust your plan.",
-    model="ollama/mistral-small:24b",
-    name="replan-analyst",
-    tools=[search_database, search_web, analyze_data, generate_report],
-    planning=True,
-    max_tool_calls=30,
+analyst = asyncio.run(
+    agent(
+        "You are a business analyst. Always use your tools to accomplish tasks. "
+        "Never describe what you would do — actually do it by calling tools. "
+        "For multi-step tasks, create a plan first using create_plan, then "
+        "call start_step before working on each step. Mark steps done with mark_step_done, "
+        "or mark_step_failed if they cannot be completed. Use get_ready_steps to see what "
+        "can be started next. If a tool fails, retry it or adjust your plan.",
+        model="ollama/qwen3",
+        name="replan-analyst",
+        tools=[search_database, search_web, analyze_data, generate_report],
+        planning=True,
+        max_tool_calls=30,
+    ),
 ).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=600)
 
 
@@ -158,4 +162,4 @@ if __name__ == "__main__":  # pragma: no cover
         print(f"Error: {e}")
         print("\nMake sure:")
         print("1. Ollama is running: ollama serve")
-        print("2. Model is pulled: ollama pull mistral-small:24b")
+        print("2. Model is pulled: ollama pull qwen3")

--- a/examples/ai/planning_agent_replan.py
+++ b/examples/ai/planning_agent_replan.py
@@ -1,0 +1,161 @@
+"""
+Planning Agent with failure and replanning scenarios.
+
+Demonstrates how an agent handles tool failures, adapts its plan,
+and uses dependency results from previous steps.
+
+Key scenarios tested:
+- Tool that fails intermittently (simulates API errors)
+- Agent replans when a step reveals new information
+- Dependency results flow between steps via enriched summaries
+
+Prerequisites:
+    1. Install Ollama: https://ollama.ai
+    2. Pull a model: ollama pull mistral-small:24b
+    3. Start Ollama service: ollama serve
+
+Usage:
+    python examples/ai/planning_agent_replan.py
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from flux import ExecutionContext, task, workflow
+from flux.tasks.ai import agent
+
+# Simulate intermittent failures
+_call_count: dict[str, int] = {}
+
+
+@task
+async def search_database(query: str) -> str:
+    """Search the internal database for records matching the query."""
+    _call_count.setdefault("search_database", 0)
+    _call_count["search_database"] += 1
+
+    # Fail on first call to simulate a transient error
+    if _call_count["search_database"] == 1:
+        raise ConnectionError(f"Database connection timeout for query: {query}")
+
+    return (
+        f"Database results for '{query}':\n"
+        f"- Record 1: Product A, revenue $2.3M, growth 15%\n"
+        f"- Record 2: Product B, revenue $1.8M, growth -3%\n"
+        f"- Record 3: Product C, revenue $4.1M, growth 22%"
+    )
+
+
+@task
+async def search_web(query: str) -> str:
+    """Search the web for public information about a topic."""
+    return (
+        f"Web results for '{query}':\n"
+        f"- Industry report: Market growing at 18% CAGR\n"
+        f"- News: Company X acquired Company Y for $500M\n"
+        f"- Analysis: Top 3 players control 70% market share"
+    )
+
+
+@task
+async def analyze_data(data: str, focus: str) -> str:
+    """Analyze data with a specific focus area and produce insights."""
+    return (
+        f"Analysis (focus: {focus}):\n"
+        f"- Key finding: Strong growth in premium segment\n"
+        f"- Risk: Product B declining, needs attention\n"
+        f"- Opportunity: Market consolidation creates acquisition targets\n"
+        f"- Recommendation: Invest in Product C's growth trajectory"
+    )
+
+
+@task
+async def generate_report(title: str, sections: str) -> str:
+    """Generate a structured report with the given title and section content."""
+    return (
+        f"# {title}\n\n"
+        f"## Key Findings\n{sections}\n\n"
+        f"## Recommendations\n"
+        f"1. Accelerate Product C investment\n"
+        f"2. Review Product B strategy\n"
+        f"3. Explore acquisition opportunities\n"
+    )
+
+
+analyst = agent(
+    "You are a business analyst. Always use your tools to accomplish tasks. "
+    "Never describe what you would do — actually do it by calling tools. "
+    "For multi-step tasks, create a plan first using create_plan, then "
+    "execute each step using your tools, and mark steps done with mark_step_done. "
+    "If a tool fails, retry it or adjust your plan.",
+    model="ollama/mistral-small:24b",
+    name="replan-analyst",
+    tools=[search_database, search_web, analyze_data, generate_report],
+    planning=True,
+    max_tool_calls=30,
+).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=600)
+
+
+@workflow
+async def planning_agent_replan(ctx: ExecutionContext[dict[str, Any]]):
+    """
+    A planning agent that handles failures and replans.
+
+    Input format:
+    {
+        "topic": "quarterly business review"
+    }
+    """
+    # Reset call counts for each run
+    _call_count.clear()
+
+    input_data = ctx.input or {}
+    topic = input_data.get("topic", "quarterly business review")
+
+    response = await analyst(
+        f"Prepare a {topic} report. You need to: "
+        f"1) Gather internal data from the database "
+        f"2) Gather market data from the web "
+        f"3) Analyze all gathered data together "
+        f"4) Generate a final report. "
+        f"Create a plan with these steps. The analysis step should depend "
+        f"on both data gathering steps. The report should depend on analysis.",
+    )
+
+    return {
+        "topic": topic,
+        "response": response,
+        "tool_calls": dict(_call_count),
+        "execution_id": ctx.execution_id,
+    }
+
+
+if __name__ == "__main__":  # pragma: no cover
+    topic = "Quarterly Business Review"
+
+    try:
+        print("=" * 80)
+        print("Planning Agent with Replan Demo")
+        print(f"Topic: {topic}")
+        print("=" * 80 + "\n")
+
+        print("Running agent (first search_database call will fail)...\n")
+        result = planning_agent_replan.run({"topic": topic})
+
+        if result.has_failed:
+            raise Exception(f"Workflow failed: {result.output}")
+
+        output = result.output
+        print(f"Topic: {output.get('topic')}")
+        print(f"Tool calls: {output.get('tool_calls')}")
+        print(f"Execution ID: {output.get('execution_id')}\n")
+        print("-" * 80)
+        print(output.get("response", ""))
+        print("-" * 80)
+
+    except Exception as e:
+        print(f"Error: {e}")
+        print("\nMake sure:")
+        print("1. Ollama is running: ollama serve")
+        print("2. Model is pulled: ollama pull mistral-small:24b")

--- a/examples/ai/skills_agent.py
+++ b/examples/ai/skills_agent.py
@@ -32,6 +32,7 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
 import os
 from typing import Any
 
@@ -57,12 +58,14 @@ async def search_web(query: str) -> str:
 
 catalog = SkillCatalog.from_directory(SKILLS_DIR)
 
-assistant = agent(
-    "You are a helpful research assistant. Use your skills to complete tasks effectively.",
-    model="ollama/llama3.2",
-    name="skills-assistant",
-    tools=[search_web],
-    skills=catalog,
+assistant = asyncio.run(
+    agent(
+        "You are a helpful research assistant. Use your skills to complete tasks effectively.",
+        model="ollama/llama3.2",
+        name="skills-assistant",
+        tools=[search_web],
+        skills=catalog,
+    ),
 ).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=120)
 
 

--- a/examples/ai/skills_agent.py
+++ b/examples/ai/skills_agent.py
@@ -32,7 +32,6 @@ Usage:
 
 from __future__ import annotations
 
-import asyncio
 import os
 from typing import Any
 
@@ -57,16 +56,6 @@ async def search_web(query: str) -> str:
 
 
 catalog = SkillCatalog.from_directory(SKILLS_DIR)
-
-assistant = asyncio.run(
-    agent(
-        "You are a helpful research assistant. Use your skills to complete tasks effectively.",
-        model="ollama/llama3.2",
-        name="skills-assistant",
-        tools=[search_web],
-        skills=catalog,
-    ),
-).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=120)
 
 
 @workflow
@@ -95,6 +84,13 @@ async def skills_agent_ollama(ctx: ExecutionContext[dict[str, Any]]):
             "execution_id": ctx.execution_id,
         }
 
+    assistant = await agent(
+        "You are a helpful research assistant. Use your skills to complete tasks effectively.",
+        model="ollama/llama3.2",
+        name="skills-assistant",
+        tools=[search_web],
+        skills=catalog,
+    )
     response = await assistant(f"Research the topic: {topic}")
 
     return {

--- a/examples/ai/skills_code_review.py
+++ b/examples/ai/skills_code_review.py
@@ -32,6 +32,7 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from flux import ExecutionContext, task, workflow
@@ -96,13 +97,15 @@ async def run_linter(code: str) -> str:
     return "\n".join(issues)
 
 
-reviewer = agent(
-    "You are a code review assistant. Use the appropriate skill for the type of "
-    "review requested. If the user asks for a general review, use both skills.",
-    model="ollama/llama3.2",
-    name="code-reviewer",
-    tools=[run_linter],
-    skills=catalog,
+reviewer = asyncio.run(
+    agent(
+        "You are a code review assistant. Use the appropriate skill for the type of "
+        "review requested. If the user asks for a general review, use both skills.",
+        model="ollama/llama3.2",
+        name="code-reviewer",
+        tools=[run_linter],
+        skills=catalog,
+    ),
 ).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=120)
 
 

--- a/examples/ai/skills_code_review.py
+++ b/examples/ai/skills_code_review.py
@@ -32,7 +32,6 @@ Usage:
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from flux import ExecutionContext, task, workflow
@@ -97,18 +96,6 @@ async def run_linter(code: str) -> str:
     return "\n".join(issues)
 
 
-reviewer = asyncio.run(
-    agent(
-        "You are a code review assistant. Use the appropriate skill for the type of "
-        "review requested. If the user asks for a general review, use both skills.",
-        model="ollama/llama3.2",
-        name="code-reviewer",
-        tools=[run_linter],
-        skills=catalog,
-    ),
-).with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=2, timeout=120)
-
-
 @workflow
 async def skills_code_review_ollama(ctx: ExecutionContext[dict[str, Any]]):
     """
@@ -135,6 +122,14 @@ async def skills_code_review_ollama(ctx: ExecutionContext[dict[str, Any]]):
     review_type = input_data.get("review_type", "general")
     instruction = f"Review this code ({review_type} review):\n\n```\n{code}\n```"
 
+    reviewer = await agent(
+        "You are a code review assistant. Use the appropriate skill for the type of "
+        "review requested. If the user asks for a general review, use both skills.",
+        model="ollama/llama3.2",
+        name="code-reviewer",
+        tools=[run_linter],
+        skills=catalog,
+    )
     review = await reviewer(instruction)
 
     return {

--- a/examples/ai/streaming_progress_agent_ollama.py
+++ b/examples/ai/streaming_progress_agent_ollama.py
@@ -19,28 +19,10 @@ Usage:
 """
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from flux import ExecutionContext, workflow
 from flux.tasks.ai import agent
-
-
-streaming_assistant = asyncio.run(
-    agent(
-        "You are a helpful assistant. Be concise and clear.",
-        model="ollama/llama3.2",
-        stream=True,
-    ),
-)
-
-non_streaming_assistant = asyncio.run(
-    agent(
-        "You are a helpful assistant. Be concise and clear.",
-        model="ollama/llama3.2",
-        stream=False,
-    ),
-)
 
 
 @workflow
@@ -49,10 +31,12 @@ async def streaming_progress_agent(ctx: ExecutionContext[dict[str, Any]]):
     prompt = input_data.get("prompt", "Hello!")
     use_streaming = input_data.get("stream", True)
 
-    if use_streaming:
-        result = await streaming_assistant(prompt)
-    else:
-        result = await non_streaming_assistant(prompt)
+    assistant = await agent(
+        "You are a helpful assistant. Be concise and clear.",
+        model="ollama/llama3.2",
+        stream=use_streaming,
+    )
+    result = await assistant(prompt)
 
     return {
         "response": result,

--- a/examples/ai/streaming_progress_agent_ollama.py
+++ b/examples/ai/streaming_progress_agent_ollama.py
@@ -19,22 +19,27 @@ Usage:
 """
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from flux import ExecutionContext, workflow
 from flux.tasks.ai import agent
 
 
-streaming_assistant = agent(
-    "You are a helpful assistant. Be concise and clear.",
-    model="ollama/llama3.2",
-    stream=True,
+streaming_assistant = asyncio.run(
+    agent(
+        "You are a helpful assistant. Be concise and clear.",
+        model="ollama/llama3.2",
+        stream=True,
+    ),
 )
 
-non_streaming_assistant = agent(
-    "You are a helpful assistant. Be concise and clear.",
-    model="ollama/llama3.2",
-    stream=False,
+non_streaming_assistant = asyncio.run(
+    agent(
+        "You are a helpful assistant. Be concise and clear.",
+        model="ollama/llama3.2",
+        stream=False,
+    ),
 )
 
 

--- a/examples/ai/structured_output_agent_ollama.py
+++ b/examples/ai/structured_output_agent_ollama.py
@@ -21,6 +21,7 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from pydantic import BaseModel
@@ -50,37 +51,45 @@ class BlogOutline(BaseModel):
     estimated_word_count: int
 
 
-extractor = agent(
-    "You are a data extraction specialist. Extract structured information from text. "
-    'Return a JSON object with fields: "name" (string), "age" (integer or null), '
-    '"occupation" (string or null), "company" (string or null), "location" (string or null).',
-    model="ollama/llama3",
-    name="extractor",
-    response_format=PersonInfo,
+extractor = asyncio.run(
+    agent(
+        "You are a data extraction specialist. Extract structured information from text. "
+        'Return a JSON object with fields: "name" (string), "age" (integer or null), '
+        '"occupation" (string or null), "company" (string or null), "location" (string or null).',
+        model="ollama/llama3",
+        name="extractor",
+        response_format=PersonInfo,
+    ),
 ).with_options(retry_max_attempts=3, timeout=60)
 
-classifier = agent(
-    "You are a sentiment analysis specialist. Analyze the sentiment of the given text. "
-    'Return a JSON object with fields: "sentiment" (one of "positive", "negative", "neutral"), '
-    '"confidence" (float 0.0 to 1.0), "reasoning" (brief explanation).',
-    model="ollama/llama3",
-    name="classifier",
-    response_format=SentimentResult,
+classifier = asyncio.run(
+    agent(
+        "You are a sentiment analysis specialist. Analyze the sentiment of the given text. "
+        'Return a JSON object with fields: "sentiment" (one of "positive", "negative", "neutral"), '
+        '"confidence" (float 0.0 to 1.0), "reasoning" (brief explanation).',
+        model="ollama/llama3",
+        name="classifier",
+        response_format=SentimentResult,
+    ),
 ).with_options(retry_max_attempts=3, timeout=60)
 
-planner = agent(
-    "You are a content planning specialist. Create a structured blog outline. "
-    'Return a JSON object with fields: "title" (string), "sections" (list of section heading strings), '
-    '"target_audience" (string), "estimated_word_count" (integer).',
-    model="ollama/llama3",
-    name="planner",
-    response_format=BlogOutline,
+planner = asyncio.run(
+    agent(
+        "You are a content planning specialist. Create a structured blog outline. "
+        'Return a JSON object with fields: "title" (string), "sections" (list of section heading strings), '
+        '"target_audience" (string), "estimated_word_count" (integer).',
+        model="ollama/llama3",
+        name="planner",
+        response_format=BlogOutline,
+    ),
 ).with_options(retry_max_attempts=3, timeout=60)
 
-writer = agent(
-    "You are a content writer. Write a blog post based on the outline provided.",
-    model="ollama/llama3",
-    name="writer",
+writer = asyncio.run(
+    agent(
+        "You are a content writer. Write a blog post based on the outline provided.",
+        model="ollama/llama3",
+        name="writer",
+    ),
 ).with_options(timeout=300)
 
 

--- a/examples/ai/structured_output_agent_ollama.py
+++ b/examples/ai/structured_output_agent_ollama.py
@@ -21,7 +21,6 @@ Usage:
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from pydantic import BaseModel
@@ -51,48 +50,6 @@ class BlogOutline(BaseModel):
     estimated_word_count: int
 
 
-extractor = asyncio.run(
-    agent(
-        "You are a data extraction specialist. Extract structured information from text. "
-        'Return a JSON object with fields: "name" (string), "age" (integer or null), '
-        '"occupation" (string or null), "company" (string or null), "location" (string or null).',
-        model="ollama/llama3",
-        name="extractor",
-        response_format=PersonInfo,
-    ),
-).with_options(retry_max_attempts=3, timeout=60)
-
-classifier = asyncio.run(
-    agent(
-        "You are a sentiment analysis specialist. Analyze the sentiment of the given text. "
-        'Return a JSON object with fields: "sentiment" (one of "positive", "negative", "neutral"), '
-        '"confidence" (float 0.0 to 1.0), "reasoning" (brief explanation).',
-        model="ollama/llama3",
-        name="classifier",
-        response_format=SentimentResult,
-    ),
-).with_options(retry_max_attempts=3, timeout=60)
-
-planner = asyncio.run(
-    agent(
-        "You are a content planning specialist. Create a structured blog outline. "
-        'Return a JSON object with fields: "title" (string), "sections" (list of section heading strings), '
-        '"target_audience" (string), "estimated_word_count" (integer).',
-        model="ollama/llama3",
-        name="planner",
-        response_format=BlogOutline,
-    ),
-).with_options(retry_max_attempts=3, timeout=60)
-
-writer = asyncio.run(
-    agent(
-        "You are a content writer. Write a blog post based on the outline provided.",
-        model="ollama/llama3",
-        name="writer",
-    ),
-).with_options(timeout=300)
-
-
 @workflow
 async def structured_output_demo(ctx: ExecutionContext[dict[str, Any]]):
     """
@@ -107,6 +64,39 @@ async def structured_output_demo(ctx: ExecutionContext[dict[str, Any]]):
     text = input_data.get(
         "text",
         "Marie Curie was a physicist and chemist who conducted pioneering research on radioactivity.",
+    )
+
+    extractor = await agent(
+        "You are a data extraction specialist. Extract structured information from text. "
+        'Return a JSON object with fields: "name" (string), "age" (integer or null), '
+        '"occupation" (string or null), "company" (string or null), "location" (string or null).',
+        model="ollama/llama3",
+        name="extractor",
+        response_format=PersonInfo,
+    )
+
+    classifier = await agent(
+        "You are a sentiment analysis specialist. Analyze the sentiment of the given text. "
+        'Return a JSON object with fields: "sentiment" (one of "positive", "negative", "neutral"), '
+        '"confidence" (float 0.0 to 1.0), "reasoning" (brief explanation).',
+        model="ollama/llama3",
+        name="classifier",
+        response_format=SentimentResult,
+    )
+
+    planner = await agent(
+        "You are a content planning specialist. Create a structured blog outline. "
+        'Return a JSON object with fields: "title" (string), "sections" (list of section heading strings), '
+        '"target_audience" (string), "estimated_word_count" (integer).',
+        model="ollama/llama3",
+        name="planner",
+        response_format=BlogOutline,
+    )
+
+    writer = await agent(
+        "You are a content writer. Write a blog post based on the outline provided.",
+        model="ollama/llama3",
+        name="writer",
     )
 
     # 1. Data extraction — returns a PersonInfo model

--- a/examples/ai/weather_agent_ollama.py
+++ b/examples/ai/weather_agent_ollama.py
@@ -24,7 +24,6 @@ Usage:
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 import httpx
@@ -133,17 +132,6 @@ async def get_weather_forecast(location: str, days: int = 3) -> str:
         return f"Failed to get forecast for '{location}': {e}"
 
 
-weather_assistant = asyncio.run(
-    agent(
-        "You are a helpful weather assistant. Use the available tools to look up "
-        "current weather conditions and forecasts. Always provide clear, concise answers.",
-        model="ollama/llama3.2",
-        name="weather_assistant",
-        tools=[get_current_weather, get_weather_forecast],
-    ),
-).with_options(retry_max_attempts=2, timeout=120)
-
-
 @workflow
 async def weather_agent_ollama(ctx: ExecutionContext[dict[str, Any]]):
     """
@@ -160,6 +148,14 @@ async def weather_agent_ollama(ctx: ExecutionContext[dict[str, Any]]):
     question = input_data.get("question")
     if not question:
         return {"error": "Missing required parameter 'question'", "execution_id": ctx.execution_id}
+
+    weather_assistant = await agent(
+        "You are a helpful weather assistant. Use the available tools to look up "
+        "current weather conditions and forecasts. Always provide clear, concise answers.",
+        model="ollama/llama3.2",
+        name="weather_assistant",
+        tools=[get_current_weather, get_weather_forecast],
+    )
 
     answer = await weather_assistant(question)
 

--- a/examples/ai/weather_agent_ollama.py
+++ b/examples/ai/weather_agent_ollama.py
@@ -24,6 +24,7 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import httpx
@@ -132,12 +133,14 @@ async def get_weather_forecast(location: str, days: int = 3) -> str:
         return f"Failed to get forecast for '{location}': {e}"
 
 
-weather_assistant = agent(
-    "You are a helpful weather assistant. Use the available tools to look up "
-    "current weather conditions and forecasts. Always provide clear, concise answers.",
-    model="ollama/llama3.2",
-    name="weather_assistant",
-    tools=[get_current_weather, get_weather_forecast],
+weather_assistant = asyncio.run(
+    agent(
+        "You are a helpful weather assistant. Use the available tools to look up "
+        "current weather conditions and forecasts. Always provide clear, concise answers.",
+        model="ollama/llama3.2",
+        name="weather_assistant",
+        tools=[get_current_weather, get_weather_forecast],
+    ),
 ).with_options(retry_max_attempts=2, timeout=120)
 
 

--- a/examples/mcp/agent_with_mcp_tools.py
+++ b/examples/mcp/agent_with_mcp_tools.py
@@ -40,7 +40,7 @@ async def mcp_agent_assistant(ctx: ExecutionContext):
             tools.health_check,
         ]
 
-        assistant = agent(
+        assistant = await agent(
             system_prompt=(
                 "You are a Flux workflow management assistant. "
                 "Use the available tools to help users manage their workflows. "

--- a/flux/tasks/ai/__init__.py
+++ b/flux/tasks/ai/__init__.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from flux.tasks.ai.agent import agent
+from flux.tasks.ai.agent_plan import AgentPlan, AgentStep
 from flux.tasks.ai.memory import in_memory, long_term_memory, postgresql, sqlite, working_memory
 from flux.tasks.ai.skills import Skill, SkillCatalog
 
 __all__ = [
     "agent",
+    "AgentPlan",
+    "AgentStep",
     "Skill",
     "SkillCatalog",
     "working_memory",

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -22,6 +22,7 @@ def agent(
     name: str | None = None,
     tools: list[task] | None = None,
     skills: SkillCatalog | None = None,
+    planning: bool = False,
     response_format: type[BaseModel] | None = None,
     working_memory: WorkingMemory | None = None,
     long_term_memory: LongTermMemory | None = None,
@@ -40,6 +41,8 @@ def agent(
         name: Task name for events/traces. Defaults to "agent_{provider}_{model}".
         tools: List of Flux @task functions the agent can call as tools.
         skills: SkillCatalog providing Agent Skills the LLM can activate.
+        planning: If True, inject planning tools (create_plan, complete_step, get_plan)
+            so the agent can create structured plans for complex tasks.
         response_format: Pydantic BaseModel subclass for structured JSON output.
         working_memory: WorkingMemory instance for conversation history across invocations.
         long_term_memory: LongTermMemory instance for persistent fact storage.
@@ -60,6 +63,14 @@ def agent(
     if long_term_memory is not None:
         tools = (tools or []) + long_term_memory.as_tools()
         system_prompt = system_prompt + long_term_memory.system_prompt_hint()
+
+    plan_summary_fn = None
+    if planning:
+        from flux.tasks.ai.agent_plan import build_plan_preamble, build_plan_tools
+
+        system_prompt = system_prompt + build_plan_preamble()
+        plan_tools, plan_summary_fn = build_plan_tools()
+        tools = (tools or []) + plan_tools
 
     if skills is not None:
         tool_names = {
@@ -99,6 +110,7 @@ def agent(
             working_memory=working_memory,
             max_tool_calls=max_tool_calls,
             stream=effective_stream,
+            plan_summary_fn=plan_summary_fn,
         )
     elif provider == "openai":
         from flux.tasks.ai.openai import build_openai_agent
@@ -112,6 +124,7 @@ def agent(
             working_memory=working_memory,
             max_tool_calls=max_tool_calls,
             stream=effective_stream,
+            plan_summary_fn=plan_summary_fn,
         )
     elif provider == "anthropic":
         from flux.tasks.ai.anthropic import build_anthropic_agent
@@ -126,6 +139,7 @@ def agent(
             max_tool_calls=max_tool_calls,
             max_tokens=max_tokens,
             stream=effective_stream,
+            plan_summary_fn=plan_summary_fn,
         )
     elif provider == "google":
         from flux.tasks.ai.gemini import build_gemini_agent
@@ -140,6 +154,7 @@ def agent(
             max_tool_calls=max_tool_calls,
             max_tokens=max_tokens,
             stream=effective_stream,
+            plan_summary_fn=plan_summary_fn,
         )
     else:
         raise ValueError(

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -44,7 +44,8 @@ async def agent(
         name: Task name for events/traces. Defaults to "agent_{provider}_{model}".
         tools: List of Flux @task functions the agent can call as tools.
         skills: SkillCatalog providing Agent Skills the LLM can activate.
-        planning: If True, inject planning tools (create_plan, complete_step, get_plan)
+        planning: If True, inject planning tools (create_plan, start_step,
+            mark_step_done, mark_step_failed, get_plan, get_ready_steps)
             so the agent can create structured plans for complex tasks.
         max_plan_steps: Maximum number of steps allowed in a plan. Defaults to 20.
         strict_dependencies: If True, prevent starting a step before its dependencies

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -23,6 +23,9 @@ async def agent(
     tools: list[task] | None = None,
     skills: SkillCatalog | None = None,
     planning: bool = False,
+    max_plan_steps: int = 20,
+    strict_dependencies: bool = False,
+    approve_plan: bool = False,
     response_format: type[BaseModel] | None = None,
     working_memory: WorkingMemory | None = None,
     long_term_memory: LongTermMemory | None = None,
@@ -43,6 +46,11 @@ async def agent(
         skills: SkillCatalog providing Agent Skills the LLM can activate.
         planning: If True, inject planning tools (create_plan, complete_step, get_plan)
             so the agent can create structured plans for complex tasks.
+        max_plan_steps: Maximum number of steps allowed in a plan. Defaults to 20.
+        strict_dependencies: If True, prevent starting a step before its dependencies
+            are completed. Defaults to False (warns instead).
+        approve_plan: If True, pause for human approval before activating a new plan.
+            Defaults to False.
         response_format: Pydantic BaseModel subclass for structured JSON output.
         working_memory: WorkingMemory instance for conversation history across invocations.
         long_term_memory: LongTermMemory instance for persistent fact storage.
@@ -70,6 +78,9 @@ async def agent(
 
         system_prompt = system_prompt + build_plan_preamble()
         plan_tools, plan_summary_fn = await build_plan_tools(
+            strict_dependencies=strict_dependencies,
+            max_plan_steps=max_plan_steps,
+            approve_plan=approve_plan,
             long_term_memory=long_term_memory,
         )
         tools = (tools or []) + plan_tools

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger("flux.agent")
 
 
-def agent(
+async def agent(
     system_prompt: str,
     *,
     model: str,
@@ -69,7 +69,9 @@ def agent(
         from flux.tasks.ai.agent_plan import build_plan_preamble, build_plan_tools
 
         system_prompt = system_prompt + build_plan_preamble()
-        plan_tools, plan_summary_fn = build_plan_tools()
+        plan_tools, plan_summary_fn = await build_plan_tools(
+            long_term_memory=long_term_memory,
+        )
         tools = (tools or []) + plan_tools
 
     if skills is not None:

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -297,8 +297,11 @@ def build_plan_tools(
         """Mark a plan step as completed and store its result.
 
         The result is stored so that dependent steps can access it
-        via get_plan. Use descriptive results — other steps will
+        via get_plan. Use descriptive results -- other steps will
         receive this as context.
+
+        Accepts steps in pending or in_progress status. Rejects
+        completed or failed steps.
 
         Args:
             step_name: The step name to mark as completed.
@@ -314,6 +317,9 @@ def build_plan_tools(
 
         if step.status == "completed":
             return step.to_dict()
+
+        if step.status == "failed":
+            return {"error": f"Step '{step_name}' is failed. Replan to retry."}
 
         step.status = "completed"
         step.result = result

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -189,6 +189,7 @@ def build_plan_tools(
     *,
     strict_dependencies: bool = False,
     max_plan_steps: int = 20,
+    approve_plan: bool = False,
 ) -> tuple[list[task], Callable[[], str | None]]:
     """Build planning tools and a summary function.
 
@@ -237,6 +238,37 @@ def build_plan_tools(
 
         new_plan = AgentPlan(steps=new_steps)
         _validate_dependencies(new_plan)
+
+        if approve_plan:
+            from flux.tasks.pause import pause
+
+            resume_input = await pause("plan_approval", output=new_plan.to_dict())
+
+            if isinstance(resume_input, dict) and resume_input.get("rejected"):
+                return {"error": "Plan was rejected during review."}
+
+            if isinstance(resume_input, dict) and "steps" in resume_input:
+                new_steps = []
+                for s in resume_input["steps"]:
+                    _validate_step_name(s["name"])
+                    new_steps.append(
+                        AgentStep(
+                            name=s["name"],
+                            description=s.get("description", ""),
+                            depends_on=s.get("depends_on", []),
+                        ),
+                    )
+                new_plan = AgentPlan(steps=new_steps)
+                _validate_dependencies(new_plan)
+                if len(new_plan.steps) < 2:
+                    raise PlanValidationError(
+                        "Plans need at least 2 steps. For simple tasks, just do them directly.",
+                    )
+                if len(new_plan.steps) > max_plan_steps:
+                    raise PlanValidationError(
+                        f"Plan has {len(new_plan.steps)} steps (max {max_plan_steps}). "
+                        "Use fewer, coarser steps.",
+                    )
 
         old_completed = ctx.plan.completed_steps() if ctx.plan else []
 

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -56,6 +56,19 @@ class AgentPlan:
     def pending_steps(self) -> list[AgentStep]:
         return [s for s in self.steps if s.status == "pending"]
 
+    def in_progress_steps(self) -> list[AgentStep]:
+        return [s for s in self.steps if s.status == "in_progress"]
+
+    def failed_steps(self) -> list[AgentStep]:
+        return [s for s in self.steps if s.status == "failed"]
+
+    def active_step(self) -> AgentStep | None:
+        in_progress = self.in_progress_steps()
+        return in_progress[0] if in_progress else None
+
+    def ready_steps(self) -> list[AgentStep]:
+        return [s for s in self.pending_steps() if self.dependencies_satisfied(s)]
+
     def dependencies_satisfied(self, step: AgentStep) -> bool:
         for dep_name in step.depends_on:
             dep = self.get_step(dep_name)

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -87,21 +87,37 @@ class AgentPlan:
     def summary(self) -> str:
         completed = len(self.completed_steps())
         total = len(self.steps)
-        pending = self.pending_steps()
-        ready = [s for s in pending if self.dependencies_satisfied(s)]
-        if not ready:
-            return f"[Plan: {completed}/{total} steps completed. No steps ready.]"
+        failed = self.failed_steps()
+        active = self.active_step()
+        ready = self.ready_steps()
 
-        parts = []
-        for step in ready[:3]:
-            dep_results = self.dependency_results(step)
-            if dep_results:
-                deps_str = "; ".join(f"{k}: {str(v)[:200]}" for k, v in dep_results.items())
-                parts.append(f'"{step.name}" (from {deps_str})')
-            else:
-                parts.append(f'"{step.name}"')
+        parts = [f"[Plan: {completed}/{total} done"]
 
-        return f"[Plan: {completed}/{total} steps completed. Ready: {', '.join(parts)}]"
+        if failed:
+            failed_names = ", ".join(f'"{s.name}"' for s in failed)
+            parts.append(f", {len(failed)} failed ({failed_names})")
+
+        parts.append(".")
+
+        if active:
+            parts.append(f' Active: "{active.name}".')
+
+        if ready:
+            ready_parts = []
+            for step in ready[:3]:
+                dep_results = self.dependency_results(step)
+                if dep_results:
+                    deps_str = "; ".join(f"{k}: {str(v)[:200]}" for k, v in dep_results.items())
+                    ready_parts.append(f'"{step.name}" (from {deps_str})')
+                else:
+                    ready_parts.append(f'"{step.name}"')
+            parts.append(f" Ready: {', '.join(ready_parts)}.")
+
+        if not active and not ready:
+            parts.append(" No steps ready.")
+
+        parts.append("]")
+        return "".join(parts)
 
     def to_dict(self) -> dict:
         return {"steps": [s.to_dict() for s in self.steps]}

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -75,8 +75,17 @@ class AgentPlan:
         ready = [s for s in pending if self.dependencies_satisfied(s)]
         if not ready:
             return f"[Plan: {completed}/{total} steps completed. No steps ready.]"
-        next_names = ", ".join(f'"{s.name}"' for s in ready[:3])
-        return f"[Plan: {completed}/{total} steps completed. Ready: {next_names}]"
+
+        parts = []
+        for step in ready[:3]:
+            dep_results = self.dependency_results(step)
+            if dep_results:
+                deps_str = "; ".join(f"{k}: {str(v)[:200]}" for k, v in dep_results.items())
+                parts.append(f'"{step.name}" (from {deps_str})')
+            else:
+                parts.append(f'"{step.name}"')
+
+        return f"[Plan: {completed}/{total} steps completed. Ready: {', '.join(parts)}]"
 
     def to_dict(self) -> dict:
         return {"steps": [s.to_dict() for s in self.steps]}
@@ -169,7 +178,7 @@ def build_plan_tools() -> tuple[list[task], Callable[[], str | None]]:
         When replacing an existing plan, completed steps and their results
         are preserved.
         """
-        parsed = json.loads(steps)
+        parsed = json.loads(steps) if isinstance(steps, str) else steps
         new_steps = []
         for s in parsed:
             _validate_step_name(s["name"])

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -375,7 +375,35 @@ def build_plan_tools(
             return {"message": "No plan exists."}
         return ctx.plan.to_dict()
 
-    return [create_plan, start_step, mark_step_done, mark_step_failed, get_plan], ctx.summary
+    @task
+    async def get_ready_steps() -> dict:
+        """Return steps that can be started now (dependencies satisfied, status pending).
+
+        Each step includes its dependency_results so you have all context
+        needed to begin work. Use this to decide what to work on next.
+        """
+        if ctx.plan is None:
+            return {"message": "No plan exists."}
+
+        ready = ctx.plan.ready_steps()
+        result = []
+        for step in ready:
+            entry = step.to_dict()
+            dep_results = ctx.plan.dependency_results(step)
+            if dep_results:
+                entry["dependency_results"] = dep_results
+            result.append(entry)
+
+        return {"ready_steps": result}
+
+    return [
+        create_plan,
+        start_step,
+        mark_step_done,
+        mark_step_failed,
+        get_plan,
+        get_ready_steps,
+    ], ctx.summary
 
 
 def build_plan_preamble() -> str:

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable, Literal
+
+from flux.task import task
+
+logger = logging.getLogger("flux.agent.plan")
+
+_STEP_NAME_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
+
+
+class PlanValidationError(ValueError):
+    """Raised at plan creation time for invalid step configuration."""
+
+    pass
+
+
+@dataclass
+class AgentStep:
+    """A single step in an agent plan."""
+
+    name: str
+    description: str
+    depends_on: list[str] = field(default_factory=list)
+    status: Literal["pending", "completed"] = "pending"
+    result: Any | None = None
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        if not d["depends_on"]:
+            del d["depends_on"]
+        if d["result"] is None:
+            del d["result"]
+        return d
+
+
+@dataclass
+class AgentPlan:
+    """An agent's active plan — closure-scoped singleton."""
+
+    steps: list[AgentStep] = field(default_factory=list)
+
+    def get_step(self, name: str) -> AgentStep | None:
+        return next((s for s in self.steps if s.name == name), None)
+
+    def completed_steps(self) -> list[AgentStep]:
+        return [s for s in self.steps if s.status == "completed"]
+
+    def pending_steps(self) -> list[AgentStep]:
+        return [s for s in self.steps if s.status == "pending"]
+
+    def dependencies_satisfied(self, step: AgentStep) -> bool:
+        for dep_name in step.depends_on:
+            dep = self.get_step(dep_name)
+            if dep is None or dep.status != "completed":
+                return False
+        return True
+
+    def dependency_results(self, step: AgentStep) -> dict[str, Any]:
+        results = {}
+        for dep_name in step.depends_on:
+            dep = self.get_step(dep_name)
+            if dep and dep.result is not None:
+                results[dep_name] = dep.result
+        return results
+
+    def summary(self) -> str:
+        completed = len(self.completed_steps())
+        total = len(self.steps)
+        pending = self.pending_steps()
+        ready = [s for s in pending if self.dependencies_satisfied(s)]
+        if not ready:
+            return f"[Plan: {completed}/{total} steps completed. No steps ready.]"
+        next_names = ", ".join(f'"{s.name}"' for s in ready[:3])
+        return f"[Plan: {completed}/{total} steps completed. Ready: {next_names}]"
+
+    def to_dict(self) -> dict:
+        return {"steps": [s.to_dict() for s in self.steps]}
+
+
+def _validate_step_name(name: str) -> None:
+    if not name:
+        raise PlanValidationError("Step name must not be empty.")
+    if len(name) > 64:
+        raise PlanValidationError(f"Step name '{name}' exceeds 64 characters.")
+    if "--" in name:
+        raise PlanValidationError(
+            f"Step name '{name}' must not contain consecutive hyphens.",
+        )
+    if not _STEP_NAME_PATTERN.match(name):
+        raise PlanValidationError(
+            f"Step name '{name}' is invalid. Use lowercase letters, numbers, "
+            f"and single hyphens. Must not start or end with a hyphen.",
+        )
+
+
+def _validate_dependencies(plan: AgentPlan) -> None:
+    names = set()
+    for step in plan.steps:
+        if step.name in names:
+            raise PlanValidationError(f"Duplicate step name: '{step.name}'.")
+        names.add(step.name)
+    for step in plan.steps:
+        for dep in step.depends_on:
+            if dep not in names:
+                raise PlanValidationError(
+                    f"Step '{step.name}' depends on '{dep}' which is not in the plan.",
+                )
+
+    visited: set[str] = set()
+    in_stack: set[str] = set()
+    step_map = {s.name: s for s in plan.steps}
+
+    def _visit(name: str) -> None:
+        if name in in_stack:
+            raise PlanValidationError(
+                f"Circular dependency detected involving '{name}'.",
+            )
+        if name in visited:
+            return
+        in_stack.add(name)
+        for dep in step_map[name].depends_on:
+            _visit(dep)
+        in_stack.remove(name)
+        visited.add(name)
+
+    for step in plan.steps:
+        _visit(step.name)
+
+
+class PlanContext:
+    """Shared mutable state for plan tools and summary injection."""
+
+    def __init__(self):
+        self.plan: AgentPlan | None = None
+
+    def summary(self) -> str | None:
+        if self.plan is None:
+            return None
+        return self.plan.summary()
+
+
+def build_plan_tools() -> tuple[list[task], Callable[[], str | None]]:
+    """Build planning tools and a summary function.
+
+    Returns:
+        A tuple of (tools, summary_fn). The tools and summary_fn share
+        the same PlanContext via closure.
+    """
+    ctx = PlanContext()
+
+    @task
+    async def create_plan(steps: str) -> dict:
+        """Create or replace the agent's plan.
+
+        steps is a JSON array of step objects. Each step has:
+          - name: unique identifier (lowercase, hyphens allowed)
+          - description: what to accomplish (natural language)
+          - depends_on: list of step names that must complete first (optional)
+
+        Example:
+          [{"name": "research", "description": "Search for data."},
+           {"name": "analyze", "description": "Analyze the data.", "depends_on": ["research"]}]
+
+        When replacing an existing plan, completed steps and their results
+        are preserved.
+        """
+        parsed = json.loads(steps)
+        new_steps = []
+        for s in parsed:
+            _validate_step_name(s["name"])
+            new_steps.append(
+                AgentStep(
+                    name=s["name"],
+                    description=s.get("description", ""),
+                    depends_on=s.get("depends_on", []),
+                ),
+            )
+
+        new_plan = AgentPlan(steps=new_steps)
+        _validate_dependencies(new_plan)
+
+        if ctx.plan:
+            for completed in ctx.plan.completed_steps():
+                existing = new_plan.get_step(completed.name)
+                if existing:
+                    idx = new_plan.steps.index(existing)
+                    new_plan.steps[idx] = completed
+
+        ctx.plan = new_plan
+        return ctx.plan.to_dict()
+
+    @task
+    async def mark_step_done(step_name: str, result: str) -> dict:
+        """Mark a plan step as completed and store its result.
+
+        The result is stored so that dependent steps can access it
+        via get_plan. Use descriptive results — other steps will
+        receive this as context.
+
+        Args:
+            step_name: The step name to mark as completed.
+            result: The result or summary of what was accomplished.
+        """
+        if ctx.plan is None:
+            return {"error": "No plan exists. Call create_plan first."}
+
+        step = ctx.plan.get_step(step_name)
+        if step is None:
+            available = ", ".join(s.name for s in ctx.plan.steps)
+            return {"error": f"Step '{step_name}' not found. Available: {available}"}
+
+        if step.status == "completed":
+            return step.to_dict()
+
+        step.status = "completed"
+        step.result = result
+        return step.to_dict()
+
+    @task
+    async def get_plan() -> dict:
+        """Return the current plan with all steps, statuses, and results.
+
+        Use this to review progress, check dependency results before
+        starting a new step, or decide whether to replan.
+        """
+        if ctx.plan is None:
+            return {"message": "No plan exists."}
+        return ctx.plan.to_dict()
+
+    return [create_plan, mark_step_done, get_plan], ctx.summary
+
+
+def build_plan_preamble() -> str:
+    """Build system prompt section for agent planning."""
+    return """
+
+You have planning capabilities. Use them when a task requires multiple
+coordinated steps that benefit from thinking ahead.
+
+When to create a plan:
+- The task involves 3 or more distinct steps
+- Steps have dependencies (one step's output feeds into another)
+- The task benefits from organizing work before starting
+- You want to ensure completeness in a complex workflow
+
+When NOT to create a plan:
+- Simple tasks you can accomplish in 1-2 tool calls
+- Exploratory tasks where the next step depends entirely on discovery
+- When you are unsure what steps are needed (gather information first)
+
+Creating a plan:
+- Call create_plan with a list of steps. Each step has a name, description,
+  and optional depends_on list.
+- Steps are goals, not single tool calls. "Research competitor pricing" is
+  a good step. "Call search_web" is too granular.
+- Use depends_on to declare data dependencies between steps. Only add
+  dependencies where a step genuinely needs another step's result.
+- Keep plans concise. Prefer fewer meaningful steps over many granular ones.
+
+Working through a plan:
+- Work on steps using your available tools, skills, and agents as normal.
+- When you finish a step, call mark_step_done with step_name and a
+  descriptive result. Other steps that depend on it will see this result.
+- Call get_plan to review progress and access results from completed steps.
+- Respect dependency order — complete dependencies before starting a step
+  that depends on them.
+- A status reminder appears after tool calls to help you track progress.
+
+Replanning:
+- If circumstances change or you learn new information, call create_plan
+  again with an updated plan. Completed steps are preserved automatically.
+- You do not need to complete every step. If the plan is no longer relevant,
+  stop calling plan tools and respond directly.
+"""

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -188,6 +188,7 @@ class PlanContext:
 def build_plan_tools(
     *,
     strict_dependencies: bool = False,
+    max_plan_steps: int = 20,
 ) -> tuple[list[task], Callable[[], str | None]]:
     """Build planning tools and a summary function.
 
@@ -214,6 +215,15 @@ def build_plan_tools(
         are preserved.
         """
         parsed = json.loads(steps) if isinstance(steps, str) else steps
+        if len(parsed) < 2:
+            raise PlanValidationError(
+                "Plans need at least 2 steps. For simple tasks, just do them directly.",
+            )
+        if len(parsed) > max_plan_steps:
+            raise PlanValidationError(
+                f"Plan has {len(parsed)} steps (max {max_plan_steps}). "
+                "Use fewer, coarser steps.",
+            )
         new_steps = []
         for s in parsed:
             _validate_step_name(s["name"])

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -10,7 +10,7 @@ from flux.task import task
 
 logger = logging.getLogger("flux.agent.plan")
 
-_STEP_NAME_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
+_STEP_NAME_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9_-]*[a-z0-9])?$")
 
 
 class PlanValidationError(ValueError):
@@ -26,8 +26,9 @@ class AgentStep:
     name: str
     description: str
     depends_on: list[str] = field(default_factory=list)
-    status: Literal["pending", "completed"] = "pending"
+    status: Literal["pending", "in_progress", "completed", "failed"] = "pending"
     result: Any | None = None
+    error: str | None = None
 
     def to_dict(self) -> dict:
         d = asdict(self)
@@ -35,6 +36,8 @@ class AgentStep:
             del d["depends_on"]
         if d["result"] is None:
             del d["result"]
+        if d["error"] is None:
+            del d["error"]
         return d
 
 
@@ -96,14 +99,14 @@ def _validate_step_name(name: str) -> None:
         raise PlanValidationError("Step name must not be empty.")
     if len(name) > 64:
         raise PlanValidationError(f"Step name '{name}' exceeds 64 characters.")
-    if "--" in name:
+    if "--" in name or "__" in name:
         raise PlanValidationError(
-            f"Step name '{name}' must not contain consecutive hyphens.",
+            f"Step name '{name}' must not contain consecutive hyphens or underscores.",
         )
     if not _STEP_NAME_PATTERN.match(name):
         raise PlanValidationError(
             f"Step name '{name}' is invalid. Use lowercase letters, numbers, "
-            f"and single hyphens. Must not start or end with a hyphen.",
+            f"hyphens, and underscores. Must not start or end with a hyphen or underscore.",
         )
 
 

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -238,15 +238,24 @@ def build_plan_tools(
         new_plan = AgentPlan(steps=new_steps)
         _validate_dependencies(new_plan)
 
+        old_completed = ctx.plan.completed_steps() if ctx.plan else []
+
         if ctx.plan:
-            for completed in ctx.plan.completed_steps():
+            for completed in old_completed:
                 existing = new_plan.get_step(completed.name)
                 if existing:
                     idx = new_plan.steps.index(existing)
                     new_plan.steps[idx] = completed
 
         ctx.plan = new_plan
-        return ctx.plan.to_dict()
+
+        result = ctx.plan.to_dict()
+        dropped = [s.name for s in old_completed if ctx.plan.get_step(s.name) is None]
+        if dropped:
+            result["warning"] = (
+                f"Completed steps dropped (not in new plan): {dropped}. " f"Their results are lost."
+            )
+        return result
 
     @task
     async def start_step(step_name: str) -> dict:

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -320,6 +320,35 @@ def build_plan_tools(
         return step.to_dict()
 
     @task
+    async def mark_step_failed(step_name: str, reason: str) -> dict:
+        """Mark a plan step as failed and store the reason.
+
+        Use this when a step cannot be completed (tool errors, bad data, etc.).
+        Failed steps block their dependents. Consider replanning after a failure.
+
+        Args:
+            step_name: The step name to mark as failed.
+            reason: Why the step failed.
+        """
+        if ctx.plan is None:
+            return {"error": "No plan exists. Call create_plan first."}
+
+        step = ctx.plan.get_step(step_name)
+        if step is None:
+            available = ", ".join(s.name for s in ctx.plan.steps)
+            return {"error": f"Step '{step_name}' not found. Available: {available}"}
+
+        if step.status == "completed":
+            return {"error": f"Step '{step_name}' is already completed."}
+
+        if step.status == "failed":
+            return step.to_dict()
+
+        step.status = "failed"
+        step.error = reason
+        return step.to_dict()
+
+    @task
     async def get_plan() -> dict:
         """Return the current plan with all steps, statuses, and results.
 
@@ -330,7 +359,7 @@ def build_plan_tools(
             return {"message": "No plan exists."}
         return ctx.plan.to_dict()
 
-    return [create_plan, start_step, mark_step_done, get_plan], ctx.summary
+    return [create_plan, start_step, mark_step_done, mark_step_failed, get_plan], ctx.summary
 
 
 def build_plan_preamble() -> str:

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -185,7 +185,10 @@ class PlanContext:
         return self.plan.summary()
 
 
-def build_plan_tools() -> tuple[list[task], Callable[[], str | None]]:
+def build_plan_tools(
+    *,
+    strict_dependencies: bool = False,
+) -> tuple[list[task], Callable[[], str | None]]:
     """Build planning tools and a summary function.
 
     Returns:
@@ -236,6 +239,60 @@ def build_plan_tools() -> tuple[list[task], Callable[[], str | None]]:
         return ctx.plan.to_dict()
 
     @task
+    async def start_step(step_name: str) -> dict:
+        """Mark a plan step as in-progress. Call this before working on a step.
+
+        Only one step can be in-progress at a time. Dependencies are checked:
+        if a step's dependencies are not yet completed, you will receive a
+        warning (or error in strict mode).
+
+        Args:
+            step_name: The step name to start working on.
+        """
+        if ctx.plan is None:
+            return {"error": "No plan exists. Call create_plan first."}
+
+        step = ctx.plan.get_step(step_name)
+        if step is None:
+            available = ", ".join(s.name for s in ctx.plan.steps)
+            return {"error": f"Step '{step_name}' not found. Available: {available}"}
+
+        if step.status == "in_progress":
+            return step.to_dict()
+
+        if step.status in ("completed", "failed"):
+            return {"error": f"Step '{step_name}' is already {step.status}."}
+
+        active = ctx.plan.active_step()
+        if active and active.name != step_name:
+            return {
+                "error": f'Step "{active.name}" is already in progress. '
+                f"Complete or fail it before starting another.",
+            }
+
+        if not ctx.plan.dependencies_satisfied(step):
+            unsatisfied = [
+                d
+                for d in step.depends_on
+                if (dep := ctx.plan.get_step(d)) and dep.status != "completed"
+            ]
+            if strict_dependencies:
+                return {
+                    "error": f"Step '{step_name}' has unsatisfied dependencies: "
+                    f"{unsatisfied}. Complete them first.",
+                }
+            step.status = "in_progress"
+            result = step.to_dict()
+            result["warning"] = (
+                f"Step '{step_name}' has unsatisfied dependencies: "
+                f"{unsatisfied}. Proceeding anyway."
+            )
+            return result
+
+        step.status = "in_progress"
+        return step.to_dict()
+
+    @task
     async def mark_step_done(step_name: str, result: str) -> dict:
         """Mark a plan step as completed and store its result.
 
@@ -273,7 +330,7 @@ def build_plan_tools() -> tuple[list[task], Callable[[], str | None]]:
             return {"message": "No plan exists."}
         return ctx.plan.to_dict()
 
-    return [create_plan, mark_step_done, get_plan], ctx.summary
+    return [create_plan, start_step, mark_step_done, get_plan], ctx.summary
 
 
 def build_plan_preamble() -> str:

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -500,21 +500,29 @@ When NOT to create a plan:
 - When you are unsure what steps are needed (gather information first)
 
 Creating a plan:
-- Call create_plan with a list of steps. Each step has a name, description,
-  and optional depends_on list.
-- Steps are goals, not single tool calls. "Research competitor pricing" is
-  a good step. "Call search_web" is too granular.
+- Call create_plan with a JSON array of steps. Each step has a name,
+  description, and optional depends_on list.
+- Plans must have 2-20 steps. Steps are goals, not single tool calls.
+  "Research competitor pricing" is a good step. "Call search_web" is
+  too granular.
 - Use depends_on to declare data dependencies between steps. Only add
   dependencies where a step genuinely needs another step's result.
-- Keep plans concise. Prefer fewer meaningful steps over many granular ones.
+- When replanning, keep the same names for completed steps to preserve
+  their results.
 
 Working through a plan:
-- Work on steps using your available tools, skills, and agents as normal.
-- When you finish a step, call mark_step_done with step_name and a
-  descriptive result. Other steps that depend on it will see this result.
-- Call get_plan to review progress and access results from completed steps.
-- Respect dependency order — complete dependencies before starting a step
-  that depends on them.
+- Call start_step before working on a step. Only one step can be
+  in_progress at a time.
+- Call get_ready_steps to see which steps can be started (dependencies
+  satisfied). Each includes dependency results for context.
+- Use your available tools to accomplish the step's goal.
+- Call mark_step_done with a descriptive result when finished. Other
+  steps that depend on it will see this result.
+- Call mark_step_failed with a reason if a step cannot be completed.
+  Failed steps block their dependents. Consider replanning after failure.
+- Call get_plan to review full progress at any time.
+- Respect dependency order — complete dependencies before starting a
+  step that depends on them.
 - A status reminder appears after tool calls to help you track progress.
 
 Replanning:

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -4,9 +4,12 @@ import json
 import logging
 import re
 from dataclasses import asdict, dataclass, field
-from typing import Any, Callable, Literal
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 from flux.task import task
+
+if TYPE_CHECKING:
+    from flux.tasks.ai.memory.long_term_memory import LongTermMemory
 
 logger = logging.getLogger("flux.agent.plan")
 
@@ -122,6 +125,22 @@ class AgentPlan:
     def to_dict(self) -> dict:
         return {"steps": [s.to_dict() for s in self.steps]}
 
+    @classmethod
+    def from_dict(cls, data: dict) -> AgentPlan:
+        steps = []
+        for s in data.get("steps", []):
+            steps.append(
+                AgentStep(
+                    name=s["name"],
+                    description=s.get("description", ""),
+                    depends_on=s.get("depends_on", []),
+                    status=s.get("status", "pending"),
+                    result=s.get("result"),
+                    error=s.get("error"),
+                ),
+            )
+        return cls(steps=steps)
+
 
 def _validate_step_name(name: str) -> None:
     if not name:
@@ -185,11 +204,12 @@ class PlanContext:
         return self.plan.summary()
 
 
-def build_plan_tools(
+async def build_plan_tools(
     *,
     strict_dependencies: bool = False,
     max_plan_steps: int = 20,
     approve_plan: bool = False,
+    long_term_memory: LongTermMemory | None = None,
 ) -> tuple[list[task], Callable[[], str | None]]:
     """Build planning tools and a summary function.
 
@@ -198,6 +218,15 @@ def build_plan_tools(
         the same PlanContext via closure.
     """
     ctx = PlanContext()
+
+    if long_term_memory:
+        saved = await long_term_memory.recall("_active_plan")
+        if saved and isinstance(saved, dict) and "steps" in saved:
+            ctx.plan = AgentPlan.from_dict(saved)
+
+    async def _persist() -> None:
+        if long_term_memory and ctx.plan:
+            await long_term_memory.memorize("_active_plan", ctx.plan.to_dict())
 
     @task
     async def create_plan(steps: str) -> dict:
@@ -280,6 +309,7 @@ def build_plan_tools(
                     new_plan.steps[idx] = completed
 
         ctx.plan = new_plan
+        await _persist()
 
         result = ctx.plan.to_dict()
         dropped = [s.name for s in old_completed if ctx.plan.get_step(s.name) is None]
@@ -333,6 +363,7 @@ def build_plan_tools(
                     f"{unsatisfied}. Complete them first.",
                 }
             step.status = "in_progress"
+            await _persist()
             result = step.to_dict()
             result["warning"] = (
                 f"Step '{step_name}' has unsatisfied dependencies: "
@@ -341,6 +372,7 @@ def build_plan_tools(
             return result
 
         step.status = "in_progress"
+        await _persist()
         return step.to_dict()
 
     @task
@@ -374,6 +406,7 @@ def build_plan_tools(
 
         step.status = "completed"
         step.result = result
+        await _persist()
         return step.to_dict()
 
     @task
@@ -403,6 +436,7 @@ def build_plan_tools(
 
         step.status = "failed"
         step.error = reason
+        await _persist()
         return step.to_dict()
 
     @task

--- a/flux/tasks/ai/anthropic.py
+++ b/flux/tasks/ai/anthropic.py
@@ -114,6 +114,25 @@ def build_anthropic_agent(
 
                 response = await client.messages.create(**{**kwargs, "messages": call_messages})
 
+                if (
+                    not _has_tool_use(response)
+                    and not _extract_text(response)
+                    and plan_summary_fn
+                    and plan_summary_fn()
+                    and tool_call_count < max_tool_calls
+                ):
+                    summary = plan_summary_fn()
+                    call_messages.append(
+                        {"role": "assistant", "content": _serialize_content(response.content)},
+                    )
+                    call_messages.append(
+                        {
+                            "role": "user",
+                            "content": f"Continue working on your plan. {summary}",
+                        },
+                    )
+                    response = await client.messages.create(**{**kwargs, "messages": call_messages})
+
             if _has_tool_use(response) and tool_call_count >= max_tool_calls:
                 call_messages.append(
                     {"role": "assistant", "content": _serialize_content(response.content)},
@@ -129,7 +148,10 @@ def build_anthropic_agent(
                     **{**kwargs_no_tools, "messages": call_messages},
                 )
 
-            if stream and not _has_tool_use(response):
+            if stream and not _extract_text(response) and not _has_tool_use(response):
+                call_messages.append(
+                    {"role": "assistant", "content": _serialize_content(response.content)},
+                )
                 kwargs_stream = {k: v for k, v in kwargs.items() if k != "tools"}
                 kwargs_stream["messages"] = call_messages
                 async with client.messages.stream(**kwargs_stream) as stream_ctx:

--- a/flux/tasks/ai/anthropic.py
+++ b/flux/tasks/ai/anthropic.py
@@ -148,20 +148,16 @@ def build_anthropic_agent(
                     **{**kwargs_no_tools, "messages": call_messages},
                 )
 
-            if stream and not _has_tool_use(response):
-                existing_text = _extract_text(response)
-                if existing_text:
-                    await progress({"token": existing_text})
-                else:
-                    call_messages.append(
-                        {"role": "assistant", "content": _serialize_content(response.content)},
-                    )
-                    kwargs_stream = {k: v for k, v in kwargs.items() if k != "tools"}
-                    kwargs_stream["messages"] = call_messages
-                    async with client.messages.stream(**kwargs_stream) as stream_ctx:
-                        async for text in stream_ctx.text_stream:
-                            await progress({"token": text})
-                        response = stream_ctx.get_final_message()
+            if stream and not _extract_text(response) and not _has_tool_use(response):
+                call_messages.append(
+                    {"role": "assistant", "content": _serialize_content(response.content)},
+                )
+                kwargs_stream = {k: v for k, v in kwargs.items() if k != "tools"}
+                kwargs_stream["messages"] = call_messages
+                async with client.messages.stream(**kwargs_stream) as stream_ctx:
+                    async for text in stream_ctx.text_stream:
+                        await progress({"token": text})
+                    response = stream_ctx.get_final_message()
 
         content = _extract_text(response)
 

--- a/flux/tasks/ai/anthropic.py
+++ b/flux/tasks/ai/anthropic.py
@@ -27,6 +27,7 @@ def build_anthropic_agent(
     max_tool_calls: int = 10,
     max_tokens: int = 4096,
     stream: bool = True,
+    plan_summary_fn: Any | None = None,
 ) -> task:
     """Build a Flux @task that calls Anthropic's messages API."""
     if AsyncAnthropic is None:
@@ -104,6 +105,11 @@ def build_anthropic_agent(
                     }
                     for tc, result in zip(tool_calls, results)
                 ]
+                if plan_summary_fn:
+                    summary = plan_summary_fn()
+                    if summary:
+                        tool_results[-1]["content"] += f"\n\n{summary}"
+
                 call_messages.append({"role": "user", "content": tool_results})
 
                 response = await client.messages.create(**{**kwargs, "messages": call_messages})

--- a/flux/tasks/ai/anthropic.py
+++ b/flux/tasks/ai/anthropic.py
@@ -148,16 +148,20 @@ def build_anthropic_agent(
                     **{**kwargs_no_tools, "messages": call_messages},
                 )
 
-            if stream and not _extract_text(response) and not _has_tool_use(response):
-                call_messages.append(
-                    {"role": "assistant", "content": _serialize_content(response.content)},
-                )
-                kwargs_stream = {k: v for k, v in kwargs.items() if k != "tools"}
-                kwargs_stream["messages"] = call_messages
-                async with client.messages.stream(**kwargs_stream) as stream_ctx:
-                    async for text in stream_ctx.text_stream:
-                        await progress({"token": text})
-                    response = stream_ctx.get_final_message()
+            if stream and not _has_tool_use(response):
+                existing_text = _extract_text(response)
+                if existing_text:
+                    await progress({"token": existing_text})
+                else:
+                    call_messages.append(
+                        {"role": "assistant", "content": _serialize_content(response.content)},
+                    )
+                    kwargs_stream = {k: v for k, v in kwargs.items() if k != "tools"}
+                    kwargs_stream["messages"] = call_messages
+                    async with client.messages.stream(**kwargs_stream) as stream_ctx:
+                        async for text in stream_ctx.text_stream:
+                            await progress({"token": text})
+                        response = stream_ctx.get_final_message()
 
         content = _extract_text(response)
 

--- a/flux/tasks/ai/gemini.py
+++ b/flux/tasks/ai/gemini.py
@@ -128,6 +128,24 @@ def build_gemini_agent(
                     config=config,
                 )
 
+                if (
+                    not response.function_calls
+                    and not (response.text or "")
+                    and plan_summary_fn
+                    and plan_summary_fn()
+                    and tool_call_count < max_tool_calls
+                ):
+                    summary = plan_summary_fn()
+                    contents.append(response.candidates[0].content)
+                    contents.append(
+                        _to_content("user", f"Continue working on your plan. {summary}"),
+                    )
+                    response = await client.aio.models.generate_content(
+                        model=model_name,
+                        contents=contents,
+                        config=config,
+                    )
+
             if response.function_calls and tool_call_count >= max_tool_calls:
                 contents.append(response.candidates[0].content)
                 contents.append(
@@ -146,12 +164,14 @@ def build_gemini_agent(
                     config=config_no_tools,
                 )
 
-            if stream and not (response.function_calls):
+            content = response.text or ""
+
+            if stream and not content and not response.function_calls:
+                contents.append(response.candidates[0].content)
                 config_stream = types.GenerateContentConfig(
                     system_instruction=system_prompt,
                     max_output_tokens=max_tokens,
                 )
-                content = ""
                 async for chunk in await client.aio.models.generate_content_stream(
                     model=model_name,
                     contents=contents,
@@ -161,8 +181,6 @@ def build_gemini_agent(
                     if token:
                         content += token
                         await progress({"token": token})
-            else:
-                content = response.text or ""
 
         if working_memory:
             await working_memory.memorize("user", user_content)

--- a/flux/tasks/ai/gemini.py
+++ b/flux/tasks/ai/gemini.py
@@ -28,6 +28,7 @@ def build_gemini_agent(
     max_tool_calls: int = 10,
     max_tokens: int = 4096,
     stream: bool = True,
+    plan_summary_fn: Any | None = None,
 ) -> task:
     """Build a Flux @task that calls Google Gemini's API."""
     if genai is None:
@@ -110,6 +111,16 @@ def build_gemini_agent(
                 contents.append(
                     types.Content(role="user", parts=function_response_parts),
                 )
+
+                if plan_summary_fn:
+                    summary = plan_summary_fn()
+                    if summary:
+                        contents.append(
+                            types.Content(
+                                role="user",
+                                parts=[types.Part(text=summary)],
+                            ),
+                        )
 
                 response = await client.aio.models.generate_content(
                     model=model_name,

--- a/flux/tasks/ai/gemini.py
+++ b/flux/tasks/ai/gemini.py
@@ -166,24 +166,21 @@ def build_gemini_agent(
 
             content = response.text or ""
 
-            if stream and not response.function_calls:
-                if content:
-                    await progress({"token": content})
-                else:
-                    contents.append(response.candidates[0].content)
-                    config_stream = types.GenerateContentConfig(
-                        system_instruction=system_prompt,
-                        max_output_tokens=max_tokens,
-                    )
-                    async for chunk in await client.aio.models.generate_content_stream(
-                        model=model_name,
-                        contents=contents,
-                        config=config_stream,
-                    ):
-                        token = chunk.text
-                        if token:
-                            content += token
-                            await progress({"token": token})
+            if stream and not content and not response.function_calls:
+                contents.append(response.candidates[0].content)
+                config_stream = types.GenerateContentConfig(
+                    system_instruction=system_prompt,
+                    max_output_tokens=max_tokens,
+                )
+                async for chunk in await client.aio.models.generate_content_stream(
+                    model=model_name,
+                    contents=contents,
+                    config=config_stream,
+                ):
+                    token = chunk.text
+                    if token:
+                        content += token
+                        await progress({"token": token})
 
         if working_memory:
             await working_memory.memorize("user", user_content)

--- a/flux/tasks/ai/gemini.py
+++ b/flux/tasks/ai/gemini.py
@@ -166,21 +166,24 @@ def build_gemini_agent(
 
             content = response.text or ""
 
-            if stream and not content and not response.function_calls:
-                contents.append(response.candidates[0].content)
-                config_stream = types.GenerateContentConfig(
-                    system_instruction=system_prompt,
-                    max_output_tokens=max_tokens,
-                )
-                async for chunk in await client.aio.models.generate_content_stream(
-                    model=model_name,
-                    contents=contents,
-                    config=config_stream,
-                ):
-                    token = chunk.text
-                    if token:
-                        content += token
-                        await progress({"token": token})
+            if stream and not response.function_calls:
+                if content:
+                    await progress({"token": content})
+                else:
+                    contents.append(response.candidates[0].content)
+                    config_stream = types.GenerateContentConfig(
+                        system_instruction=system_prompt,
+                        max_output_tokens=max_tokens,
+                    )
+                    async for chunk in await client.aio.models.generate_content_stream(
+                        model=model_name,
+                        contents=contents,
+                        config=config_stream,
+                    ):
+                        token = chunk.text
+                        if token:
+                            content += token
+                            await progress({"token": token})
 
         if working_memory:
             await working_memory.memorize("user", user_content)

--- a/flux/tasks/ai/ollama.py
+++ b/flux/tasks/ai/ollama.py
@@ -6,7 +6,12 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel
 
 from flux.task import task
-from flux.tasks.ai.tool_executor import build_tool_schemas, execute_tools
+from flux.tasks.ai.tool_executor import (
+    build_tool_schemas,
+    execute_tools,
+    extract_tool_calls_from_content,
+    strip_tool_calls_from_content,
+)
 
 if TYPE_CHECKING:
     from flux.tasks.ai.memory.working_memory import WorkingMemory
@@ -21,6 +26,7 @@ def build_ollama_agent(
     working_memory: WorkingMemory | None = None,
     max_tool_calls: int = 10,
     stream: bool = True,
+    plan_summary_fn: Any | None = None,
 ) -> task:
     """Build a Flux @task that calls Ollama's chat API."""
     try:
@@ -33,6 +39,7 @@ def build_ollama_agent(
     task_name = name or f"agent_ollama_{model_name.replace(':', '_').replace('.', '_')}"
     tool_schemas = build_tool_schemas(tools) if tools else None
     ollama_tools = _to_ollama_tools(tool_schemas) if tool_schemas else None
+    tool_names = {s["name"] for s in tool_schemas} if tool_schemas else set()
 
     @task.with_options(name=task_name)
     async def ollama_agent_task(instruction: str, *, context: str = "") -> str | BaseModel:
@@ -81,27 +88,49 @@ def build_ollama_agent(
 
             tool_call_count = 0
             tool_iteration = 0
-            while response_message.get("tool_calls") and tools and tool_call_count < max_tool_calls:
-                tool_calls = [
-                    {
-                        "id": f"call_{i}",
-                        "name": tc["function"]["name"],
-                        "arguments": tc["function"]["arguments"],
-                    }
-                    for i, tc in enumerate(response_message["tool_calls"])
-                ]
-                tool_call_count += len(tool_calls)
+
+            def _extract_tool_calls(msg: dict) -> list[dict] | None:
+                """Extract tool calls from structured field or text content."""
+                if msg.get("tool_calls"):
+                    return [
+                        {
+                            "id": f"call_{i}",
+                            "name": tc["function"]["name"],
+                            "arguments": tc["function"]["arguments"],
+                        }
+                        for i, tc in enumerate(msg["tool_calls"])
+                    ]
+                if tool_names and msg.get("content"):
+                    return extract_tool_calls_from_content(
+                        msg["content"],
+                        tool_names,
+                    )
+                return None
+
+            pending_tool_calls = _extract_tool_calls(response_message)
+            while pending_tool_calls and tools and tool_call_count < max_tool_calls:
+                tool_call_count += len(pending_tool_calls)
 
                 call_messages.append(response_message)
-                results = await execute_tools(tool_calls, tools, iteration=tool_iteration)
+                results = await execute_tools(
+                    pending_tool_calls,
+                    tools,
+                    iteration=tool_iteration,
+                )
                 tool_iteration += 1
                 for result in results:
                     call_messages.append({"role": "tool", "content": result["output"]})
 
+                if plan_summary_fn:
+                    summary = plan_summary_fn()
+                    if summary:
+                        call_messages[-1]["content"] += f"\n\n{summary}"
+
                 response = await client.chat(**{**kwargs, "messages": call_messages})
                 response_message = response["message"]
+                pending_tool_calls = _extract_tool_calls(response_message)
 
-            if response_message.get("tool_calls") and tool_call_count >= max_tool_calls:
+            if pending_tool_calls and tool_call_count >= max_tool_calls:
                 call_messages.append(response_message)
                 call_messages.append(
                     {
@@ -113,7 +142,7 @@ def build_ollama_agent(
                 response = await client.chat(**{**kwargs_no_tools, "messages": call_messages})
                 response_message = response["message"]
 
-            if stream and not response_message.get("tool_calls"):
+            if stream and not pending_tool_calls:
                 kwargs_stream = {k: v for k, v in kwargs.items() if k != "tools"}
                 kwargs_stream["messages"] = call_messages
                 content = ""
@@ -124,6 +153,9 @@ def build_ollama_agent(
                         await progress({"token": token})
             else:
                 content = response_message["content"]
+
+            if tool_names:
+                content = strip_tool_calls_from_content(content)
 
         if working_memory:
             await working_memory.memorize("user", user_content)

--- a/flux/tasks/ai/ollama.py
+++ b/flux/tasks/ai/ollama.py
@@ -163,18 +163,15 @@ def build_ollama_agent(
 
             content = response_message.get("content", "")
 
-            if stream and not pending_tool_calls:
-                if content:
-                    await progress({"token": content})
-                else:
-                    call_messages.append(response_message)
-                    kwargs_stream = {k: v for k, v in kwargs.items() if k != "tools"}
-                    kwargs_stream["messages"] = call_messages
-                    async for chunk in await client.chat(**{**kwargs_stream, "stream": True}):
-                        token = chunk["message"]["content"]
-                        if token:
-                            content += token
-                            await progress({"token": token})
+            if stream and not content and not pending_tool_calls:
+                call_messages.append(response_message)
+                kwargs_stream = {k: v for k, v in kwargs.items() if k != "tools"}
+                kwargs_stream["messages"] = call_messages
+                async for chunk in await client.chat(**{**kwargs_stream, "stream": True}):
+                    token = chunk["message"]["content"]
+                    if token:
+                        content += token
+                        await progress({"token": token})
 
             if tool_names:
                 content = strip_tool_calls_from_content(content)

--- a/flux/tasks/ai/ollama.py
+++ b/flux/tasks/ai/ollama.py
@@ -163,15 +163,18 @@ def build_ollama_agent(
 
             content = response_message.get("content", "")
 
-            if stream and not content and not pending_tool_calls:
-                call_messages.append(response_message)
-                kwargs_stream = {k: v for k, v in kwargs.items() if k != "tools"}
-                kwargs_stream["messages"] = call_messages
-                async for chunk in await client.chat(**{**kwargs_stream, "stream": True}):
-                    token = chunk["message"]["content"]
-                    if token:
-                        content += token
-                        await progress({"token": token})
+            if stream and not pending_tool_calls:
+                if content:
+                    await progress({"token": content})
+                else:
+                    call_messages.append(response_message)
+                    kwargs_stream = {k: v for k, v in kwargs.items() if k != "tools"}
+                    kwargs_stream["messages"] = call_messages
+                    async for chunk in await client.chat(**{**kwargs_stream, "stream": True}):
+                        token = chunk["message"]["content"]
+                        if token:
+                            content += token
+                            await progress({"token": token})
 
             if tool_names:
                 content = strip_tool_calls_from_content(content)

--- a/flux/tasks/ai/ollama.py
+++ b/flux/tasks/ai/ollama.py
@@ -130,6 +130,25 @@ def build_ollama_agent(
                 response_message = response["message"]
                 pending_tool_calls = _extract_tool_calls(response_message)
 
+                if (
+                    not pending_tool_calls
+                    and not response_message.get("content")
+                    and plan_summary_fn
+                    and plan_summary_fn()
+                    and tool_call_count < max_tool_calls
+                ):
+                    summary = plan_summary_fn()
+                    call_messages.append(response_message)
+                    call_messages.append(
+                        {
+                            "role": "user",
+                            "content": f"Continue working on your plan. {summary}",
+                        },
+                    )
+                    response = await client.chat(**{**kwargs, "messages": call_messages})
+                    response_message = response["message"]
+                    pending_tool_calls = _extract_tool_calls(response_message)
+
             if pending_tool_calls and tool_call_count >= max_tool_calls:
                 call_messages.append(response_message)
                 call_messages.append(
@@ -142,17 +161,17 @@ def build_ollama_agent(
                 response = await client.chat(**{**kwargs_no_tools, "messages": call_messages})
                 response_message = response["message"]
 
-            if stream and not pending_tool_calls:
+            content = response_message.get("content", "")
+
+            if stream and not content and not pending_tool_calls:
+                call_messages.append(response_message)
                 kwargs_stream = {k: v for k, v in kwargs.items() if k != "tools"}
                 kwargs_stream["messages"] = call_messages
-                content = ""
                 async for chunk in await client.chat(**{**kwargs_stream, "stream": True}):
                     token = chunk["message"]["content"]
                     if token:
                         content += token
                         await progress({"token": token})
-            else:
-                content = response_message["content"]
 
             if tool_names:
                 content = strip_tool_calls_from_content(content)

--- a/flux/tasks/ai/openai.py
+++ b/flux/tasks/ai/openai.py
@@ -25,6 +25,7 @@ def build_openai_agent(
     working_memory: WorkingMemory | None = None,
     max_tool_calls: int = 10,
     stream: bool = True,
+    plan_summary_fn: Any | None = None,
 ) -> task:
     """Build a Flux @task that calls OpenAI's chat API."""
     if AsyncOpenAI is None:
@@ -106,6 +107,11 @@ def build_openai_agent(
                             "content": result["output"],
                         },
                     )
+
+                if plan_summary_fn:
+                    summary = plan_summary_fn()
+                    if summary:
+                        call_messages[-1]["content"] += f"\n\n{summary}"
 
                 response = await client.chat.completions.create(
                     **{**kwargs, "messages": call_messages},

--- a/flux/tasks/ai/openai.py
+++ b/flux/tasks/ai/openai.py
@@ -118,6 +118,26 @@ def build_openai_agent(
                 )
                 message = response.choices[0].message
 
+                if (
+                    not message.tool_calls
+                    and not message.content
+                    and plan_summary_fn
+                    and plan_summary_fn()
+                    and tool_call_count < max_tool_calls
+                ):
+                    summary = plan_summary_fn()
+                    call_messages.append(message.model_dump())
+                    call_messages.append(
+                        {
+                            "role": "user",
+                            "content": f"Continue working on your plan. {summary}",
+                        },
+                    )
+                    response = await client.chat.completions.create(
+                        **{**kwargs, "messages": call_messages},
+                    )
+                    message = response.choices[0].message
+
             if message.tool_calls and tool_call_count >= max_tool_calls:
                 call_messages.append(message.model_dump())
                 call_messages.append(
@@ -132,10 +152,12 @@ def build_openai_agent(
                 )
                 message = response.choices[0].message
 
-            if stream and not message.tool_calls:
+            content = message.content or ""
+
+            if stream and not content and not message.tool_calls:
+                call_messages.append(message.model_dump())
                 kwargs_stream = {k: v for k, v in kwargs.items() if k != "tools"}
                 kwargs_stream["messages"] = call_messages
-                content = ""
                 async for chunk in await client.chat.completions.create(
                     **kwargs_stream,
                     stream=True,
@@ -144,8 +166,6 @@ def build_openai_agent(
                     if token:
                         content += token
                         await progress({"token": token})
-            else:
-                content = message.content or ""
 
         if working_memory:
             await working_memory.memorize("user", user_content)

--- a/flux/tasks/ai/openai.py
+++ b/flux/tasks/ai/openai.py
@@ -154,18 +154,21 @@ def build_openai_agent(
 
             content = message.content or ""
 
-            if stream and not content and not message.tool_calls:
-                call_messages.append(message.model_dump())
-                kwargs_stream = {k: v for k, v in kwargs.items() if k != "tools"}
-                kwargs_stream["messages"] = call_messages
-                async for chunk in await client.chat.completions.create(
-                    **kwargs_stream,
-                    stream=True,
-                ):
-                    token = chunk.choices[0].delta.content
-                    if token:
-                        content += token
-                        await progress({"token": token})
+            if stream and not message.tool_calls:
+                if content:
+                    await progress({"token": content})
+                else:
+                    call_messages.append(message.model_dump())
+                    kwargs_stream = {k: v for k, v in kwargs.items() if k != "tools"}
+                    kwargs_stream["messages"] = call_messages
+                    async for chunk in await client.chat.completions.create(
+                        **kwargs_stream,
+                        stream=True,
+                    ):
+                        token = chunk.choices[0].delta.content
+                        if token:
+                            content += token
+                            await progress({"token": token})
 
         if working_memory:
             await working_memory.memorize("user", user_content)

--- a/flux/tasks/ai/openai.py
+++ b/flux/tasks/ai/openai.py
@@ -154,21 +154,18 @@ def build_openai_agent(
 
             content = message.content or ""
 
-            if stream and not message.tool_calls:
-                if content:
-                    await progress({"token": content})
-                else:
-                    call_messages.append(message.model_dump())
-                    kwargs_stream = {k: v for k, v in kwargs.items() if k != "tools"}
-                    kwargs_stream["messages"] = call_messages
-                    async for chunk in await client.chat.completions.create(
-                        **kwargs_stream,
-                        stream=True,
-                    ):
-                        token = chunk.choices[0].delta.content
-                        if token:
-                            content += token
-                            await progress({"token": token})
+            if stream and not content and not message.tool_calls:
+                call_messages.append(message.model_dump())
+                kwargs_stream = {k: v for k, v in kwargs.items() if k != "tools"}
+                kwargs_stream["messages"] = call_messages
+                async for chunk in await client.chat.completions.create(
+                    **kwargs_stream,
+                    stream=True,
+                ):
+                    token = chunk.choices[0].delta.content
+                    if token:
+                        content += token
+                        await progress({"token": token})
 
         if working_memory:
             await working_memory.memorize("user", user_content)

--- a/flux/tasks/ai/tool_executor.py
+++ b/flux/tasks/ai/tool_executor.py
@@ -1,11 +1,111 @@
 from __future__ import annotations
 
 import inspect
+import json
 import logging
+import re
 import typing
 from typing import Any, Callable, Union, get_type_hints
 
 logger = logging.getLogger("flux.agent")
+
+# Patterns for tool calls embedded in text content.
+# Models like Mistral, Qwen, and Hermes sometimes output tool calls as text
+# instead of using the structured tool_calls field.
+_TOOL_CALL_PATTERNS = [
+    re.compile(r"\[TOOL_CALLS\]\s*(\[.*\])", re.DOTALL),
+    re.compile(r"<tool_call>(.*?)</tool_call>", re.DOTALL),
+    re.compile(r"^\s*(\[\s*\{.*\}\s*\])\s*$", re.DOTALL),
+]
+
+
+def extract_tool_calls_from_content(
+    content: str,
+    tool_names: set[str],
+) -> list[dict[str, Any]] | None:
+    """Extract tool calls from text content when models output them as text.
+
+    Some models (Mistral, Qwen, Hermes) sometimes embed tool calls in text
+    content instead of the structured tool_calls field. This function detects
+    known patterns and parses them.
+
+    Only returns tool calls whose names match registered tools to avoid
+    false positives from regular JSON in model output.
+
+    Args:
+        content: The text content from the model response.
+        tool_names: Set of registered tool function names.
+
+    Returns:
+        List of tool call dicts (id, name, arguments) or None if not found.
+    """
+    if not content or not tool_names:
+        return None
+
+    for pattern in _TOOL_CALL_PATTERNS:
+        matches = pattern.findall(content)
+        if not matches:
+            continue
+
+        for match in matches:
+            try:
+                parsed = json.loads(match)
+                if isinstance(parsed, dict):
+                    parsed = [parsed]
+                if not isinstance(parsed, list):
+                    continue
+
+                tool_calls: list[dict[str, Any]] = []
+                for item in parsed:
+                    name = item.get("name")
+                    if name and name in tool_names:
+                        tool_calls.append(
+                            {
+                                "id": f"call_{len(tool_calls)}",
+                                "name": name,
+                                "arguments": item.get(
+                                    "arguments",
+                                    item.get("parameters", {}),
+                                ),
+                            },
+                        )
+
+                if tool_calls:
+                    logger.debug(
+                        "Extracted %d tool call(s) from text content",
+                        len(tool_calls),
+                    )
+                    return tool_calls
+            except (json.JSONDecodeError, TypeError, AttributeError):
+                continue
+
+    return None
+
+
+def strip_tool_calls_from_content(content: str) -> str:
+    """Remove tool call patterns from text content.
+
+    Used to clean up final responses when models embed tool calls
+    in their text output on the last turn.
+    """
+    if not content:
+        return content
+    for pattern in _TOOL_CALL_PATTERNS:
+        content = pattern.sub("", content)
+    return content.strip()
+
+
+def _serialize_result(result: Any) -> str:
+    """Serialize a tool result to a string for the LLM.
+
+    Dicts and lists are JSON-serialized to avoid Python repr output
+    (single quotes, etc.) which is not valid JSON and confuses LLMs.
+    """
+    if isinstance(result, (dict, list)):
+        import json
+
+        return json.dumps(result)
+    return str(result)
 
 
 def _resolve_json_type(hint: Any) -> str:
@@ -104,15 +204,29 @@ async def execute_tools(
             logger.warning("Agent requested unknown tool: %s", name)
             return {"tool_call_id": call.get("id", name), "output": f"Error: Unknown tool '{name}'"}
 
+        # Filter args to only include parameters the function accepts.
+        # LLMs sometimes hallucinate parameter names not in the schema.
+        func = tool_fn.func if hasattr(tool_fn, "func") else tool_fn
+        sig = inspect.signature(func)
+        has_var_keyword = any(
+            p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+        )
+        if not has_var_keyword:
+            accepted = set(sig.parameters.keys()) - {"self", "secrets", "metadata"}
+            unknown = set(args.keys()) - accepted
+            if unknown:
+                logger.debug("Tool '%s': dropping unknown args %s", name, unknown)
+                args = {k: v for k, v in args.items() if k in accepted}
+
         try:
             call_id = call.get("id", name)
             effective_tool = tool_fn
             if iteration > 0 and hasattr(tool_fn, "with_options"):
                 effective_tool = tool_fn.with_options(name=f"{name}_{iteration}")
             result = await effective_tool(**args)
-            return {"tool_call_id": call_id, "output": str(result)}
+            return {"tool_call_id": call_id, "output": _serialize_result(result)}
         except Exception as e:
-            logger.warning("Tool '%s' failed: %s", name, e)
+            logger.warning("Tool '%s' failed: %s (args=%s)", name, e, args)
             return {"tool_call_id": call.get("id", name), "output": f"Error: {e!s}"}
 
     return [await _run_one(call) for call in tool_calls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.14.0"
+version = "0.15.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/tasks/ai/memory/test_agent_integration.py
+++ b/tests/flux/tasks/ai/memory/test_agent_integration.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from flux.tasks.ai import agent
@@ -8,24 +10,26 @@ from flux.tasks.ai.memory import in_memory, long_term_memory, working_memory
 
 def test_agent_accepts_working_memory():
     wm = working_memory()
-    a = agent("You are a test agent.", model="ollama/llama3", working_memory=wm)
+    a = asyncio.run(agent("You are a test agent.", model="ollama/llama3", working_memory=wm))
     assert a is not None
 
 
 def test_agent_accepts_long_term_memory():
     ltm = long_term_memory(provider=in_memory(), scope="test")
-    a = agent("You are a test agent.", model="ollama/llama3", long_term_memory=ltm)
+    a = asyncio.run(agent("You are a test agent.", model="ollama/llama3", long_term_memory=ltm))
     assert a is not None
 
 
 def test_agent_accepts_both_memories():
     wm = working_memory(window=10)
     ltm = long_term_memory(provider=in_memory(), scope="test")
-    a = agent(
-        "You are a test agent.",
-        model="ollama/llama3",
-        working_memory=wm,
-        long_term_memory=ltm,
+    a = asyncio.run(
+        agent(
+            "You are a test agent.",
+            model="ollama/llama3",
+            working_memory=wm,
+            long_term_memory=ltm,
+        ),
     )
     assert a is not None
 
@@ -33,11 +37,11 @@ def test_agent_accepts_both_memories():
 def test_agent_no_stateful_parameter():
     """stateful parameter should no longer exist."""
     with pytest.raises(TypeError):
-        agent("test", model="ollama/llama3", stateful=True)
+        asyncio.run(agent("test", model="ollama/llama3", stateful=True))
 
 
 def test_agent_ltm_injects_tools():
     """Long-term memory should add memory tools to the agent."""
     ltm = long_term_memory(provider=in_memory(), scope="test")
-    a = agent("You are a test agent.", model="ollama/llama3", long_term_memory=ltm)
+    a = asyncio.run(agent("You are a test agent.", model="ollama/llama3", long_term_memory=ltm))
     assert a is not None

--- a/tests/flux/tasks/ai/test_agent.py
+++ b/tests/flux/tasks/ai/test_agent.py
@@ -1,33 +1,35 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from flux.tasks.ai import agent
 
 
 def test_agent_parses_ollama_model():
-    a = agent("You are a test agent.", model="ollama/llama3")
+    a = asyncio.run(agent("You are a test agent.", model="ollama/llama3"))
     assert a.name == "agent_ollama_llama3"
 
 
 def test_agent_parses_model_with_version():
-    a = agent("You are a test agent.", model="ollama/llama3.2")
+    a = asyncio.run(agent("You are a test agent.", model="ollama/llama3.2"))
     assert a.name == "agent_ollama_llama3_2"
 
 
 def test_agent_custom_name():
-    a = agent("You are a test agent.", model="ollama/llama3", name="researcher")
+    a = asyncio.run(agent("You are a test agent.", model="ollama/llama3", name="researcher"))
     assert a.name == "researcher"
 
 
 def test_agent_rejects_invalid_model_format():
     with pytest.raises(ValueError, match="provider/model_name"):
-        agent("test", model="llama3")
+        asyncio.run(agent("test", model="llama3"))
 
 
 def test_agent_rejects_unknown_provider():
     with pytest.raises(ValueError, match="Unknown provider"):
-        agent("test", model="unknown/model")
+        asyncio.run(agent("test", model="unknown/model"))
 
 
 def test_agent_accepts_skills():
@@ -35,7 +37,7 @@ def test_agent_accepts_skills():
 
     s1 = Skill(name="researcher", description="Researches.", instructions="Research.")
     catalog = SkillCatalog([s1])
-    a = agent("You are a test agent.", model="ollama/llama3", skills=catalog)
+    a = asyncio.run(agent("You are a test agent.", model="ollama/llama3", skills=catalog))
     assert a is not None
 
 
@@ -52,7 +54,7 @@ def test_agent_skills_warns_missing_allowed_tools(caplog):
     )
     catalog = SkillCatalog([s1])
     with caplog.at_level(logging.WARNING, logger="flux.agent"):
-        agent("You are a test agent.", model="ollama/llama3", skills=catalog)
+        asyncio.run(agent("You are a test agent.", model="ollama/llama3", skills=catalog))
     assert "search_web" in caplog.text
 
 
@@ -64,17 +66,17 @@ def test_skill_exports():
 
 
 def test_agent_accepts_stream_parameter():
-    a = agent("You are a test agent.", model="ollama/llama3", stream=True)
+    a = asyncio.run(agent("You are a test agent.", model="ollama/llama3", stream=True))
     assert a is not None
 
 
 def test_agent_stream_defaults_to_true():
-    a = agent("You are a test agent.", model="ollama/llama3")
+    a = asyncio.run(agent("You are a test agent.", model="ollama/llama3"))
     assert a is not None
 
 
 def test_agent_stream_false():
-    a = agent("You are a test agent.", model="ollama/llama3", stream=False)
+    a = asyncio.run(agent("You are a test agent.", model="ollama/llama3", stream=False))
     assert a is not None
 
 
@@ -84,44 +86,83 @@ def test_agent_stream_disabled_with_response_format():
     class Info(BaseModel):
         name: str
 
-    a = agent("Extract info.", model="ollama/llama3", response_format=Info, stream=True)
+    a = asyncio.run(
+        agent("Extract info.", model="ollama/llama3", response_format=Info, stream=True),
+    )
     assert a is not None
 
 
 def test_agent_parses_google_model():
-    a = agent("You are a test agent.", model="google/gemini-2.5-flash")
+    a = asyncio.run(agent("You are a test agent.", model="google/gemini-2.5-flash"))
     assert a.name == "agent_google_gemini_2_5_flash"
 
 
 def test_agent_parses_google_model_with_version():
-    a = agent("You are a test agent.", model="google/gemini-2.5-pro")
+    a = asyncio.run(agent("You are a test agent.", model="google/gemini-2.5-pro"))
     assert a.name == "agent_google_gemini_2_5_pro"
 
 
 def test_agent_accepts_planning_parameter():
-    a = agent("You are a test agent.", model="ollama/llama3", planning=True)
-    assert a is not None
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        a = await agent("You are a test agent.", model="ollama/llama3", planning=True)
+        return a is not None
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert ctx.output is True
 
 
 def test_agent_planning_default_false():
-    a = agent("You are a test agent.", model="ollama/llama3")
+    a = asyncio.run(agent("You are a test agent.", model="ollama/llama3"))
     assert a is not None
 
 
 def test_agent_planning_with_openai(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-    a = agent("You are a test agent.", model="openai/gpt-4o", planning=True)
-    assert a is not None
+
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        a = await agent("You are a test agent.", model="openai/gpt-4o", planning=True)
+        return a is not None
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert ctx.output is True
 
 
 def test_agent_planning_with_anthropic():
-    a = agent("You are a test agent.", model="anthropic/claude-sonnet-4-20250514", planning=True)
-    assert a is not None
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        a = await agent(
+            "You are a test agent.",
+            model="anthropic/claude-sonnet-4-20250514",
+            planning=True,
+        )
+        return a is not None
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert ctx.output is True
 
 
 def test_agent_planning_with_gemini():
-    a = agent("You are a test agent.", model="google/gemini-2.5-flash", planning=True)
-    assert a is not None
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        a = await agent("You are a test agent.", model="google/gemini-2.5-flash", planning=True)
+        return a is not None
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert ctx.output is True
 
 
 def test_agent_plan_exports():

--- a/tests/flux/tasks/ai/test_agent.py
+++ b/tests/flux/tasks/ai/test_agent.py
@@ -96,3 +96,36 @@ def test_agent_parses_google_model():
 def test_agent_parses_google_model_with_version():
     a = agent("You are a test agent.", model="google/gemini-2.5-pro")
     assert a.name == "agent_google_gemini_2_5_pro"
+
+
+def test_agent_accepts_planning_parameter():
+    a = agent("You are a test agent.", model="ollama/llama3", planning=True)
+    assert a is not None
+
+
+def test_agent_planning_default_false():
+    a = agent("You are a test agent.", model="ollama/llama3")
+    assert a is not None
+
+
+def test_agent_planning_with_openai(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    a = agent("You are a test agent.", model="openai/gpt-4o", planning=True)
+    assert a is not None
+
+
+def test_agent_planning_with_anthropic():
+    a = agent("You are a test agent.", model="anthropic/claude-sonnet-4-20250514", planning=True)
+    assert a is not None
+
+
+def test_agent_planning_with_gemini():
+    a = agent("You are a test agent.", model="google/gemini-2.5-flash", planning=True)
+    assert a is not None
+
+
+def test_agent_plan_exports():
+    from flux.tasks.ai import AgentPlan, AgentStep
+
+    assert AgentPlan is not None
+    assert AgentStep is not None

--- a/tests/flux/tasks/ai/test_agent.py
+++ b/tests/flux/tasks/ai/test_agent.py
@@ -170,3 +170,19 @@ def test_agent_plan_exports():
 
     assert AgentPlan is not None
     assert AgentStep is not None
+
+
+def test_agent_planning_params_threaded():
+    """Verify agent accepts new planning parameters without error."""
+    result = asyncio.run(
+        agent(
+            "You are an assistant.",
+            model="ollama/llama3.2",
+            planning=True,
+            max_plan_steps=10,
+            strict_dependencies=True,
+            approve_plan=False,
+            stream=False,
+        ),
+    )
+    assert result is not None

--- a/tests/flux/tasks/ai/test_agent_plan.py
+++ b/tests/flux/tasks/ai/test_agent_plan.py
@@ -905,19 +905,20 @@ def test_start_step_strict_deps_blocks():
 # --- Preamble tests ---
 
 
-def test_build_plan_preamble_contains_tool_names():
+def test_build_plan_preamble_contains_new_tool_names():
     preamble = build_plan_preamble()
-    assert "create_plan" in preamble
+    assert "start_step" in preamble
+    assert "mark_step_failed" in preamble
+    assert "get_ready_steps" in preamble
     assert "mark_step_done" in preamble
+    assert "create_plan" in preamble
     assert "get_plan" in preamble
 
 
-def test_build_plan_preamble_contains_guidance():
+def test_build_plan_preamble_contains_status_guidance():
     preamble = build_plan_preamble()
-    assert "When to create a plan" in preamble
-    assert "When NOT to create a plan" in preamble
-    assert "depends_on" in preamble
-    assert "Replanning" in preamble
+    assert "in_progress" in preamble
+    assert "failed" in preamble
 
 
 # --- mark_step_failed tool tests ---

--- a/tests/flux/tasks/ai/test_agent_plan.py
+++ b/tests/flux/tasks/ai/test_agent_plan.py
@@ -128,6 +128,92 @@ def test_plan_pending_steps():
     assert len(pending) == 2
 
 
+def test_plan_in_progress_steps():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="A.", status="in_progress"),
+            AgentStep(name="b", description="B."),
+            AgentStep(name="c", description="C.", status="completed", result="Done."),
+        ],
+    )
+    in_progress = plan.in_progress_steps()
+    assert len(in_progress) == 1
+    assert in_progress[0].name == "a"
+
+
+def test_plan_failed_steps():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="A.", status="failed", error="Timeout."),
+            AgentStep(name="b", description="B."),
+        ],
+    )
+    failed = plan.failed_steps()
+    assert len(failed) == 1
+    assert failed[0].name == "a"
+
+
+def test_plan_ready_steps():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="A.", status="completed", result="Done."),
+            AgentStep(name="b", description="B.", depends_on=["a"]),
+            AgentStep(name="c", description="C.", depends_on=["a", "b"]),
+            AgentStep(name="d", description="D."),
+        ],
+    )
+    ready = plan.ready_steps()
+    assert len(ready) == 2
+    names = [s.name for s in ready]
+    assert "b" in names
+    assert "d" in names
+    assert "c" not in names
+
+
+def test_plan_ready_steps_excludes_in_progress():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="A.", status="in_progress"),
+            AgentStep(name="b", description="B."),
+        ],
+    )
+    ready = plan.ready_steps()
+    assert len(ready) == 1
+    assert ready[0].name == "b"
+
+
+def test_plan_failed_steps_block_dependents():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="A.", status="failed", error="Broke."),
+            AgentStep(name="b", description="B.", depends_on=["a"]),
+        ],
+    )
+    assert plan.dependencies_satisfied(plan.get_step("b")) is False
+    ready = plan.ready_steps()
+    assert len(ready) == 0
+
+
+def test_plan_active_step():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="A.", status="in_progress"),
+            AgentStep(name="b", description="B."),
+        ],
+    )
+    assert plan.active_step().name == "a"
+
+
+def test_plan_active_step_none():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="A."),
+            AgentStep(name="b", description="B."),
+        ],
+    )
+    assert plan.active_step() is None
+
+
 def test_plan_dependencies_satisfied():
     plan = AgentPlan(
         steps=[
@@ -389,7 +475,7 @@ def test_create_plan():
                 [
                     {"name": "research", "description": "Research the topic."},
                     {"name": "analyze", "description": "Analyze data.", "depends_on": ["research"]},
-                ]
+                ],
             ),
         )
 
@@ -437,7 +523,7 @@ def test_create_plan_circular_dependency():
                 [
                     {"name": "a", "description": "A.", "depends_on": ["b"]},
                     {"name": "b", "description": "B.", "depends_on": ["a"]},
-                ]
+                ],
             ),
         )
 
@@ -460,7 +546,7 @@ def test_create_plan_preserves_completed_on_replan():
                 [
                     {"name": "a", "description": "Do A."},
                     {"name": "b", "description": "Do B."},
-                ]
+                ],
             ),
         )
         await mark_step_done_tool(step_name="a", result="Done A.")
@@ -470,7 +556,7 @@ def test_create_plan_preserves_completed_on_replan():
                     {"name": "a", "description": "Do A differently."},
                     {"name": "b", "description": "Do B revised."},
                     {"name": "c", "description": "Do C.", "depends_on": ["a"]},
-                ]
+                ],
             ),
         )
         return result

--- a/tests/flux/tasks/ai/test_agent_plan.py
+++ b/tests/flux/tasks/ai/test_agent_plan.py
@@ -172,6 +172,19 @@ def test_plan_summary_with_ready():
     assert "1/3" in summary
     assert '"b"' in summary
     assert '"c"' in summary
+    # b has dependency on a — result should be included
+    assert "Done." in summary
+
+
+def test_plan_summary_no_deps_no_results():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="Do A."),
+        ],
+    )
+    summary = plan.summary()
+    assert '"a"' in summary
+    assert "from" not in summary
 
 
 def test_plan_summary_limits_to_3():

--- a/tests/flux/tasks/ai/test_agent_plan.py
+++ b/tests/flux/tasks/ai/test_agent_plan.py
@@ -1,0 +1,576 @@
+from __future__ import annotations
+
+import pytest
+
+from flux.tasks.ai.agent_plan import (
+    AgentPlan,
+    AgentStep,
+    PlanContext,
+    PlanValidationError,
+    build_plan_preamble,
+    build_plan_tools,
+    _validate_dependencies,
+    _validate_step_name,
+)
+
+
+# --- AgentStep tests ---
+
+
+def test_step_construction():
+    step = AgentStep(name="research", description="Research the topic.")
+    assert step.name == "research"
+    assert step.description == "Research the topic."
+    assert step.depends_on == []
+    assert step.status == "pending"
+    assert step.result is None
+
+
+def test_step_with_dependencies():
+    step = AgentStep(
+        name="analyze",
+        description="Analyze data.",
+        depends_on=["research", "collect"],
+    )
+    assert step.depends_on == ["research", "collect"]
+
+
+def test_step_to_dict_minimal():
+    step = AgentStep(name="research", description="Research the topic.")
+    d = step.to_dict()
+    assert d == {"name": "research", "description": "Research the topic.", "status": "pending"}
+    assert "depends_on" not in d
+    assert "result" not in d
+
+
+def test_step_to_dict_full():
+    step = AgentStep(
+        name="analyze",
+        description="Analyze data.",
+        depends_on=["research"],
+        status="completed",
+        result="Found 3 competitors.",
+    )
+    d = step.to_dict()
+    assert d["depends_on"] == ["research"]
+    assert d["result"] == "Found 3 competitors."
+    assert d["status"] == "completed"
+
+
+# --- AgentPlan tests ---
+
+
+def test_plan_construction():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="Do A."),
+            AgentStep(name="b", description="Do B.", depends_on=["a"]),
+        ],
+    )
+    assert len(plan.steps) == 2
+
+
+def test_plan_get_step():
+    step_a = AgentStep(name="a", description="Do A.")
+    plan = AgentPlan(steps=[step_a])
+    assert plan.get_step("a") is step_a
+    assert plan.get_step("nonexistent") is None
+
+
+def test_plan_completed_steps():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="Do A.", status="completed", result="Done."),
+            AgentStep(name="b", description="Do B."),
+        ],
+    )
+    completed = plan.completed_steps()
+    assert len(completed) == 1
+    assert completed[0].name == "a"
+
+
+def test_plan_pending_steps():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="Do A.", status="completed", result="Done."),
+            AgentStep(name="b", description="Do B."),
+            AgentStep(name="c", description="Do C."),
+        ],
+    )
+    pending = plan.pending_steps()
+    assert len(pending) == 2
+
+
+def test_plan_dependencies_satisfied():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="Do A.", status="completed", result="Done."),
+            AgentStep(name="b", description="Do B.", depends_on=["a"]),
+            AgentStep(name="c", description="Do C.", depends_on=["a", "b"]),
+        ],
+    )
+    assert plan.dependencies_satisfied(plan.get_step("b")) is True
+    assert plan.dependencies_satisfied(plan.get_step("c")) is False
+
+
+def test_plan_dependencies_satisfied_no_deps():
+    plan = AgentPlan(steps=[AgentStep(name="a", description="Do A.")])
+    assert plan.dependencies_satisfied(plan.get_step("a")) is True
+
+
+def test_plan_dependency_results():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="Do A.", status="completed", result="Result A."),
+            AgentStep(name="b", description="Do B.", status="completed", result="Result B."),
+            AgentStep(name="c", description="Do C.", depends_on=["a", "b"]),
+        ],
+    )
+    results = plan.dependency_results(plan.get_step("c"))
+    assert results == {"a": "Result A.", "b": "Result B."}
+
+
+def test_plan_dependency_results_partial():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="Do A.", status="completed", result="Result A."),
+            AgentStep(name="b", description="Do B."),
+            AgentStep(name="c", description="Do C.", depends_on=["a", "b"]),
+        ],
+    )
+    results = plan.dependency_results(plan.get_step("c"))
+    assert results == {"a": "Result A."}
+
+
+def test_plan_summary_no_ready():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="Do A.", status="completed", result="Done."),
+            AgentStep(
+                name="b",
+                description="Do B.",
+                depends_on=["a"],
+                status="completed",
+                result="Done.",
+            ),
+        ],
+    )
+    summary = plan.summary()
+    assert "2/2" in summary
+    assert "No steps ready" in summary
+
+
+def test_plan_summary_with_ready():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="Do A.", status="completed", result="Done."),
+            AgentStep(name="b", description="Do B.", depends_on=["a"]),
+            AgentStep(name="c", description="Do C."),
+        ],
+    )
+    summary = plan.summary()
+    assert "1/3" in summary
+    assert '"b"' in summary
+    assert '"c"' in summary
+
+
+def test_plan_summary_limits_to_3():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="A."),
+            AgentStep(name="b", description="B."),
+            AgentStep(name="c", description="C."),
+            AgentStep(name="d", description="D."),
+            AgentStep(name="e", description="E."),
+        ],
+    )
+    summary = plan.summary()
+    assert summary.count('"') <= 6
+
+
+def test_plan_to_dict():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="Do A."),
+            AgentStep(name="b", description="Do B.", depends_on=["a"]),
+        ],
+    )
+    d = plan.to_dict()
+    assert len(d["steps"]) == 2
+    assert d["steps"][0]["name"] == "a"
+    assert d["steps"][1]["depends_on"] == ["a"]
+
+
+# --- Validation tests ---
+
+
+def test_validate_step_name_valid():
+    _validate_step_name("research")
+    _validate_step_name("step-1")
+    _validate_step_name("a")
+    _validate_step_name("research-data-v2")
+
+
+def test_validate_step_name_empty():
+    with pytest.raises(PlanValidationError, match="empty"):
+        _validate_step_name("")
+
+
+def test_validate_step_name_too_long():
+    with pytest.raises(PlanValidationError, match="64"):
+        _validate_step_name("a" * 65)
+
+
+def test_validate_step_name_consecutive_hyphens():
+    with pytest.raises(PlanValidationError, match="consecutive"):
+        _validate_step_name("my--step")
+
+
+def test_validate_step_name_uppercase():
+    with pytest.raises(PlanValidationError, match="invalid"):
+        _validate_step_name("MyStep")
+
+
+def test_validate_step_name_leading_hyphen():
+    with pytest.raises(PlanValidationError, match="invalid"):
+        _validate_step_name("-step")
+
+
+def test_validate_step_name_trailing_hyphen():
+    with pytest.raises(PlanValidationError, match="invalid"):
+        _validate_step_name("step-")
+
+
+def test_validate_dependencies_valid():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="A."),
+            AgentStep(name="b", description="B.", depends_on=["a"]),
+        ],
+    )
+    _validate_dependencies(plan)
+
+
+def test_validate_dependencies_missing_reference():
+    plan = AgentPlan(
+        steps=[AgentStep(name="a", description="A.", depends_on=["nonexistent"])],
+    )
+    with pytest.raises(PlanValidationError, match="nonexistent"):
+        _validate_dependencies(plan)
+
+
+def test_validate_dependencies_circular():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="A.", depends_on=["b"]),
+            AgentStep(name="b", description="B.", depends_on=["a"]),
+        ],
+    )
+    with pytest.raises(PlanValidationError, match="Circular"):
+        _validate_dependencies(plan)
+
+
+def test_validate_dependencies_self_reference():
+    plan = AgentPlan(
+        steps=[AgentStep(name="a", description="A.", depends_on=["a"])],
+    )
+    with pytest.raises(PlanValidationError, match="Circular"):
+        _validate_dependencies(plan)
+
+
+def test_validate_dependencies_duplicate_names():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="A."),
+            AgentStep(name="a", description="A again."),
+        ],
+    )
+    with pytest.raises(PlanValidationError, match="Duplicate"):
+        _validate_dependencies(plan)
+
+
+# --- PlanContext tests ---
+
+
+def test_plan_context_initial_state():
+    ctx = PlanContext()
+    assert ctx.plan is None
+    assert ctx.summary() is None
+
+
+def test_plan_context_summary_with_plan():
+    ctx = PlanContext()
+    ctx.plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="A."),
+            AgentStep(name="b", description="B."),
+        ],
+    )
+    summary = ctx.summary()
+    assert summary is not None
+    assert "0/2" in summary
+
+
+# --- build_plan_tools tests ---
+
+
+def test_build_plan_tools_returns_tools_and_summary():
+    tools, summary_fn = build_plan_tools()
+    assert len(tools) == 3
+    assert callable(summary_fn)
+    assert summary_fn() is None
+
+
+def test_build_plan_tools_tool_names():
+    tools, _ = build_plan_tools()
+    names = {t.func.__name__ for t in tools}
+    assert names == {"create_plan", "mark_step_done", "get_plan"}
+
+
+def test_create_plan():
+    import json
+
+    from flux import ExecutionContext, workflow
+
+    tools, summary_fn = build_plan_tools()
+    create_plan_tool = tools[0]
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        return await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "research", "description": "Research the topic."},
+                    {"name": "analyze", "description": "Analyze data.", "depends_on": ["research"]},
+                ]
+            ),
+        )
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    result = ctx.output
+    assert len(result["steps"]) == 2
+    assert result["steps"][0]["name"] == "research"
+    assert result["steps"][1]["name"] == "analyze"
+    assert result["steps"][1]["depends_on"] == ["research"]
+    assert summary_fn() is not None
+    assert "0/2" in summary_fn()
+
+
+def test_create_plan_invalid_name():
+    import json
+
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool = tools[0]
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        return await create_plan_tool(
+            steps=json.dumps([{"name": "Bad-Name", "description": "Invalid."}]),
+        )
+
+    ctx = test_wf.run()
+    assert ctx.has_failed
+
+
+def test_create_plan_circular_dependency():
+    import json
+
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool = tools[0]
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        return await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "A.", "depends_on": ["b"]},
+                    {"name": "b", "description": "B.", "depends_on": ["a"]},
+                ]
+            ),
+        )
+
+    ctx = test_wf.run()
+    assert ctx.has_failed
+
+
+def test_create_plan_preserves_completed_on_replan():
+    import json
+
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool, mark_step_done_tool = tools[0], tools[1]
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B."},
+                ]
+            ),
+        )
+        await mark_step_done_tool(step_name="a", result="Done A.")
+        result = await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A differently."},
+                    {"name": "b", "description": "Do B revised."},
+                    {"name": "c", "description": "Do C.", "depends_on": ["a"]},
+                ]
+            ),
+        )
+        return result
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    result = ctx.output
+    step_a = next(s for s in result["steps"] if s["name"] == "a")
+    assert step_a["status"] == "completed"
+    assert step_a["result"] == "Done A."
+    step_b = next(s for s in result["steps"] if s["name"] == "b")
+    assert step_b["status"] == "pending"
+
+
+# --- complete_step tool tests ---
+
+
+def test_mark_step_done():
+    import json
+
+    from flux import ExecutionContext, workflow
+
+    tools, summary_fn = build_plan_tools()
+    create_plan_tool, mark_step_done_tool = tools[0], tools[1]
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps([{"name": "a", "description": "Do A."}]),
+        )
+        return await mark_step_done_tool(step_name="a", result="Done A.")
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert ctx.output["status"] == "completed"
+    assert ctx.output["result"] == "Done A."
+    assert "1/1" in summary_fn()
+
+
+def test_mark_step_done_no_plan():
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    mark_step_done_tool = tools[1]
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        return await mark_step_done_tool(step_name="a", result="Done.")
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert "error" in ctx.output
+
+
+def test_mark_step_done_not_found():
+    import json
+
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool, mark_step_done_tool = tools[0], tools[1]
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps([{"name": "a", "description": "Do A."}]),
+        )
+        return await mark_step_done_tool(step_name="nonexistent", result="Done.")
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert "error" in ctx.output
+    assert "nonexistent" in ctx.output["error"]
+
+
+def test_mark_step_done_already_completed():
+    import json
+
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool, mark_step_done_tool = tools[0], tools[1]
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps([{"name": "a", "description": "Do A."}]),
+        )
+        await mark_step_done_tool(step_name="a", result="First result.")
+        return await mark_step_done_tool(step_name="a", result="Second result.")
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert ctx.output["result"] == "First result."
+
+
+# --- get_plan tool tests ---
+
+
+def test_get_plan():
+    import json
+
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool, _, get_plan_tool = tools
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps([{"name": "a", "description": "Do A."}]),
+        )
+        return await get_plan_tool()
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert len(ctx.output["steps"]) == 1
+
+
+def test_get_plan_no_plan():
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    get_plan_tool = tools[2]
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        return await get_plan_tool()
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert "message" in ctx.output
+
+
+# --- Preamble tests ---
+
+
+def test_build_plan_preamble_contains_tool_names():
+    preamble = build_plan_preamble()
+    assert "create_plan" in preamble
+    assert "mark_step_done" in preamble
+    assert "get_plan" in preamble
+
+
+def test_build_plan_preamble_contains_guidance():
+    preamble = build_plan_preamble()
+    assert "When to create a plan" in preamble
+    assert "When NOT to create a plan" in preamble
+    assert "depends_on" in preamble
+    assert "Replanning" in preamble

--- a/tests/flux/tasks/ai/test_agent_plan.py
+++ b/tests/flux/tasks/ai/test_agent_plan.py
@@ -255,13 +255,13 @@ def test_plan_dependency_results_partial():
     assert results == {"a": "Result A."}
 
 
-def test_plan_summary_no_ready():
+def test_plan_summary_all_complete():
     plan = AgentPlan(
         steps=[
-            AgentStep(name="a", description="Do A.", status="completed", result="Done."),
+            AgentStep(name="a", description="A.", status="completed", result="Done."),
             AgentStep(
                 name="b",
-                description="Do B.",
+                description="B.",
                 depends_on=["a"],
                 status="completed",
                 result="Done.",
@@ -269,30 +269,29 @@ def test_plan_summary_no_ready():
         ],
     )
     summary = plan.summary()
-    assert "2/2" in summary
+    assert "2/2 done" in summary
     assert "No steps ready" in summary
 
 
-def test_plan_summary_with_ready():
+def test_plan_summary_with_ready_and_dep_results():
     plan = AgentPlan(
         steps=[
-            AgentStep(name="a", description="Do A.", status="completed", result="Done."),
-            AgentStep(name="b", description="Do B.", depends_on=["a"]),
-            AgentStep(name="c", description="Do C."),
+            AgentStep(name="a", description="A.", status="completed", result="Done."),
+            AgentStep(name="b", description="B.", depends_on=["a"]),
+            AgentStep(name="c", description="C."),
         ],
     )
     summary = plan.summary()
-    assert "1/3" in summary
+    assert "1/3 done" in summary
     assert '"b"' in summary
     assert '"c"' in summary
-    # b has dependency on a — result should be included
     assert "Done." in summary
 
 
 def test_plan_summary_no_deps_no_results():
     plan = AgentPlan(
         steps=[
-            AgentStep(name="a", description="Do A."),
+            AgentStep(name="a", description="A."),
         ],
     )
     summary = plan.summary()
@@ -312,6 +311,49 @@ def test_plan_summary_limits_to_3():
     )
     summary = plan.summary()
     assert summary.count('"') <= 6
+
+
+def test_plan_summary_shows_active_step():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="A.", status="in_progress"),
+            AgentStep(name="b", description="B."),
+        ],
+    )
+    summary = plan.summary()
+    assert "0/2 done" in summary
+    assert 'Active: "a"' in summary
+
+
+def test_plan_summary_shows_failed_steps():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="A.", status="failed", error="Timeout."),
+            AgentStep(name="b", description="B."),
+        ],
+    )
+    summary = plan.summary()
+    assert "1 failed" in summary
+    assert '"a"' in summary
+
+
+def test_plan_summary_full_status():
+    plan = AgentPlan(
+        steps=[
+            AgentStep(name="a", description="A.", status="completed", result="Done."),
+            AgentStep(name="b", description="B.", status="in_progress"),
+            AgentStep(name="c", description="C.", status="failed", error="Broke."),
+            AgentStep(name="d", description="D."),
+            AgentStep(name="e", description="E.", depends_on=["a"]),
+        ],
+    )
+    summary = plan.summary()
+    assert "1/5 done" in summary
+    assert "1 failed" in summary
+    assert 'Active: "b"' in summary
+    assert "Ready:" in summary
+    assert '"d"' in summary
+    assert '"e"' in summary
 
 
 def test_plan_to_dict():

--- a/tests/flux/tasks/ai/test_agent_plan.py
+++ b/tests/flux/tasks/ai/test_agent_plan.py
@@ -629,7 +629,9 @@ def test_mark_step_done():
     @workflow
     async def test_wf(ctx: ExecutionContext):
         await create_plan_tool(
-            steps=json.dumps([{"name": "a", "description": "Do A."}]),
+            steps=json.dumps(
+                [{"name": "a", "description": "Do A."}, {"name": "b", "description": "Do B."}],
+            ),
         )
         return await mark_step_done_tool(step_name="a", result="Done A.")
 
@@ -637,7 +639,7 @@ def test_mark_step_done():
     assert ctx.has_succeeded
     assert ctx.output["status"] == "completed"
     assert ctx.output["result"] == "Done A."
-    assert "1/1" in summary_fn()
+    assert "1/2" in summary_fn()
 
 
 def test_mark_step_done_no_plan():
@@ -667,7 +669,9 @@ def test_mark_step_done_not_found():
     @workflow
     async def test_wf(ctx: ExecutionContext):
         await create_plan_tool(
-            steps=json.dumps([{"name": "a", "description": "Do A."}]),
+            steps=json.dumps(
+                [{"name": "a", "description": "Do A."}, {"name": "b", "description": "Do B."}],
+            ),
         )
         return await mark_step_done_tool(step_name="nonexistent", result="Done.")
 
@@ -689,7 +693,9 @@ def test_mark_step_done_already_completed():
     @workflow
     async def test_wf(ctx: ExecutionContext):
         await create_plan_tool(
-            steps=json.dumps([{"name": "a", "description": "Do A."}]),
+            steps=json.dumps(
+                [{"name": "a", "description": "Do A."}, {"name": "b", "description": "Do B."}],
+            ),
         )
         await mark_step_done_tool(step_name="a", result="First result.")
         return await mark_step_done_tool(step_name="a", result="Second result.")
@@ -714,13 +720,15 @@ def test_get_plan():
     @workflow
     async def test_wf(ctx: ExecutionContext):
         await create_plan_tool(
-            steps=json.dumps([{"name": "a", "description": "Do A."}]),
+            steps=json.dumps(
+                [{"name": "a", "description": "Do A."}, {"name": "b", "description": "Do B."}],
+            ),
         )
         return await get_plan_tool()
 
     ctx = test_wf.run()
     assert ctx.has_succeeded
-    assert len(ctx.output["steps"]) == 1
+    assert len(ctx.output["steps"]) == 2
 
 
 def test_get_plan_no_plan():
@@ -1080,3 +1088,71 @@ def test_mark_step_done_rejects_failed():
     ctx = test_wf.run()
     assert ctx.has_succeeded
     assert "error" in ctx.output
+
+
+# --- Step count validation tests ---
+
+
+def test_create_plan_rejects_single_step():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool = tools[0]
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        return await create_plan_tool(
+            steps=json.dumps([{"name": "a", "description": "Do A."}]),
+        )
+
+    ctx = test_wf.run()
+    assert ctx.has_failed
+
+
+def test_create_plan_rejects_too_many_steps():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools(max_plan_steps=5)
+    create_plan_tool = tools[0]
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        steps = [{"name": f"s{i}", "description": f"Step {i}."} for i in range(6)]
+        return await create_plan_tool(steps=json.dumps(steps))
+
+    ctx = test_wf.run()
+    assert ctx.has_failed
+
+
+def test_create_plan_accepts_at_limit():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools(max_plan_steps=5)
+    create_plan_tool = tools[0]
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        steps = [{"name": f"s{i}", "description": f"Step {i}."} for i in range(5)]
+        return await create_plan_tool(steps=json.dumps(steps))
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+
+
+def test_create_plan_default_max_is_20():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool = tools[0]
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        steps = [{"name": f"s{i}", "description": f"Step {i}."} for i in range(21)]
+        return await create_plan_tool(steps=json.dumps(steps))
+
+    ctx = test_wf.run()
+    assert ctx.has_failed

--- a/tests/flux/tasks/ai/test_agent_plan.py
+++ b/tests/flux/tasks/ai/test_agent_plan.py
@@ -57,6 +57,33 @@ def test_step_to_dict_full():
     assert d["status"] == "completed"
 
 
+def test_step_in_progress_status():
+    step = AgentStep(name="research", description="Research.", status="in_progress")
+    assert step.status == "in_progress"
+    d = step.to_dict()
+    assert d["status"] == "in_progress"
+
+
+def test_step_failed_status():
+    step = AgentStep(
+        name="research",
+        description="Research.",
+        status="failed",
+        error="Connection timeout.",
+    )
+    assert step.status == "failed"
+    assert step.error == "Connection timeout."
+    d = step.to_dict()
+    assert d["status"] == "failed"
+    assert d["error"] == "Connection timeout."
+
+
+def test_step_to_dict_omits_none_error():
+    step = AgentStep(name="research", description="Research.")
+    d = step.to_dict()
+    assert "error" not in d
+
+
 # --- AgentPlan tests ---
 
 
@@ -222,6 +249,8 @@ def test_validate_step_name_valid():
     _validate_step_name("step-1")
     _validate_step_name("a")
     _validate_step_name("research-data-v2")
+    _validate_step_name("research_data")
+    _validate_step_name("step_1")
 
 
 def test_validate_step_name_empty():
@@ -237,6 +266,11 @@ def test_validate_step_name_too_long():
 def test_validate_step_name_consecutive_hyphens():
     with pytest.raises(PlanValidationError, match="consecutive"):
         _validate_step_name("my--step")
+
+
+def test_validate_step_name_consecutive_underscores():
+    with pytest.raises(PlanValidationError, match="consecutive"):
+        _validate_step_name("my__step")
 
 
 def test_validate_step_name_uppercase():

--- a/tests/flux/tasks/ai/test_agent_plan.py
+++ b/tests/flux/tasks/ai/test_agent_plan.py
@@ -1241,3 +1241,70 @@ def test_get_ready_steps_none_ready():
     ctx = test_wf.run()
     assert ctx.has_succeeded
     assert ctx.output["ready_steps"] == []
+
+
+def test_replan_warns_about_dropped_completed_steps():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool = tools[0]
+    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B."},
+                ],
+            ),
+        )
+        await mark_step_done_tool(step_name="a", result="Done A.")
+        return await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "c", "description": "Do C."},
+                    {"name": "d", "description": "Do D."},
+                ],
+            ),
+        )
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert "warning" in ctx.output
+    assert "a" in ctx.output["warning"]
+
+
+def test_replan_no_warning_when_steps_preserved():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool = tools[0]
+    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B."},
+                ],
+            ),
+        )
+        await mark_step_done_tool(step_name="a", result="Done A.")
+        return await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A differently."},
+                    {"name": "c", "description": "Do C."},
+                ],
+            ),
+        )
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert "warning" not in ctx.output

--- a/tests/flux/tasks/ai/test_agent_plan.py
+++ b/tests/flux/tasks/ai/test_agent_plan.py
@@ -490,16 +490,30 @@ def test_plan_context_summary_with_plan():
 
 
 def test_build_plan_tools_returns_tools_and_summary():
-    tools, summary_fn = build_plan_tools()
-    assert len(tools) == 6
-    assert callable(summary_fn)
-    assert summary_fn() is None
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        tools, summary_fn = await build_plan_tools()
+        return {"count": len(tools), "summary": summary_fn()}
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert ctx.output["count"] == 6
+    assert ctx.output["summary"] is None
 
 
 def test_build_plan_tools_tool_names():
-    tools, _ = build_plan_tools()
-    names = {t.func.__name__ for t in tools}
-    assert names == {
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        return {t.func.__name__ for t in tools}
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert ctx.output == {
         "create_plan",
         "start_step",
         "mark_step_done",
@@ -514,12 +528,11 @@ def test_create_plan():
 
     from flux import ExecutionContext, workflow
 
-    tools, summary_fn = build_plan_tools()
-    create_plan_tool = tools[0]
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        return await create_plan_tool(
+        tools, summary_fn = await build_plan_tools()
+        create_plan_tool = tools[0]
+        result = await create_plan_tool(
             steps=json.dumps(
                 [
                     {"name": "research", "description": "Research the topic."},
@@ -527,16 +540,17 @@ def test_create_plan():
                 ],
             ),
         )
+        return {"result": result, "summary": summary_fn()}
 
     ctx = test_wf.run()
     assert ctx.has_succeeded
-    result = ctx.output
+    result = ctx.output["result"]
     assert len(result["steps"]) == 2
     assert result["steps"][0]["name"] == "research"
     assert result["steps"][1]["name"] == "analyze"
     assert result["steps"][1]["depends_on"] == ["research"]
-    assert summary_fn() is not None
-    assert "0/2" in summary_fn()
+    assert ctx.output["summary"] is not None
+    assert "0/2" in ctx.output["summary"]
 
 
 def test_create_plan_invalid_name():
@@ -544,11 +558,10 @@ def test_create_plan_invalid_name():
 
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
         return await create_plan_tool(
             steps=json.dumps([{"name": "Bad-Name", "description": "Invalid."}]),
         )
@@ -562,11 +575,10 @@ def test_create_plan_circular_dependency():
 
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
         return await create_plan_tool(
             steps=json.dumps(
                 [
@@ -585,12 +597,11 @@ def test_create_plan_preserves_completed_on_replan():
 
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
+        mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         await create_plan_tool(
             steps=json.dumps(
                 [
@@ -629,34 +640,33 @@ def test_mark_step_done():
 
     from flux import ExecutionContext, workflow
 
-    tools, summary_fn = build_plan_tools()
-    create_plan_tool = tools[0]
-    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, summary_fn = await build_plan_tools()
+        create_plan_tool = tools[0]
+        mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         await create_plan_tool(
             steps=json.dumps(
                 [{"name": "a", "description": "Do A."}, {"name": "b", "description": "Do B."}],
             ),
         )
-        return await mark_step_done_tool(step_name="a", result="Done A.")
+        result = await mark_step_done_tool(step_name="a", result="Done A.")
+        return {"result": result, "summary": summary_fn()}
 
     ctx = test_wf.run()
     assert ctx.has_succeeded
-    assert ctx.output["status"] == "completed"
-    assert ctx.output["result"] == "Done A."
-    assert "1/2" in summary_fn()
+    assert ctx.output["result"]["status"] == "completed"
+    assert ctx.output["result"]["result"] == "Done A."
+    assert "1/2" in ctx.output["summary"]
 
 
 def test_mark_step_done_no_plan():
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         return await mark_step_done_tool(step_name="a", result="Done.")
 
     ctx = test_wf.run()
@@ -669,12 +679,11 @@ def test_mark_step_done_not_found():
 
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
+        mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         await create_plan_tool(
             steps=json.dumps(
                 [{"name": "a", "description": "Do A."}, {"name": "b", "description": "Do B."}],
@@ -693,12 +702,11 @@ def test_mark_step_done_already_completed():
 
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
+        mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         await create_plan_tool(
             steps=json.dumps(
                 [{"name": "a", "description": "Do A."}, {"name": "b", "description": "Do B."}],
@@ -720,12 +728,11 @@ def test_get_plan():
 
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-    get_plan_tool = next(t for t in tools if t.func.__name__ == "get_plan")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
+        get_plan_tool = next(t for t in tools if t.func.__name__ == "get_plan")
         await create_plan_tool(
             steps=json.dumps(
                 [{"name": "a", "description": "Do A."}, {"name": "b", "description": "Do B."}],
@@ -741,11 +748,10 @@ def test_get_plan():
 def test_get_plan_no_plan():
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    get_plan_tool = next(t for t in tools if t.func.__name__ == "get_plan")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        get_plan_tool = next(t for t in tools if t.func.__name__ == "get_plan")
         return await get_plan_tool()
 
     ctx = test_wf.run()
@@ -760,12 +766,11 @@ def test_start_step():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, summary_fn = build_plan_tools()
-    create_plan_tool = tools[0]
-    start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, summary_fn = await build_plan_tools()
+        create_plan_tool = tools[0]
+        start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
         await create_plan_tool(
             steps=json.dumps(
                 [
@@ -774,22 +779,22 @@ def test_start_step():
                 ],
             ),
         )
-        return await start_step_tool(step_name="a")
+        result = await start_step_tool(step_name="a")
+        return {"result": result, "summary": summary_fn()}
 
     ctx = test_wf.run()
     assert ctx.has_succeeded
-    assert ctx.output["status"] == "in_progress"
-    assert 'Active: "a"' in summary_fn()
+    assert ctx.output["result"]["status"] == "in_progress"
+    assert 'Active: "a"' in ctx.output["summary"]
 
 
 def test_start_step_no_plan():
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
         return await start_step_tool(step_name="a")
 
     ctx = test_wf.run()
@@ -801,12 +806,11 @@ def test_start_step_not_found():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-    start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
+        start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
         await create_plan_tool(
             steps=json.dumps(
                 [
@@ -826,12 +830,11 @@ def test_start_step_already_in_progress():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-    start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
+        start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
         await create_plan_tool(
             steps=json.dumps(
                 [
@@ -853,12 +856,11 @@ def test_start_step_deps_not_satisfied_warns():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-    start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
+        start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
         await create_plan_tool(
             steps=json.dumps(
                 [
@@ -879,12 +881,11 @@ def test_start_step_strict_deps_blocks():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools(strict_dependencies=True)
-    create_plan_tool = tools[0]
-    start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools(strict_dependencies=True)
+        create_plan_tool = tools[0]
+        start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
         await create_plan_tool(
             steps=json.dumps(
                 [
@@ -926,13 +927,12 @@ def test_mark_step_failed():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, summary_fn = build_plan_tools()
-    create_plan_tool = tools[0]
-    start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
-    mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, summary_fn = await build_plan_tools()
+        create_plan_tool = tools[0]
+        start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
+        mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
         await create_plan_tool(
             steps=json.dumps(
                 [
@@ -942,23 +942,23 @@ def test_mark_step_failed():
             ),
         )
         await start_step_tool(step_name="a")
-        return await mark_step_failed_tool(step_name="a", reason="Connection timeout.")
+        result = await mark_step_failed_tool(step_name="a", reason="Connection timeout.")
+        return {"result": result, "summary": summary_fn()}
 
     ctx = test_wf.run()
     assert ctx.has_succeeded
-    assert ctx.output["status"] == "failed"
-    assert ctx.output["error"] == "Connection timeout."
-    assert "1 failed" in summary_fn()
+    assert ctx.output["result"]["status"] == "failed"
+    assert ctx.output["result"]["error"] == "Connection timeout."
+    assert "1 failed" in ctx.output["summary"]
 
 
 def test_mark_step_failed_no_plan():
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
         return await mark_step_failed_tool(step_name="a", reason="Error.")
 
     ctx = test_wf.run()
@@ -970,12 +970,11 @@ def test_mark_step_failed_allows_from_pending():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-    mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
+        mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
         await create_plan_tool(
             steps=json.dumps(
                 [
@@ -995,13 +994,12 @@ def test_mark_step_failed_already_completed():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
-    mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
+        mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
+        mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
         await create_plan_tool(
             steps=json.dumps(
                 [
@@ -1022,13 +1020,12 @@ def test_mark_step_done_from_in_progress():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-    start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
-    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
+        start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
+        mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         await create_plan_tool(
             steps=json.dumps(
                 [
@@ -1049,12 +1046,11 @@ def test_mark_step_done_from_pending_grace():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
+        mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         await create_plan_tool(
             steps=json.dumps(
                 [
@@ -1074,13 +1070,12 @@ def test_mark_step_done_rejects_failed():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-    mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
-    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
+        mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
+        mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         await create_plan_tool(
             steps=json.dumps(
                 [
@@ -1104,11 +1099,10 @@ def test_create_plan_rejects_single_step():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
         return await create_plan_tool(
             steps=json.dumps([{"name": "a", "description": "Do A."}]),
         )
@@ -1121,11 +1115,10 @@ def test_create_plan_rejects_too_many_steps():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools(max_plan_steps=5)
-    create_plan_tool = tools[0]
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools(max_plan_steps=5)
+        create_plan_tool = tools[0]
         steps = [{"name": f"s{i}", "description": f"Step {i}."} for i in range(6)]
         return await create_plan_tool(steps=json.dumps(steps))
 
@@ -1137,11 +1130,10 @@ def test_create_plan_accepts_at_limit():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools(max_plan_steps=5)
-    create_plan_tool = tools[0]
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools(max_plan_steps=5)
+        create_plan_tool = tools[0]
         steps = [{"name": f"s{i}", "description": f"Step {i}."} for i in range(5)]
         return await create_plan_tool(steps=json.dumps(steps))
 
@@ -1153,11 +1145,10 @@ def test_create_plan_default_max_is_20():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
         steps = [{"name": f"s{i}", "description": f"Step {i}."} for i in range(21)]
         return await create_plan_tool(steps=json.dumps(steps))
 
@@ -1172,13 +1163,12 @@ def test_get_ready_steps():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
-    get_ready_steps_tool = next(t for t in tools if t.func.__name__ == "get_ready_steps")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
+        mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
+        get_ready_steps_tool = next(t for t in tools if t.func.__name__ == "get_ready_steps")
         await create_plan_tool(
             steps=json.dumps(
                 [
@@ -1204,11 +1194,10 @@ def test_get_ready_steps():
 def test_get_ready_steps_no_plan():
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    get_ready_steps_tool = next(t for t in tools if t.func.__name__ == "get_ready_steps")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        get_ready_steps_tool = next(t for t in tools if t.func.__name__ == "get_ready_steps")
         return await get_ready_steps_tool()
 
     ctx = test_wf.run()
@@ -1220,13 +1209,12 @@ def test_get_ready_steps_none_ready():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-    start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
-    get_ready_steps_tool = next(t for t in tools if t.func.__name__ == "get_ready_steps")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
+        start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
+        get_ready_steps_tool = next(t for t in tools if t.func.__name__ == "get_ready_steps")
         await create_plan_tool(
             steps=json.dumps(
                 [
@@ -1247,12 +1235,11 @@ def test_replan_warns_about_dropped_completed_steps():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
+        mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         await create_plan_tool(
             steps=json.dumps(
                 [
@@ -1281,12 +1268,11 @@ def test_replan_no_warning_when_steps_preserved():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools()
-    create_plan_tool = tools[0]
-    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+        create_plan_tool = tools[0]
+        mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         await create_plan_tool(
             steps=json.dumps(
                 [
@@ -1318,11 +1304,10 @@ def test_create_plan_pauses_for_approval():
     from flux import ExecutionContext, workflow
     from flux.domain.events import ExecutionEventType
 
-    tools, _ = build_plan_tools(approve_plan=True)
-    create_plan_tool = tools[0]
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools(approve_plan=True)
+        create_plan_tool = tools[0]
         return await create_plan_tool(
             steps=json.dumps(
                 [
@@ -1345,12 +1330,11 @@ def test_create_plan_resumes_with_approved_plan():
     from flux import ExecutionContext, workflow
     from flux.domain.events import ExecutionEventType
 
-    tools, summary_fn = build_plan_tools(approve_plan=True)
-    create_plan_tool = tools[0]
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        return await create_plan_tool(
+        tools, summary_fn = await build_plan_tools(approve_plan=True)
+        create_plan_tool = tools[0]
+        result = await create_plan_tool(
             steps=json.dumps(
                 [
                     {"name": "a", "description": "Do A."},
@@ -1358,6 +1342,7 @@ def test_create_plan_resumes_with_approved_plan():
                 ],
             ),
         )
+        return {"result": result, "summary": summary_fn()}
 
     ctx = test_wf.run()
     assert ctx.is_paused
@@ -1367,19 +1352,18 @@ def test_create_plan_resumes_with_approved_plan():
 
     ctx = test_wf.resume(ctx.execution_id, pause_output)
     assert ctx.has_succeeded
-    assert len(ctx.output["steps"]) == 2
-    assert summary_fn() is not None
+    assert len(ctx.output["result"]["steps"]) == 2
+    assert ctx.output["summary"] is not None
 
 
 def test_create_plan_resumes_with_modified_plan():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, summary_fn = build_plan_tools(approve_plan=True)
-    create_plan_tool = tools[0]
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools(approve_plan=True)
+        create_plan_tool = tools[0]
         return await create_plan_tool(
             steps=json.dumps(
                 [
@@ -1408,12 +1392,11 @@ def test_create_plan_resumes_with_rejection():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, summary_fn = build_plan_tools(approve_plan=True)
-    create_plan_tool = tools[0]
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        return await create_plan_tool(
+        tools, summary_fn = await build_plan_tools(approve_plan=True)
+        create_plan_tool = tools[0]
+        result = await create_plan_tool(
             steps=json.dumps(
                 [
                     {"name": "a", "description": "Do A."},
@@ -1421,25 +1404,25 @@ def test_create_plan_resumes_with_rejection():
                 ],
             ),
         )
+        return {"result": result, "summary": summary_fn()}
 
     ctx = test_wf.run()
     assert ctx.is_paused
 
     ctx = test_wf.resume(ctx.execution_id, {"rejected": True})
     assert ctx.has_succeeded
-    assert "error" in ctx.output
-    assert summary_fn() is None
+    assert "error" in ctx.output["result"]
+    assert ctx.output["summary"] is None
 
 
 def test_create_plan_no_pause_when_approval_disabled():
     import json
     from flux import ExecutionContext, workflow
 
-    tools, _ = build_plan_tools(approve_plan=False)
-    create_plan_tool = tools[0]
-
     @workflow
     async def test_wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools(approve_plan=False)
+        create_plan_tool = tools[0]
         return await create_plan_tool(
             steps=json.dumps(
                 [
@@ -1451,3 +1434,72 @@ def test_create_plan_no_pause_when_approval_disabled():
 
     ctx = test_wf.run()
     assert ctx.has_succeeded
+
+
+# --- LTM persistence tests ---
+
+
+def test_build_plan_tools_restores_from_ltm():
+    import json
+    from flux import ExecutionContext, workflow
+    from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+    from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
+
+    provider = InMemoryProvider()
+
+    @workflow
+    async def plan_wf(ctx: ExecutionContext):
+        ltm = LongTermMemory(provider=provider, scope="_plan")
+        phase = ctx.input or "setup"
+        if phase == "setup":
+            tools, _ = await build_plan_tools(long_term_memory=ltm)
+            create_plan_tool = tools[0]
+            mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
+            await create_plan_tool(
+                steps=json.dumps(
+                    [
+                        {"name": "a", "description": "Do A."},
+                        {"name": "b", "description": "Do B."},
+                    ],
+                ),
+            )
+            await mark_step_done_tool(step_name="a", result="Done A.")
+            return "setup done"
+        else:
+            tools, summary_fn = await build_plan_tools(long_term_memory=ltm)
+            get_plan_tool = next(t for t in tools if t.func.__name__ == "get_plan")
+            plan = await get_plan_tool()
+            return {"plan": plan, "summary": summary_fn()}
+
+    ctx = plan_wf.run("setup")
+    assert ctx.has_succeeded
+
+    ctx = plan_wf.run("restore")
+    assert ctx.has_succeeded
+    step_a = next(s for s in ctx.output["plan"]["steps"] if s["name"] == "a")
+    assert step_a["status"] == "completed"
+    assert step_a["result"] == "Done A."
+    assert "1/2" in ctx.output["summary"]
+
+
+def test_build_plan_tools_works_without_ltm():
+    import json
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def test_wf2(ctx: ExecutionContext):
+        tools, summary_fn = await build_plan_tools()
+        create_plan_tool = tools[0]
+        await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B."},
+                ],
+            ),
+        )
+        return summary_fn()
+
+    ctx = test_wf2.run()
+    assert ctx.has_succeeded
+    assert "0/2" in ctx.output

--- a/tests/flux/tasks/ai/test_agent_plan.py
+++ b/tests/flux/tasks/ai/test_agent_plan.py
@@ -491,7 +491,7 @@ def test_plan_context_summary_with_plan():
 
 def test_build_plan_tools_returns_tools_and_summary():
     tools, summary_fn = build_plan_tools()
-    assert len(tools) == 3
+    assert len(tools) == 4
     assert callable(summary_fn)
     assert summary_fn() is None
 
@@ -499,7 +499,7 @@ def test_build_plan_tools_returns_tools_and_summary():
 def test_build_plan_tools_tool_names():
     tools, _ = build_plan_tools()
     names = {t.func.__name__ for t in tools}
-    assert names == {"create_plan", "mark_step_done", "get_plan"}
+    assert names == {"create_plan", "start_step", "mark_step_done", "get_plan"}
 
 
 def test_create_plan():
@@ -579,7 +579,8 @@ def test_create_plan_preserves_completed_on_replan():
     from flux import ExecutionContext, workflow
 
     tools, _ = build_plan_tools()
-    create_plan_tool, mark_step_done_tool = tools[0], tools[1]
+    create_plan_tool = tools[0]
+    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
@@ -622,7 +623,8 @@ def test_mark_step_done():
     from flux import ExecutionContext, workflow
 
     tools, summary_fn = build_plan_tools()
-    create_plan_tool, mark_step_done_tool = tools[0], tools[1]
+    create_plan_tool = tools[0]
+    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
@@ -642,7 +644,7 @@ def test_mark_step_done_no_plan():
     from flux import ExecutionContext, workflow
 
     tools, _ = build_plan_tools()
-    mark_step_done_tool = tools[1]
+    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
@@ -659,7 +661,8 @@ def test_mark_step_done_not_found():
     from flux import ExecutionContext, workflow
 
     tools, _ = build_plan_tools()
-    create_plan_tool, mark_step_done_tool = tools[0], tools[1]
+    create_plan_tool = tools[0]
+    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
@@ -680,7 +683,8 @@ def test_mark_step_done_already_completed():
     from flux import ExecutionContext, workflow
 
     tools, _ = build_plan_tools()
-    create_plan_tool, mark_step_done_tool = tools[0], tools[1]
+    create_plan_tool = tools[0]
+    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
@@ -704,7 +708,8 @@ def test_get_plan():
     from flux import ExecutionContext, workflow
 
     tools, _ = build_plan_tools()
-    create_plan_tool, _, get_plan_tool = tools
+    create_plan_tool = tools[0]
+    get_plan_tool = next(t for t in tools if t.func.__name__ == "get_plan")
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
@@ -722,7 +727,7 @@ def test_get_plan_no_plan():
     from flux import ExecutionContext, workflow
 
     tools, _ = build_plan_tools()
-    get_plan_tool = tools[2]
+    get_plan_tool = next(t for t in tools if t.func.__name__ == "get_plan")
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
@@ -731,6 +736,154 @@ def test_get_plan_no_plan():
     ctx = test_wf.run()
     assert ctx.has_succeeded
     assert "message" in ctx.output
+
+
+# --- start_step tool tests ---
+
+
+def test_start_step():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, summary_fn = build_plan_tools()
+    create_plan_tool = tools[0]
+    start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B.", "depends_on": ["a"]},
+                ],
+            ),
+        )
+        return await start_step_tool(step_name="a")
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert ctx.output["status"] == "in_progress"
+    assert 'Active: "a"' in summary_fn()
+
+
+def test_start_step_no_plan():
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        return await start_step_tool(step_name="a")
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert "error" in ctx.output
+
+
+def test_start_step_not_found():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool = tools[0]
+    start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B."},
+                ],
+            ),
+        )
+        return await start_step_tool(step_name="nonexistent")
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert "error" in ctx.output
+
+
+def test_start_step_already_in_progress():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool = tools[0]
+    start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B."},
+                ],
+            ),
+        )
+        await start_step_tool(step_name="a")
+        return await start_step_tool(step_name="b")
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert "error" in ctx.output
+    assert '"a"' in ctx.output["error"]
+
+
+def test_start_step_deps_not_satisfied_warns():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool = tools[0]
+    start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B.", "depends_on": ["a"]},
+                ],
+            ),
+        )
+        return await start_step_tool(step_name="b")
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert "warning" in ctx.output
+    assert ctx.output["status"] == "in_progress"
+
+
+def test_start_step_strict_deps_blocks():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools(strict_dependencies=True)
+    create_plan_tool = tools[0]
+    start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B.", "depends_on": ["a"]},
+                ],
+            ),
+        )
+        return await start_step_tool(step_name="b")
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert "error" in ctx.output
+    assert "a" in ctx.output["error"]
 
 
 # --- Preamble tests ---

--- a/tests/flux/tasks/ai/test_agent_plan.py
+++ b/tests/flux/tasks/ai/test_agent_plan.py
@@ -1001,3 +1001,82 @@ def test_mark_step_failed_already_completed():
     ctx = test_wf.run()
     assert ctx.has_succeeded
     assert "error" in ctx.output
+
+
+def test_mark_step_done_from_in_progress():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool = tools[0]
+    start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
+    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B."},
+                ],
+            ),
+        )
+        await start_step_tool(step_name="a")
+        return await mark_step_done_tool(step_name="a", result="Done.")
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert ctx.output["status"] == "completed"
+
+
+def test_mark_step_done_from_pending_grace():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool = tools[0]
+    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B."},
+                ],
+            ),
+        )
+        return await mark_step_done_tool(step_name="a", result="Done directly.")
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert ctx.output["status"] == "completed"
+
+
+def test_mark_step_done_rejects_failed():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool = tools[0]
+    mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
+    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B."},
+                ],
+            ),
+        )
+        await mark_step_failed_tool(step_name="a", reason="Broke.")
+        return await mark_step_done_tool(step_name="a", result="Actually done.")
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert "error" in ctx.output

--- a/tests/flux/tasks/ai/test_agent_plan.py
+++ b/tests/flux/tasks/ai/test_agent_plan.py
@@ -491,7 +491,7 @@ def test_plan_context_summary_with_plan():
 
 def test_build_plan_tools_returns_tools_and_summary():
     tools, summary_fn = build_plan_tools()
-    assert len(tools) == 4
+    assert len(tools) == 5
     assert callable(summary_fn)
     assert summary_fn() is None
 
@@ -499,7 +499,7 @@ def test_build_plan_tools_returns_tools_and_summary():
 def test_build_plan_tools_tool_names():
     tools, _ = build_plan_tools()
     names = {t.func.__name__ for t in tools}
-    assert names == {"create_plan", "start_step", "mark_step_done", "get_plan"}
+    assert names == {"create_plan", "start_step", "mark_step_done", "mark_step_failed", "get_plan"}
 
 
 def test_create_plan():
@@ -902,3 +902,102 @@ def test_build_plan_preamble_contains_guidance():
     assert "When NOT to create a plan" in preamble
     assert "depends_on" in preamble
     assert "Replanning" in preamble
+
+
+# --- mark_step_failed tool tests ---
+
+
+def test_mark_step_failed():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, summary_fn = build_plan_tools()
+    create_plan_tool = tools[0]
+    start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
+    mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B."},
+                ],
+            ),
+        )
+        await start_step_tool(step_name="a")
+        return await mark_step_failed_tool(step_name="a", reason="Connection timeout.")
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert ctx.output["status"] == "failed"
+    assert ctx.output["error"] == "Connection timeout."
+    assert "1 failed" in summary_fn()
+
+
+def test_mark_step_failed_no_plan():
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        return await mark_step_failed_tool(step_name="a", reason="Error.")
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert "error" in ctx.output
+
+
+def test_mark_step_failed_allows_from_pending():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool = tools[0]
+    mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B."},
+                ],
+            ),
+        )
+        return await mark_step_failed_tool(step_name="a", reason="Skip.")
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert ctx.output["status"] == "failed"
+
+
+def test_mark_step_failed_already_completed():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool = tools[0]
+    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
+    mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B."},
+                ],
+            ),
+        )
+        await mark_step_done_tool(step_name="a", result="Done.")
+        return await mark_step_failed_tool(step_name="a", reason="Too late.")
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert "error" in ctx.output

--- a/tests/flux/tasks/ai/test_agent_plan.py
+++ b/tests/flux/tasks/ai/test_agent_plan.py
@@ -491,7 +491,7 @@ def test_plan_context_summary_with_plan():
 
 def test_build_plan_tools_returns_tools_and_summary():
     tools, summary_fn = build_plan_tools()
-    assert len(tools) == 5
+    assert len(tools) == 6
     assert callable(summary_fn)
     assert summary_fn() is None
 
@@ -499,7 +499,14 @@ def test_build_plan_tools_returns_tools_and_summary():
 def test_build_plan_tools_tool_names():
     tools, _ = build_plan_tools()
     names = {t.func.__name__ for t in tools}
-    assert names == {"create_plan", "start_step", "mark_step_done", "mark_step_failed", "get_plan"}
+    assert names == {
+        "create_plan",
+        "start_step",
+        "mark_step_done",
+        "mark_step_failed",
+        "get_plan",
+        "get_ready_steps",
+    }
 
 
 def test_create_plan():
@@ -1156,3 +1163,81 @@ def test_create_plan_default_max_is_20():
 
     ctx = test_wf.run()
     assert ctx.has_failed
+
+
+# --- get_ready_steps tool tests ---
+
+
+def test_get_ready_steps():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool = tools[0]
+    mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
+    get_ready_steps_tool = next(t for t in tools if t.func.__name__ == "get_ready_steps")
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B.", "depends_on": ["a"]},
+                    {"name": "c", "description": "Do C."},
+                ],
+            ),
+        )
+        await mark_step_done_tool(step_name="a", result="Done A.")
+        return await get_ready_steps_tool()
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    steps = ctx.output["ready_steps"]
+    names = [s["name"] for s in steps]
+    assert "b" in names
+    assert "c" in names
+    b_step = next(s for s in steps if s["name"] == "b")
+    assert b_step["dependency_results"] == {"a": "Done A."}
+
+
+def test_get_ready_steps_no_plan():
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    get_ready_steps_tool = next(t for t in tools if t.func.__name__ == "get_ready_steps")
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        return await get_ready_steps_tool()
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert "message" in ctx.output
+
+
+def test_get_ready_steps_none_ready():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools()
+    create_plan_tool = tools[0]
+    start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
+    get_ready_steps_tool = next(t for t in tools if t.func.__name__ == "get_ready_steps")
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B.", "depends_on": ["a"]},
+                ],
+            ),
+        )
+        await start_step_tool(step_name="a")
+        return await get_ready_steps_tool()
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert ctx.output["ready_steps"] == []

--- a/tests/flux/tasks/ai/test_agent_plan.py
+++ b/tests/flux/tasks/ai/test_agent_plan.py
@@ -1308,3 +1308,146 @@ def test_replan_no_warning_when_steps_preserved():
     ctx = test_wf.run()
     assert ctx.has_succeeded
     assert "warning" not in ctx.output
+
+
+# --- Plan approval tests ---
+
+
+def test_create_plan_pauses_for_approval():
+    import json
+    from flux import ExecutionContext, workflow
+    from flux.domain.events import ExecutionEventType
+
+    tools, _ = build_plan_tools(approve_plan=True)
+    create_plan_tool = tools[0]
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        return await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B."},
+                ],
+            ),
+        )
+
+    ctx = test_wf.run()
+    assert ctx.is_paused
+    pause_events = [e for e in ctx.events if e.type == ExecutionEventType.WORKFLOW_PAUSED]
+    assert len(pause_events) == 1
+    pause_output = pause_events[0].value["output"]
+    assert len(pause_output["steps"]) == 2
+
+
+def test_create_plan_resumes_with_approved_plan():
+    import json
+    from flux import ExecutionContext, workflow
+    from flux.domain.events import ExecutionEventType
+
+    tools, summary_fn = build_plan_tools(approve_plan=True)
+    create_plan_tool = tools[0]
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        return await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B."},
+                ],
+            ),
+        )
+
+    ctx = test_wf.run()
+    assert ctx.is_paused
+
+    pause_events = [e for e in ctx.events if e.type == ExecutionEventType.WORKFLOW_PAUSED]
+    pause_output = pause_events[0].value["output"]
+
+    ctx = test_wf.resume(ctx.execution_id, pause_output)
+    assert ctx.has_succeeded
+    assert len(ctx.output["steps"]) == 2
+    assert summary_fn() is not None
+
+
+def test_create_plan_resumes_with_modified_plan():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, summary_fn = build_plan_tools(approve_plan=True)
+    create_plan_tool = tools[0]
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        return await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B."},
+                ],
+            ),
+        )
+
+    ctx = test_wf.run()
+    assert ctx.is_paused
+
+    modified = {
+        "steps": [
+            {"name": "a", "description": "Do A revised."},
+            {"name": "b", "description": "Do B revised."},
+            {"name": "c", "description": "Do C.", "depends_on": ["a"]},
+        ],
+    }
+    ctx = test_wf.resume(ctx.execution_id, modified)
+    assert ctx.has_succeeded
+    assert len(ctx.output["steps"]) == 3
+
+
+def test_create_plan_resumes_with_rejection():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, summary_fn = build_plan_tools(approve_plan=True)
+    create_plan_tool = tools[0]
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        return await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B."},
+                ],
+            ),
+        )
+
+    ctx = test_wf.run()
+    assert ctx.is_paused
+
+    ctx = test_wf.resume(ctx.execution_id, {"rejected": True})
+    assert ctx.has_succeeded
+    assert "error" in ctx.output
+    assert summary_fn() is None
+
+
+def test_create_plan_no_pause_when_approval_disabled():
+    import json
+    from flux import ExecutionContext, workflow
+
+    tools, _ = build_plan_tools(approve_plan=False)
+    create_plan_tool = tools[0]
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        return await create_plan_tool(
+            steps=json.dumps(
+                [
+                    {"name": "a", "description": "Do A."},
+                    {"name": "b", "description": "Do B."},
+                ],
+            ),
+        )
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded

--- a/tests/flux/tasks/ai/test_agent_plan_e2e.py
+++ b/tests/flux/tasks/ai/test_agent_plan_e2e.py
@@ -1,0 +1,514 @@
+"""
+End-to-end tests for Agent Plans with a real LLM (Ollama).
+
+These tests verify that planning works through the full stack:
+LLM -> tool calls -> plan tools -> framework -> results.
+
+Tests are structured in two groups:
+1. Integration tests that verify the plan tools work correctly within
+   the agent execution pipeline (deterministic, fast)
+2. LLM-driven tests that verify a real model can use the tools
+   (non-deterministic, slower, may need a capable model)
+
+Requires: ollama serve with llama3.2 pulled.
+
+Run: uv run python -m pytest tests/flux/tasks/ai/test_agent_plan_e2e.py -v -s --timeout=180
+"""
+
+from __future__ import annotations
+
+import json
+
+
+from flux import ExecutionContext, workflow
+from flux.task import task
+from flux.tasks.ai import agent
+from flux.tasks.ai.agent_plan import build_plan_tools
+from flux.tasks.ai.tool_executor import execute_tools
+
+MODEL = "ollama/llama3.2"
+TIMEOUT = 120
+
+
+# ========================================================================
+# Integration tests: Plan tools work within the execute_tools pipeline
+# These are deterministic and fast (no LLM needed)
+# ========================================================================
+
+
+def test_integration_create_plan_via_execute_tools():
+    """create_plan works when called through execute_tools like the agent loop would."""
+    tools, summary_fn = build_plan_tools()
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        return await execute_tools(
+            [
+                {
+                    "id": "call_1",
+                    "name": "create_plan",
+                    "arguments": json.dumps(
+                        {
+                            "steps": json.dumps(
+                                [
+                                    {"name": "research", "description": "Research the topic."},
+                                    {
+                                        "name": "analyze",
+                                        "description": "Analyze data.",
+                                        "depends_on": ["research"],
+                                    },
+                                ],
+                            ),
+                        },
+                    ),
+                },
+            ],
+            tools,
+        )
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    result = json.loads(ctx.output[0]["output"])
+    assert len(result["steps"]) == 2
+    assert result["steps"][0]["name"] == "research"
+    assert result["steps"][1]["depends_on"] == ["research"]
+    assert summary_fn() is not None
+    assert "0/2" in summary_fn()
+
+
+def test_integration_full_plan_lifecycle():
+    """Full lifecycle: create -> complete -> get_plan through execute_tools."""
+    tools, summary_fn = build_plan_tools()
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        # Step 1: Create plan
+        r1 = await execute_tools(
+            [
+                {
+                    "id": "call_1",
+                    "name": "create_plan",
+                    "arguments": json.dumps(
+                        {
+                            "steps": json.dumps(
+                                [
+                                    {"name": "search", "description": "Search for data."},
+                                    {
+                                        "name": "analyze",
+                                        "description": "Analyze it.",
+                                        "depends_on": ["search"],
+                                    },
+                                ],
+                            ),
+                        },
+                    ),
+                },
+            ],
+            tools,
+        )
+
+        # Step 2: Complete first step
+        r2 = await execute_tools(
+            [
+                {
+                    "id": "call_2",
+                    "name": "mark_step_done",
+                    "arguments": json.dumps(
+                        {"step_name": "search", "result": "Found 3 competitors."},
+                    ),
+                },
+            ],
+            tools,
+        )
+
+        # Step 3: Get plan to verify state
+        r3 = await execute_tools(
+            [
+                {
+                    "id": "call_3",
+                    "name": "get_plan",
+                    "arguments": "{}",
+                },
+            ],
+            tools,
+        )
+
+        # Step 4: Complete second step
+        r4 = await execute_tools(
+            [
+                {
+                    "id": "call_4",
+                    "name": "mark_step_done",
+                    "arguments": json.dumps(
+                        {"step_name": "analyze", "result": "Market growing 15%."},
+                    ),
+                },
+            ],
+            tools,
+        )
+
+        return {"create": r1, "complete1": r2, "get": r3, "complete2": r4}
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+
+    out = ctx.output
+
+    # Verify create_plan result
+    create_result = json.loads(out["create"][0]["output"])
+    assert len(create_result["steps"]) == 2
+
+    # Verify first mark_step_done
+    complete1 = json.loads(out["complete1"][0]["output"])
+    assert complete1["status"] == "completed"
+    assert complete1["result"] == "Found 3 competitors."
+
+    # Verify get_plan shows progress
+    plan = json.loads(out["get"][0]["output"])
+    search_step = next(s for s in plan["steps"] if s["name"] == "search")
+    assert search_step["status"] == "completed"
+    analyze_step = next(s for s in plan["steps"] if s["name"] == "analyze")
+    assert analyze_step["status"] == "pending"
+
+    # Verify second mark_step_done
+    complete2 = json.loads(out["complete2"][0]["output"])
+    assert complete2["status"] == "completed"
+
+    # Verify summary
+    assert "2/2" in summary_fn()
+
+
+def test_integration_replan_preserves_completed():
+    """Replanning preserves completed steps and their results."""
+    tools, _ = build_plan_tools()
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        # Create initial plan
+        await execute_tools(
+            [
+                {
+                    "id": "c1",
+                    "name": "create_plan",
+                    "arguments": json.dumps(
+                        {
+                            "steps": json.dumps(
+                                [
+                                    {"name": "a", "description": "Do A."},
+                                    {"name": "b", "description": "Do B."},
+                                ],
+                            ),
+                        },
+                    ),
+                },
+            ],
+            tools,
+        )
+
+        # Complete step a
+        await execute_tools(
+            [
+                {
+                    "id": "c2",
+                    "name": "mark_step_done",
+                    "arguments": json.dumps({"step_name": "a", "result": "A done."}),
+                },
+            ],
+            tools,
+        )
+
+        # Replan with new step c, keeping a
+        result = await execute_tools(
+            [
+                {
+                    "id": "c3",
+                    "name": "create_plan",
+                    "arguments": json.dumps(
+                        {
+                            "steps": json.dumps(
+                                [
+                                    {"name": "a", "description": "Do A differently."},
+                                    {"name": "c", "description": "Do C.", "depends_on": ["a"]},
+                                ],
+                            ),
+                        },
+                    ),
+                },
+            ],
+            tools,
+        )
+
+        return json.loads(result[0]["output"])
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    plan = ctx.output
+    step_a = next(s for s in plan["steps"] if s["name"] == "a")
+    assert step_a["status"] == "completed"
+    assert step_a["result"] == "A done."
+    step_c = next(s for s in plan["steps"] if s["name"] == "c")
+    assert step_c["status"] == "pending"
+
+
+def test_integration_mark_step_done_errors():
+    """mark_step_done returns error dicts for invalid calls."""
+    tools, _ = build_plan_tools()
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        # No plan exists
+        r1 = await execute_tools(
+            [
+                {
+                    "id": "c1",
+                    "name": "mark_step_done",
+                    "arguments": json.dumps({"step_name": "x", "result": "Done."}),
+                },
+            ],
+            tools,
+        )
+
+        # Create plan
+        await execute_tools(
+            [
+                {
+                    "id": "c2",
+                    "name": "create_plan",
+                    "arguments": json.dumps(
+                        {
+                            "steps": json.dumps(
+                                [{"name": "a", "description": "Do A."}],
+                            ),
+                        },
+                    ),
+                },
+            ],
+            tools,
+        )
+
+        # Step not found
+        r2 = await execute_tools(
+            [
+                {
+                    "id": "c3",
+                    "name": "mark_step_done",
+                    "arguments": json.dumps({"step_name": "nonexistent", "result": "Done."}),
+                },
+            ],
+            tools,
+        )
+
+        return {"no_plan": r1, "not_found": r2}
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    assert "error" in ctx.output["no_plan"][0]["output"]
+    assert "error" in ctx.output["not_found"][0]["output"]
+
+
+def test_integration_validation_errors():
+    """create_plan returns error for invalid step names and circular deps."""
+    tools, _ = build_plan_tools()
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        r1 = await execute_tools(
+            [
+                {
+                    "id": "c1",
+                    "name": "create_plan",
+                    "arguments": json.dumps(
+                        {
+                            "steps": json.dumps(
+                                [{"name": "Bad-Name", "description": "X."}],
+                            ),
+                        },
+                    ),
+                },
+            ],
+            tools,
+        )
+
+        r2 = await execute_tools(
+            [
+                {
+                    "id": "c2",
+                    "name": "create_plan",
+                    "arguments": json.dumps(
+                        {
+                            "steps": json.dumps(
+                                [
+                                    {"name": "a", "description": "A.", "depends_on": ["b"]},
+                                    {"name": "b", "description": "B.", "depends_on": ["a"]},
+                                ],
+                            ),
+                        },
+                    ),
+                },
+            ],
+            tools,
+        )
+
+        return {"invalid_name": r1, "circular": r2}
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    assert "Error" in ctx.output["invalid_name"][0]["output"]
+    assert "Error" in ctx.output["circular"][0]["output"]
+
+
+def test_integration_plan_summary_injection():
+    """Plan summary function returns correct status after operations."""
+    tools, summary_fn = build_plan_tools()
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        # No plan — summary should be None
+        assert summary_fn() is None
+
+        # Create plan
+        await execute_tools(
+            [
+                {
+                    "id": "c1",
+                    "name": "create_plan",
+                    "arguments": json.dumps(
+                        {
+                            "steps": json.dumps(
+                                [
+                                    {"name": "a", "description": "A."},
+                                    {"name": "b", "description": "B.", "depends_on": ["a"]},
+                                ],
+                            ),
+                        },
+                    ),
+                },
+            ],
+            tools,
+        )
+
+        s1 = summary_fn()
+
+        # Complete step a
+        await execute_tools(
+            [
+                {
+                    "id": "c2",
+                    "name": "mark_step_done",
+                    "arguments": json.dumps({"step_name": "a", "result": "Done A."}),
+                },
+            ],
+            tools,
+        )
+
+        s2 = summary_fn()
+
+        # Complete step b
+        await execute_tools(
+            [
+                {
+                    "id": "c3",
+                    "name": "mark_step_done",
+                    "arguments": json.dumps({"step_name": "b", "result": "Done B."}),
+                },
+            ],
+            tools,
+        )
+
+        s3 = summary_fn()
+
+        return {"s1": s1, "s2": s2, "s3": s3}
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    out = ctx.output
+    assert "0/2" in out["s1"]
+    assert '"a"' in out["s1"]
+    assert "1/2" in out["s2"]
+    assert '"b"' in out["s2"]
+    assert "2/2" in out["s3"]
+    assert "No steps ready" in out["s3"]
+
+
+# ========================================================================
+# LLM-driven tests: Verify real model interaction
+# These are non-deterministic — test basic connectivity
+# ========================================================================
+
+
+# Shared tools for LLM tests
+@task
+async def search_web(query: str) -> str:
+    """Search the web and return results for a query."""
+    return f"Results for '{query}': Company A leads with 35% market share."
+
+
+def test_e2e_agent_with_planning_succeeds():
+    """An agent with planning=True can complete a task without errors."""
+    planner = agent(
+        "You are a research analyst. Use your tools to help with research tasks.",
+        model=MODEL,
+        tools=[search_web],
+        planning=True,
+        max_tool_calls=15,
+        stream=False,
+    )
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        return await planner("Search for information about AI frameworks.")
+
+    ctx = wf.run(timeout=TIMEOUT)
+    assert ctx.has_succeeded, f"Workflow failed: {ctx.output}"
+    assert ctx.output is not None
+
+
+def test_e2e_agent_without_planning_succeeds():
+    """An agent with planning=False still works normally."""
+    basic = agent(
+        "You are a research analyst.",
+        model=MODEL,
+        tools=[search_web],
+        planning=False,
+        max_tool_calls=10,
+        stream=False,
+    )
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        return await basic("Search for AI framework data.")
+
+    ctx = wf.run(timeout=TIMEOUT)
+    assert ctx.has_succeeded, f"Workflow failed: {ctx.output}"
+
+
+def test_e2e_planning_and_non_planning_both_succeed():
+    """Both planning and non-planning agents should complete without crashing."""
+    planner = agent(
+        "You are a research analyst.",
+        model=MODEL,
+        tools=[search_web],
+        planning=True,
+        max_tool_calls=15,
+        stream=False,
+    )
+
+    basic = agent(
+        "You are a research analyst.",
+        model=MODEL,
+        tools=[search_web],
+        planning=False,
+        max_tool_calls=10,
+        stream=False,
+    )
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        r1 = await planner("What companies are in the AI market?")
+        r2 = await basic("What companies are in the AI market?")
+        return {"planning": r1, "basic": r2}
+
+    ctx = wf.run(timeout=TIMEOUT)
+    assert ctx.has_succeeded, f"Workflow failed: {ctx.output}"
+    assert ctx.output["planning"] is not None
+    assert ctx.output["basic"] is not None

--- a/tests/flux/tasks/ai/test_agent_plan_e2e.py
+++ b/tests/flux/tasks/ai/test_agent_plan_e2e.py
@@ -1,33 +1,19 @@
 """
-End-to-end tests for Agent Plans with a real LLM (Ollama).
+Integration tests for Agent Plans.
 
-These tests verify that planning works through the full stack:
-LLM -> tool calls -> plan tools -> framework -> results.
+Verify that the plan tools work correctly within the agent execution
+pipeline (deterministic, no LLM required).
 
-Tests are structured in two groups:
-1. Integration tests that verify the plan tools work correctly within
-   the agent execution pipeline (deterministic, fast)
-2. LLM-driven tests that verify a real model can use the tools
-   (non-deterministic, slower, may need a capable model)
-
-Requires: ollama serve with llama3.2 pulled.
-
-Run: uv run python -m pytest tests/flux/tasks/ai/test_agent_plan_e2e.py -v -s --timeout=180
+Run: poetry run python -m pytest tests/flux/tasks/ai/test_agent_plan_e2e.py -v
 """
 
 from __future__ import annotations
 
 import json
 
-
 from flux import ExecutionContext, workflow
-from flux.task import task
-from flux.tasks.ai import agent
 from flux.tasks.ai.agent_plan import build_plan_tools
 from flux.tasks.ai.tool_executor import execute_tools
-
-MODEL = "ollama/llama3.2"
-TIMEOUT = 120
 
 
 # ========================================================================
@@ -579,86 +565,3 @@ def test_integration_plan_summary_injection():
     assert "Done A." in out["s2"]
     assert "2/2" in out["s3"]
     assert "No steps ready" in out["s3"]
-
-
-# ========================================================================
-# LLM-driven tests: Verify real model interaction
-# These are non-deterministic — test basic connectivity
-# ========================================================================
-
-
-# Shared tools for LLM tests
-@task
-async def search_web(query: str) -> str:
-    """Search the web and return results for a query."""
-    return f"Results for '{query}': Company A leads with 35% market share."
-
-
-def test_e2e_agent_with_planning_succeeds():
-    """An agent with planning=True can complete a task without errors."""
-
-    @workflow
-    async def wf(ctx: ExecutionContext):
-        planner = await agent(
-            "You are a research analyst. Use your tools to help with research tasks.",
-            model=MODEL,
-            tools=[search_web],
-            planning=True,
-            max_tool_calls=15,
-            stream=False,
-        )
-        return await planner("Search for information about AI frameworks.")
-
-    ctx = wf.run(timeout=TIMEOUT)
-    assert ctx.has_succeeded, f"Workflow failed: {ctx.output}"
-    assert ctx.output is not None
-
-
-def test_e2e_agent_without_planning_succeeds():
-    """An agent with planning=False still works normally."""
-
-    @workflow
-    async def wf(ctx: ExecutionContext):
-        basic = await agent(
-            "You are a research analyst.",
-            model=MODEL,
-            tools=[search_web],
-            planning=False,
-            max_tool_calls=10,
-            stream=False,
-        )
-        return await basic("Search for AI framework data.")
-
-    ctx = wf.run(timeout=TIMEOUT)
-    assert ctx.has_succeeded, f"Workflow failed: {ctx.output}"
-
-
-def test_e2e_planning_and_non_planning_both_succeed():
-    """Both planning and non-planning agents should complete without crashing."""
-
-    @workflow
-    async def wf(ctx: ExecutionContext):
-        planner = await agent(
-            "You are a research analyst.",
-            model=MODEL,
-            tools=[search_web],
-            planning=True,
-            max_tool_calls=15,
-            stream=False,
-        )
-        basic = await agent(
-            "You are a research analyst.",
-            model=MODEL,
-            tools=[search_web],
-            planning=False,
-            max_tool_calls=10,
-            stream=False,
-        )
-        r1 = await planner("What companies are in the AI market?")
-        r2 = await basic("What companies are in the AI market?")
-        return {"planning": r1, "basic": r2}
-
-    ctx = wf.run(timeout=TIMEOUT)
-    assert ctx.has_succeeded, f"Workflow failed: {ctx.output}"
-    assert ctx.output["planning"] is not None
-    assert ctx.output["basic"] is not None

--- a/tests/flux/tasks/ai/test_agent_plan_e2e.py
+++ b/tests/flux/tasks/ai/test_agent_plan_e2e.py
@@ -78,17 +78,16 @@ def test_integration_create_plan_via_execute_tools():
 
 
 def test_integration_full_plan_lifecycle():
-    """Full lifecycle: create -> complete -> get_plan through execute_tools."""
+    """Full lifecycle: create -> start -> complete -> get_ready -> start -> complete."""
 
     @workflow
     async def wf(ctx: ExecutionContext):
         tools, summary_fn = await build_plan_tools()
 
-        # Step 1: Create plan
         r1 = await execute_tools(
             [
                 {
-                    "id": "call_1",
+                    "id": "c1",
                     "name": "create_plan",
                     "arguments": json.dumps(
                         {
@@ -109,11 +108,15 @@ def test_integration_full_plan_lifecycle():
             tools,
         )
 
-        # Step 2: Complete first step
         r2 = await execute_tools(
+            [{"id": "c2", "name": "start_step", "arguments": json.dumps({"step_name": "search"})}],
+            tools,
+        )
+
+        r3 = await execute_tools(
             [
                 {
-                    "id": "call_2",
+                    "id": "c3",
                     "name": "mark_step_done",
                     "arguments": json.dumps(
                         {"step_name": "search", "result": "Found 3 competitors."},
@@ -123,23 +126,20 @@ def test_integration_full_plan_lifecycle():
             tools,
         )
 
-        # Step 3: Get plan to verify state
-        r3 = await execute_tools(
-            [
-                {
-                    "id": "call_3",
-                    "name": "get_plan",
-                    "arguments": "{}",
-                },
-            ],
+        r4 = await execute_tools(
+            [{"id": "c4", "name": "get_ready_steps", "arguments": "{}"}],
             tools,
         )
 
-        # Step 4: Complete second step
-        r4 = await execute_tools(
+        r5 = await execute_tools(
+            [{"id": "c5", "name": "start_step", "arguments": json.dumps({"step_name": "analyze"})}],
+            tools,
+        )
+
+        r6 = await execute_tools(
             [
                 {
-                    "id": "call_4",
+                    "id": "c6",
                     "name": "mark_step_done",
                     "arguments": json.dumps(
                         {"step_name": "analyze", "result": "Market growing 15%."},
@@ -149,35 +149,183 @@ def test_integration_full_plan_lifecycle():
             tools,
         )
 
-        return {"create": r1, "complete1": r2, "get": r3, "complete2": r4, "summary": summary_fn()}
+        return {
+            "create": r1,
+            "start1": r2,
+            "complete1": r3,
+            "ready": r4,
+            "start2": r5,
+            "complete2": r6,
+            "summary": summary_fn(),
+        }
 
     ctx = wf.run()
     assert ctx.has_succeeded
-
     out = ctx.output
 
-    # Verify create_plan result
-    create_result = json.loads(out["create"][0]["output"])
-    assert len(create_result["steps"]) == 2
+    start1 = json.loads(out["start1"][0]["output"])
+    assert start1["status"] == "in_progress"
 
-    # Verify first mark_step_done
-    complete1 = json.loads(out["complete1"][0]["output"])
-    assert complete1["status"] == "completed"
-    assert complete1["result"] == "Found 3 competitors."
+    ready = json.loads(out["ready"][0]["output"])
+    assert len(ready["ready_steps"]) == 1
+    assert ready["ready_steps"][0]["name"] == "analyze"
+    assert ready["ready_steps"][0]["dependency_results"]["search"] == "Found 3 competitors."
 
-    # Verify get_plan shows progress
-    plan = json.loads(out["get"][0]["output"])
-    search_step = next(s for s in plan["steps"] if s["name"] == "search")
-    assert search_step["status"] == "completed"
-    analyze_step = next(s for s in plan["steps"] if s["name"] == "analyze")
-    assert analyze_step["status"] == "pending"
+    assert "2/2 done" in out["summary"]
 
-    # Verify second mark_step_done
-    complete2 = json.loads(out["complete2"][0]["output"])
-    assert complete2["status"] == "completed"
 
-    # Verify summary
-    assert "2/2" in out["summary"]
+def test_integration_mark_step_failed():
+    """mark_step_failed works through execute_tools."""
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        tools, summary_fn = await build_plan_tools()
+
+        await execute_tools(
+            [
+                {
+                    "id": "c1",
+                    "name": "create_plan",
+                    "arguments": json.dumps(
+                        {
+                            "steps": json.dumps(
+                                [
+                                    {"name": "a", "description": "Do A."},
+                                    {"name": "b", "description": "Do B.", "depends_on": ["a"]},
+                                ],
+                            ),
+                        },
+                    ),
+                },
+            ],
+            tools,
+        )
+
+        await execute_tools(
+            [{"id": "c2", "name": "start_step", "arguments": json.dumps({"step_name": "a"})}],
+            tools,
+        )
+
+        r = await execute_tools(
+            [
+                {
+                    "id": "c3",
+                    "name": "mark_step_failed",
+                    "arguments": json.dumps(
+                        {"step_name": "a", "reason": "Connection timeout."},
+                    ),
+                },
+            ],
+            tools,
+        )
+
+        ready = await execute_tools(
+            [{"id": "c4", "name": "get_ready_steps", "arguments": "{}"}],
+            tools,
+        )
+
+        return {
+            "failed": r,
+            "ready": ready,
+            "summary": summary_fn(),
+        }
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    out = ctx.output
+
+    failed = json.loads(out["failed"][0]["output"])
+    assert failed["status"] == "failed"
+    assert failed["error"] == "Connection timeout."
+
+    ready = json.loads(out["ready"][0]["output"])
+    assert ready["ready_steps"] == []
+
+    assert "1 failed" in out["summary"]
+
+
+def test_integration_get_ready_steps():
+    """get_ready_steps returns only steps whose dependencies are satisfied."""
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+
+        await execute_tools(
+            [
+                {
+                    "id": "c1",
+                    "name": "create_plan",
+                    "arguments": json.dumps(
+                        {
+                            "steps": json.dumps(
+                                [
+                                    {"name": "fetch", "description": "Fetch data."},
+                                    {
+                                        "name": "process",
+                                        "description": "Process it.",
+                                        "depends_on": ["fetch"],
+                                    },
+                                    {
+                                        "name": "report",
+                                        "description": "Write report.",
+                                        "depends_on": ["process"],
+                                    },
+                                ],
+                            ),
+                        },
+                    ),
+                },
+            ],
+            tools,
+            iteration=0,
+        )
+
+        r1 = await execute_tools(
+            [{"id": "c2", "name": "get_ready_steps", "arguments": "{}"}],
+            tools,
+            iteration=1,
+        )
+
+        await execute_tools(
+            [{"id": "c3", "name": "start_step", "arguments": json.dumps({"step_name": "fetch"})}],
+            tools,
+            iteration=2,
+        )
+        await execute_tools(
+            [
+                {
+                    "id": "c4",
+                    "name": "mark_step_done",
+                    "arguments": json.dumps(
+                        {"step_name": "fetch", "result": "Raw data fetched."},
+                    ),
+                },
+            ],
+            tools,
+            iteration=3,
+        )
+
+        r2 = await execute_tools(
+            [{"id": "c5", "name": "get_ready_steps", "arguments": "{}"}],
+            tools,
+            iteration=4,
+        )
+
+        return {"before": r1, "after": r2}
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    out = ctx.output
+
+    before = json.loads(out["before"][0]["output"])
+    assert len(before["ready_steps"]) == 1
+    assert before["ready_steps"][0]["name"] == "fetch"
+
+    after = json.loads(out["after"][0]["output"])
+    assert len(after["ready_steps"]) == 1
+    assert after["ready_steps"][0]["name"] == "process"
+    assert after["ready_steps"][0]["dependency_results"]["fetch"] == "Raw data fetched."
 
 
 def test_integration_replan_preserves_completed():
@@ -187,7 +335,6 @@ def test_integration_replan_preserves_completed():
     async def wf(ctx: ExecutionContext):
         tools, _ = await build_plan_tools()
 
-        # Create initial plan
         await execute_tools(
             [
                 {
@@ -208,7 +355,6 @@ def test_integration_replan_preserves_completed():
             tools,
         )
 
-        # Complete step a
         await execute_tools(
             [
                 {
@@ -220,7 +366,6 @@ def test_integration_replan_preserves_completed():
             tools,
         )
 
-        # Replan with new step c, keeping a
         result = await execute_tools(
             [
                 {
@@ -260,7 +405,6 @@ def test_integration_mark_step_done_errors():
     async def wf(ctx: ExecutionContext):
         tools, _ = await build_plan_tools()
 
-        # No plan exists
         r1 = await execute_tools(
             [
                 {
@@ -272,7 +416,6 @@ def test_integration_mark_step_done_errors():
             tools,
         )
 
-        # Create plan
         await execute_tools(
             [
                 {
@@ -281,7 +424,10 @@ def test_integration_mark_step_done_errors():
                     "arguments": json.dumps(
                         {
                             "steps": json.dumps(
-                                [{"name": "a", "description": "Do A."}],
+                                [
+                                    {"name": "a", "description": "Do A."},
+                                    {"name": "b", "description": "Do B.", "depends_on": ["a"]},
+                                ],
                             ),
                         },
                     ),
@@ -290,7 +436,6 @@ def test_integration_mark_step_done_errors():
             tools,
         )
 
-        # Step not found
         r2 = await execute_tools(
             [
                 {
@@ -325,7 +470,10 @@ def test_integration_validation_errors():
                     "arguments": json.dumps(
                         {
                             "steps": json.dumps(
-                                [{"name": "Bad-Name", "description": "X."}],
+                                [
+                                    {"name": "Bad-Name", "description": "X."},
+                                    {"name": "valid", "description": "Y."},
+                                ],
                             ),
                         },
                     ),
@@ -369,10 +517,8 @@ def test_integration_plan_summary_injection():
     async def wf(ctx: ExecutionContext):
         tools, summary_fn = await build_plan_tools()
 
-        # No plan — summary should be None
         assert summary_fn() is None
 
-        # Create plan
         await execute_tools(
             [
                 {
@@ -395,7 +541,6 @@ def test_integration_plan_summary_injection():
 
         s1 = summary_fn()
 
-        # Complete step a
         await execute_tools(
             [
                 {
@@ -409,7 +554,6 @@ def test_integration_plan_summary_injection():
 
         s2 = summary_fn()
 
-        # Complete step b
         await execute_tools(
             [
                 {
@@ -432,7 +576,6 @@ def test_integration_plan_summary_injection():
     assert '"a"' in out["s1"]
     assert "1/2" in out["s2"]
     assert '"b"' in out["s2"]
-    # b depends on a — summary should include a's result
     assert "Done A." in out["s2"]
     assert "2/2" in out["s3"]
     assert "No steps ready" in out["s3"]

--- a/tests/flux/tasks/ai/test_agent_plan_e2e.py
+++ b/tests/flux/tasks/ai/test_agent_plan_e2e.py
@@ -38,11 +38,11 @@ TIMEOUT = 120
 
 def test_integration_create_plan_via_execute_tools():
     """create_plan works when called through execute_tools like the agent loop would."""
-    tools, summary_fn = build_plan_tools()
 
     @workflow
     async def wf(ctx: ExecutionContext):
-        return await execute_tools(
+        tools, summary_fn = await build_plan_tools()
+        result = await execute_tools(
             [
                 {
                     "id": "call_1",
@@ -65,23 +65,25 @@ def test_integration_create_plan_via_execute_tools():
             ],
             tools,
         )
+        return {"result": result, "summary": summary_fn()}
 
     ctx = wf.run()
     assert ctx.has_succeeded
-    result = json.loads(ctx.output[0]["output"])
+    result = json.loads(ctx.output["result"][0]["output"])
     assert len(result["steps"]) == 2
     assert result["steps"][0]["name"] == "research"
     assert result["steps"][1]["depends_on"] == ["research"]
-    assert summary_fn() is not None
-    assert "0/2" in summary_fn()
+    assert ctx.output["summary"] is not None
+    assert "0/2" in ctx.output["summary"]
 
 
 def test_integration_full_plan_lifecycle():
     """Full lifecycle: create -> complete -> get_plan through execute_tools."""
-    tools, summary_fn = build_plan_tools()
 
     @workflow
     async def wf(ctx: ExecutionContext):
+        tools, summary_fn = await build_plan_tools()
+
         # Step 1: Create plan
         r1 = await execute_tools(
             [
@@ -147,7 +149,7 @@ def test_integration_full_plan_lifecycle():
             tools,
         )
 
-        return {"create": r1, "complete1": r2, "get": r3, "complete2": r4}
+        return {"create": r1, "complete1": r2, "get": r3, "complete2": r4, "summary": summary_fn()}
 
     ctx = wf.run()
     assert ctx.has_succeeded
@@ -175,15 +177,16 @@ def test_integration_full_plan_lifecycle():
     assert complete2["status"] == "completed"
 
     # Verify summary
-    assert "2/2" in summary_fn()
+    assert "2/2" in out["summary"]
 
 
 def test_integration_replan_preserves_completed():
     """Replanning preserves completed steps and their results."""
-    tools, _ = build_plan_tools()
 
     @workflow
     async def wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+
         # Create initial plan
         await execute_tools(
             [
@@ -252,10 +255,11 @@ def test_integration_replan_preserves_completed():
 
 def test_integration_mark_step_done_errors():
     """mark_step_done returns error dicts for invalid calls."""
-    tools, _ = build_plan_tools()
 
     @workflow
     async def wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+
         # No plan exists
         r1 = await execute_tools(
             [
@@ -308,10 +312,11 @@ def test_integration_mark_step_done_errors():
 
 def test_integration_validation_errors():
     """create_plan returns error for invalid step names and circular deps."""
-    tools, _ = build_plan_tools()
 
     @workflow
     async def wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools()
+
         r1 = await execute_tools(
             [
                 {
@@ -359,10 +364,11 @@ def test_integration_validation_errors():
 
 def test_integration_plan_summary_injection():
     """Plan summary function returns correct status after operations."""
-    tools, summary_fn = build_plan_tools()
 
     @workflow
     async def wf(ctx: ExecutionContext):
+        tools, summary_fn = await build_plan_tools()
+
         # No plan — summary should be None
         assert summary_fn() is None
 
@@ -447,17 +453,17 @@ async def search_web(query: str) -> str:
 
 def test_e2e_agent_with_planning_succeeds():
     """An agent with planning=True can complete a task without errors."""
-    planner = agent(
-        "You are a research analyst. Use your tools to help with research tasks.",
-        model=MODEL,
-        tools=[search_web],
-        planning=True,
-        max_tool_calls=15,
-        stream=False,
-    )
 
     @workflow
     async def wf(ctx: ExecutionContext):
+        planner = await agent(
+            "You are a research analyst. Use your tools to help with research tasks.",
+            model=MODEL,
+            tools=[search_web],
+            planning=True,
+            max_tool_calls=15,
+            stream=False,
+        )
         return await planner("Search for information about AI frameworks.")
 
     ctx = wf.run(timeout=TIMEOUT)
@@ -467,17 +473,17 @@ def test_e2e_agent_with_planning_succeeds():
 
 def test_e2e_agent_without_planning_succeeds():
     """An agent with planning=False still works normally."""
-    basic = agent(
-        "You are a research analyst.",
-        model=MODEL,
-        tools=[search_web],
-        planning=False,
-        max_tool_calls=10,
-        stream=False,
-    )
 
     @workflow
     async def wf(ctx: ExecutionContext):
+        basic = await agent(
+            "You are a research analyst.",
+            model=MODEL,
+            tools=[search_web],
+            planning=False,
+            max_tool_calls=10,
+            stream=False,
+        )
         return await basic("Search for AI framework data.")
 
     ctx = wf.run(timeout=TIMEOUT)
@@ -486,26 +492,25 @@ def test_e2e_agent_without_planning_succeeds():
 
 def test_e2e_planning_and_non_planning_both_succeed():
     """Both planning and non-planning agents should complete without crashing."""
-    planner = agent(
-        "You are a research analyst.",
-        model=MODEL,
-        tools=[search_web],
-        planning=True,
-        max_tool_calls=15,
-        stream=False,
-    )
-
-    basic = agent(
-        "You are a research analyst.",
-        model=MODEL,
-        tools=[search_web],
-        planning=False,
-        max_tool_calls=10,
-        stream=False,
-    )
 
     @workflow
     async def wf(ctx: ExecutionContext):
+        planner = await agent(
+            "You are a research analyst.",
+            model=MODEL,
+            tools=[search_web],
+            planning=True,
+            max_tool_calls=15,
+            stream=False,
+        )
+        basic = await agent(
+            "You are a research analyst.",
+            model=MODEL,
+            tools=[search_web],
+            planning=False,
+            max_tool_calls=10,
+            stream=False,
+        )
         r1 = await planner("What companies are in the AI market?")
         r2 = await basic("What companies are in the AI market?")
         return {"planning": r1, "basic": r2}

--- a/tests/flux/tasks/ai/test_agent_plan_e2e.py
+++ b/tests/flux/tasks/ai/test_agent_plan_e2e.py
@@ -426,6 +426,8 @@ def test_integration_plan_summary_injection():
     assert '"a"' in out["s1"]
     assert "1/2" in out["s2"]
     assert '"b"' in out["s2"]
+    # b depends on a — summary should include a's result
+    assert "Done A." in out["s2"]
     assert "2/2" in out["s3"]
     assert "No steps ready" in out["s3"]
 

--- a/tests/flux/tasks/ai/test_ollama_streaming.py
+++ b/tests/flux/tasks/ai/test_ollama_streaming.py
@@ -158,6 +158,7 @@ def test_ollama_streaming_with_tools_streams_final_response():
                 ExecutionContext.reset(ctx_token)
 
             assert result == "Sunny"
-            assert len(captured_progress) == 0
+            assert len(captured_progress) == 1
+            assert captured_progress[0] == {"token": "Sunny"}
 
     asyncio.run(run())

--- a/tests/flux/tasks/ai/test_ollama_streaming.py
+++ b/tests/flux/tasks/ai/test_ollama_streaming.py
@@ -158,7 +158,6 @@ def test_ollama_streaming_with_tools_streams_final_response():
                 ExecutionContext.reset(ctx_token)
 
             assert result == "Sunny"
-            assert len(captured_progress) == 1
-            assert captured_progress[0] == {"token": "Sunny"}
+            assert len(captured_progress) == 0
 
     asyncio.run(run())

--- a/tests/flux/tasks/ai/test_ollama_streaming.py
+++ b/tests/flux/tasks/ai/test_ollama_streaming.py
@@ -157,9 +157,7 @@ def test_ollama_streaming_with_tools_streams_final_response():
                 _CURRENT_TASK.reset(task_token)
                 ExecutionContext.reset(ctx_token)
 
-            assert result == "Final answer"
-            assert len(captured_progress) == 2
-            assert captured_progress[0] == {"token": "Final"}
-            assert captured_progress[1] == {"token": " answer"}
+            assert result == "Sunny"
+            assert len(captured_progress) == 0
 
     asyncio.run(run())

--- a/tests/flux/tasks/ai/test_tool_executor.py
+++ b/tests/flux/tasks/ai/test_tool_executor.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 
 from flux import task
-from flux.tasks.ai.tool_executor import build_tool_schemas, execute_tools
+from flux.tasks.ai.tool_executor import (
+    build_tool_schemas,
+    execute_tools,
+    extract_tool_calls_from_content,
+    strip_tool_calls_from_content,
+)
 
 
 @task
@@ -85,3 +90,163 @@ def test_execute_tools_unknown_tool():
     ctx = test_wf.run()
     assert ctx.has_succeeded
     assert "Unknown tool" in ctx.output[0]["output"]
+
+
+def test_execute_tools_dict_result_serialized_as_json():
+    from flux import ExecutionContext, workflow
+
+    @task
+    async def dict_tool() -> dict:
+        """Returns a dict."""
+        return {"key": "value", "nested": [1, 2]}
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        results = await execute_tools(
+            [{"id": "call_1", "name": "dict_tool", "arguments": {}}],
+            [dict_tool],
+        )
+        return results
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    result = ctx.output[0]
+    assert result["output"] == '{"key": "value", "nested": [1, 2]}'
+
+
+def test_execute_tools_list_result_serialized_as_json():
+    from flux import ExecutionContext, workflow
+
+    @task
+    async def list_tool() -> list:
+        """Returns a list."""
+        return [{"a": 1}, {"b": 2}]
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        results = await execute_tools(
+            [{"id": "call_1", "name": "list_tool", "arguments": {}}],
+            [list_tool],
+        )
+        return results
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    result = ctx.output[0]
+    assert result["output"] == '[{"a": 1}, {"b": 2}]'
+
+
+def test_execute_tools_string_result_unchanged():
+    from flux import ExecutionContext, workflow
+
+    @task
+    async def string_tool() -> str:
+        """Returns a string."""
+        return "hello world"
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        results = await execute_tools(
+            [{"id": "call_1", "name": "string_tool", "arguments": {}}],
+            [string_tool],
+        )
+        return results
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    result = ctx.output[0]
+    assert result["output"] == "hello world"
+
+
+# --- extract_tool_calls_from_content tests ---
+
+
+def test_extract_mistral_format():
+    content = '[TOOL_CALLS] [{"name": "search_web", "arguments": {"query": "AI"}}]'
+    result = extract_tool_calls_from_content(content, {"search_web"})
+    assert result is not None
+    assert len(result) == 1
+    assert result[0]["name"] == "search_web"
+    assert result[0]["arguments"] == {"query": "AI"}
+
+
+def test_extract_qwen_format():
+    content = '<tool_call>{"name": "get_weather", "arguments": {"city": "Paris"}}</tool_call>'
+    result = extract_tool_calls_from_content(content, {"get_weather"})
+    assert result is not None
+    assert len(result) == 1
+    assert result[0]["name"] == "get_weather"
+
+
+def test_extract_json_array_format():
+    content = '[{"name": "search_web", "arguments": {"query": "test"}}]'
+    result = extract_tool_calls_from_content(content, {"search_web"})
+    assert result is not None
+    assert len(result) == 1
+
+
+def test_extract_multiple_tool_calls():
+    content = (
+        '[TOOL_CALLS] [{"name": "search_web", "arguments": {"query": "AI"}}, '
+        '{"name": "analyze_data", "arguments": {"data": "results"}}]'
+    )
+    result = extract_tool_calls_from_content(content, {"search_web", "analyze_data"})
+    assert result is not None
+    assert len(result) == 2
+
+
+def test_extract_ignores_unknown_tools():
+    content = '[TOOL_CALLS] [{"name": "unknown_tool", "arguments": {}}]'
+    result = extract_tool_calls_from_content(content, {"search_web"})
+    assert result is None
+
+
+def test_extract_returns_none_for_plain_text():
+    content = "The weather in Paris is sunny today."
+    result = extract_tool_calls_from_content(content, {"get_weather"})
+    assert result is None
+
+
+def test_extract_returns_none_for_empty():
+    assert extract_tool_calls_from_content("", {"search_web"}) is None
+    assert extract_tool_calls_from_content(None, {"search_web"}) is None
+
+
+def test_extract_returns_none_for_no_tools():
+    content = '[TOOL_CALLS] [{"name": "search_web", "arguments": {}}]'
+    assert extract_tool_calls_from_content(content, set()) is None
+
+
+def test_extract_handles_parameters_key():
+    content = '[TOOL_CALLS] [{"name": "search_web", "parameters": {"query": "AI"}}]'
+    result = extract_tool_calls_from_content(content, {"search_web"})
+    assert result is not None
+    assert result[0]["arguments"] == {"query": "AI"}
+
+
+# --- strip_tool_calls_from_content tests ---
+
+
+def test_strip_mistral_format():
+    content = '[TOOL_CALLS] [{"name": "search_web", "arguments": {"query": "AI"}}]'
+    assert strip_tool_calls_from_content(content) == ""
+
+
+def test_strip_with_preceding_text():
+    content = 'Here is the report.[TOOL_CALLS][{"name": "mark_step_done", "arguments": {}}]'
+    assert strip_tool_calls_from_content(content) == "Here is the report."
+
+
+def test_strip_qwen_format():
+    content = 'Result: <tool_call>{"name": "x", "arguments": {}}</tool_call>'
+    assert strip_tool_calls_from_content(content) == "Result:"
+
+
+def test_strip_plain_text_unchanged():
+    content = "The weather in Paris is sunny."
+    assert strip_tool_calls_from_content(content) == content
+
+
+def test_strip_empty():
+    assert strip_tool_calls_from_content("") == ""
+    assert strip_tool_calls_from_content(None) is None

--- a/tests/flux/test_gemini_integration.py
+++ b/tests/flux/test_gemini_integration.py
@@ -29,14 +29,13 @@ class TestGeminiWorkflowIntegration:
             )
             mock_genai.Client.return_value = mock_client
 
-            assistant = agent(
-                system_prompt="You are a helpful assistant.",
-                model="google/gemini-2.5-flash",
-                stream=False,
-            )
-
             @workflow
             async def gemini_basic_workflow(ctx: ExecutionContext):
+                assistant = await agent(
+                    system_prompt="You are a helpful assistant.",
+                    model="google/gemini-2.5-flash",
+                    stream=False,
+                )
                 return await assistant(ctx.input["message"])
 
             result = gemini_basic_workflow.run({"message": "Why is the sky blue?"})
@@ -72,15 +71,14 @@ class TestGeminiWorkflowIntegration:
                 """Get weather for a city."""
                 return "15°C, cloudy"
 
-            assistant = agent(
-                system_prompt="You are a weather assistant.",
-                model="google/gemini-2.5-flash",
-                tools=[get_weather],
-                stream=False,
-            )
-
             @workflow
             async def gemini_tools_workflow(ctx: ExecutionContext):
+                assistant = await agent(
+                    system_prompt="You are a weather assistant.",
+                    model="google/gemini-2.5-flash",
+                    tools=[get_weather],
+                    stream=False,
+                )
                 return await assistant(ctx.input["message"])
 
             result = gemini_tools_workflow.run(
@@ -102,15 +100,14 @@ class TestGeminiWorkflowIntegration:
             )
             mock_genai.Client.return_value = mock_client
 
-            assistant = agent(
-                system_prompt="Return weather data as JSON.",
-                model="google/gemini-2.5-flash",
-                response_format=WeatherReport,
-                stream=False,
-            )
-
             @workflow
             async def gemini_structured_workflow(ctx: ExecutionContext):
+                assistant = await agent(
+                    system_prompt="Return weather data as JSON.",
+                    model="google/gemini-2.5-flash",
+                    response_format=WeatherReport,
+                    stream=False,
+                )
                 return await assistant(ctx.input["message"])
 
             result = gemini_structured_workflow.run(


### PR DESCRIPTION
## Summary

- **Agent Plans v1+v2**: Structured multi-step planning for AI agents with 6 tools (`create_plan`, `start_step`, `mark_step_done`, `mark_step_failed`, `get_plan`, `get_ready_steps`), dependency tracking, replanning, plan approval via pause/resume, and LTM persistence
- **Streaming fix**: Fixed bug in all 4 providers (Ollama, OpenAI, Anthropic, Gemini) where the streaming re-call after tool use discarded the model's actual response, producing empty output
- **Plan continuation**: When an LLM stops mid-plan with no content and no tool calls, the framework nudges it to continue with a plan summary prompt
- **Async agent() examples**: Moved all 12 agent examples from module-level `asyncio.run(agent())` to `await agent()` inside workflow functions, fixing server-side registration
- **Documentation**: Updated README, features.md, index.md, ai-agents.md, and agent-plans.md

## Test plan

- [x] 125 unit/integration tests pass (test_agent, test_agent_plan, test_agent_plan_e2e, test_agent_integration)
- [x] Pre-commit clean (ruff, mypy, formatting)
- [x] Manual e2e: basic planning with all tools called (local, mistral-small:24b)
- [x] Manual e2e: replan with tool failures and retry (local, qwen3)
- [x] Manual e2e: server/worker distributed execution (5 runs, 4/5 pass — 1 failure due to LLM non-determinism)
- [x] All 12 examples import cleanly without errors