### PR TITLE
fix(delegation): reuse _parse_input in workflow_agent

### DIFF
--- a/flux/tasks/ai/delegation.py
+++ b/flux/tasks/ai/delegation.py
@@ -245,12 +245,7 @@ def workflow_agent(
         execution_id: str | None = None,
     ) -> WorkflowAgentResult:
         async with _get_client() as client:
-            input_value: Any = context or None
-            if isinstance(input_value, str):
-                try:
-                    input_value = json.loads(input_value)
-                except (json.JSONDecodeError, TypeError):
-                    pass
+            input_value: Any = _parse_input(context or None)
             payload = {"instruction": instruction, "input": input_value}
             if execution_id:
                 response = await client.resume_execution_sync(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.18.1"
+version = "0.18.2"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"


### PR DESCRIPTION
## Summary
- Replace duplicated inline JSON parsing in `workflow_agent` with existing `_parse_input()` helper
- Bump version to 0.18.2

## Test plan
- [x] All 41 delegation tests pass