### PR TITLE
feat: human-in-the-loop tool approval with requires_approval wrapper

### DIFF
--- a/examples/ai/tool_approval_agent.py
+++ b/examples/ai/tool_approval_agent.py
@@ -1,0 +1,71 @@
+"""
+Tool Approval Example.
+
+Demonstrates human-in-the-loop approval for dangerous tool calls.
+The agent has system tools with the shell command requiring approval.
+
+Prerequisites:
+    1. Install Ollama and pull a model: ollama pull llama3.2
+    2. Start Ollama service: ollama serve
+
+Usage:
+    flux workflow register examples/ai/tool_approval_agent.py
+    flux workflow run tool_approval_demo '{"task": "List files in the current directory"}'
+
+    When the agent calls the shell tool, the workflow will pause.
+    Check the execution status to see the pending approval:
+        flux workflow status tool_approval_demo <execution_id>
+
+    Approve the tool call:
+        flux workflow resume tool_approval_demo <execution_id> '{"approved": true}'
+
+    Or reject:
+        flux workflow resume tool_approval_demo <execution_id> '{"approved": false}'
+
+    Or approve and skip future approvals for this tool:
+        flux workflow resume tool_approval_demo <execution_id> '{"approved": true, "always_approve": true}'
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from flux import ExecutionContext, workflow
+from flux.tasks.ai import agent
+from flux.tasks.ai.approval import requires_approval
+from flux.tasks.ai.tools.system_tools import system_tools
+
+
+@workflow
+async def tool_approval_demo(ctx: ExecutionContext[dict[str, Any]]):
+    raw = ctx.input or {}
+    task_description = raw.get("task", "List the files in the current directory")
+
+    tools = requires_approval(
+        system_tools("./workspace", timeout=10),
+        only=["shell"],
+    )
+
+    assistant = await agent(
+        "You are a helpful assistant with access to system tools. "
+        "Use them to complete the user's request.",
+        model="ollama/llama3.2",
+        name="tool_approval_assistant",
+        tools=tools,
+        stream=False,
+    )
+
+    return await assistant(task_description)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import json
+
+    result = tool_approval_demo.run({"task": "List all Python files"})
+    if result.is_paused:
+        print(f"Paused for approval. Execution ID: {result.execution_id}")
+        print(f"Pending: {json.dumps(result.output, indent=2)}")
+    elif result.has_succeeded:
+        print(result.output)
+    else:
+        print(f"Failed: {result.output}")

--- a/flux/tasks/ai/__init__.py
+++ b/flux/tasks/ai/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from flux.tasks.ai.agent import agent
 from flux.tasks.ai.agent_plan import AgentPlan, AgentStep
+from flux.tasks.ai.approval import requires_approval
 from flux.tasks.ai.delegation import DelegationResult, workflow_agent
 from flux.tasks.ai.models import LLMResponse, ToolCall
 from flux.tasks.ai.memory import in_memory, long_term_memory, postgresql, sqlite, working_memory
@@ -24,4 +25,5 @@ __all__ = [
     "DelegationResult",
     "LLMResponse",
     "ToolCall",
+    "requires_approval",
 ]

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -35,6 +35,7 @@ async def agent(
     max_concurrent_tools: int | None = None,
     max_tokens: int = 4096,
     stream: bool = True,
+    approval_mode: str = "default",
 ) -> task:
     """Create a Flux @task that calls an LLM.
 
