### PR TITLE
fix(sub-agents): align workflow_agent context param and use configured timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Lock files (project uses poetry)
+uv.lock
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/docs/advanced-features/sub-agents.md
+++ b/docs/advanced-features/sub-agents.md
@@ -113,12 +113,6 @@ manager = await agent(
 
 Workflow agents use `FluxClient` to call the remote workflow synchronously (`run_workflow_sync` / `resume_execution_sync`). The target workflow must be registered on the server.
 
-### Configuration
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `FLUX_WORKERS__SERVER_URL` | `http://localhost:8000` | Flux server URL (via `flux.config.Configuration`) |
-
 ## The `delegate` Tool
 
 The `delegate` tool is a `@task` with the following parameters:

--- a/examples/ai/sub_agents_workflow.py
+++ b/examples/ai/sub_agents_workflow.py
@@ -6,8 +6,7 @@ including the pause/resume pattern for human approval.
 
 Prerequisites:
     1. A running Flux server with a 'deploy_pipeline' workflow registered
-    2. Set FLUX_SERVER_URL if not using the default (http://localhost:8000)
-    3. Install Ollama and pull a model: ollama pull mistral-small:24b
+    2. Install Ollama and pull a model: ollama pull mistral-small:24b
 
 Usage:
     flux workflow run sub_agents_workflow '{"service": "api-gateway", "version": "2.1.0"}'

--- a/flux/tasks/ai/delegation.py
+++ b/flux/tasks/ai/delegation.py
@@ -241,20 +241,27 @@ def workflow_agent(
     async def _workflow_task(
         instruction: str,
         *,
-        input: Any | None = None,
+        context: str = "",
         execution_id: str | None = None,
     ) -> WorkflowAgentResult:
         async with _get_client() as client:
+            input_value: Any = context or None
+            if isinstance(input_value, str):
+                try:
+                    input_value = json.loads(input_value)
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            payload = {"instruction": instruction, "input": input_value}
             if execution_id:
                 response = await client.resume_execution_sync(
                     workflow,
                     execution_id,
-                    {"instruction": instruction, "input": input},
+                    payload,
                 )
             else:
                 response = await client.run_workflow_sync(
                     workflow,
-                    {"instruction": instruction, "input": input},
+                    payload,
                 )
 
         return WorkflowAgentResult(
@@ -272,7 +279,10 @@ def _get_client():
     from flux.config import Configuration
 
     config = Configuration.get()
-    return FluxClient(config.settings.workers.server_url, timeout=None)
+    return FluxClient(
+        config.settings.workers.server_url,
+        timeout=config.settings.workers.default_timeout or None,
+    )
 
 
 def _map_execution_state(response: dict) -> Literal["completed", "paused", "failed"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.18.0"
+version = "0.18.1"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/tasks/ai/test_delegation.py
+++ b/tests/flux/tasks/ai/test_delegation.py
@@ -397,7 +397,7 @@ class TestWorkflowAgent:
         @workflow
         async def test_wf(ctx: ExecutionContext):
             with patch("flux.tasks.ai.delegation._get_client", return_value=mock_client):
-                return await wa("Deploy v2", input={"version": "2.0"})
+                return await wa("Deploy v2", context='{"version": "2.0"}')
 
         ctx = test_wf.run()
         assert ctx.has_succeeded
@@ -452,7 +452,7 @@ class TestWorkflowAgent:
         @workflow
         async def test_wf(ctx: ExecutionContext):
             with patch("flux.tasks.ai.delegation._get_client", return_value=mock_client):
-                return await wa("Approved", input={"approved": True}, execution_id="exec-1")
+                return await wa("Approved", context='{"approved": true}', execution_id="exec-1")
 
         ctx = test_wf.run()
         assert ctx.has_succeeded

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
- **Fix parameter mismatch**: Rename `workflow_agent`'s `input` param to `context` to match the delegate tool interface — was a bug where delegate passed `context=...` but workflow_agent expected `input=...`
- **Parse JSON context**: Context strings are parsed back to dicts so target workflows (e.g. `deploy_pipeline`) receive structured data instead of raw strings
- **Use configured timeout**: `FluxClient` in `_get_client()` now uses `default_timeout` from config instead of hardcoded `None`
- **Doc cleanup**: Remove stale `FLUX_SERVER_URL` config references from docs and examples
- **Remove uv.lock**: Project uses poetry; added `uv.lock` to `.gitignore`
- **Bump version**: 0.18.0 → 0.18.1

## Test plan
- [x] All 41 delegation tests pass
- [x] Full test suite: 935 passed, 38 skipped, 0 failures
- [x] Pre-commit checks pass (ruff, mypy, formatting)
- [x] E2E: local sub-agents workflow completed successfully
- [x] E2E: workflow sub-agents workflow completed via server/worker