@@ -119,7 +120,7 @@ async def agent(
     if tools:
         from flux.tasks.ai.tool_executor import build_tools_preamble
 
-        system_prompt = system_prompt + build_tools_preamble(tools)
+        system_prompt = system_prompt + build_tools_preamble(tools, approval_mode=approval_mode)
 
     effective_stream = stream and response_format is None
 
@@ -164,6 +165,7 @@ async def agent(
                 max_concurrent_tools=max_concurrent_tools,
                 stream=effective_stream,
                 plan_summary_fn=plan_summary_fn,
+                approval_mode=approval_mode,
             )
 
         result = _ollama_agent
@@ -195,6 +197,7 @@ async def agent(
                 max_concurrent_tools=max_concurrent_tools,
                 stream=effective_stream,
                 plan_summary_fn=plan_summary_fn,
+                approval_mode=approval_mode,
             )
 
         result = _openai_agent
@@ -226,6 +229,7 @@ async def agent(
                 max_concurrent_tools=max_concurrent_tools,
                 stream=effective_stream,
                 plan_summary_fn=plan_summary_fn,
+                approval_mode=approval_mode,
             )
 
         result = _anthropic_agent
@@ -261,6 +265,7 @@ async def agent(
                 max_concurrent_tools=max_concurrent_tools,
                 stream=effective_stream,
                 plan_summary_fn=plan_summary_fn,
+                approval_mode=approval_mode,
             )
 
         result = _google_agent

--- a/flux/tasks/ai/agent_loop.py
+++ b/flux/tasks/ai/agent_loop.py
@@ -32,6 +32,7 @@ async def run_agent_loop(
     max_concurrent_tools: int | None = None,
     stream: bool = False,
     plan_summary_fn: Any | None = None,
+    approval_mode: str = "default",
 ) -> str | BaseModel:
     from flux.tasks.progress import progress
 
@@ -70,6 +71,8 @@ async def run_agent_loop(
     call_counter += 1
     response = _ensure_llm_response(result)
 
+    always_approved: set[str] = set()
+
     tool_call_count = 0
     tool_iteration = 0
 
@@ -84,6 +87,8 @@ async def run_agent_loop(
             tools,
             iteration=tool_iteration,
             max_concurrent=max_concurrent_tools,
+            always_approved=always_approved,
+            approval_mode=approval_mode,
         )
         tool_iteration += 1
 

--- a/flux/tasks/ai/approval.py
+++ b/flux/tasks/ai/approval.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any, overload
+
+from flux.task import task
+
+
+class _ApprovalWrapper:
+    """Transparent wrapper that adds .requires_approval to a task."""
+
+    def __init__(self, wrapped: task):
+        self._wrapped = wrapped
+        self.requires_approval = True
+
+    @property
+    def func(self):
+        return self._wrapped.func if hasattr(self._wrapped, "func") else self._wrapped
+
+    @property
+    def name(self):
+        return self._wrapped.name
+
+    @name.setter
+    def name(self, value):
+        self._wrapped.name = value
+
+    @property
+    def description(self):
+        return getattr(self._wrapped, "description", None)
+
+    @description.setter
+    def description(self, value):
+        self._wrapped.description = value
+
+    def with_options(self, **kwargs) -> _ApprovalWrapper:
+        new_task = (
+            self._wrapped.with_options(**kwargs)
+            if hasattr(self._wrapped, "with_options")
+            else self._wrapped
+        )
+        return _ApprovalWrapper(new_task)
+
+    async def __call__(self, *args, **kwargs):
+        return await self._wrapped(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._wrapped, name)
+
+
+@overload
+def requires_approval(tool: task, *, only: list[str] | None = None) -> _ApprovalWrapper: ...
+
+
+@overload
+def requires_approval(tool: list, *, only: list[str] | None = None) -> list: ...
+
+
+def requires_approval(
+    tool: Any,
+    *,
+    only: list[str] | None = None,
+) -> Any:
+    """Mark tools as requiring human approval before execution.
+
+    Args:
+        tool: A single task or list of tasks.
+        only: If provided, only wrap tools whose func.__name__ is in this list.
+            Ignored when wrapping a single tool.
+
+    Returns:
+        Wrapped tool(s) with .requires_approval = True.
+    """
+    if isinstance(tool, list):
+        result = []
+        for t in tool:
+            func = t.func if hasattr(t, "func") else t
+            func_name = func.__name__
+            if only is None or func_name in only:
+                result.append(_ApprovalWrapper(t))
+            else:
+                result.append(t)
+        return result
+
+    return _ApprovalWrapper(tool)

--- a/flux/tasks/ai/approval.py
+++ b/flux/tasks/ai/approval.py
@@ -48,11 +48,13 @@ class _ApprovalWrapper:
 
 
 @overload
-def requires_approval(tool: task, *, only: list[str] | None = None) -> _ApprovalWrapper: ...
+def requires_approval(tool: task, *, only: list[str] | None = None) -> _ApprovalWrapper:
+    ...
 
 
 @overload
-def requires_approval(tool: list, *, only: list[str] | None = None) -> list: ...
+def requires_approval(tool: list, *, only: list[str] | None = None) -> list:
+    ...
 
 
 def requires_approval(

--- a/flux/tasks/ai/tool_executor.py
+++ b/flux/tasks/ai/tool_executor.py
@@ -8,6 +8,8 @@ import re
 import typing
 from typing import Any, Callable, Union, get_type_hints
 
+from flux.errors import PauseRequested
+
 logger = logging.getLogger("flux.agent")
 
 # Patterns for tool calls embedded in text content.
@@ -170,6 +172,27 @@ def build_tools_preamble(tools: list[Any]) -> str:
             "plain text. Do not include tool call JSON in your text response.",
         ],
     )
+
+    approval_tools = [
+        (t.func if hasattr(t, "func") else t).__name__
+        for t in tools
+        if getattr(t, "requires_approval", False)
+    ]
+    if approval_tools:
+        lines.extend(
+            [
+                "",
+                "## Tool Approval",
+                "",
+                "Some tools require human approval before execution. When you call "
+                "these tools, execution will pause until a human approves or rejects "
+                "the call. If rejected, you will receive an error — adapt your "
+                "approach accordingly.",
+                "",
+                f"Tools requiring approval: {', '.join(approval_tools)}",
+            ],
+        )
+
     return "\n".join(lines)
 
 
@@ -216,6 +239,8 @@ async def execute_tools(
     tools: list[Any],
     iteration: int = 0,
     max_concurrent: int | None = None,
+    always_approved: set[str] | None = None,
+    approval_mode: str = "default",
 ) -> list[dict[str, Any]]:
     """Execute tool calls and return results.
 
@@ -230,6 +255,10 @@ async def execute_tools(
         max_concurrent: Maximum number of tools to run concurrently.
             When ``None`` (the default) all tools run in parallel with no limit.
             Set to ``1`` for fully sequential execution.
+        always_approved: Set of tool names that have been permanently approved
+            by the user. Tools in this set skip the approval check.
+        approval_mode: When set to ``"autonomous"``, all approval checks are
+            skipped regardless of the tool's ``requires_approval`` flag.
     """
     tool_map: dict[str, Callable] = {}
     for tool in tools:
@@ -263,6 +292,30 @@ async def execute_tools(
                 logger.debug("Tool '%s': dropping unknown args %s", name, unknown)
                 args = {k: v for k, v in args.items() if k in accepted}
 
+        _always_approved = always_approved if always_approved is not None else set()
+        if (
+            approval_mode != "autonomous"
+            and name not in _always_approved
+            and getattr(tool_fn, "requires_approval", False)
+        ):
+            from flux.tasks.pause import pause
+
+            approval = await pause(
+                f"tool_approval:{name}",
+                output={
+                    "type": "tool_approval",
+                    "tool": name,
+                    "arguments": args,
+                },
+            )
+            if not isinstance(approval, dict) or approval.get("approved") is not True:
+                return {
+                    "tool_call_id": call.get("id", name),
+                    "output": "Error: Tool call rejected by human.",
+                }
+            if approval.get("always_approve"):
+                _always_approved.add(name)
+
         try:
             call_id = call.get("id", name)
             effective_tool = tool_fn
@@ -270,6 +323,8 @@ async def execute_tools(
                 effective_tool = tool_fn.with_options(name=f"{name}_{iteration}")
             result = await effective_tool(**args)
             return {"tool_call_id": call_id, "output": _serialize_result(result)}
+        except PauseRequested:
+            raise
         except Exception as e:
             logger.warning("Tool '%s' failed: %s (args=%s)", name, e, args)
             return {"tool_call_id": call.get("id", name), "output": f"Error: {e!s}"}

--- a/flux/tasks/ai/tool_executor.py
+++ b/flux/tasks/ai/tool_executor.py
@@ -135,7 +135,7 @@ def _resolve_json_type(hint: Any) -> str:
     return "string"
 
 
-def build_tools_preamble(tools: list[Any]) -> str:
+def build_tools_preamble(tools: list[Any], approval_mode: str = "default") -> str:
     """Build a system-prompt section listing available tools.
 
     Reinforces the API-level tool schema with a human-readable summary
@@ -178,7 +178,7 @@ def build_tools_preamble(tools: list[Any]) -> str:
         for t in tools
         if getattr(t, "requires_approval", False)
     ]
-    if approval_tools:
+    if approval_tools and approval_mode != "autonomous":
         lines.extend(
             [
                 "",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.19.0"
+version = "0.20.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/tasks/ai/test_approval.py
+++ b/tests/flux/tasks/ai/test_approval.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import inspect
+
+from flux.task import task
+from flux.tasks.ai.approval import requires_approval
+
+
+@task
+async def read_file(path: str) -> str:
+    """Read a file."""
+    return f"contents of {path}"
+
+
+@task
+async def shell(command: str) -> str:
+    """Execute a shell command."""
+    return f"output of {command}"
+
+
+@task
+async def list_files(directory: str) -> str:
+    """List files in a directory."""
+    return f"files in {directory}"
+
+
+def test_requires_approval_single_tool():
+    wrapped = requires_approval(shell)
+    assert getattr(wrapped, "requires_approval", False) is True
+
+
+def test_requires_approval_preserves_func():
+    wrapped = requires_approval(shell)
+    assert wrapped.func.__name__ == "shell"
+
+
+def test_requires_approval_preserves_name():
+    wrapped = requires_approval(shell)
+    assert wrapped.name == "shell"
+
+
+def test_requires_approval_preserves_doc():
+    wrapped = requires_approval(shell)
+    assert wrapped.func.__doc__ == "Execute a shell command."
+
+
+def test_requires_approval_preserves_signature():
+    wrapped = requires_approval(shell)
+    sig = inspect.signature(wrapped.func)
+    assert "command" in sig.parameters
+
+
+def test_requires_approval_is_callable():
+    wrapped = requires_approval(shell)
+    assert callable(wrapped)
+
+
+def test_requires_approval_list_wraps_all():
+    tools = requires_approval([shell, read_file, list_files])
+    assert len(tools) == 3
+    for t in tools:
+        assert getattr(t, "requires_approval", False) is True
+
+
+def test_requires_approval_list_with_only():
+    tools = requires_approval([shell, read_file, list_files], only=["shell"])
+    shell_tool = [t for t in tools if t.func.__name__ == "shell"][0]
+    read_tool = [t for t in tools if t.func.__name__ == "read_file"][0]
+    list_tool = [t for t in tools if t.func.__name__ == "list_files"][0]
+    assert getattr(shell_tool, "requires_approval", False) is True
+    assert getattr(read_tool, "requires_approval", False) is False
+    assert getattr(list_tool, "requires_approval", False) is False
+
+
+def test_unwrapped_tool_has_no_requires_approval():
+    assert getattr(shell, "requires_approval", False) is False
+
+
+def test_requires_approval_with_options_preserves_flag():
+    wrapped = requires_approval(shell)
+    renamed = wrapped.with_options(name="shell_1")
+    assert getattr(renamed, "requires_approval", False) is True
+
+
+def test_requires_approval_only_matches_func_name():
+    @task.with_options(name="custom_name")
+    async def my_func(x: str) -> str:
+        """A tool."""
+        return x
+
+    tools = requires_approval([my_func], only=["my_func"])
+    assert getattr(tools[0], "requires_approval", False) is True

--- a/tests/flux/tasks/ai/test_tool_executor.py
+++ b/tests/flux/tasks/ai/test_tool_executor.py
@@ -5,8 +5,10 @@ import time
 
 
 from flux import task
+from flux.tasks.ai.approval import requires_approval
 from flux.tasks.ai.tool_executor import (
     build_tool_schemas,
+    build_tools_preamble,
     execute_tools,
     extract_tool_calls_from_content,
     strip_tool_calls_from_content,
@@ -409,3 +411,148 @@ def test_execute_tools_single_call_unchanged():
     ctx = test_wf.run()
     assert ctx.has_succeeded
     assert ctx.output[0]["output"] == "Results for: test"
+
+
+# --- tool approval tests ---
+
+
+@task
+async def dangerous_tool(target: str) -> str:
+    """Delete something dangerous."""
+    return f"deleted:{target}"
+
+
+dangerous_tool_approved = requires_approval(dangerous_tool)
+
+
+def test_approval_tool_pauses_workflow():
+    from flux import ExecutionContext, workflow
+    from flux.domain.events import ExecutionEventType
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        results = await execute_tools(
+            [{"id": "c1", "name": "dangerous_tool", "arguments": {"target": "prod"}}],
+            [dangerous_tool_approved],
+        )
+        return results
+
+    ctx = test_wf.run()
+    assert ctx.is_paused
+
+    pause_events = [e for e in ctx.events if e.type == ExecutionEventType.WORKFLOW_PAUSED]
+    assert len(pause_events) == 1
+    pause_output = pause_events[0].value["output"]
+    assert pause_output["type"] == "tool_approval"
+    assert pause_output["tool"] == "dangerous_tool"
+    assert pause_output["arguments"] == {"target": "prod"}
+
+
+def test_approval_tool_executes_after_approve():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        results = await execute_tools(
+            [{"id": "c1", "name": "dangerous_tool", "arguments": {"target": "prod"}}],
+            [dangerous_tool_approved],
+        )
+        return results
+
+    ctx = test_wf.run()
+    assert ctx.is_paused
+
+    ctx = test_wf.resume(ctx.execution_id, {"approved": True})
+    assert ctx.has_succeeded
+    assert ctx.output[0]["output"] == "deleted:prod"
+
+
+def test_approval_tool_rejected_returns_error():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        results = await execute_tools(
+            [{"id": "c1", "name": "dangerous_tool", "arguments": {"target": "prod"}}],
+            [dangerous_tool_approved],
+        )
+        return results
+
+    ctx = test_wf.run()
+    assert ctx.is_paused
+
+    ctx = test_wf.resume(ctx.execution_id, {"approved": False})
+    assert ctx.has_succeeded
+    assert "rejected" in ctx.output[0]["output"].lower()
+
+
+def test_approval_always_approve_skips_subsequent():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        approved_set: set[str] = set()
+        r1 = await execute_tools(
+            [{"id": "c1", "name": "dangerous_tool", "arguments": {"target": "first"}}],
+            [dangerous_tool_approved],
+            always_approved=approved_set,
+        )
+        r2 = await execute_tools(
+            [{"id": "c2", "name": "dangerous_tool", "arguments": {"target": "second"}}],
+            [dangerous_tool_approved],
+            always_approved=approved_set,
+        )
+        return {"r1": r1, "r2": r2}
+
+    ctx = test_wf.run()
+    assert ctx.is_paused
+
+    ctx = test_wf.resume(ctx.execution_id, {"approved": True, "always_approve": True})
+    assert ctx.has_succeeded
+    assert ctx.output["r1"][0]["output"] == "deleted:first"
+    assert ctx.output["r2"][0]["output"] == "deleted:second"
+
+
+def test_approval_autonomous_mode_skips_all():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        results = await execute_tools(
+            [{"id": "c1", "name": "dangerous_tool", "arguments": {"target": "prod"}}],
+            [dangerous_tool_approved],
+            approval_mode="autonomous",
+        )
+        return results
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert ctx.output[0]["output"] == "deleted:prod"
+
+
+def test_non_approval_tools_unaffected():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        results = await execute_tools(
+            [{"id": "c1", "name": "search_web", "arguments": {"query": "hello"}}],
+            [search_web],
+        )
+        return results
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded
+    assert ctx.output[0]["output"] == "Results for: hello"
+
+
+def test_build_tools_preamble_includes_approval_section():
+    preamble = build_tools_preamble([search_web, dangerous_tool_approved])
+    assert "Tool Approval" in preamble
+    assert "dangerous_tool" in preamble
+    assert "search_web" not in preamble.split("Tool Approval")[1]
+
+
+def test_build_tools_preamble_no_approval_section_without_approval_tools():
+    preamble = build_tools_preamble([search_web])
+    assert "Tool Approval" not in preamble


### PR DESCRIPTION
## Summary

- Add `requires_approval()` wrapper to mark tools as needing human approval before execution
- Tool executor pauses workflow via `PauseRequested` when an approval-gated tool is called
- Human resumes with `{"approved": true}`, `{"approved": false}`, or `{"approved": true, "always_approve": true}`
- `always_approve` sticky decisions skip subsequent approvals for the same tool within a run
- `approval_mode="autonomous"` parameter on `agent()` skips all approvals (for CI/isolated environments)
- System prompt injection lists tools requiring approval so the LLM knows about the mechanism

## API

```python
from flux.tasks.ai import agent
from flux.tasks.ai.approval import requires_approval
from flux.tasks.ai.tools.system_tools import system_tools

# Interactive — shell requires approval
assistant = await agent(
    "You are a helpful assistant.",
    model="ollama/llama3.2",
    tools=requires_approval(system_tools("./workspace"), only=["shell"]),
)

# CI — skip all approvals
ci_agent = await agent(
    "You are a CI assistant.",
    model="ollama/llama3.2",
    tools=requires_approval(system_tools("./workspace"), only=["shell"]),
    approval_mode="autonomous",
)
```

## Test plan

- [x] 1021 unit tests passing, 0 skipped
- [x] Pre-commit clean (all 13 hooks)
- [x] E2E: Tool approval demo — agent calls shell, workflow PAUSES, human approves, workflow COMPLETES