### PR TITLE
feat: AI dreaming — memory consolidation via lifecycle hooks

### DIFF
--- a/examples/ai/dreaming_agent_ollama.py
+++ b/examples/ai/dreaming_agent_ollama.py
@@ -1,0 +1,117 @@
+"""
+Agent with Working Memory, Long-Term Memory, and Dreaming.
+
+Demonstrates a coding assistant that:
+- Stores full tool interactions in working memory (tool_call + tool_result)
+- Uses long-term memory for persistent facts across sessions
+- Fires a dream workflow on completion for memory consolidation
+
+The dream workflow runs four phases (orient, gather signal, consolidate, prune)
+to distill working memory into clean long-term knowledge.
+
+Prerequisites:
+    1. Install Ollama: https://ollama.ai
+    2. Pull a model: ollama pull llama3.2
+    3. Start Ollama service: ollama serve
+
+Usage (in-process):
+    python examples/ai/dreaming_agent_ollama.py
+
+Usage (server/worker):
+    flux start server
+    flux start worker
+    flux workflow register examples/ai/dreaming_agent_ollama.py
+    flux workflow register flux/tasks/ai/dreaming.py
+    flux workflow run dreaming_agent '{"task": "Explore the workspace and list all files"}'
+"""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from flux import ExecutionContext, workflow
+from flux.tasks.ai import agent, system_tools
+from flux.tasks.ai.dreaming import dream
+from flux.tasks.ai.memory import long_term_memory, sqlite, working_memory
+
+
+@workflow
+async def dreaming_agent(ctx: ExecutionContext[dict[str, Any]]):
+    """
+    Coding assistant with working memory, long-term memory, and dreaming.
+
+    Input format:
+    {
+        "task": "What should the agent do?",
+        "workspace": "/optional/path/to/workspace"
+    }
+    """
+    input_data = ctx.input or {}
+    task_description = input_data.get("task", "List all files in the workspace")
+
+    workspace = Path(input_data.get("workspace", tempfile.mkdtemp(prefix="flux_dreaming_")))
+    if not workspace.exists():
+        workspace.mkdir(parents=True)
+
+    wm = working_memory(max_tokens=50_000)
+    ltm = long_term_memory(
+        provider=sqlite(str(workspace / "memory.db")),
+        agent="dreaming_agent",
+        scope="default",
+    )
+
+    tools = system_tools(workspace=str(workspace), timeout=30)
+
+    assistant = await agent(
+        "You are a helpful coding assistant. Use your tools to accomplish tasks. "
+        "Be concise in your responses.",
+        model="ollama/llama3.2",
+        name="dreaming_agent",
+        tools=tools,
+        working_memory=wm,
+        long_term_memory=ltm,
+        max_tool_calls=10,
+        stream=False,
+        on_complete=[dream(working_memory=wm, long_term_memory=ltm)],
+    )
+
+    answer = await assistant(task_description)
+
+    wm_messages = wm.recall()
+
+    return {
+        "task": task_description,
+        "answer": answer,
+        "workspace": str(workspace),
+        "working_memory_count": len(wm_messages),
+        "working_memory_roles": [m["role"] for m in wm_messages],
+        "execution_id": ctx.execution_id,
+    }
+
+
+if __name__ == "__main__":
+    workspace = Path(tempfile.mkdtemp(prefix="flux_dreaming_"))
+    (workspace / "hello.py").write_text('def greet(name):\n    return f"Hello, {name}!"\n')
+    (workspace / "config.yaml").write_text("database: postgres\nport: 5432\n")
+    (workspace / "README.md").write_text("# Sample Project\n\nA demo for dreaming agents.\n")
+
+    print(f"Workspace: {workspace}")
+    print("=" * 70)
+
+    result = dreaming_agent.run(
+        {
+            "task": "List all files and show the contents of hello.py",
+            "workspace": str(workspace),
+        },
+    )
+
+    if result.has_succeeded:
+        output = result.output
+        print(f"\nAnswer:\n{output['answer'][:500]}")
+        print(f"\nWorking Memory: {output['working_memory_count']} messages")
+        print(f"Roles: {output['working_memory_roles']}")
+    elif result.has_failed:
+        print(f"\nFailed: {result.output}")
+    else:
+        print(f"\nState: {result.state}")

--- a/examples/ai/dreaming_agent_ollama.py
+++ b/examples/ai/dreaming_agent_ollama.py
@@ -71,6 +71,7 @@ async def dreaming_agent(ctx: ExecutionContext[dict[str, Any]]):
     workspace.mkdir(parents=True, exist_ok=True)
 
     max_turns = input_data.get("max_turns", 10)
+    model = input_data.get("model", "ollama/llama3.2")
 
     wm = working_memory(max_tokens=50_000)
     ltm = long_term_memory(
@@ -86,14 +87,14 @@ async def dreaming_agent(ctx: ExecutionContext[dict[str, Any]]):
         "Always check your long-term memory first for relevant context. "
         "Store important facts you learn using store_memory. "
         "Be concise in your responses.",
-        model="ollama/llama3.2",
+        model=model,
         name="dreaming_agent",
         tools=tools,
         working_memory=wm,
         long_term_memory=ltm,
         max_tool_calls=10,
         stream=False,
-        on_complete=[dream(working_memory=wm, long_term_memory=ltm)],
+        on_complete=[dream(working_memory=wm, long_term_memory=ltm, model=model)],
     )
 
     message = first_message

--- a/examples/ai/dreaming_agent_ollama.py
+++ b/examples/ai/dreaming_agent_ollama.py
@@ -33,7 +33,6 @@ Usage (server/worker):
 """
 from __future__ import annotations
 
-import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -61,12 +60,15 @@ async def dreaming_agent(ctx: ExecutionContext[dict[str, Any]]):
         "message": "Follow-up question or instruction"
     }
     """
+    from flux.config import Configuration
+
     input_data = ctx.input or {}
     first_message = input_data.get("message", "List all files in the workspace")
 
-    workspace = Path(input_data.get("workspace", tempfile.mkdtemp(prefix="flux_dreaming_")))
-    if not workspace.exists():
-        workspace.mkdir(parents=True)
+    flux_home = Path(Configuration.get().settings.home)
+    default_workspace = str(flux_home / "dreaming")
+    workspace = Path(input_data.get("workspace", default_workspace))
+    workspace.mkdir(parents=True, exist_ok=True)
 
     max_turns = input_data.get("max_turns", 10)
 
@@ -122,8 +124,29 @@ async def dreaming_agent(ctx: ExecutionContext[dict[str, Any]]):
     }
 
 
+def _print_result(result):
+    if result.has_succeeded:
+        output = result.output
+        print(f"\nConversation ({len(output['conversation'])} turns):")
+        for turn in output["conversation"]:
+            print(f"  Turn {turn['turn']}:")
+            print(f"    User: {turn['user'][:100]}")
+            print(f"    Agent: {turn['assistant'][:200]}")
+        print(f"\nWorking Memory: {output['working_memory_count']} messages")
+        print(f"LTM keys: {output['ltm_keys']}")
+    elif result.has_failed:
+        print(f"\nFailed: {result.output}")
+    elif result.is_paused:
+        print(f"\nPaused. Execution ID: {result.execution_id}")
+
+
 if __name__ == "__main__":
-    workspace = Path(tempfile.mkdtemp(prefix="flux_dreaming_"))
+    # Use Flux home for persistent data (defaults to .flux/)
+    from flux.config import Configuration
+
+    flux_home = Path(Configuration.get().settings.home)
+    workspace = flux_home / "dreaming"
+    workspace.mkdir(parents=True, exist_ok=True)
     (workspace / "hello.py").write_text('def greet(name):\n    return f"Hello, {name}!"\n')
     (workspace / "config.yaml").write_text(
         "database: postgres\nport: 5432\nhost: db.example.com\n",
@@ -136,55 +159,36 @@ if __name__ == "__main__":
     )
 
     print(f"Workspace: {workspace}")
+    print(f"Memory DB: {workspace / 'memory.db'}")
     print("=" * 70)
 
-    # Turn 1: Explore
-    print("\n--- Turn 1: Explore workspace ---")
+    # --- Session 1: Explore and learn ---
+    print("\n=== SESSION 1: Explore and learn ===")
     result = dreaming_agent.run(
         {
             "message": "Explore the workspace. List all files and read config.yaml. "
-            "Store the database configuration in your memory.",
+            "Store the database host, port, and type in your long-term memory.",
             "workspace": str(workspace),
         },
     )
 
     if result.is_paused:
-        output = result.output
-        if isinstance(output, dict):
-            print(f"Paused. Execution ID: {result.execution_id}")
-        else:
-            print(f"Paused: {output}")
+        # End session 1
+        result = dreaming_agent.resume(result.execution_id, {"message": ""})
 
-        # Turn 2: Ask what it remembers
-        print("\n--- Turn 2: What do you remember? ---")
-        result = dreaming_agent.resume(
-            result.execution_id,
-            {
-                "message": "What database configuration do you remember? Check your long-term memory.",
-            },
-        )
+    _print_result(result)
 
-        if result.is_paused:
-            print(f"Paused again. Execution ID: {result.execution_id}")
+    # --- Session 2: New execution — recall from LTM ---
+    print("\n=== SESSION 2: New execution — what do you remember? ===")
+    result = dreaming_agent.run(
+        {
+            "message": "Without using any tools, what database configuration do you "
+            "remember from previous sessions? Check your long-term memory.",
+            "workspace": str(workspace),
+        },
+    )
 
-            # Turn 3: End conversation
-            print("\n--- Turn 3: End conversation ---")
-            result = dreaming_agent.resume(
-                result.execution_id,
-                {"message": ""},
-            )
+    if result.is_paused:
+        result = dreaming_agent.resume(result.execution_id, {"message": ""})
 
-    if result.has_succeeded:
-        output = result.output
-        print(f"\nConversation ({len(output['conversation'])} turns):")
-        for turn in output["conversation"]:
-            print(f"  Turn {turn['turn']}:")
-            print(f"    User: {turn['user'][:100]}")
-            print(f"    Agent: {turn['assistant'][:200]}")
-        print(f"\nWorking Memory: {output['working_memory_count']} messages")
-        print(f"Roles: {output['working_memory_roles']}")
-        print(f"LTM keys: {output['ltm_keys']}")
-    elif result.has_failed:
-        print(f"\nFailed: {result.output}")
-    else:
-        print(f"\nState: {result.state}")
+    _print_result(result)

--- a/examples/ai/dreaming_agent_ollama.py
+++ b/examples/ai/dreaming_agent_ollama.py
@@ -4,6 +4,7 @@ Agent with Working Memory, Long-Term Memory, and Dreaming.
 Demonstrates a coding assistant that:
 - Stores full tool interactions in working memory (tool_call + tool_result)
 - Uses long-term memory for persistent facts across sessions
+- Supports multi-turn conversations via pause/resume
 - Fires a dream workflow on completion for memory consolidation
 
 The dream workflow runs four phases (orient, gather signal, consolidate, prune)
@@ -22,7 +23,13 @@ Usage (server/worker):
     flux start worker
     flux workflow register examples/ai/dreaming_agent_ollama.py
     flux workflow register flux/tasks/ai/dreaming.py
-    flux workflow run dreaming_agent '{"task": "Explore the workspace and list all files"}'
+    flux workflow run dreaming_agent '{"message": "Explore the workspace and list all files"}'
+
+    # Follow up (resume the same execution):
+    flux workflow resume dreaming_agent <execution_id> '{"message": "What database is configured?"}'
+
+    # End the conversation:
+    flux workflow resume dreaming_agent <execution_id> '{"message": ""}'
 """
 from __future__ import annotations
 
@@ -31,6 +38,7 @@ from pathlib import Path
 from typing import Any
 
 from flux import ExecutionContext, workflow
+from flux.tasks import pause
 from flux.tasks.ai import agent, system_tools
 from flux.tasks.ai.dreaming import dream
 from flux.tasks.ai.memory import long_term_memory, sqlite, working_memory
@@ -39,20 +47,28 @@ from flux.tasks.ai.memory import long_term_memory, sqlite, working_memory
 @workflow
 async def dreaming_agent(ctx: ExecutionContext[dict[str, Any]]):
     """
-    Coding assistant with working memory, long-term memory, and dreaming.
+    Multi-turn coding assistant with working memory, long-term memory, and dreaming.
 
-    Input format:
+    Initial input:
     {
-        "task": "What should the agent do?",
-        "workspace": "/optional/path/to/workspace"
+        "message": "What should the agent do?",
+        "workspace": "/optional/path/to/workspace",
+        "max_turns": 10
+    }
+
+    Resume input:
+    {
+        "message": "Follow-up question or instruction"
     }
     """
     input_data = ctx.input or {}
-    task_description = input_data.get("task", "List all files in the workspace")
+    first_message = input_data.get("message", "List all files in the workspace")
 
     workspace = Path(input_data.get("workspace", tempfile.mkdtemp(prefix="flux_dreaming_")))
     if not workspace.exists():
         workspace.mkdir(parents=True)
+
+    max_turns = input_data.get("max_turns", 10)
 
     wm = working_memory(max_tokens=50_000)
     ltm = long_term_memory(
@@ -65,6 +81,8 @@ async def dreaming_agent(ctx: ExecutionContext[dict[str, Any]]):
 
     assistant = await agent(
         "You are a helpful coding assistant. Use your tools to accomplish tasks. "
+        "Always check your long-term memory first for relevant context. "
+        "Store important facts you learn using store_memory. "
         "Be concise in your responses.",
         model="ollama/llama3.2",
         name="dreaming_agent",
@@ -76,16 +94,30 @@ async def dreaming_agent(ctx: ExecutionContext[dict[str, Any]]):
         on_complete=[dream(working_memory=wm, long_term_memory=ltm)],
     )
 
-    answer = await assistant(task_description)
+    message = first_message
+    conversation = []
+
+    for turn in range(max_turns):
+        answer = await assistant(message)
+        conversation.append({"turn": turn + 1, "user": message, "assistant": answer})
+
+        resume_input = await pause(f"waiting_for_input_turn_{turn + 1}")
+
+        next_message = (resume_input or {}).get("message", "")
+        if not next_message:
+            break
+
+        message = next_message
 
     wm_messages = wm.recall()
+    ltm_keys = await ltm.keys()
 
     return {
-        "task": task_description,
-        "answer": answer,
         "workspace": str(workspace),
+        "conversation": conversation,
         "working_memory_count": len(wm_messages),
         "working_memory_roles": [m["role"] for m in wm_messages],
+        "ltm_keys": ltm_keys,
         "execution_id": ctx.execution_id,
     }
 
@@ -93,24 +125,65 @@ async def dreaming_agent(ctx: ExecutionContext[dict[str, Any]]):
 if __name__ == "__main__":
     workspace = Path(tempfile.mkdtemp(prefix="flux_dreaming_"))
     (workspace / "hello.py").write_text('def greet(name):\n    return f"Hello, {name}!"\n')
-    (workspace / "config.yaml").write_text("database: postgres\nport: 5432\n")
-    (workspace / "README.md").write_text("# Sample Project\n\nA demo for dreaming agents.\n")
+    (workspace / "config.yaml").write_text(
+        "database: postgres\nport: 5432\nhost: db.example.com\n",
+    )
+    (workspace / "main.py").write_text(
+        'from fastapi import FastAPI\napp = FastAPI()\n\n@app.get("/")\ndef root():\n    return {"status": "ok"}\n',
+    )
+    (workspace / "README.md").write_text(
+        "# My Project\n\nA Python web API using FastAPI and PostgreSQL.\n",
+    )
 
     print(f"Workspace: {workspace}")
     print("=" * 70)
 
+    # Turn 1: Explore
+    print("\n--- Turn 1: Explore workspace ---")
     result = dreaming_agent.run(
         {
-            "task": "List all files and show the contents of hello.py",
+            "message": "Explore the workspace. List all files and read config.yaml. "
+            "Store the database configuration in your memory.",
             "workspace": str(workspace),
         },
     )
 
+    if result.is_paused:
+        output = result.output
+        if isinstance(output, dict):
+            print(f"Paused. Execution ID: {result.execution_id}")
+        else:
+            print(f"Paused: {output}")
+
+        # Turn 2: Ask what it remembers
+        print("\n--- Turn 2: What do you remember? ---")
+        result = dreaming_agent.resume(
+            result.execution_id,
+            {
+                "message": "What database configuration do you remember? Check your long-term memory.",
+            },
+        )
+
+        if result.is_paused:
+            print(f"Paused again. Execution ID: {result.execution_id}")
+
+            # Turn 3: End conversation
+            print("\n--- Turn 3: End conversation ---")
+            result = dreaming_agent.resume(
+                result.execution_id,
+                {"message": ""},
+            )
+
     if result.has_succeeded:
         output = result.output
-        print(f"\nAnswer:\n{output['answer'][:500]}")
+        print(f"\nConversation ({len(output['conversation'])} turns):")
+        for turn in output["conversation"]:
+            print(f"  Turn {turn['turn']}:")
+            print(f"    User: {turn['user'][:100]}")
+            print(f"    Agent: {turn['assistant'][:200]}")
         print(f"\nWorking Memory: {output['working_memory_count']} messages")
         print(f"Roles: {output['working_memory_roles']}")
+        print(f"LTM keys: {output['ltm_keys']}")
     elif result.has_failed:
         print(f"\nFailed: {result.output}")
     else:

--- a/examples/ai/memory_long_term_ollama.py
+++ b/examples/ai/memory_long_term_ollama.py
@@ -36,6 +36,7 @@ async def memory_long_term(ctx: ExecutionContext[dict[str, Any]]):
         working_memory=working_memory(),
         long_term_memory=long_term_memory(
             provider=sqlite("memory_example.db"),
+            agent="memory_long_term",
             scope="user:default",
         ),
     )

--- a/examples/ai/memory_shared_agents_ollama.py
+++ b/examples/ai/memory_shared_agents_ollama.py
@@ -13,7 +13,7 @@ from flux import workflow, ExecutionContext
 from flux.tasks.ai import agent
 from flux.tasks.ai.memory import long_term_memory, in_memory
 
-shared = long_term_memory(provider=in_memory(), scope="review:pr-42")
+shared = long_term_memory(provider=in_memory(), agent="shared_agent", scope="review:pr-42")
 
 
 @workflow

--- a/examples/ai/system_tools_with_memory_ollama.py
+++ b/examples/ai/system_tools_with_memory_ollama.py
@@ -54,6 +54,7 @@ async def system_tools_with_memory_ollama(ctx: ExecutionContext[dict[str, Any]])
 
     ltm = long_term_memory(
         provider=sqlite(f"{workspace}/.agent_memory.db"),
+        agent="memory_coding_agent",
         scope="project",
     )
 

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -8,6 +8,8 @@ from pydantic import BaseModel
 from flux.task import task
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from flux.tasks.ai.memory.long_term_memory import LongTermMemory
     from flux.tasks.ai.memory.working_memory import WorkingMemory
     from flux.tasks.ai.skills import SkillCatalog
@@ -36,8 +38,8 @@ async def agent(
     max_tokens: int = 4096,
     stream: bool = True,
     approval_mode: str = "default",
-    on_complete: list | None = None,
-    on_pause: list | None = None,
+    on_complete: list[Callable] | None = None,
+    on_pause: list[Callable] | None = None,
 ) -> task:
     """Create a Flux @task that calls an LLM.
 

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -70,6 +70,11 @@ async def agent(
             unlimited. Defaults to None.
         max_tokens: Maximum tokens in the LLM response (used by Anthropic and Google, ignored by others).
         stream: If True, enable streaming responses. Automatically disabled when response_format is set.
+        on_complete: List of hook callables fired after the agent returns.
+            Signature: ``async (agent_id: str, value: Any) -> None``. Sync hooks are also supported.
+            Failures are logged but never affect the return value.
+        on_pause: List of hook callables fired when the agent pauses (PauseRequested).
+            Same signature as on_complete. Fired before the pause propagates.
 
     Returns:
         A Flux @task callable with signature (instruction: str, *, context: str = "") -> str | BaseModel

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -36,6 +36,8 @@ async def agent(
     max_tokens: int = 4096,
     stream: bool = True,
     approval_mode: str = "default",
+    on_complete: list | None = None,
+    on_pause: list | None = None,
 ) -> task:
     """Create a Flux @task that calls an LLM.
 
@@ -166,6 +168,9 @@ async def agent(
                 stream=effective_stream,
                 plan_summary_fn=plan_summary_fn,
                 approval_mode=approval_mode,
+                on_complete=on_complete,
+                on_pause=on_pause,
+                agent_name=task_name,
             )
 
         result = _ollama_agent
@@ -198,6 +203,9 @@ async def agent(
                 stream=effective_stream,
                 plan_summary_fn=plan_summary_fn,
                 approval_mode=approval_mode,
+                on_complete=on_complete,
+                on_pause=on_pause,
+                agent_name=task_name,
             )
 
         result = _openai_agent
@@ -230,6 +238,9 @@ async def agent(
                 stream=effective_stream,
                 plan_summary_fn=plan_summary_fn,
                 approval_mode=approval_mode,
+                on_complete=on_complete,
+                on_pause=on_pause,
+                agent_name=task_name,
             )
 
         result = _anthropic_agent
@@ -266,6 +277,9 @@ async def agent(
                 stream=effective_stream,
                 plan_summary_fn=plan_summary_fn,
                 approval_mode=approval_mode,
+                on_complete=on_complete,
+                on_pause=on_pause,
+                agent_name=task_name,
             )
 
         result = _google_agent

--- a/flux/tasks/ai/agent_loop.py
+++ b/flux/tasks/ai/agent_loop.py
@@ -95,13 +95,29 @@ async def run_agent_loop(
 
     tool_call_count = 0
     tool_iteration = 0
+    entered_tool_loop = False
 
     while response.tool_calls and tools and tool_call_count < max_tool_calls:
+        if not entered_tool_loop:
+            entered_tool_loop = True
+            if working_memory:
+                await working_memory.memorize("user", user_content)
+
         tool_call_count += len(response.tool_calls)
 
         messages.append(formatter.format_assistant_message(response))
 
+        if working_memory and response.text:
+            await working_memory.memorize("assistant", response.text)
+
         tool_call_dicts = [tc.model_dump() for tc in response.tool_calls]
+
+        if working_memory:
+            await working_memory.memorize(
+                "tool_call",
+                json.dumps({"calls": tool_call_dicts}),
+            )
+
         try:
             results = await execute_tools(
                 tool_call_dicts,
@@ -115,6 +131,17 @@ async def run_agent_loop(
             await _fire_hooks(on_pause, agent_name, None)
             raise
         tool_iteration += 1
+
+        if working_memory:
+            for tc_dict, result in zip(tool_call_dicts, results):
+                await working_memory.memorize(
+                    "tool_result",
+                    json.dumps({
+                        "call_id": tc_dict.get("id", ""),
+                        "name": tc_dict.get("name", ""),
+                        "output": str(result.get("output", "")),
+                    }),
+                )
 
         tool_result_messages = formatter.format_tool_results(response.tool_calls, results)
 
@@ -176,8 +203,10 @@ async def run_agent_loop(
             content += token
             await progress({"token": token})
 
-    if working_memory:
+    if working_memory and not entered_tool_loop:
         await working_memory.memorize("user", user_content)
+        await working_memory.memorize("assistant", content)
+    elif working_memory and entered_tool_loop:
         await working_memory.memorize("assistant", content)
 
     if response_format:

--- a/flux/tasks/ai/agent_loop.py
+++ b/flux/tasks/ai/agent_loop.py
@@ -136,11 +136,13 @@ async def run_agent_loop(
             for tc_dict, result in zip(tool_call_dicts, results):
                 await working_memory.memorize(
                     "tool_result",
-                    json.dumps({
-                        "call_id": tc_dict.get("id", ""),
-                        "name": tc_dict.get("name", ""),
-                        "output": str(result.get("output", "")),
-                    }),
+                    json.dumps(
+                        {
+                            "call_id": tc_dict.get("id", ""),
+                            "name": tc_dict.get("name", ""),
+                            "output": str(result.get("output", "")),
+                        },
+                    ),
                 )
 
         tool_result_messages = formatter.format_tool_results(response.tool_calls, results)

--- a/flux/tasks/ai/agent_loop.py
+++ b/flux/tasks/ai/agent_loop.py
@@ -20,13 +20,17 @@ logger = logging.getLogger("flux.agent")
 
 
 async def _fire_hooks(hooks: list[Any] | None, agent_name: str, value: Any) -> None:
+    import asyncio
+
     if not hooks:
         return
     for hook in hooks:
         try:
             result = hook(agent_name, value)
             if inspect.isawaitable(result):
-                await result
+                await asyncio.wait_for(result, timeout=30)
+        except asyncio.TimeoutError:
+            logger.warning("Hook %s timed out after 30s", hook)
         except Exception:
             logger.warning("Hook %s failed", hook, exc_info=True)
 

--- a/flux/tasks/ai/agent_loop.py
+++ b/flux/tasks/ai/agent_loop.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
+from flux.errors import PauseRequested
 from flux.tasks.ai.models import LLMResponse
 from flux.tasks.ai.tool_executor import execute_tools
 
@@ -22,7 +24,9 @@ async def _fire_hooks(hooks: list[Any] | None, agent_name: str, value: Any) -> N
         return
     for hook in hooks:
         try:
-            await hook(agent_name, value)
+            result = hook(agent_name, value)
+            if inspect.isawaitable(result):
+                await result
         except Exception:
             logger.warning("Hook %s failed", hook, exc_info=True)
 
@@ -98,14 +102,18 @@ async def run_agent_loop(
         messages.append(formatter.format_assistant_message(response))
 
         tool_call_dicts = [tc.model_dump() for tc in response.tool_calls]
-        results = await execute_tools(
-            tool_call_dicts,
-            tools,
-            iteration=tool_iteration,
-            max_concurrent=max_concurrent_tools,
-            always_approved=always_approved,
-            approval_mode=approval_mode,
-        )
+        try:
+            results = await execute_tools(
+                tool_call_dicts,
+                tools,
+                iteration=tool_iteration,
+                max_concurrent=max_concurrent_tools,
+                always_approved=always_approved,
+                approval_mode=approval_mode,
+            )
+        except PauseRequested:
+            await _fire_hooks(on_pause, agent_name, None)
+            raise
         tool_iteration += 1
 
         tool_result_messages = formatter.format_tool_results(response.tool_calls, results)

--- a/flux/tasks/ai/agent_loop.py
+++ b/flux/tasks/ai/agent_loop.py
@@ -17,6 +17,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger("flux.agent")
 
 
+async def _fire_hooks(hooks: list[Any] | None, agent_name: str, value: Any) -> None:
+    if not hooks:
+        return
+    for hook in hooks:
+        try:
+            await hook(agent_name, value)
+        except Exception:
+            logger.warning("Hook %s failed", hook, exc_info=True)
+
+
 async def run_agent_loop(
     *,
     llm_task: TaskType,
@@ -33,6 +43,9 @@ async def run_agent_loop(
     stream: bool = False,
     plan_summary_fn: Any | None = None,
     approval_mode: str = "default",
+    on_complete: list[Any] | None = None,
+    on_pause: list[Any] | None = None,
+    agent_name: str = "agent",
 ) -> str | BaseModel:
     from flux.tasks.progress import progress
 
@@ -63,8 +76,11 @@ async def run_agent_loop(
             await working_memory.memorize("assistant", content)
 
         if response_format:
-            return response_format.model_validate_json(content)
+            return_value = response_format.model_validate_json(content)
+            await _fire_hooks(on_complete, agent_name, return_value)
+            return return_value
 
+        await _fire_hooks(on_complete, agent_name, content)
         return content
 
     result = await llm_task.with_options(name=f"llm_{call_counter}")(messages, **call_kwargs)
@@ -157,8 +173,11 @@ async def run_agent_loop(
         await working_memory.memorize("assistant", content)
 
     if response_format:
-        return response_format.model_validate_json(content)
+        return_value = response_format.model_validate_json(content)
+        await _fire_hooks(on_complete, agent_name, return_value)
+        return return_value
 
+    await _fire_hooks(on_complete, agent_name, content)
     return content
 
 

--- a/flux/tasks/ai/anthropic.py
+++ b/flux/tasks/ai/anthropic.py
@@ -42,6 +42,29 @@ class AnthropicFormatter(LLMFormatter):
         self._model_name = model_name
         self._max_tokens = max_tokens
 
+    def _convert_memory_messages(self, memory_messages: list[dict]) -> list[dict]:
+        import json
+
+        converted = []
+        for msg in memory_messages:
+            role, content = msg["role"], msg["content"]
+            if role == "tool_call":
+                data = json.loads(content)
+                blocks = [
+                    {"type": "tool_use", "id": c["id"], "name": c["name"], "input": c.get("arguments", {})}
+                    for c in data["calls"]
+                ]
+                converted.append({"role": "assistant", "content": blocks})
+            elif role == "tool_result":
+                data = json.loads(content)
+                converted.append({
+                    "role": "user",
+                    "content": [{"type": "tool_result", "tool_use_id": data["call_id"], "content": data["output"]}],
+                })
+            elif role in ("user", "assistant"):
+                converted.append({"role": role, "content": content})
+        return converted
+
     def build_messages(
         self,
         system_prompt: str,
@@ -50,7 +73,7 @@ class AnthropicFormatter(LLMFormatter):
     ) -> tuple[list[dict], dict]:
         if working_memory:
             prior = working_memory.recall()
-            messages = prior + [{"role": "user", "content": user_content}]
+            messages = self._convert_memory_messages(prior) + [{"role": "user", "content": user_content}]
         else:
             messages = [{"role": "user", "content": user_content}]
 

--- a/flux/tasks/ai/anthropic.py
+++ b/flux/tasks/ai/anthropic.py
@@ -76,7 +76,22 @@ class AnthropicFormatter(LLMFormatter):
                 )
             elif role in ("user", "assistant"):
                 converted.append({"role": role, "content": content})
-        return converted
+        if not converted:
+            return converted
+        merged = [converted[0]]
+        for msg in converted[1:]:
+            if msg.get("role") == merged[-1].get("role"):
+                prev_content = merged[-1].get("content", "")
+                curr_content = msg.get("content", "")
+                if isinstance(prev_content, str) and isinstance(curr_content, str):
+                    merged[-1]["content"] = prev_content + "\n" + curr_content
+                elif isinstance(prev_content, list) and isinstance(curr_content, list):
+                    merged[-1]["content"] = prev_content + curr_content
+                else:
+                    merged.append(msg)
+            else:
+                merged.append(msg)
+        return merged
 
     def build_messages(
         self,

--- a/flux/tasks/ai/anthropic.py
+++ b/flux/tasks/ai/anthropic.py
@@ -51,16 +51,29 @@ class AnthropicFormatter(LLMFormatter):
             if role == "tool_call":
                 data = json.loads(content)
                 blocks = [
-                    {"type": "tool_use", "id": c["id"], "name": c["name"], "input": c.get("arguments", {})}
+                    {
+                        "type": "tool_use",
+                        "id": c["id"],
+                        "name": c["name"],
+                        "input": c.get("arguments", {}),
+                    }
                     for c in data["calls"]
                 ]
                 converted.append({"role": "assistant", "content": blocks})
             elif role == "tool_result":
                 data = json.loads(content)
-                converted.append({
-                    "role": "user",
-                    "content": [{"type": "tool_result", "tool_use_id": data["call_id"], "content": data["output"]}],
-                })
+                converted.append(
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": data["call_id"],
+                                "content": data["output"],
+                            },
+                        ],
+                    },
+                )
             elif role in ("user", "assistant"):
                 converted.append({"role": role, "content": content})
         return converted
@@ -73,7 +86,9 @@ class AnthropicFormatter(LLMFormatter):
     ) -> tuple[list[dict], dict]:
         if working_memory:
             prior = working_memory.recall()
-            messages = self._convert_memory_messages(prior) + [{"role": "user", "content": user_content}]
+            messages = self._convert_memory_messages(prior) + [
+                {"role": "user", "content": user_content},
+            ]
         else:
             messages = [{"role": "user", "content": user_content}]
 

--- a/flux/tasks/ai/dreaming.py
+++ b/flux/tasks/ai/dreaming.py
@@ -49,24 +49,29 @@ def dream(
     *,
     working_memory: WorkingMemory,
     long_term_memory: LongTermMemory,
+    model: str | None = None,
     workflow: str = "agent_dream",
 ) -> Callable[[str, Any], Awaitable[None]]:
     """Return an async hook that fires a dream workflow."""
     scope = long_term_memory.scope
     provider_type = long_term_memory.provider_type
+    dream_model = model
     wm = working_memory
 
     async def _hook(agent_id: str, value: Any) -> None:
         try:
             snapshot = wm.recall()
+            payload: dict[str, Any] = {
+                "agent": agent_id,
+                "scope": scope,
+                "provider_type": provider_type,
+                "working_memory": snapshot,
+            }
+            if dream_model:
+                payload["model"] = dream_model
             await call(
                 workflow,
-                {
-                    "agent": agent_id,
-                    "scope": scope,
-                    "provider_type": provider_type,
-                    "working_memory": snapshot,
-                },
+                payload,
                 mode="async",
             )
         except Exception:

--- a/flux/tasks/ai/dreaming.py
+++ b/flux/tasks/ai/dreaming.py
@@ -178,13 +178,14 @@ async def agent_dream(ctx):
 
     model = input_data.get("model", "ollama/llama3.2")
 
-    provider = _build_provider(provider_type)
-    memory = long_term_memory(provider=provider, agent=agent_id, scope=scope)
-
-    if not await check_failure_gate(memory):
-        return {"status": "skipped", "reason": "max consecutive failures reached"}
-
+    memory = None
     try:
+        provider = _build_provider(provider_type)
+        memory = long_term_memory(provider=provider, agent=agent_id, scope=scope)
+
+        if not await check_failure_gate(memory):
+            return {"status": "skipped", "reason": "max consecutive failures reached"}
+
         ltm_tools = memory.as_tools()
 
         orient_agent = await agent(
@@ -241,6 +242,7 @@ async def agent_dream(ctx):
         return {"status": "completed", "summary": summary}
 
     except Exception as e:
-        await increment_failure_counter(memory)
+        if memory is not None:
+            await increment_failure_counter(memory)
         logger.error("Dream workflow failed: %s", e, exc_info=True)
         return {"status": "failed", "error": str(e)}

--- a/flux/tasks/ai/dreaming.py
+++ b/flux/tasks/ai/dreaming.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from flux.tasks.call import call
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+
+logger = logging.getLogger("flux.dreaming")
+
+
+def dream(
+    memory: LongTermMemory,
+    execution_id: str,
+    *,
+    workflow: str = "agent_dream",
+) -> Callable[[str, Any], Awaitable[None]]:
+    """Return an async hook that fires a dream workflow."""
+    scope = memory.scope
+
+    async def _hook(agent_id: str, value: Any) -> None:
+        try:
+            await call(
+                workflow,
+                {
+                    "execution_id": execution_id,
+                    "agent": agent_id,
+                    "scope": scope,
+                },
+                mode="async",
+            )
+        except Exception:
+            logger.warning("Dream workflow submission failed", exc_info=True)
+
+    return _hook
+
+
+async def check_failure_gate(memory: LongTermMemory, max_failures: int = 3) -> bool:
+    count = await memory.recall("_dream:failures")
+    if count is not None and int(count) >= max_failures:
+        logger.warning(
+            "Dream skipped: %d consecutive failures (max: %d)",
+            count,
+            max_failures,
+        )
+        return False
+    return True
+
+
+async def increment_failure_counter(memory: LongTermMemory) -> None:
+    count = await memory.recall("_dream:failures")
+    await memory.memorize("_dream:failures", int(count or 0) + 1)
+
+
+async def reset_failure_counter(memory: LongTermMemory) -> None:
+    await memory.memorize("_dream:failures", 0)
+
+
+ORIENT_PROMPT = (
+    "You are performing memory consolidation. Your task is to understand the current "
+    "state of the agent's long-term memory.\n\n"
+    "Use `list_memory_keys` to see all stored keys, then use `recall_memory` to read "
+    "the contents of each key. Build a mental map of what facts are stored, how they "
+    "are organized, and identify any obvious issues (duplicates, contradictions, stale entries).\n\n"
+    "Produce a brief orientation report summarizing:\n"
+    "- Total number of memory entries\n"
+    "- Key topics/categories covered\n"
+    "- Any obvious issues you notice"
+)
+
+GATHER_SIGNAL_PROMPT = (
+    "You are scanning execution events for high-value signals worth persisting to memory.\n\n"
+    "Focus on these signal types:\n"
+    "- **Corrections**: Where the user or agent reversed or amended a prior statement\n"
+    "- **Decisions**: Explicit choices (technology selections, configuration changes, approach pivots)\n"
+    "- **Repeated patterns**: Facts or entities referenced across 3+ distinct events\n"
+    "- **Staleness indicators**: Tool calls that returned errors for entities that may exist in memory\n\n"
+    "Do NOT read every event in detail. Scan for patterns and extract only high-value signals.\n\n"
+    "Produce a signal report listing each signal with its type and a brief description."
+)
+
+CONSOLIDATE_PROMPT = (
+    "You are consolidating the agent's long-term memory using signals from a recent execution.\n\n"
+    "Rules:\n"
+    "1. **Merge duplicates** — if multiple facts express the same information, use `store_memory` "
+    "with a combined version and `forget_memory` on redundant keys.\n"
+    "2. **Resolve contradictions** — when two facts conflict, keep the one consistent with the most "
+    "recent execution events. `forget_memory` the outdated fact.\n"
+    "3. **Convert temporal references** — replace relative time expressions (yesterday, last week) "
+    "with absolute dates.\n"
+    "4. **Enrich with signals** — corrections and decisions from the signal report should be stored "
+    "as new facts via `store_memory`.\n"
+    "5. **Preserve provenance** — when storing or updating a fact, include the execution_id in the "
+    "value so the origin is traceable.\n\n"
+    "Use `recall_memory`, `store_memory`, `forget_memory`, and `list_memory_keys` to read and "
+    "modify memory."
+)
+
+PRUNE_PROMPT = (
+    "You are pruning and indexing the agent's long-term memory after consolidation.\n\n"
+    "Rules:\n"
+    "1. **Remove stale entries** — facts referencing deleted files, removed endpoints, or changed "
+    "APIs that are no longer valid.\n"
+    "2. **Demote verbose entries** — if a memory value is excessively long, summarize it.\n"
+    "3. **Cap total entries** — if the total number of memory keys exceeds 100, remove the least "
+    "important entries to bring it under the cap.\n"
+    "4. **Verify consistency** — ensure no remaining contradictions exist.\n\n"
+    "Use `list_memory_keys`, `recall_memory`, `forget_memory`, and `store_memory` as needed.\n\n"
+    "Produce a brief summary of what changed: entries before, entries after, what was pruned."
+)

--- a/flux/tasks/ai/dreaming.py
+++ b/flux/tasks/ai/dreaming.py
@@ -34,11 +34,11 @@ def _build_provider(provider_type: str):
                 f"Set it with: flux secrets set {MEMORY_PROVIDER_URL_SECRET} <connection_string>",
             )
 
-        from flux.tasks.ai.memory import postgresql, sqlite
+        from flux.tasks.ai.memory.providers.sqlalchemy import SqlAlchemyProvider
 
-        if provider_type == "postgresql":
-            return postgresql(url)
-        return sqlite(url)
+        if provider_type == "sqlite":
+            return SqlAlchemyProvider(f"sqlite:///{url}")
+        return SqlAlchemyProvider(url)
 
     from flux.tasks.ai.memory import in_memory
 
@@ -193,7 +193,6 @@ async def agent_dream(ctx):
             model=model,
             name="dream_orient",
             tools=ltm_tools,
-            long_term_memory=memory,
             max_tool_calls=20,
             stream=False,
         )
@@ -219,7 +218,6 @@ async def agent_dream(ctx):
             model=model,
             name="dream_consolidate",
             tools=ltm_tools,
-            long_term_memory=memory,
             max_tool_calls=30,
             stream=False,
         )
@@ -232,7 +230,6 @@ async def agent_dream(ctx):
             model=model,
             name="dream_prune",
             tools=ltm_tools,
-            long_term_memory=memory,
             max_tool_calls=20,
             stream=False,
         )

--- a/flux/tasks/ai/dreaming.py
+++ b/flux/tasks/ai/dreaming.py
@@ -160,9 +160,7 @@ async def agent_dream(ctx):
         )
         orientation = await orient_agent("Review the current memory state.")
 
-        formatted_wm = "\n".join(
-            f"[{m['role']}] {m['content']}" for m in wm_snapshot
-        )
+        formatted_wm = "\n".join(f"[{m['role']}] {m['content']}" for m in wm_snapshot)
 
         signal_agent = await agent(
             GATHER_SIGNAL_PROMPT,

--- a/flux/tasks/ai/dreaming.py
+++ b/flux/tasks/ai/dreaming.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from flux.task import task
 from flux.tasks.call import call
+from flux.workflow import workflow
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -112,3 +114,110 @@ PRUNE_PROMPT = (
     "Use `list_memory_keys`, `recall_memory`, `forget_memory`, and `store_memory` as needed.\n\n"
     "Produce a brief summary of what changed: entries before, entries after, what was pruned."
 )
+
+
+@task
+async def load_execution_events(execution_id: str) -> str:
+    """Fetch execution events via the Flux client."""
+
+    from flux.client import FluxClient
+    from flux.config import Configuration
+
+    settings = Configuration.get().settings
+    server_url = settings.workers.server_url
+
+    async with FluxClient(server_url) as client:
+        data = await client.get_execution(execution_id, detailed=True)
+
+    events = data.get("events", [])
+    summary_lines = []
+    for event in events:
+        name = event.get("name", "unknown")
+        event_type = event.get("type", "unknown")
+        value = event.get("value")
+        value_preview = str(value)[:200] if value else ""
+        summary_lines.append(f"[{event_type}] {name}: {value_preview}")
+
+    return "\n".join(summary_lines)
+
+
+@workflow
+async def agent_dream(ctx):
+    """Memory consolidation workflow — four-phase dream pipeline."""
+    from flux.tasks.ai import agent
+    from flux.tasks.ai.memory import long_term_memory
+    from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
+
+    input_data = ctx.input or {}
+    execution_id = input_data.get("execution_id", "")
+    agent_id = input_data.get("agent", "")
+    scope = input_data.get("scope", "")
+    model = input_data.get("model", "ollama/llama3.2")
+
+    provider = InMemoryProvider()
+    memory = long_term_memory(provider=provider, agent=agent_id, scope=scope)
+
+    if not await check_failure_gate(memory):
+        return {"status": "skipped", "reason": "max consecutive failures reached"}
+
+    try:
+        events_summary = await load_execution_events(execution_id)
+
+        ltm_tools = memory.as_tools()
+
+        orient_agent = await agent(
+            ORIENT_PROMPT,
+            model=model,
+            name="dream_orient",
+            tools=ltm_tools,
+            long_term_memory=memory,
+            max_tool_calls=20,
+            stream=False,
+        )
+        orientation = await orient_agent("Review the current memory state.")
+
+        signal_agent = await agent(
+            GATHER_SIGNAL_PROMPT,
+            model=model,
+            name="dream_gather_signal",
+            tools=ltm_tools,
+            max_tool_calls=10,
+            stream=False,
+        )
+        signal_report = await signal_agent(
+            f"Scan these execution events for signals:\n\n{events_summary}"
+            f"\n\nOrientation report:\n{orientation}",
+        )
+
+        consolidate_agent = await agent(
+            CONSOLIDATE_PROMPT,
+            model=model,
+            name="dream_consolidate",
+            tools=ltm_tools,
+            long_term_memory=memory,
+            max_tool_calls=30,
+            stream=False,
+        )
+        await consolidate_agent(
+            f"Signal report:\n{signal_report}\n\nOrientation:\n{orientation}"
+            f"\n\nExecution ID for provenance: {execution_id}",
+        )
+
+        prune_agent = await agent(
+            PRUNE_PROMPT,
+            model=model,
+            name="dream_prune",
+            tools=ltm_tools,
+            long_term_memory=memory,
+            max_tool_calls=20,
+            stream=False,
+        )
+        summary = await prune_agent("Review and prune the memory. Report what changed.")
+
+        await reset_failure_counter(memory)
+        return {"status": "completed", "summary": summary}
+
+    except Exception as e:
+        await increment_failure_counter(memory)
+        logger.error("Dream workflow failed: %s", e, exc_info=True)
+        return {"status": "failed", "error": str(e)}

--- a/flux/tasks/ai/dreaming.py
+++ b/flux/tasks/ai/dreaming.py
@@ -43,19 +43,25 @@ def dream(
 
 async def check_failure_gate(memory: LongTermMemory, max_failures: int = 3) -> bool:
     count = await memory.recall("_dream:failures")
-    if count is not None and int(count) >= max_failures:
-        logger.warning(
-            "Dream skipped: %d consecutive failures (max: %d)",
-            count,
-            max_failures,
-        )
-        return False
+    try:
+        if count is not None and int(count) >= max_failures:
+            logger.warning(
+                "Dream skipped: %d consecutive failures (max: %d)",
+                int(count),
+                max_failures,
+            )
+            return False
+    except (ValueError, TypeError):
+        await memory.memorize("_dream:failures", 0)
     return True
 
 
 async def increment_failure_counter(memory: LongTermMemory) -> None:
     count = await memory.recall("_dream:failures")
-    await memory.memorize("_dream:failures", int(count or 0) + 1)
+    try:
+        await memory.memorize("_dream:failures", int(count or 0) + 1)
+    except (ValueError, TypeError):
+        await memory.memorize("_dream:failures", 1)
 
 
 async def reset_failure_counter(memory: LongTermMemory) -> None:
@@ -135,7 +141,7 @@ async def load_execution_events(execution_id: str) -> str:
         name = event.get("name", "unknown")
         event_type = event.get("type", "unknown")
         value = event.get("value")
-        value_preview = str(value)[:200] if value else ""
+        value_preview = str(value)[:200] if value is not None else ""
         summary_lines.append(f"[{event_type}] {name}: {value_preview}")
 
     return "\n".join(summary_lines)
@@ -145,16 +151,22 @@ async def load_execution_events(execution_id: str) -> str:
 async def agent_dream(ctx):
     """Memory consolidation workflow — four-phase dream pipeline."""
     from flux.tasks.ai import agent
-    from flux.tasks.ai.memory import long_term_memory
-    from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
+    from flux.tasks.ai.memory import long_term_memory, sqlite
 
     input_data = ctx.input or {}
-    execution_id = input_data.get("execution_id", "")
-    agent_id = input_data.get("agent", "")
-    scope = input_data.get("scope", "")
+    execution_id = input_data.get("execution_id")
+    agent_id = input_data.get("agent")
+    scope = input_data.get("scope")
+
+    if not execution_id or not agent_id or not scope:
+        return {
+            "status": "failed",
+            "error": "Missing required input: execution_id, agent, and scope are all required",
+        }
+
     model = input_data.get("model", "ollama/llama3.2")
 
-    provider = InMemoryProvider()
+    provider = sqlite("memory.db")
     memory = long_term_memory(provider=provider, agent=agent_id, scope=scope)
 
     if not await check_failure_gate(memory):

--- a/flux/tasks/ai/dreaming.py
+++ b/flux/tasks/ai/dreaming.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from flux.task import task
 from flux.tasks.call import call
 from flux.workflow import workflow
 
@@ -11,27 +10,30 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+    from flux.tasks.ai.memory.working_memory import WorkingMemory
 
 logger = logging.getLogger("flux.dreaming")
 
 
 def dream(
-    memory: LongTermMemory,
-    execution_id: str,
     *,
+    working_memory: WorkingMemory,
+    long_term_memory: LongTermMemory,
     workflow: str = "agent_dream",
 ) -> Callable[[str, Any], Awaitable[None]]:
     """Return an async hook that fires a dream workflow."""
-    scope = memory.scope
+    scope = long_term_memory.scope
+    wm = working_memory
 
     async def _hook(agent_id: str, value: Any) -> None:
         try:
+            snapshot = wm.recall()
             await call(
                 workflow,
                 {
-                    "execution_id": execution_id,
                     "agent": agent_id,
                     "scope": scope,
+                    "working_memory": snapshot,
                 },
                 mode="async",
             )
@@ -81,13 +83,15 @@ ORIENT_PROMPT = (
 )
 
 GATHER_SIGNAL_PROMPT = (
-    "You are scanning execution events for high-value signals worth persisting to memory.\n\n"
+    "You are scanning the agent's working memory for high-value signals worth persisting "
+    "to long-term memory.\n\n"
+    "The working memory contains the conversation history including user messages, "
+    "assistant responses, tool calls, and tool results.\n\n"
     "Focus on these signal types:\n"
     "- **Corrections**: Where the user or agent reversed or amended a prior statement\n"
     "- **Decisions**: Explicit choices (technology selections, configuration changes, approach pivots)\n"
-    "- **Repeated patterns**: Facts or entities referenced across 3+ distinct events\n"
+    "- **Repeated patterns**: Facts or entities referenced across 3+ distinct messages\n"
     "- **Staleness indicators**: Tool calls that returned errors for entities that may exist in memory\n\n"
-    "Do NOT read every event in detail. Scan for patterns and extract only high-value signals.\n\n"
     "Produce a signal report listing each signal with its type and a brief description."
 )
 
@@ -101,9 +105,7 @@ CONSOLIDATE_PROMPT = (
     "3. **Convert temporal references** — replace relative time expressions (yesterday, last week) "
     "with absolute dates.\n"
     "4. **Enrich with signals** — corrections and decisions from the signal report should be stored "
-    "as new facts via `store_memory`.\n"
-    "5. **Preserve provenance** — when storing or updating a fact, include the execution_id in the "
-    "value so the origin is traceable.\n\n"
+    "as new facts via `store_memory`.\n\n"
     "Use `recall_memory`, `store_memory`, `forget_memory`, and `list_memory_keys` to read and "
     "modify memory."
 )
@@ -122,31 +124,6 @@ PRUNE_PROMPT = (
 )
 
 
-@task
-async def load_execution_events(execution_id: str) -> str:
-    """Fetch execution events via the Flux client."""
-
-    from flux.client import FluxClient
-    from flux.config import Configuration
-
-    settings = Configuration.get().settings
-    server_url = settings.workers.server_url
-
-    async with FluxClient(server_url) as client:
-        data = await client.get_execution(execution_id, detailed=True)
-
-    events = data.get("events", [])
-    summary_lines = []
-    for event in events:
-        name = event.get("name", "unknown")
-        event_type = event.get("type", "unknown")
-        value = event.get("value")
-        value_preview = str(value)[:200] if value is not None else ""
-        summary_lines.append(f"[{event_type}] {name}: {value_preview}")
-
-    return "\n".join(summary_lines)
-
-
 @workflow
 async def agent_dream(ctx):
     """Memory consolidation workflow — four-phase dream pipeline."""
@@ -154,15 +131,12 @@ async def agent_dream(ctx):
     from flux.tasks.ai.memory import long_term_memory, sqlite
 
     input_data = ctx.input or {}
-    execution_id = input_data.get("execution_id")
     agent_id = input_data.get("agent")
     scope = input_data.get("scope")
+    wm_snapshot = input_data.get("working_memory", [])
 
-    if not execution_id or not agent_id or not scope:
-        return {
-            "status": "failed",
-            "error": "Missing required input: execution_id, agent, and scope are all required",
-        }
+    if not agent_id or not scope:
+        return {"status": "failed", "error": "Missing required input: agent and scope are required"}
 
     model = input_data.get("model", "ollama/llama3.2")
 
@@ -173,8 +147,6 @@ async def agent_dream(ctx):
         return {"status": "skipped", "reason": "max consecutive failures reached"}
 
     try:
-        events_summary = await load_execution_events(execution_id)
-
         ltm_tools = memory.as_tools()
 
         orient_agent = await agent(
@@ -188,6 +160,10 @@ async def agent_dream(ctx):
         )
         orientation = await orient_agent("Review the current memory state.")
 
+        formatted_wm = "\n".join(
+            f"[{m['role']}] {m['content']}" for m in wm_snapshot
+        )
+
         signal_agent = await agent(
             GATHER_SIGNAL_PROMPT,
             model=model,
@@ -197,7 +173,7 @@ async def agent_dream(ctx):
             stream=False,
         )
         signal_report = await signal_agent(
-            f"Scan these execution events for signals:\n\n{events_summary}"
+            f"Scan this working memory for signals:\n\n{formatted_wm}"
             f"\n\nOrientation report:\n{orientation}",
         )
 
@@ -211,8 +187,7 @@ async def agent_dream(ctx):
             stream=False,
         )
         await consolidate_agent(
-            f"Signal report:\n{signal_report}\n\nOrientation:\n{orientation}"
-            f"\n\nExecution ID for provenance: {execution_id}",
+            f"Signal report:\n{signal_report}\n\nOrientation:\n{orientation}",
         )
 
         prune_agent = await agent(

--- a/flux/tasks/ai/dreaming.py
+++ b/flux/tasks/ai/dreaming.py
@@ -14,6 +14,28 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("flux.dreaming")
 
+MEMORY_PROVIDER_URL_SECRET = "MEMORY_PROVIDER_URL"
+
+
+def _build_provider(provider_type: str):
+    """Build a MemoryProvider from type string + secret."""
+    if provider_type == "sqlalchemy":
+        from flux.secret_managers import SecretManager
+        from flux.tasks.ai.memory.providers.sqlalchemy import SqlAlchemyProvider
+
+        secrets = SecretManager.current().get([MEMORY_PROVIDER_URL_SECRET])
+        url = secrets.get(MEMORY_PROVIDER_URL_SECRET)
+        if not url:
+            raise ValueError(
+                f"Secret '{MEMORY_PROVIDER_URL_SECRET}' is required for sqlalchemy provider. "
+                f"Set it with: flux secrets set {MEMORY_PROVIDER_URL_SECRET} <connection_string>",
+            )
+        return SqlAlchemyProvider(url)
+
+    from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
+
+    return InMemoryProvider()
+
 
 def dream(
     *,
@@ -23,6 +45,7 @@ def dream(
 ) -> Callable[[str, Any], Awaitable[None]]:
     """Return an async hook that fires a dream workflow."""
     scope = long_term_memory.scope
+    provider_type = long_term_memory.provider_type
     wm = working_memory
 
     async def _hook(agent_id: str, value: Any) -> None:
@@ -33,6 +56,7 @@ def dream(
                 {
                     "agent": agent_id,
                     "scope": scope,
+                    "provider_type": provider_type,
                     "working_memory": snapshot,
                 },
                 mode="async",
@@ -128,11 +152,12 @@ PRUNE_PROMPT = (
 async def agent_dream(ctx):
     """Memory consolidation workflow — four-phase dream pipeline."""
     from flux.tasks.ai import agent
-    from flux.tasks.ai.memory import long_term_memory, sqlite
+    from flux.tasks.ai.memory import long_term_memory
 
     input_data = ctx.input or {}
     agent_id = input_data.get("agent")
     scope = input_data.get("scope")
+    provider_type = input_data.get("provider_type", "in_memory")
     wm_snapshot = input_data.get("working_memory", [])
 
     if not agent_id or not scope:
@@ -140,7 +165,7 @@ async def agent_dream(ctx):
 
     model = input_data.get("model", "ollama/llama3.2")
 
-    provider = sqlite("memory.db")
+    provider = _build_provider(provider_type)
     memory = long_term_memory(provider=provider, agent=agent_id, scope=scope)
 
     if not await check_failure_gate(memory):

--- a/flux/tasks/ai/dreaming.py
+++ b/flux/tasks/ai/dreaming.py
@@ -18,23 +18,31 @@ MEMORY_PROVIDER_URL_SECRET = "MEMORY_PROVIDER_URL"
 
 
 def _build_provider(provider_type: str):
-    """Build a MemoryProvider from type string + secret."""
-    if provider_type == "sqlalchemy":
+    """Build a MemoryProvider from type string + secret.
+
+    Uses the same factory names as flux.tasks.ai.memory (sqlite, postgresql, in_memory).
+    Connection string is read from the MEMORY_PROVIDER_URL secret.
+    """
+    if provider_type in ("sqlite", "postgresql"):
         from flux.secret_managers import SecretManager
-        from flux.tasks.ai.memory.providers.sqlalchemy import SqlAlchemyProvider
 
         secrets = SecretManager.current().get([MEMORY_PROVIDER_URL_SECRET])
         url = secrets.get(MEMORY_PROVIDER_URL_SECRET)
         if not url:
             raise ValueError(
-                f"Secret '{MEMORY_PROVIDER_URL_SECRET}' is required for sqlalchemy provider. "
+                f"Secret '{MEMORY_PROVIDER_URL_SECRET}' is required for {provider_type} provider. "
                 f"Set it with: flux secrets set {MEMORY_PROVIDER_URL_SECRET} <connection_string>",
             )
-        return SqlAlchemyProvider(url)
 
-    from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
+        from flux.tasks.ai.memory import postgresql, sqlite
 
-    return InMemoryProvider()
+        if provider_type == "postgresql":
+            return postgresql(url)
+        return sqlite(url)
+
+    from flux.tasks.ai.memory import in_memory
+
+    return in_memory()
 
 
 def dream(

--- a/flux/tasks/ai/gemini.py
+++ b/flux/tasks/ai/gemini.py
@@ -73,7 +73,10 @@ class GeminiFormatter(LLMFormatter):
                 data = json.loads(content)
                 parts = [
                     _types.Part(
-                        function_call=_types.FunctionCall(name=c["name"], args=c.get("arguments", {}))
+                        function_call=_types.FunctionCall(
+                            name=c["name"],
+                            args=c.get("arguments", {}),
+                        ),
                     )
                     for c in data["calls"]
                 ]
@@ -88,10 +91,10 @@ class GeminiFormatter(LLMFormatter):
                                 function_response=_types.FunctionResponse(
                                     name=data["name"],
                                     response={"output": data["output"]},
-                                )
-                            )
+                                ),
+                            ),
                         ],
-                    )
+                    ),
                 )
             elif role in ("user", "assistant"):
                 converted.append(_to_content(role, content))

--- a/flux/tasks/ai/gemini.py
+++ b/flux/tasks/ai/gemini.py
@@ -62,6 +62,41 @@ class GeminiFormatter(LLMFormatter):
         self._max_tokens = max_tokens
         self._response_format = response_format
 
+    def _convert_memory_messages(self, memory_messages: list[dict]) -> list:
+        import json
+        from google.genai import types as _types
+
+        converted = []
+        for msg in memory_messages:
+            role, content = msg["role"], msg["content"]
+            if role == "tool_call":
+                data = json.loads(content)
+                parts = [
+                    _types.Part(
+                        function_call=_types.FunctionCall(name=c["name"], args=c.get("arguments", {}))
+                    )
+                    for c in data["calls"]
+                ]
+                converted.append(_types.Content(role="model", parts=parts))
+            elif role == "tool_result":
+                data = json.loads(content)
+                converted.append(
+                    _types.Content(
+                        role="user",
+                        parts=[
+                            _types.Part(
+                                function_response=_types.FunctionResponse(
+                                    name=data["name"],
+                                    response={"output": data["output"]},
+                                )
+                            )
+                        ],
+                    )
+                )
+            elif role in ("user", "assistant"):
+                converted.append(_to_content(role, content))
+        return converted
+
     def build_messages(
         self,
         system_prompt: str,
@@ -70,7 +105,7 @@ class GeminiFormatter(LLMFormatter):
     ) -> tuple[list, dict]:
         if working_memory:
             prior = working_memory.recall()
-            contents = [_to_content(m["role"], m["content"]) for m in prior]
+            contents = self._convert_memory_messages(prior)
             contents.append(_to_content("user", user_content))
         else:
             contents = [_to_content("user", user_content)]

--- a/flux/tasks/ai/memory/__init__.py
+++ b/flux/tasks/ai/memory/__init__.py
@@ -22,9 +22,9 @@ def postgresql(connection_string: str) -> SqlAlchemyProvider:
     return SqlAlchemyProvider(connection_string)
 
 
-def long_term_memory(provider: MemoryProvider, scope: str) -> LongTermMemory:
+def long_term_memory(provider: MemoryProvider, agent: str, scope: str) -> LongTermMemory:
     """Create a long-term memory backed by a provider."""
-    return LongTermMemory(provider=provider, scope=scope)
+    return LongTermMemory(provider=provider, agent=agent, scope=scope)
 
 
 def working_memory(

--- a/flux/tasks/ai/memory/__init__.py
+++ b/flux/tasks/ai/memory/__init__.py
@@ -30,9 +30,18 @@ def long_term_memory(provider: MemoryProvider, agent: str, scope: str) -> LongTe
 def working_memory(
     window: int | None = None,
     max_tokens: int | None = None,
+    compact_model: str | None = None,
+    compact_threshold: float = 0.70,
+    compact_preserve: int = 4,
 ) -> WorkingMemory:
     """Create a working memory for conversation history."""
-    return WorkingMemory(window=window, max_tokens=max_tokens)
+    return WorkingMemory(
+        window=window,
+        max_tokens=max_tokens,
+        compact_model=compact_model,
+        compact_threshold=compact_threshold,
+        compact_preserve=compact_preserve,
+    )
 
 
 __all__ = [

--- a/flux/tasks/ai/memory/long_term_memory.py
+++ b/flux/tasks/ai/memory/long_term_memory.py
@@ -24,7 +24,10 @@ class LongTermMemory:
         from flux.tasks.ai.memory.providers.sqlalchemy import SqlAlchemyProvider
 
         if isinstance(self._provider, SqlAlchemyProvider):
-            return "sqlalchemy"
+            dialect = self._provider._get_engine().dialect.name
+            if dialect == "postgresql":
+                return "postgresql"
+            return "sqlite"
         return "in_memory"
 
     async def memorize(self, key: str, value: Any) -> None:

--- a/flux/tasks/ai/memory/long_term_memory.py
+++ b/flux/tasks/ai/memory/long_term_memory.py
@@ -19,6 +19,14 @@ class LongTermMemory:
     def scope(self) -> str:
         return self._scope
 
+    @property
+    def provider_type(self) -> str:
+        from flux.tasks.ai.memory.providers.sqlalchemy import SqlAlchemyProvider
+
+        if isinstance(self._provider, SqlAlchemyProvider):
+            return "sqlalchemy"
+        return "in_memory"
+
     async def memorize(self, key: str, value: Any) -> None:
         await self._provider.memorize(self._agent, self._scope, key, value)
 

--- a/flux/tasks/ai/memory/long_term_memory.py
+++ b/flux/tasks/ai/memory/long_term_memory.py
@@ -6,32 +6,33 @@ from flux.tasks.ai.memory.providers.protocol import MemoryProvider
 
 
 class LongTermMemory:
-    def __init__(self, provider: MemoryProvider, scope: str) -> None:
+    def __init__(self, provider: MemoryProvider, agent: str, scope: str) -> None:
         self._provider = provider
+        self._agent = agent
         self._scope = scope
 
-    def _get_workflow(self) -> str:
-        from flux.domain.execution_context import CURRENT_CONTEXT
+    @property
+    def agent(self) -> str:
+        return self._agent
 
-        ctx = CURRENT_CONTEXT.get()
-        if ctx is None:
-            return "__default__"
-        return ctx.workflow_name
+    @property
+    def scope(self) -> str:
+        return self._scope
 
     async def memorize(self, key: str, value: Any) -> None:
-        await self._provider.memorize(self._get_workflow(), self._scope, key, value)
+        await self._provider.memorize(self._agent, self._scope, key, value)
 
     async def recall(self, key: str | None = None) -> Any:
-        return await self._provider.recall(self._get_workflow(), self._scope, key)
+        return await self._provider.recall(self._agent, self._scope, key)
 
     async def forget(self, key: str | None = None) -> None:
-        await self._provider.forget(self._get_workflow(), self._scope, key)
+        await self._provider.forget(self._agent, self._scope, key)
 
     async def keys(self) -> list[str]:
-        return await self._provider.keys(self._get_workflow(), self._scope)
+        return await self._provider.keys(self._agent, self._scope)
 
     async def scopes(self) -> list[str]:
-        return await self._provider.scopes(self._get_workflow())
+        return await self._provider.scopes(self._agent)
 
     def as_tools(self) -> list:
         """Create Flux @task tools for agent integration.

--- a/flux/tasks/ai/memory/long_term_memory.py
+++ b/flux/tasks/ai/memory/long_term_memory.py
@@ -24,7 +24,7 @@ class LongTermMemory:
         from flux.tasks.ai.memory.providers.sqlalchemy import SqlAlchemyProvider
 
         if isinstance(self._provider, SqlAlchemyProvider):
-            dialect = self._provider._get_engine().dialect.name
+            dialect = self._provider.dialect_name
             if dialect == "postgresql":
                 return "postgresql"
             return "sqlite"

--- a/flux/tasks/ai/memory/providers/in_memory.py
+++ b/flux/tasks/ai/memory/providers/in_memory.py
@@ -7,27 +7,27 @@ class InMemoryProvider:
     def __init__(self) -> None:
         self._store: dict[str, dict[str, dict[str, Any]]] = {}
 
-    def _get_scope(self, workflow: str, scope: str) -> dict[str, Any]:
-        return self._store.setdefault(workflow, {}).setdefault(scope, {})
+    def _get_scope(self, agent: str, scope: str) -> dict[str, Any]:
+        return self._store.setdefault(agent, {}).setdefault(scope, {})
 
-    async def memorize(self, workflow: str, scope: str, key: str, value: Any) -> None:
-        self._get_scope(workflow, scope)[key] = value
+    async def memorize(self, agent: str, scope: str, key: str, value: Any) -> None:
+        self._get_scope(agent, scope)[key] = value
 
-    async def recall(self, workflow: str, scope: str, key: str | None = None) -> Any:
-        scope_data = self._get_scope(workflow, scope)
+    async def recall(self, agent: str, scope: str, key: str | None = None) -> Any:
+        scope_data = self._get_scope(agent, scope)
         if key is None:
             return dict(scope_data)
         return scope_data.get(key)
 
-    async def forget(self, workflow: str, scope: str, key: str | None = None) -> None:
-        scope_data = self._get_scope(workflow, scope)
+    async def forget(self, agent: str, scope: str, key: str | None = None) -> None:
+        scope_data = self._get_scope(agent, scope)
         if key is None:
             scope_data.clear()
         else:
             scope_data.pop(key, None)
 
-    async def keys(self, workflow: str, scope: str) -> list[str]:
-        return list(self._get_scope(workflow, scope).keys())
+    async def keys(self, agent: str, scope: str) -> list[str]:
+        return list(self._get_scope(agent, scope).keys())
 
-    async def scopes(self, workflow: str) -> list[str]:
-        return list(self._store.get(workflow, {}).keys())
+    async def scopes(self, agent: str) -> list[str]:
+        return list(self._store.get(agent, {}).keys())

--- a/flux/tasks/ai/memory/providers/protocol.py
+++ b/flux/tasks/ai/memory/providers/protocol.py
@@ -5,17 +5,17 @@ from typing import Any, Protocol, runtime_checkable
 
 @runtime_checkable
 class MemoryProvider(Protocol):
-    async def memorize(self, workflow: str, scope: str, key: str, value: Any) -> None:
+    async def memorize(self, agent: str, scope: str, key: str, value: Any) -> None:
         ...
 
-    async def recall(self, workflow: str, scope: str, key: str | None = None) -> Any:
+    async def recall(self, agent: str, scope: str, key: str | None = None) -> Any:
         ...
 
-    async def forget(self, workflow: str, scope: str, key: str | None = None) -> None:
+    async def forget(self, agent: str, scope: str, key: str | None = None) -> None:
         ...
 
-    async def keys(self, workflow: str, scope: str) -> list[str]:
+    async def keys(self, agent: str, scope: str) -> list[str]:
         ...
 
-    async def scopes(self, workflow: str) -> list[str]:
+    async def scopes(self, agent: str) -> list[str]:
         ...

--- a/flux/tasks/ai/memory/providers/sqlalchemy.py
+++ b/flux/tasks/ai/memory/providers/sqlalchemy.py
@@ -24,7 +24,7 @@ _metadata = MetaData()
 _memory_table = Table(
     "memory",
     _metadata,
-    Column("workflow", String, primary_key=True),
+    Column("agent", String, primary_key=True),
     Column("scope", String, primary_key=True),
     Column("key", String, primary_key=True),
     Column("value", Text, nullable=False),
@@ -42,37 +42,36 @@ class SqlAlchemyProvider:
             _metadata.create_all(self._engine)
         return self._engine
 
-    def _upsert_stmt(self, workflow: str, scope: str, key: str, serialized: str) -> Any:
+    def _upsert_stmt(self, agent: str, scope: str, key: str, serialized: str) -> Any:
         """Build a dialect-aware atomic upsert statement."""
         engine = self._get_engine()
-        values = {"workflow": workflow, "scope": scope, "key": key, "value": serialized}
+        values = {"agent": agent, "scope": scope, "key": key, "value": serialized}
         dialect = engine.dialect.name
         if dialect == "postgresql":
             stmt = pg_insert(_memory_table).values(**values)
             return stmt.on_conflict_do_update(
-                index_elements=["workflow", "scope", "key"],
+                index_elements=["agent", "scope", "key"],
                 set_={"value": stmt.excluded.value},
             )
-        # SQLite and other dialects
         stmt = sqlite_insert(_memory_table).values(**values)
         return stmt.on_conflict_do_update(
-            index_elements=["workflow", "scope", "key"],
+            index_elements=["agent", "scope", "key"],
             set_={"value": stmt.excluded.value},
         )
 
-    async def memorize(self, workflow: str, scope: str, key: str, value: Any) -> None:
+    async def memorize(self, agent: str, scope: str, key: str, value: Any) -> None:
         engine = self._get_engine()
         serialized = json.dumps(value)
         with engine.begin() as conn:
-            conn.execute(self._upsert_stmt(workflow, scope, key, serialized))
+            conn.execute(self._upsert_stmt(agent, scope, key, serialized))
 
-    async def recall(self, workflow: str, scope: str, key: str | None = None) -> Any:
+    async def recall(self, agent: str, scope: str, key: str | None = None) -> Any:
         engine = self._get_engine()
         with engine.connect() as conn:
             if key is not None:
                 row = conn.execute(
                     select(_memory_table.c.value).where(
-                        _memory_table.c.workflow == workflow,
+                        _memory_table.c.agent == agent,
                         _memory_table.c.scope == scope,
                         _memory_table.c.key == key,
                     ),
@@ -80,19 +79,19 @@ class SqlAlchemyProvider:
                 return json.loads(row[0]) if row else None
             rows = conn.execute(
                 select(_memory_table.c.key, _memory_table.c.value).where(
-                    _memory_table.c.workflow == workflow,
+                    _memory_table.c.agent == agent,
                     _memory_table.c.scope == scope,
                 ),
             ).fetchall()
             return {row[0]: json.loads(row[1]) for row in rows}
 
-    async def forget(self, workflow: str, scope: str, key: str | None = None) -> None:
+    async def forget(self, agent: str, scope: str, key: str | None = None) -> None:
         engine = self._get_engine()
         with engine.begin() as conn:
             if key is not None:
                 conn.execute(
                     delete(_memory_table).where(
-                        _memory_table.c.workflow == workflow,
+                        _memory_table.c.agent == agent,
                         _memory_table.c.scope == scope,
                         _memory_table.c.key == key,
                     ),
@@ -100,28 +99,28 @@ class SqlAlchemyProvider:
             else:
                 conn.execute(
                     delete(_memory_table).where(
-                        _memory_table.c.workflow == workflow,
+                        _memory_table.c.agent == agent,
                         _memory_table.c.scope == scope,
                     ),
                 )
 
-    async def keys(self, workflow: str, scope: str) -> list[str]:
+    async def keys(self, agent: str, scope: str) -> list[str]:
         engine = self._get_engine()
         with engine.connect() as conn:
             rows = conn.execute(
                 select(_memory_table.c.key).where(
-                    _memory_table.c.workflow == workflow,
+                    _memory_table.c.agent == agent,
                     _memory_table.c.scope == scope,
                 ),
             ).fetchall()
             return [row[0] for row in rows]
 
-    async def scopes(self, workflow: str) -> list[str]:
+    async def scopes(self, agent: str) -> list[str]:
         engine = self._get_engine()
         with engine.connect() as conn:
             rows = conn.execute(
                 select(distinct(_memory_table.c.scope)).where(
-                    _memory_table.c.workflow == workflow,
+                    _memory_table.c.agent == agent,
                 ),
             ).fetchall()
             return [row[0] for row in rows]

--- a/flux/tasks/ai/memory/providers/sqlalchemy.py
+++ b/flux/tasks/ai/memory/providers/sqlalchemy.py
@@ -42,6 +42,10 @@ class SqlAlchemyProvider:
             _metadata.create_all(self._engine)
         return self._engine
 
+    @property
+    def dialect_name(self) -> str:
+        return self._get_engine().dialect.name
+
     def _upsert_stmt(self, agent: str, scope: str, key: str, serialized: str) -> Any:
         """Build a dialect-aware atomic upsert statement."""
         engine = self._get_engine()

--- a/flux/tasks/ai/memory/types.py
+++ b/flux/tasks/ai/memory/types.py
@@ -6,7 +6,7 @@ from typing import Any
 
 @dataclass
 class MemoryEntry:
-    workflow: str
+    agent: str
     scope: str
     key: str
     value: Any

--- a/flux/tasks/ai/memory/working_memory.py
+++ b/flux/tasks/ai/memory/working_memory.py
@@ -221,11 +221,12 @@ class WorkingMemory:
             trimmed: list[dict[str, str]] = []
             token_count = 0
             for msg in reversed(messages):
-                msg_tokens = len(msg["content"]) // 4
+                msg_tokens = max(1, len(msg["content"]) // 4)
                 if token_count + msg_tokens > self._max_tokens:
                     break
-                trimmed.insert(0, msg)
+                trimmed.append(msg)
                 token_count += msg_tokens
+            trimmed.reverse()
             messages = trimmed
 
         return messages

--- a/flux/tasks/ai/memory/working_memory.py
+++ b/flux/tasks/ai/memory/working_memory.py
@@ -48,6 +48,7 @@ class WorkingMemory:
                         and (
                             event.name.startswith(_TASK_PREFIX)
                             or event.name.startswith("wm_forget")
+                            or event.name.startswith("wm_compact")
                         )
                     ):
                         parts = event.name.rsplit("_", 1)
@@ -80,15 +81,22 @@ class WorkingMemory:
             return []
 
         forgotten: set[str] = set()
+        compacted: set[str] = set()
         for event in ctx.events:
             if (
                 event.type == ExecutionEventType.TASK_COMPLETED
                 and event.name is not None
-                and event.name.startswith("wm_forget")
             ):
-                value = _extract_value(event.value)
-                if isinstance(value, dict) and "forgotten_id" in value:
-                    forgotten.add(value["forgotten_id"])
+                if event.name.startswith("wm_forget"):
+                    value = _extract_value(event.value)
+                    if isinstance(value, dict) and "forgotten_id" in value:
+                        forgotten.add(value["forgotten_id"])
+                elif event.name.startswith("wm_compact"):
+                    value = _extract_value(event.value)
+                    if isinstance(value, dict) and "compacted_id" in value:
+                        compacted.add(value["compacted_id"])
+
+        excluded = forgotten | compacted
 
         messages: list[dict[str, str]] = []
         for event in ctx.events:
@@ -97,7 +105,7 @@ class WorkingMemory:
                 and event.name is not None
                 and event.name.startswith(_TASK_PREFIX)
             ):
-                if event.name in forgotten:
+                if event.name in excluded:
                     continue
                 value = _extract_value(event.value)
                 if isinstance(value, dict) and "role" in value and "content" in value:
@@ -142,6 +150,18 @@ class WorkingMemory:
             return {"forgotten_id": forgotten_id}
 
         await _forget_message(message_id)
+
+    async def _mark_compacted(self, message_id: str) -> None:
+        """Mark a message as compacted by its stable ID (task name)."""
+        from flux.task import task
+
+        task_name = f"wm_compact_{self._next_counter()}"
+
+        @task.with_options(name=task_name)
+        async def _compact_message(compacted_id: str) -> dict[str, Any]:
+            return {"compacted_id": compacted_id}
+
+        await _compact_message(message_id)
 
     def keys(self) -> list[str]:
         """Return stable IDs of all messages in the current recall window."""

--- a/flux/tasks/ai/memory/working_memory.py
+++ b/flux/tasks/ai/memory/working_memory.py
@@ -80,7 +80,7 @@ class WorkingMemory:
         return value
 
     def _estimate_tokens(self, messages: list[dict[str, str]]) -> int:
-        return sum(len(m["content"]) // 4 for m in messages)
+        return sum(max(1, len(m["content"]) // 4) for m in messages)
 
     def _should_compact(self) -> bool:
         if self._compact_model is None or self._max_tokens is None:
@@ -108,8 +108,10 @@ class WorkingMemory:
             if len(output) <= 200:
                 continue
             data["output"] = f"[truncated] {data.get('name', 'tool')}: {output[:200]}..."
-            await self._mark_compacted(msg["_id"])
-            await self.memorize("tool_result", json.dumps(data))
+            await self._mark_compacted(
+                msg["_id"],
+                replacement={"role": "tool_result", "content": json.dumps(data)},
+            )
 
     async def _summarize_messages(self) -> None:
         messages = self._collect_messages()
@@ -169,6 +171,7 @@ class WorkingMemory:
 
         forgotten: set[str] = set()
         compacted: set[str] = set()
+        replacements: dict[str, dict[str, str]] = {}
         for event in ctx.events:
             if event.type == ExecutionEventType.TASK_COMPLETED and event.name is not None:
                 if event.name.startswith("wm_forget"):
@@ -178,7 +181,11 @@ class WorkingMemory:
                 elif event.name.startswith("wm_compact"):
                     value = _extract_value(event.value)
                     if isinstance(value, dict) and "compacted_id" in value:
-                        compacted.add(value["compacted_id"])
+                        cid = value["compacted_id"]
+                        if "replacement" in value:
+                            replacements[cid] = value["replacement"]
+                        else:
+                            compacted.add(cid)
 
         excluded = forgotten | compacted
 
@@ -190,6 +197,12 @@ class WorkingMemory:
                 and event.name.startswith(_TASK_PREFIX)
             ):
                 if event.name in excluded:
+                    continue
+                if event.name in replacements:
+                    r = replacements[event.name]
+                    messages.append(
+                        {"_id": event.name, "role": r["role"], "content": r["content"]},
+                    )
                     continue
                 value = _extract_value(event.value)
                 if isinstance(value, dict) and "role" in value and "content" in value:
@@ -235,17 +248,28 @@ class WorkingMemory:
 
         await _forget_message(message_id)
 
-    async def _mark_compacted(self, message_id: str) -> None:
-        """Mark a message as compacted by its stable ID (task name)."""
+    async def _mark_compacted(
+        self,
+        message_id: str,
+        replacement: dict[str, str] | None = None,
+    ) -> None:
+        """Mark a message as compacted. Optionally provide a replacement that
+        keeps the original position in the message sequence."""
         from flux.task import task
 
         task_name = f"wm_compact_{self._next_counter()}"
 
         @task.with_options(name=task_name)
-        async def _compact_message(compacted_id: str) -> dict[str, Any]:
-            return {"compacted_id": compacted_id}
+        async def _compact_message(
+            compacted_id: str,
+            replacement: dict[str, str] | None = None,
+        ) -> dict[str, Any]:
+            result: dict[str, Any] = {"compacted_id": compacted_id}
+            if replacement is not None:
+                result["replacement"] = replacement
+            return result
 
-        await _compact_message(message_id)
+        await _compact_message(compacted_id=message_id, replacement=replacement)
 
     def keys(self) -> list[str]:
         """Return stable IDs of all messages in the current recall window."""

--- a/flux/tasks/ai/memory/working_memory.py
+++ b/flux/tasks/ai/memory/working_memory.py
@@ -9,6 +9,19 @@ from flux.output_storage import OutputStorageReference
 
 _TASK_PREFIX = "wm_memorize"
 
+COMPACT_PROMPT = (
+    "Summarize the following conversation into a structured summary. "
+    "Preserve all important information.\n\n"
+    "Your summary must cover these sections:\n"
+    "1. **User Requests** — what the user asked for\n"
+    "2. **Key Decisions** — technology choices, approach pivots, configuration changes\n"
+    "3. **Tools Used** — which tools were called and key results (not full output)\n"
+    "4. **Errors and Fixes** — problems encountered and how they were resolved\n"
+    "5. **Current State** — what was being worked on at the point of compaction\n"
+    "6. **Pending Tasks** — anything explicitly requested but not yet completed\n\n"
+    "Be concise but preserve all facts that would be needed to continue the work."
+)
+
 
 def _extract_value(event_value: Any) -> Any:
     """Extract the actual value from an event, handling OutputStorageReference."""
@@ -28,10 +41,17 @@ class WorkingMemory:
         self,
         window: int | None = None,
         max_tokens: int | None = None,
+        compact_model: str | None = None,
+        compact_threshold: float = 0.70,
+        compact_preserve: int = 4,
     ) -> None:
         self._window = window
         self._max_tokens = max_tokens
+        self._compact_model = compact_model
+        self._compact_threshold = compact_threshold
+        self._compact_preserve = compact_preserve
         self._counter: int | None = None
+        self._compacting: bool = False
 
     def _next_counter(self) -> int:
         """Get the next counter value, initializing from existing events if needed."""
@@ -59,8 +79,66 @@ class WorkingMemory:
         self._counter += 1
         return value
 
+    def _estimate_tokens(self, messages: list[dict[str, str]]) -> int:
+        return sum(len(m["content"]) // 4 for m in messages)
+
+    def _should_compact(self) -> bool:
+        if self._compact_model is None or self._max_tokens is None:
+            return False
+        messages = self._collect_messages()
+        tokens = self._estimate_tokens(messages)
+        return tokens > self._max_tokens * self._compact_threshold
+
+    async def _prune_tool_results(self) -> None:
+        import json
+
+        messages = self._collect_messages()
+        if len(messages) <= self._compact_preserve:
+            return
+
+        prunable = messages[: -self._compact_preserve]
+        for msg in prunable:
+            if msg["role"] != "tool_result":
+                continue
+            try:
+                data = json.loads(msg["content"])
+            except (json.JSONDecodeError, TypeError):
+                continue
+            output = data.get("output", "")
+            if len(output) <= 200:
+                continue
+            data["output"] = f"[truncated] {data.get('name', 'tool')}: {output[:200]}..."
+            await self._mark_compacted(msg["_id"])
+            await self.memorize("tool_result", json.dumps(data))
+
+    async def _summarize_messages(self) -> None:
+        messages = self._collect_messages()
+        if len(messages) <= self._compact_preserve:
+            return
+
+        to_summarize = messages[: -self._compact_preserve]
+        if not to_summarize:
+            return
+
+        from flux.tasks.ai import agent
+
+        assert self._compact_model is not None
+        compact_agent = await agent(
+            COMPACT_PROMPT,
+            model=self._compact_model,
+            name="wm_compact_summarizer",
+            stream=False,
+        )
+
+        formatted = "\n".join(f"[{m['role']}] {m['content']}" for m in to_summarize)
+        summary = await compact_agent(formatted)
+
+        for msg in to_summarize:
+            await self._mark_compacted(msg["_id"])
+
+        await self.memorize("assistant", summary)
+
     async def memorize(self, role: str, content: str) -> None:
-        """Store a message as a task event. Each call gets a unique task name."""
         from flux.task import task
 
         task_name = f"{_TASK_PREFIX}_{self._next_counter()}"
@@ -70,6 +148,15 @@ class WorkingMemory:
             return {"role": role, "content": content}
 
         await _store_message(role, content)
+
+        if not self._compacting and self._should_compact():
+            self._compacting = True
+            try:
+                await self._prune_tool_results()
+                if self._should_compact():
+                    await self._summarize_messages()
+            finally:
+                self._compacting = False
 
     def _collect_messages(self) -> list[dict[str, str]]:
         """Read all memorized messages from execution events, filtering out forgotten ones.
@@ -83,10 +170,7 @@ class WorkingMemory:
         forgotten: set[str] = set()
         compacted: set[str] = set()
         for event in ctx.events:
-            if (
-                event.type == ExecutionEventType.TASK_COMPLETED
-                and event.name is not None
-            ):
+            if event.type == ExecutionEventType.TASK_COMPLETED and event.name is not None:
                 if event.name.startswith("wm_forget"):
                     value = _extract_value(event.value)
                     if isinstance(value, dict) and "forgotten_id" in value:

--- a/flux/tasks/ai/ollama.py
+++ b/flux/tasks/ai/ollama.py
@@ -63,14 +63,16 @@ class OllamaFormatter(LLMFormatter):
             role, content = msg["role"], msg["content"]
             if role == "tool_call":
                 data = json.loads(content)
-                converted.append({
-                    "role": "assistant",
-                    "content": "",
-                    "tool_calls": [
-                        {"function": {"name": c["name"], "arguments": c.get("arguments", {})}}
-                        for c in data["calls"]
-                    ],
-                })
+                converted.append(
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {"function": {"name": c["name"], "arguments": c.get("arguments", {})}}
+                            for c in data["calls"]
+                        ],
+                    },
+                )
             elif role == "tool_result":
                 data = json.loads(content)
                 converted.append({"role": "tool", "content": data["output"]})

--- a/flux/tasks/ai/ollama.py
+++ b/flux/tasks/ai/ollama.py
@@ -57,6 +57,27 @@ class OllamaFormatter(LLMFormatter):
     def set_tool_names(self, tool_names: set[str]) -> None:
         self._tool_names = tool_names
 
+    def _convert_memory_messages(self, memory_messages: list[dict]) -> list[dict]:
+        converted = []
+        for msg in memory_messages:
+            role, content = msg["role"], msg["content"]
+            if role == "tool_call":
+                data = json.loads(content)
+                converted.append({
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {"function": {"name": c["name"], "arguments": c.get("arguments", {})}}
+                        for c in data["calls"]
+                    ],
+                })
+            elif role == "tool_result":
+                data = json.loads(content)
+                converted.append({"role": "tool", "content": data["output"]})
+            elif role in ("user", "assistant"):
+                converted.append({"role": role, "content": content})
+        return converted
+
     def build_messages(
         self,
         system_prompt: str,
@@ -67,7 +88,7 @@ class OllamaFormatter(LLMFormatter):
             prior = working_memory.recall()
             messages = (
                 [{"role": "system", "content": system_prompt}]
-                + prior
+                + self._convert_memory_messages(prior)
                 + [{"role": "user", "content": user_content}]
             )
         else:

--- a/flux/tasks/ai/openai.py
+++ b/flux/tasks/ai/openai.py
@@ -48,6 +48,35 @@ class OpenAIFormatter(LLMFormatter):
         self._model_name = model_name
         self._response_format = response_format
 
+    def _convert_memory_messages(self, memory_messages: list[dict]) -> list[dict]:
+        converted = []
+        for msg in memory_messages:
+            role, content = msg["role"], msg["content"]
+            if role == "tool_call":
+                data = json.loads(content)
+                converted.append({
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": c["id"],
+                            "type": "function",
+                            "function": {"name": c["name"], "arguments": json.dumps(c.get("arguments", {}))},
+                        }
+                        for c in data["calls"]
+                    ],
+                })
+            elif role == "tool_result":
+                data = json.loads(content)
+                converted.append({
+                    "role": "tool",
+                    "tool_call_id": data["call_id"],
+                    "content": data["output"],
+                })
+            elif role in ("user", "assistant"):
+                converted.append({"role": role, "content": content})
+        return converted
+
     def build_messages(
         self,
         system_prompt: str,
@@ -58,7 +87,7 @@ class OpenAIFormatter(LLMFormatter):
             prior = working_memory.recall()
             messages = (
                 [{"role": "system", "content": system_prompt}]
-                + prior
+                + self._convert_memory_messages(prior)
                 + [{"role": "user", "content": user_content}]
             )
         else:

--- a/flux/tasks/ai/openai.py
+++ b/flux/tasks/ai/openai.py
@@ -54,25 +54,32 @@ class OpenAIFormatter(LLMFormatter):
             role, content = msg["role"], msg["content"]
             if role == "tool_call":
                 data = json.loads(content)
-                converted.append({
-                    "role": "assistant",
-                    "content": None,
-                    "tool_calls": [
-                        {
-                            "id": c["id"],
-                            "type": "function",
-                            "function": {"name": c["name"], "arguments": json.dumps(c.get("arguments", {}))},
-                        }
-                        for c in data["calls"]
-                    ],
-                })
+                converted.append(
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": c["id"],
+                                "type": "function",
+                                "function": {
+                                    "name": c["name"],
+                                    "arguments": json.dumps(c.get("arguments", {})),
+                                },
+                            }
+                            for c in data["calls"]
+                        ],
+                    },
+                )
             elif role == "tool_result":
                 data = json.loads(content)
-                converted.append({
-                    "role": "tool",
-                    "tool_call_id": data["call_id"],
-                    "content": data["output"],
-                })
+                converted.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": data["call_id"],
+                        "content": data["output"],
+                    },
+                )
             elif role in ("user", "assistant"):
                 converted.append({"role": role, "content": content})
         return converted

--- a/flux/tasks/call.py
+++ b/flux/tasks/call.py
@@ -8,20 +8,23 @@ from flux.workflow import workflow as workflow_cls
 
 
 @task.with_options(name="call_workflow_{workflow}")
-async def call(workflow: workflow_cls | str, *args):
-    """Call a workflow directly or via the HTTP API in sync mode.
+async def call(workflow: workflow_cls | str, *args, mode: str = "sync"):
+    """Call a workflow directly or via the HTTP API in sync or async mode.
 
     Args:
         workflow: The workflow to call, can be either:
             - A workflow object: Will be called directly
             - A string: Will be called via the HTTP API
+        mode: Execution mode, either "sync" (default) or "async".
+            In async mode, returns the execution_id immediately without waiting.
 
     Raises:
         WorkflowNotFoundError: If the workflow does not exist (when using string name)
         ExecutionError: If the workflow execution fails
 
     Returns:
-        Any: The output of the workflow execution
+        Any: In sync mode, the output of the workflow execution.
+             In async mode, the execution_id string.
     """
     from flux.errors import WorkflowNotFoundError
     from flux.domain.execution_context import ExecutionContext
@@ -36,8 +39,17 @@ async def call(workflow: workflow_cls | str, *args):
     server_url = settings.workers.server_url
 
     try:
-        url = f"{server_url}/workflows/{workflow}/run/sync?detailed=true"
         payload = args[0] if len(args) == 1 else args
+
+        if mode == "async":
+            url = f"{server_url}/workflows/{workflow}/run/async"
+            with httpx.Client(timeout=settings.workers.default_timeout) as client:
+                response = client.post(url, json=payload)
+                response.raise_for_status()
+                data = response.json()
+                return data["execution_id"]
+
+        url = f"{server_url}/workflows/{workflow}/run/sync?detailed=true"
         with httpx.Client(timeout=settings.workers.default_timeout) as client:
             response = client.post(url, json=payload)
             response.raise_for_status()

--- a/flux/tasks/call.py
+++ b/flux/tasks/call.py
@@ -28,6 +28,9 @@ async def call(workflow: workflow_cls | str, *args, mode: Literal["sync", "async
     if isinstance(workflow, workflow_cls):
         workflow = workflow.name
 
+    if mode not in ("sync", "async"):
+        raise ValueError(f"mode must be 'sync' or 'async', got: '{mode}'")
+
     import httpx
     from flux.config import Configuration
 

--- a/flux/tasks/call.py
+++ b/flux/tasks/call.py
@@ -1,33 +1,29 @@
 from __future__ import annotations
 
-from flux.domain.events import ExecutionEvent
-from flux.domain.events import ExecutionEventType
+from typing import Literal
+
+from flux.domain.events import ExecutionEvent, ExecutionEventType
 from flux.errors import ExecutionError
 from flux.task import task
 from flux.workflow import workflow as workflow_cls
 
 
 @task.with_options(name="call_workflow_{workflow}")
-async def call(workflow: workflow_cls | str, *args, mode: str = "sync"):
-    """Call a workflow directly or via the HTTP API in sync or async mode.
+async def call(workflow: workflow_cls | str, *args, mode: Literal["sync", "async"] = "sync"):
+    """Call a workflow via the HTTP API.
 
     Args:
-        workflow: The workflow to call, can be either:
-            - A workflow object: Will be called directly
-            - A string: Will be called via the HTTP API
-        mode: Execution mode, either "sync" (default) or "async".
-            In async mode, returns the execution_id immediately without waiting.
-
-    Raises:
-        WorkflowNotFoundError: If the workflow does not exist (when using string name)
-        ExecutionError: If the workflow execution fails
+        workflow: The workflow to call (workflow object or string name).
+        *args: Arguments passed to the workflow.
+        mode: Execution mode — "sync" waits for completion and returns output,
+              "async" submits and returns the execution_id immediately.
 
     Returns:
-        Any: In sync mode, the output of the workflow execution.
-             In async mode, the execution_id string.
+        mode="sync": The workflow output.
+        mode="async": The execution_id (str).
     """
-    from flux.errors import WorkflowNotFoundError
     from flux.domain.execution_context import ExecutionContext
+    from flux.errors import WorkflowNotFoundError
 
     if isinstance(workflow, workflow_cls):
         workflow = workflow.name
@@ -40,16 +36,16 @@ async def call(workflow: workflow_cls | str, *args, mode: str = "sync"):
 
     try:
         payload = args[0] if len(args) == 1 else args
+        url = f"{server_url}/workflows/{workflow}/run/{mode}"
 
         if mode == "async":
-            url = f"{server_url}/workflows/{workflow}/run/async"
             with httpx.Client(timeout=settings.workers.default_timeout) as client:
                 response = client.post(url, json=payload)
                 response.raise_for_status()
                 data = response.json()
                 return data["execution_id"]
 
-        url = f"{server_url}/workflows/{workflow}/run/sync?detailed=true"
+        url = f"{url}?detailed=true"
         with httpx.Client(timeout=settings.workers.default_timeout) as client:
             response = client.post(url, json=payload)
             response.raise_for_status()
@@ -79,7 +75,6 @@ async def call(workflow: workflow_cls | str, *args, mode: str = "sync"):
             if ctx.has_failed:
                 raise ExecutionError(ctx.output)
 
-            # TODO: add support for paused workflows
             if ctx.is_paused:
                 raise ExecutionError(
                     message=f"Workflow execution {ctx.workflow_name} was paused, but is not supported for nested calls.",

--- a/flux/tasks/call.py
+++ b/flux/tasks/call.py
@@ -38,16 +38,15 @@ async def call(workflow: workflow_cls | str, *args, mode: Literal["sync", "async
         payload = args[0] if len(args) == 1 else args
         url = f"{server_url}/workflows/{workflow}/run/{mode}"
 
-        if mode == "async":
-            with httpx.Client(timeout=settings.workers.default_timeout) as client:
-                response = client.post(url, json=payload)
+        async with httpx.AsyncClient(timeout=settings.workers.default_timeout) as client:
+            if mode == "async":
+                response = await client.post(url, json=payload)
                 response.raise_for_status()
                 data = response.json()
                 return data["execution_id"]
 
-        url = f"{url}?detailed=true"
-        with httpx.Client(timeout=settings.workers.default_timeout) as client:
-            response = client.post(url, json=payload)
+            url = f"{url}?detailed=true"
+            response = await client.post(url, json=payload)
             response.raise_for_status()
 
             data = response.json()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.21.0"
+version = "0.22.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/examples/test_subflows_github_stars.py
+++ b/tests/examples/test_subflows_github_stars.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
+
 import copy
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from examples.subflows import subflows
 from flux.domain.events import ExecutionEventType
@@ -19,7 +20,7 @@ REPO_STAR_COUNTS = {
 
 @pytest.fixture
 def mock_httpx_client():
-    """Fixture that creates and configures a mock for httpx.Client.
+    """Fixture that creates and configures a mock for httpx.AsyncClient.
 
     This fixture mocks the HTTP client used by the 'call' task to call
     the get_stars_workflow. It returns mocked star counts for each repository.
@@ -46,7 +47,7 @@ def mock_httpx_client():
     }
 
     # Create side effect function to generate appropriate response for each repo
-    def mock_post_side_effect(url, json, **kwargs):
+    async def mock_post_side_effect(url, json, **kwargs):
         repo = json  # The repo name is passed as the JSON payload
 
         # Create a copy of the mock data with the repository-specific information
@@ -62,9 +63,13 @@ def mock_httpx_client():
         return mock_response
 
     # Create and configure the mock client
-    with patch("httpx.Client") as mock_client:
-        mock_client.return_value.__enter__.return_value.post.side_effect = mock_post_side_effect
-        yield mock_client
+    with patch("httpx.AsyncClient") as mock_client:
+        mock_instance = AsyncMock()
+        mock_instance.post.side_effect = mock_post_side_effect
+        mock_instance.__aenter__.return_value = mock_instance
+        mock_instance.__aexit__.return_value = None
+        mock_client.return_value = mock_instance
+        yield mock_instance
 
 
 def test_should_succeed(mock_httpx_client):
@@ -76,7 +81,7 @@ def test_should_succeed(mock_httpx_client):
     ctx = subflows.run(repos)
 
     # Verify the mock was called once for each repository
-    assert mock_httpx_client.return_value.__enter__.return_value.post.call_count == len(repos)
+    assert mock_httpx_client.post.call_count == len(repos)
 
     # Verify the workflow completed successfully
     assert (
@@ -103,13 +108,13 @@ def test_should_skip_if_finished(mock_httpx_client):
     first_ctx = test_should_succeed(mock_httpx_client)
 
     # Reset the mock to verify it's not called again
-    mock_httpx_client.reset_mock()
+    mock_httpx_client.post.reset_mock()
 
     # Second execution with same execution_id
     second_ctx = subflows.run(execution_id=first_ctx.execution_id)
 
     # Verify execution was skipped (no additional HTTP calls)
-    assert mock_httpx_client.return_value.__enter__.return_value.post.call_count == 0
+    assert mock_httpx_client.post.call_count == 0
 
     # Verify contexts match
     assert first_ctx.execution_id == second_ctx.execution_id

--- a/tests/flux/tasks/ai/memory/test_agent_integration.py
+++ b/tests/flux/tasks/ai/memory/test_agent_integration.py
@@ -15,14 +15,14 @@ def test_agent_accepts_working_memory():
 
 
 def test_agent_accepts_long_term_memory():
-    ltm = long_term_memory(provider=in_memory(), scope="test")
+    ltm = long_term_memory(provider=in_memory(), agent="test_agent", scope="test")
     a = asyncio.run(agent("You are a test agent.", model="ollama/llama3", long_term_memory=ltm))
     assert a is not None
 
 
 def test_agent_accepts_both_memories():
     wm = working_memory(window=10)
-    ltm = long_term_memory(provider=in_memory(), scope="test")
+    ltm = long_term_memory(provider=in_memory(), agent="test_agent", scope="test")
     a = asyncio.run(
         agent(
             "You are a test agent.",
@@ -42,6 +42,6 @@ def test_agent_no_stateful_parameter():
 
 def test_agent_ltm_injects_tools():
     """Long-term memory should add memory tools to the agent."""
-    ltm = long_term_memory(provider=in_memory(), scope="test")
+    ltm = long_term_memory(provider=in_memory(), agent="test_agent", scope="test")
     a = asyncio.run(agent("You are a test agent.", model="ollama/llama3", long_term_memory=ltm))
     assert a is not None

--- a/tests/flux/tasks/ai/memory/test_long_term_memory.py
+++ b/tests/flux/tasks/ai/memory/test_long_term_memory.py
@@ -97,6 +97,27 @@ async def test_ltm_scope_property():
     assert ltm.scope == "user:1"
 
 
+def test_ltm_provider_type_in_memory():
+    from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+
+    provider = InMemoryProvider()
+    ltm = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+    assert ltm.provider_type == "in_memory"
+
+
+def test_ltm_provider_type_sqlalchemy():
+    import os
+    import tempfile
+
+    from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+    from flux.tasks.ai.memory.providers.sqlalchemy import SqlAlchemyProvider
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        provider = SqlAlchemyProvider(f"sqlite:///{os.path.join(tmpdir, 'test.db')}")
+        ltm = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+        assert ltm.provider_type == "sqlalchemy"
+
+
 @pytest.mark.asyncio
 async def test_ltm_tools_generation():
     """LTM generates tool definitions for agent integration."""

--- a/tests/flux/tasks/ai/memory/test_long_term_memory.py
+++ b/tests/flux/tasks/ai/memory/test_long_term_memory.py
@@ -105,7 +105,7 @@ def test_ltm_provider_type_in_memory():
     assert ltm.provider_type == "in_memory"
 
 
-def test_ltm_provider_type_sqlalchemy():
+def test_ltm_provider_type_sqlite():
     import os
     import tempfile
 
@@ -115,7 +115,7 @@ def test_ltm_provider_type_sqlalchemy():
     with tempfile.TemporaryDirectory() as tmpdir:
         provider = SqlAlchemyProvider(f"sqlite:///{os.path.join(tmpdir, 'test.db')}")
         ltm = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
-        assert ltm.provider_type == "sqlalchemy"
+        assert ltm.provider_type == "sqlite"
 
 
 @pytest.mark.asyncio

--- a/tests/flux/tasks/ai/memory/test_long_term_memory.py
+++ b/tests/flux/tasks/ai/memory/test_long_term_memory.py
@@ -2,115 +2,99 @@ from __future__ import annotations
 
 import pytest
 
-from flux.domain.events import ExecutionState
-from flux.domain.execution_context import ExecutionContext
 from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
-
-
-def _make_ctx(workflow_name: str = "test_workflow"):  # type: ignore[no-untyped-def]
-    ctx: ExecutionContext = ExecutionContext(
-        workflow_id="wf1",
-        workflow_name=workflow_name,
-        state=ExecutionState.RUNNING,
-    )
-    token = ExecutionContext.set(ctx)
-    return ctx, token
 
 
 @pytest.mark.asyncio
 async def test_ltm_memorize_and_recall():
     from flux.tasks.ai.memory.long_term_memory import LongTermMemory
 
-    ctx, token = _make_ctx()
-    try:
-        provider = InMemoryProvider()
-        ltm = LongTermMemory(provider=provider, scope="user:1")
-        await ltm.memorize("name", "Alice")
-        result = await ltm.recall("name")
-        assert result == "Alice"
-    finally:
-        ExecutionContext.reset(token)
+    provider = InMemoryProvider()
+    ltm = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+    await ltm.memorize("name", "Alice")
+    result = await ltm.recall("name")
+    assert result == "Alice"
 
 
 @pytest.mark.asyncio
 async def test_ltm_recall_all():
     from flux.tasks.ai.memory.long_term_memory import LongTermMemory
 
-    ctx, token = _make_ctx()
-    try:
-        provider = InMemoryProvider()
-        ltm = LongTermMemory(provider=provider, scope="user:1")
-        await ltm.memorize("name", "Alice")
-        await ltm.memorize("role", "developer")
-        result = await ltm.recall()
-        assert result == {"name": "Alice", "role": "developer"}
-    finally:
-        ExecutionContext.reset(token)
+    provider = InMemoryProvider()
+    ltm = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+    await ltm.memorize("name", "Alice")
+    await ltm.memorize("role", "developer")
+    result = await ltm.recall()
+    assert result == {"name": "Alice", "role": "developer"}
 
 
 @pytest.mark.asyncio
 async def test_ltm_forget():
     from flux.tasks.ai.memory.long_term_memory import LongTermMemory
 
-    ctx, token = _make_ctx()
-    try:
-        provider = InMemoryProvider()
-        ltm = LongTermMemory(provider=provider, scope="user:1")
-        await ltm.memorize("name", "Alice")
-        await ltm.forget("name")
-        result = await ltm.recall("name")
-        assert result is None
-    finally:
-        ExecutionContext.reset(token)
+    provider = InMemoryProvider()
+    ltm = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+    await ltm.memorize("name", "Alice")
+    await ltm.forget("name")
+    result = await ltm.recall("name")
+    assert result is None
 
 
 @pytest.mark.asyncio
 async def test_ltm_keys():
     from flux.tasks.ai.memory.long_term_memory import LongTermMemory
 
-    ctx, token = _make_ctx()
-    try:
-        provider = InMemoryProvider()
-        ltm = LongTermMemory(provider=provider, scope="user:1")
-        await ltm.memorize("name", "Alice")
-        await ltm.memorize("role", "developer")
-        keys = await ltm.keys()
-        assert sorted(keys) == ["name", "role"]
-    finally:
-        ExecutionContext.reset(token)
+    provider = InMemoryProvider()
+    ltm = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+    await ltm.memorize("name", "Alice")
+    await ltm.memorize("role", "developer")
+    keys = await ltm.keys()
+    assert sorted(keys) == ["name", "role"]
 
 
 @pytest.mark.asyncio
 async def test_ltm_scopes():
     from flux.tasks.ai.memory.long_term_memory import LongTermMemory
 
-    ctx, token = _make_ctx()
-    try:
-        provider = InMemoryProvider()
-        ltm1 = LongTermMemory(provider=provider, scope="user:1")
-        ltm2 = LongTermMemory(provider=provider, scope="user:2")
-        await ltm1.memorize("name", "Alice")
-        await ltm2.memorize("name", "Bob")
-        scopes = await ltm1.scopes()
-        assert sorted(scopes) == ["user:1", "user:2"]
-    finally:
-        ExecutionContext.reset(token)
+    provider = InMemoryProvider()
+    ltm1 = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+    ltm2 = LongTermMemory(provider=provider, agent="assistant", scope="user:2")
+    await ltm1.memorize("name", "Alice")
+    await ltm2.memorize("name", "Bob")
+    scopes = await ltm1.scopes()
+    assert sorted(scopes) == ["user:1", "user:2"]
 
 
 @pytest.mark.asyncio
-async def test_ltm_workflow_auto_scoping():
-    """Workflow name is auto-injected from ExecutionContext."""
+async def test_ltm_agent_scoping():
+    """Agent name is passed explicitly and reaches the provider directly."""
     from flux.tasks.ai.memory.long_term_memory import LongTermMemory
 
-    ctx, token = _make_ctx("my_workflow")
-    try:
-        provider = InMemoryProvider()
-        ltm = LongTermMemory(provider=provider, scope="user:1")
-        await ltm.memorize("name", "Alice")
-        result = await provider.recall("my_workflow", "user:1", "name")
-        assert result == "Alice"
-    finally:
-        ExecutionContext.reset(token)
+    provider = InMemoryProvider()
+    ltm = LongTermMemory(provider=provider, agent="my_agent", scope="user:1")
+    await ltm.memorize("name", "Alice")
+    result = await provider.recall("my_agent", "user:1", "name")
+    assert result == "Alice"
+
+
+@pytest.mark.asyncio
+async def test_ltm_agent_property():
+    """LTM exposes the agent name via a property."""
+    from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+
+    provider = InMemoryProvider()
+    ltm = LongTermMemory(provider=provider, agent="my_agent", scope="user:1")
+    assert ltm.agent == "my_agent"
+
+
+@pytest.mark.asyncio
+async def test_ltm_scope_property():
+    """LTM exposes the scope via a property."""
+    from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+
+    provider = InMemoryProvider()
+    ltm = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+    assert ltm.scope == "user:1"
 
 
 @pytest.mark.asyncio
@@ -119,7 +103,7 @@ async def test_ltm_tools_generation():
     from flux.tasks.ai.memory.long_term_memory import LongTermMemory
 
     provider = InMemoryProvider()
-    ltm = LongTermMemory(provider=provider, scope="user:1")
+    ltm = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
     tools = ltm.as_tools()
     tool_names = [t.func.__name__ if hasattr(t, "func") else t.__name__ for t in tools]
     assert "recall_memory" in tool_names
@@ -134,7 +118,7 @@ async def test_ltm_system_prompt_hint():
     from flux.tasks.ai.memory.long_term_memory import LongTermMemory
 
     provider = InMemoryProvider()
-    ltm = LongTermMemory(provider=provider, scope="user:1")
+    ltm = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
     hint = ltm.system_prompt_hint()
     assert "recall_memory" in hint
     assert "store_memory" in hint

--- a/tests/flux/tasks/ai/memory/test_providers.py
+++ b/tests/flux/tasks/ai/memory/test_providers.py
@@ -12,8 +12,8 @@ async def test_provider_memorize_and_recall():
     from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
 
     provider = InMemoryProvider()
-    await provider.memorize("wf", "user:1", "name", "Alice")
-    result = await provider.recall("wf", "user:1", "name")
+    await provider.memorize("agent_id", "user:1", "name", "Alice")
+    result = await provider.recall("agent_id", "user:1", "name")
     assert result == "Alice"
 
 
@@ -23,9 +23,9 @@ async def test_provider_recall_all_in_scope():
     from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
 
     provider = InMemoryProvider()
-    await provider.memorize("wf", "user:1", "name", "Alice")
-    await provider.memorize("wf", "user:1", "role", "developer")
-    result = await provider.recall("wf", "user:1")
+    await provider.memorize("agent_id", "user:1", "name", "Alice")
+    await provider.memorize("agent_id", "user:1", "role", "developer")
+    result = await provider.recall("agent_id", "user:1")
     assert result == {"name": "Alice", "role": "developer"}
 
 
@@ -34,7 +34,7 @@ async def test_provider_recall_missing_key_returns_none():
     from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
 
     provider = InMemoryProvider()
-    result = await provider.recall("wf", "user:1", "missing")
+    result = await provider.recall("agent_id", "user:1", "missing")
     assert result is None
 
 
@@ -43,7 +43,7 @@ async def test_provider_recall_empty_scope_returns_empty_dict():
     from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
 
     provider = InMemoryProvider()
-    result = await provider.recall("wf", "user:1")
+    result = await provider.recall("agent_id", "user:1")
     assert result == {}
 
 
@@ -53,9 +53,9 @@ async def test_provider_memorize_overwrites():
     from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
 
     provider = InMemoryProvider()
-    await provider.memorize("wf", "user:1", "role", "Engineer")
-    await provider.memorize("wf", "user:1", "role", "developer")
-    result = await provider.recall("wf", "user:1", "role")
+    await provider.memorize("agent_id", "user:1", "role", "Engineer")
+    await provider.memorize("agent_id", "user:1", "role", "developer")
+    result = await provider.recall("agent_id", "user:1", "role")
     assert result == "developer"
 
 
@@ -64,9 +64,9 @@ async def test_provider_forget_key():
     from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
 
     provider = InMemoryProvider()
-    await provider.memorize("wf", "user:1", "name", "Alice")
-    await provider.forget("wf", "user:1", "name")
-    result = await provider.recall("wf", "user:1", "name")
+    await provider.memorize("agent_id", "user:1", "name", "Alice")
+    await provider.forget("agent_id", "user:1", "name")
+    result = await provider.recall("agent_id", "user:1", "name")
     assert result is None
 
 
@@ -76,10 +76,10 @@ async def test_provider_forget_scope():
     from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
 
     provider = InMemoryProvider()
-    await provider.memorize("wf", "user:1", "name", "Alice")
-    await provider.memorize("wf", "user:1", "role", "developer")
-    await provider.forget("wf", "user:1")
-    result = await provider.recall("wf", "user:1")
+    await provider.memorize("agent_id", "user:1", "name", "Alice")
+    await provider.memorize("agent_id", "user:1", "role", "developer")
+    await provider.forget("agent_id", "user:1")
+    result = await provider.recall("agent_id", "user:1")
     assert result == {}
 
 
@@ -88,9 +88,9 @@ async def test_provider_keys():
     from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
 
     provider = InMemoryProvider()
-    await provider.memorize("wf", "user:1", "name", "Alice")
-    await provider.memorize("wf", "user:1", "role", "developer")
-    keys = await provider.keys("wf", "user:1")
+    await provider.memorize("agent_id", "user:1", "name", "Alice")
+    await provider.memorize("agent_id", "user:1", "role", "developer")
+    keys = await provider.keys("agent_id", "user:1")
     assert sorted(keys) == ["name", "role"]
 
 
@@ -99,22 +99,22 @@ async def test_provider_scopes():
     from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
 
     provider = InMemoryProvider()
-    await provider.memorize("wf", "user:1", "name", "Alice")
-    await provider.memorize("wf", "user:2", "name", "Bob")
-    scopes = await provider.scopes("wf")
+    await provider.memorize("agent_id", "user:1", "name", "Alice")
+    await provider.memorize("agent_id", "user:2", "name", "Bob")
+    scopes = await provider.scopes("agent_id")
     assert sorted(scopes) == ["user:1", "user:2"]
 
 
 @pytest.mark.asyncio
-async def test_provider_workflow_isolation():
-    """Different workflows don't see each other's data."""
+async def test_provider_agent_isolation():
+    """Different agents don't see each other's data."""
     from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
 
     provider = InMemoryProvider()
-    await provider.memorize("wf_a", "user:1", "name", "Alice")
-    await provider.memorize("wf_b", "user:1", "name", "Bob")
-    assert await provider.recall("wf_a", "user:1", "name") == "Alice"
-    assert await provider.recall("wf_b", "user:1", "name") == "Bob"
+    await provider.memorize("agent_a", "user:1", "name", "Alice")
+    await provider.memorize("agent_b", "user:1", "name", "Bob")
+    assert await provider.recall("agent_a", "user:1", "name") == "Alice"
+    assert await provider.recall("agent_b", "user:1", "name") == "Bob"
 
 
 def test_in_memory_provider_conforms_to_protocol():
@@ -127,8 +127,8 @@ def test_in_memory_provider_conforms_to_protocol():
 def test_memory_entry_fields():
     from flux.tasks.ai.memory.types import MemoryEntry
 
-    entry = MemoryEntry(workflow="wf", scope="user:1", key="name", value="Alice")
-    assert entry.workflow == "wf"
+    entry = MemoryEntry(agent="agent_id", scope="user:1", key="name", value="Alice")
+    assert entry.agent == "agent_id"
     assert entry.scope == "user:1"
     assert entry.key == "name"
     assert entry.value == "Alice"
@@ -141,8 +141,8 @@ async def test_sqlalchemy_provider_memorize_and_recall():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         provider = SqlAlchemyProvider(f"sqlite:///{db_path}")
-        await provider.memorize("wf", "user:1", "name", "Alice")
-        result = await provider.recall("wf", "user:1", "name")
+        await provider.memorize("agent_id", "user:1", "name", "Alice")
+        result = await provider.recall("agent_id", "user:1", "name")
         assert result == "Alice"
 
 
@@ -153,9 +153,9 @@ async def test_sqlalchemy_provider_recall_all():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         provider = SqlAlchemyProvider(f"sqlite:///{db_path}")
-        await provider.memorize("wf", "user:1", "name", "Alice")
-        await provider.memorize("wf", "user:1", "role", "developer")
-        result = await provider.recall("wf", "user:1")
+        await provider.memorize("agent_id", "user:1", "name", "Alice")
+        await provider.memorize("agent_id", "user:1", "role", "developer")
+        result = await provider.recall("agent_id", "user:1")
         assert result == {"name": "Alice", "role": "developer"}
 
 
@@ -166,9 +166,9 @@ async def test_sqlalchemy_provider_upsert():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         provider = SqlAlchemyProvider(f"sqlite:///{db_path}")
-        await provider.memorize("wf", "user:1", "role", "Engineer")
-        await provider.memorize("wf", "user:1", "role", "developer")
-        result = await provider.recall("wf", "user:1", "role")
+        await provider.memorize("agent_id", "user:1", "role", "Engineer")
+        await provider.memorize("agent_id", "user:1", "role", "developer")
+        result = await provider.recall("agent_id", "user:1", "role")
         assert result == "developer"
 
 
@@ -179,9 +179,9 @@ async def test_sqlalchemy_provider_forget_key():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         provider = SqlAlchemyProvider(f"sqlite:///{db_path}")
-        await provider.memorize("wf", "user:1", "name", "Alice")
-        await provider.forget("wf", "user:1", "name")
-        result = await provider.recall("wf", "user:1", "name")
+        await provider.memorize("agent_id", "user:1", "name", "Alice")
+        await provider.forget("agent_id", "user:1", "name")
+        result = await provider.recall("agent_id", "user:1", "name")
         assert result is None
 
 
@@ -192,10 +192,10 @@ async def test_sqlalchemy_provider_forget_scope():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         provider = SqlAlchemyProvider(f"sqlite:///{db_path}")
-        await provider.memorize("wf", "user:1", "name", "Alice")
-        await provider.memorize("wf", "user:1", "role", "developer")
-        await provider.forget("wf", "user:1")
-        result = await provider.recall("wf", "user:1")
+        await provider.memorize("agent_id", "user:1", "name", "Alice")
+        await provider.memorize("agent_id", "user:1", "role", "developer")
+        await provider.forget("agent_id", "user:1")
+        result = await provider.recall("agent_id", "user:1")
         assert result == {}
 
 
@@ -206,23 +206,23 @@ async def test_sqlalchemy_provider_keys_and_scopes():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         provider = SqlAlchemyProvider(f"sqlite:///{db_path}")
-        await provider.memorize("wf", "user:1", "name", "Alice")
-        await provider.memorize("wf", "user:2", "name", "Bob")
-        assert sorted(await provider.keys("wf", "user:1")) == ["name"]
-        assert sorted(await provider.scopes("wf")) == ["user:1", "user:2"]
+        await provider.memorize("agent_id", "user:1", "name", "Alice")
+        await provider.memorize("agent_id", "user:2", "name", "Bob")
+        assert sorted(await provider.keys("agent_id", "user:1")) == ["name"]
+        assert sorted(await provider.scopes("agent_id")) == ["user:1", "user:2"]
 
 
 @pytest.mark.asyncio
-async def test_sqlalchemy_provider_workflow_isolation():
+async def test_sqlalchemy_provider_agent_isolation():
     from flux.tasks.ai.memory.providers.sqlalchemy import SqlAlchemyProvider
 
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         provider = SqlAlchemyProvider(f"sqlite:///{db_path}")
-        await provider.memorize("wf_a", "user:1", "name", "Alice")
-        await provider.memorize("wf_b", "user:1", "name", "Bob")
-        assert await provider.recall("wf_a", "user:1", "name") == "Alice"
-        assert await provider.recall("wf_b", "user:1", "name") == "Bob"
+        await provider.memorize("agent_a", "user:1", "name", "Alice")
+        await provider.memorize("agent_b", "user:1", "name", "Bob")
+        assert await provider.recall("agent_a", "user:1", "name") == "Alice"
+        assert await provider.recall("agent_b", "user:1", "name") == "Bob"
 
 
 @pytest.mark.asyncio
@@ -233,7 +233,7 @@ async def test_sqlalchemy_provider_persists_across_instances():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         provider1 = SqlAlchemyProvider(f"sqlite:///{db_path}")
-        await provider1.memorize("wf", "user:1", "name", "Alice")
+        await provider1.memorize("agent_id", "user:1", "name", "Alice")
         provider2 = SqlAlchemyProvider(f"sqlite:///{db_path}")
-        result = await provider2.recall("wf", "user:1", "name")
+        result = await provider2.recall("agent_id", "user:1", "name")
         assert result == "Alice"

--- a/tests/flux/tasks/ai/memory/test_working_memory.py
+++ b/tests/flux/tasks/ai/memory/test_working_memory.py
@@ -148,3 +148,45 @@ async def test_working_memory_forget_by_stable_id():
         assert messages[0] == {"role": "assistant", "content": "reply1"}
     finally:
         ExecutionContext.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_working_memory_tool_call_role():
+    from flux.tasks.ai.memory.working_memory import WorkingMemory
+
+    ctx, token = _make_ctx()
+    try:
+        wm = WorkingMemory()
+        await wm.memorize("user", "find TODOs")
+        await wm.memorize("tool_call", '{"calls": [{"id": "c1", "name": "grep", "arguments": {"pattern": "TODO"}}]}')
+        await wm.memorize("tool_result", '{"call_id": "c1", "name": "grep", "output": "file.py:10: TODO fix"}')
+        await wm.memorize("assistant", "Found 1 TODO in file.py")
+        messages = wm.recall()
+        assert len(messages) == 4
+        assert messages[1]["role"] == "tool_call"
+        assert messages[2]["role"] == "tool_result"
+    finally:
+        ExecutionContext.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_working_memory_compact_marks_messages():
+    from flux.tasks.ai.memory.working_memory import WorkingMemory
+
+    ctx, token = _make_ctx()
+    try:
+        wm = WorkingMemory()
+        await wm.memorize("user", "msg1")
+        await wm.memorize("assistant", "reply1")
+        await wm.memorize("user", "msg2")
+        await wm.memorize("assistant", "reply2")
+
+        ids = wm.keys()
+        await wm._mark_compacted(ids[0])
+        await wm._mark_compacted(ids[1])
+
+        messages = wm.recall()
+        assert len(messages) == 2
+        assert messages[0]["content"] == "msg2"
+    finally:
+        ExecutionContext.reset(token)

--- a/tests/flux/tasks/ai/memory/test_working_memory.py
+++ b/tests/flux/tasks/ai/memory/test_working_memory.py
@@ -158,8 +158,14 @@ async def test_working_memory_tool_call_role():
     try:
         wm = WorkingMemory()
         await wm.memorize("user", "find TODOs")
-        await wm.memorize("tool_call", '{"calls": [{"id": "c1", "name": "grep", "arguments": {"pattern": "TODO"}}]}')
-        await wm.memorize("tool_result", '{"call_id": "c1", "name": "grep", "output": "file.py:10: TODO fix"}')
+        await wm.memorize(
+            "tool_call",
+            '{"calls": [{"id": "c1", "name": "grep", "arguments": {"pattern": "TODO"}}]}',
+        )
+        await wm.memorize(
+            "tool_result",
+            '{"call_id": "c1", "name": "grep", "output": "file.py:10: TODO fix"}',
+        )
         await wm.memorize("assistant", "Found 1 TODO in file.py")
         messages = wm.recall()
         assert len(messages) == 4
@@ -188,5 +194,54 @@ async def test_working_memory_compact_marks_messages():
         messages = wm.recall()
         assert len(messages) == 2
         assert messages[0]["content"] == "msg2"
+    finally:
+        ExecutionContext.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_working_memory_tool_pruning():
+    from flux.tasks.ai.memory.working_memory import WorkingMemory
+
+    ctx, token = _make_ctx()
+    try:
+        wm = WorkingMemory(
+            max_tokens=100,
+            compact_model="ollama/llama3.2",
+            compact_threshold=0.5,
+            compact_preserve=2,
+        )
+        await wm.memorize("user", "find files")
+        await wm.memorize("tool_call", '{"calls": [{"id": "c1", "name": "grep", "arguments": {}}]}')
+        long_output = "x" * 1000
+        await wm.memorize(
+            "tool_result",
+            '{"call_id": "c1", "name": "grep", "output": "' + long_output + '"}',
+        )
+        await wm.memorize("assistant", "found results")
+        await wm.memorize("user", "next question")
+
+        messages = wm.recall()
+        tool_results = [m for m in messages if m["role"] == "tool_result"]
+        for tr in tool_results:
+            import json
+
+            data = json.loads(tr["content"])
+            if "[truncated]" in data.get("output", ""):
+                assert len(data["output"]) < 300
+    finally:
+        ExecutionContext.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_working_memory_no_compact_without_model():
+    from flux.tasks.ai.memory.working_memory import WorkingMemory
+
+    ctx, token = _make_ctx()
+    try:
+        wm = WorkingMemory(max_tokens=10)
+        for i in range(20):
+            await wm.memorize("user", f"message {i}" * 10)
+        messages = wm.recall()
+        assert len(messages) < 20
     finally:
         ExecutionContext.reset(token)

--- a/tests/flux/tasks/ai/test_agent_hooks.py
+++ b/tests/flux/tasks/ai/test_agent_hooks.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import pytest
 
 from flux.domain.execution_context import ExecutionContext
-from flux.tasks.ai.models import LLMResponse
+from flux.errors import PauseRequested
+from flux.tasks.ai.models import LLMResponse, ToolCall
 from flux.task import task
 
 
@@ -127,5 +128,57 @@ class TestAgentHooks:
                 stream=False,
             )
             assert result == "response text"
+        finally:
+            ExecutionContext.reset(token)
+
+    @pytest.mark.asyncio
+    async def test_on_pause_fires_on_pause_requested(self):
+        captured = []
+
+        async def pause_hook(agent_id: str, value):
+            captured.append({"agent_id": agent_id, "value": value})
+
+        @task
+        async def pausing_tool(command: str) -> str:
+            """A tool that pauses."""
+            raise PauseRequested("approval needed")
+
+        @task
+        async def llm_with_tool_call(messages, **kwargs):
+            return LLMResponse(
+                text="",
+                tool_calls=[
+                    ToolCall(id="call_0", name="pausing_tool", arguments={"command": "test"}),
+                ],
+            )
+
+        class ToolFormatter(FakeFormatter):
+            def format_tool_results(self, tc, results):
+                return [{"role": "tool", "content": str(r)} for r in results]
+
+        from flux.tasks.ai.agent_loop import run_agent_loop
+        from flux.tasks.ai.tool_executor import build_tool_schemas
+
+        tools = [pausing_tool]
+        schemas = build_tool_schemas(tools)
+
+        ctx = ExecutionContext(workflow_id="test", workflow_name="test")
+        token = ExecutionContext.set(ctx)
+        try:
+            with pytest.raises(PauseRequested):
+                await run_agent_loop(
+                    llm_task=llm_with_tool_call,
+                    formatter=ToolFormatter(),
+                    system_prompt="test",
+                    instruction="test",
+                    tools=tools,
+                    tool_schemas=schemas,
+                    stream=False,
+                    on_pause=[pause_hook],
+                    agent_name="test_agent",
+                )
+            assert len(captured) == 1
+            assert captured[0]["agent_id"] == "test_agent"
+            assert captured[0]["value"] is None
         finally:
             ExecutionContext.reset(token)

--- a/tests/flux/tasks/ai/test_agent_hooks.py
+++ b/tests/flux/tasks/ai/test_agent_hooks.py
@@ -220,7 +220,7 @@ class TestAgentLoopToolStorage:
         token = ExecutionContext.set(ctx)
         try:
             wm = WorkingMemory()
-            result = await run_agent_loop(
+            await run_agent_loop(
                 llm_task=fake_llm_with_tools,
                 formatter=ToolFormatter(),
                 system_prompt="test",

--- a/tests/flux/tasks/ai/test_agent_hooks.py
+++ b/tests/flux/tasks/ai/test_agent_hooks.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import pytest
+
+from flux.domain.execution_context import ExecutionContext
+from flux.tasks.ai.models import LLMResponse
+from flux.task import task
+
+
+class FakeFormatter:
+    def build_messages(self, sys, user, wm):
+        return [{"role": "user", "content": user}], {}
+
+    def format_assistant_message(self, r):
+        return {"role": "assistant", "content": r.text}
+
+    def format_tool_results(self, tc, results):
+        return []
+
+    def format_user_message(self, text):
+        return {"role": "user", "content": text}
+
+    def remove_tools_from_kwargs(self, kw):
+        return kw
+
+    async def stream(self, messages, kwargs):
+        yield "hello"
+
+
+@task
+async def fake_llm(messages, **kwargs):
+    return LLMResponse(text="response text")
+
+
+class TestAgentHooks:
+    @pytest.mark.asyncio
+    async def test_on_complete_receives_agent_id_and_value(self):
+        captured = []
+
+        async def hook(agent_id: str, value):
+            captured.append({"agent_id": agent_id, "value": value})
+
+        from flux.tasks.ai.agent_loop import run_agent_loop
+
+        ctx = ExecutionContext(workflow_id="test", workflow_name="test")
+        token = ExecutionContext.set(ctx)
+        try:
+            result = await run_agent_loop(
+                llm_task=fake_llm,
+                formatter=FakeFormatter(),
+                system_prompt="test",
+                instruction="test",
+                stream=False,
+                on_complete=[hook],
+                agent_name="test_agent",
+            )
+            assert result == "response text"
+            assert len(captured) == 1
+            assert captured[0]["agent_id"] == "test_agent"
+            assert captured[0]["value"] == "response text"
+        finally:
+            ExecutionContext.reset(token)
+
+    @pytest.mark.asyncio
+    async def test_on_complete_failure_does_not_affect_result(self):
+        async def failing_hook(agent_id: str, value):
+            raise RuntimeError("hook failed")
+
+        from flux.tasks.ai.agent_loop import run_agent_loop
+
+        ctx = ExecutionContext(workflow_id="test", workflow_name="test")
+        token = ExecutionContext.set(ctx)
+        try:
+            result = await run_agent_loop(
+                llm_task=fake_llm,
+                formatter=FakeFormatter(),
+                system_prompt="test",
+                instruction="test",
+                stream=False,
+                on_complete=[failing_hook],
+                agent_name="test_agent",
+            )
+            assert result == "response text"
+        finally:
+            ExecutionContext.reset(token)
+
+    @pytest.mark.asyncio
+    async def test_multiple_hooks_all_called(self):
+        calls = []
+
+        async def hook_a(agent_id: str, value):
+            calls.append("a")
+
+        async def hook_b(agent_id: str, value):
+            calls.append("b")
+
+        from flux.tasks.ai.agent_loop import run_agent_loop
+
+        ctx = ExecutionContext(workflow_id="test", workflow_name="test")
+        token = ExecutionContext.set(ctx)
+        try:
+            await run_agent_loop(
+                llm_task=fake_llm,
+                formatter=FakeFormatter(),
+                system_prompt="test",
+                instruction="test",
+                stream=False,
+                on_complete=[hook_a, hook_b],
+                agent_name="test_agent",
+            )
+            assert calls == ["a", "b"]
+        finally:
+            ExecutionContext.reset(token)
+
+    @pytest.mark.asyncio
+    async def test_no_hooks_works_fine(self):
+        from flux.tasks.ai.agent_loop import run_agent_loop
+
+        ctx = ExecutionContext(workflow_id="test", workflow_name="test")
+        token = ExecutionContext.set(ctx)
+        try:
+            result = await run_agent_loop(
+                llm_task=fake_llm,
+                formatter=FakeFormatter(),
+                system_prompt="test",
+                instruction="test",
+                stream=False,
+            )
+            assert result == "response text"
+        finally:
+            ExecutionContext.reset(token)

--- a/tests/flux/tasks/ai/test_agent_hooks.py
+++ b/tests/flux/tasks/ai/test_agent_hooks.py
@@ -182,3 +182,59 @@ class TestAgentHooks:
             assert captured[0]["value"] is None
         finally:
             ExecutionContext.reset(token)
+
+
+class TestAgentLoopToolStorage:
+    @pytest.mark.asyncio
+    async def test_tool_calls_stored_in_working_memory(self):
+        from flux.tasks.ai.agent_loop import run_agent_loop
+        from flux.tasks.ai.memory.working_memory import WorkingMemory
+        from flux.tasks.ai.tool_executor import build_tool_schemas
+
+        call_count = 0
+
+        @task
+        async def fake_llm_with_tools(messages, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return LLMResponse(
+                    text="",
+                    tool_calls=[ToolCall(id="c1", name="my_tool", arguments={"x": 1})],
+                )
+            return LLMResponse(text="done")
+
+        @task
+        async def my_tool(x: int) -> str:
+            """A test tool."""
+            return f"result_{x}"
+
+        tools = [my_tool]
+        schemas = build_tool_schemas(tools)
+
+        class ToolFormatter(FakeFormatter):
+            def format_tool_results(self, tc, results):
+                return [{"role": "tool", "content": r["output"]} for r in results]
+
+        ctx = ExecutionContext(workflow_id="test", workflow_name="test")
+        token = ExecutionContext.set(ctx)
+        try:
+            wm = WorkingMemory()
+            result = await run_agent_loop(
+                llm_task=fake_llm_with_tools,
+                formatter=ToolFormatter(),
+                system_prompt="test",
+                instruction="do something",
+                tools=tools,
+                tool_schemas=schemas,
+                working_memory=wm,
+                stream=False,
+            )
+            messages = wm.recall()
+            roles = [m["role"] for m in messages]
+            assert "tool_call" in roles
+            assert "tool_result" in roles
+            assert roles[0] == "user"
+            assert roles[-1] == "assistant"
+        finally:
+            ExecutionContext.reset(token)

--- a/tests/flux/tasks/ai/test_agent_plan.py
+++ b/tests/flux/tasks/ai/test_agent_plan.py
@@ -1450,7 +1450,7 @@ def test_build_plan_tools_restores_from_ltm():
 
     @workflow
     async def plan_wf(ctx: ExecutionContext):
-        ltm = LongTermMemory(provider=provider, scope="_plan")
+        ltm = LongTermMemory(provider=provider, agent="plan_wf", scope="_plan")
         phase = ctx.input or "setup"
         if phase == "setup":
             tools, _ = await build_plan_tools(long_term_memory=ltm)

--- a/tests/flux/tasks/ai/test_dreaming.py
+++ b/tests/flux/tasks/ai/test_dreaming.py
@@ -11,20 +11,24 @@ class TestDreamFactory:
     def test_dream_returns_callable(self):
         from flux.tasks.ai.dreaming import dream
         from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+        from flux.tasks.ai.memory.working_memory import WorkingMemory
 
         provider = InMemoryProvider()
-        memory = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
-        hook = dream(memory, execution_id="exec_123")
+        ltm = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+        wm = WorkingMemory()
+        hook = dream(working_memory=wm, long_term_memory=ltm)
         assert callable(hook)
 
     @pytest.mark.asyncio
     async def test_dream_submits_async_workflow(self):
         from flux.tasks.ai.dreaming import dream
         from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+        from flux.tasks.ai.memory.working_memory import WorkingMemory
 
         provider = InMemoryProvider()
-        memory = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
-        hook = dream(memory, execution_id="exec_123")
+        ltm = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+        wm = WorkingMemory()
+        hook = dream(working_memory=wm, long_term_memory=ltm)
 
         with patch("flux.tasks.ai.dreaming.call", new_callable=AsyncMock) as mock_call:
             mock_call.return_value = "dream_exec_456"
@@ -33,9 +37,9 @@ class TestDreamFactory:
             mock_call.assert_called_once_with(
                 "agent_dream",
                 {
-                    "execution_id": "exec_123",
                     "agent": "my_agent",
                     "scope": "user:1",
+                    "working_memory": wm.recall(),
                 },
                 mode="async",
             )
@@ -44,10 +48,12 @@ class TestDreamFactory:
     async def test_dream_custom_workflow_name(self):
         from flux.tasks.ai.dreaming import dream
         from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+        from flux.tasks.ai.memory.working_memory import WorkingMemory
 
         provider = InMemoryProvider()
-        memory = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
-        hook = dream(memory, execution_id="exec_123", workflow="custom_dream")
+        ltm = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+        wm = WorkingMemory()
+        hook = dream(working_memory=wm, long_term_memory=ltm, workflow="custom_dream")
 
         with patch("flux.tasks.ai.dreaming.call", new_callable=AsyncMock) as mock_call:
             mock_call.return_value = "dream_exec_789"
@@ -59,10 +65,12 @@ class TestDreamFactory:
     async def test_dream_failure_is_logged_not_raised(self):
         from flux.tasks.ai.dreaming import dream
         from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+        from flux.tasks.ai.memory.working_memory import WorkingMemory
 
         provider = InMemoryProvider()
-        memory = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
-        hook = dream(memory, execution_id="exec_123")
+        ltm = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+        wm = WorkingMemory()
+        hook = dream(working_memory=wm, long_term_memory=ltm)
 
         with patch("flux.tasks.ai.dreaming.call", new_callable=AsyncMock) as mock_call:
             mock_call.side_effect = RuntimeError("connection failed")
@@ -152,7 +160,6 @@ class TestDreamPrompts:
 
         assert "merge" in CONSOLIDATE_PROMPT.lower()
         assert "contradict" in CONSOLIDATE_PROMPT.lower()
-        assert "provenance" in CONSOLIDATE_PROMPT.lower()
 
     def test_prune_prompt_mentions_cap(self):
         from flux.tasks.ai.dreaming import PRUNE_PROMPT
@@ -167,8 +174,3 @@ class TestAgentDreamWorkflow:
         from flux.workflow import workflow as workflow_cls
 
         assert isinstance(agent_dream, workflow_cls)
-
-    def test_load_execution_events_is_a_task(self):
-        from flux.tasks.ai.dreaming import load_execution_events
-
-        assert hasattr(load_execution_events, "func") or callable(load_execution_events)

--- a/tests/flux/tasks/ai/test_dreaming.py
+++ b/tests/flux/tasks/ai/test_dreaming.py
@@ -159,3 +159,16 @@ class TestDreamPrompts:
 
         assert "100" in PRUNE_PROMPT
         assert "stale" in PRUNE_PROMPT.lower()
+
+
+class TestAgentDreamWorkflow:
+    def test_agent_dream_is_a_workflow(self):
+        from flux.tasks.ai.dreaming import agent_dream
+        from flux.workflow import workflow as workflow_cls
+
+        assert isinstance(agent_dream, workflow_cls)
+
+    def test_load_execution_events_is_a_task(self):
+        from flux.tasks.ai.dreaming import load_execution_events
+
+        assert hasattr(load_execution_events, "func") or callable(load_execution_events)

--- a/tests/flux/tasks/ai/test_dreaming.py
+++ b/tests/flux/tasks/ai/test_dreaming.py
@@ -175,3 +175,21 @@ class TestAgentDreamWorkflow:
         from flux.workflow import workflow as workflow_cls
 
         assert isinstance(agent_dream, workflow_cls)
+
+
+class TestAgentDreamExecution:
+    def test_agent_dream_rejects_missing_agent(self):
+        from flux.tasks.ai.dreaming import agent_dream
+
+        result = agent_dream.run({"scope": "test", "working_memory": []})
+        assert result.has_succeeded
+        assert result.output["status"] == "failed"
+        assert "agent" in result.output["error"].lower()
+
+    def test_agent_dream_rejects_missing_scope(self):
+        from flux.tasks.ai.dreaming import agent_dream
+
+        result = agent_dream.run({"agent": "test", "working_memory": []})
+        assert result.has_succeeded
+        assert result.output["status"] == "failed"
+        assert "scope" in result.output["error"].lower()

--- a/tests/flux/tasks/ai/test_dreaming.py
+++ b/tests/flux/tasks/ai/test_dreaming.py
@@ -39,6 +39,7 @@ class TestDreamFactory:
                 {
                     "agent": "my_agent",
                     "scope": "user:1",
+                    "provider_type": "in_memory",
                     "working_memory": wm.recall(),
                 },
                 mode="async",

--- a/tests/flux/tasks/ai/test_dreaming.py
+++ b/tests/flux/tasks/ai/test_dreaming.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from flux.tasks.ai.memory.providers.in_memory import InMemoryProvider
+
+
+class TestDreamFactory:
+    def test_dream_returns_callable(self):
+        from flux.tasks.ai.dreaming import dream
+        from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+
+        provider = InMemoryProvider()
+        memory = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+        hook = dream(memory, execution_id="exec_123")
+        assert callable(hook)
+
+    @pytest.mark.asyncio
+    async def test_dream_submits_async_workflow(self):
+        from flux.tasks.ai.dreaming import dream
+        from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+
+        provider = InMemoryProvider()
+        memory = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+        hook = dream(memory, execution_id="exec_123")
+
+        with patch("flux.tasks.ai.dreaming.call", new_callable=AsyncMock) as mock_call:
+            mock_call.return_value = "dream_exec_456"
+            await hook("my_agent", "some result")
+
+            mock_call.assert_called_once_with(
+                "agent_dream",
+                {
+                    "execution_id": "exec_123",
+                    "agent": "my_agent",
+                    "scope": "user:1",
+                },
+                mode="async",
+            )
+
+    @pytest.mark.asyncio
+    async def test_dream_custom_workflow_name(self):
+        from flux.tasks.ai.dreaming import dream
+        from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+
+        provider = InMemoryProvider()
+        memory = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+        hook = dream(memory, execution_id="exec_123", workflow="custom_dream")
+
+        with patch("flux.tasks.ai.dreaming.call", new_callable=AsyncMock) as mock_call:
+            mock_call.return_value = "dream_exec_789"
+            await hook("my_agent", "result")
+
+            assert mock_call.call_args[0][0] == "custom_dream"
+
+    @pytest.mark.asyncio
+    async def test_dream_failure_is_logged_not_raised(self):
+        from flux.tasks.ai.dreaming import dream
+        from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+
+        provider = InMemoryProvider()
+        memory = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+        hook = dream(memory, execution_id="exec_123")
+
+        with patch("flux.tasks.ai.dreaming.call", new_callable=AsyncMock) as mock_call:
+            mock_call.side_effect = RuntimeError("connection failed")
+            await hook("my_agent", "result")
+
+
+class TestFailureGate:
+    @pytest.mark.asyncio
+    async def test_skips_when_max_failures_reached(self):
+        from flux.tasks.ai.dreaming import check_failure_gate
+        from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+
+        provider = InMemoryProvider()
+        memory = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+        await memory.memorize("_dream:failures", 3)
+
+        result = await check_failure_gate(memory, max_failures=3)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_passes_when_below_max_failures(self):
+        from flux.tasks.ai.dreaming import check_failure_gate
+        from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+
+        provider = InMemoryProvider()
+        memory = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+        await memory.memorize("_dream:failures", 2)
+
+        result = await check_failure_gate(memory, max_failures=3)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_passes_when_no_failure_key(self):
+        from flux.tasks.ai.dreaming import check_failure_gate
+        from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+
+        provider = InMemoryProvider()
+        memory = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+
+        result = await check_failure_gate(memory, max_failures=3)
+        assert result is True
+
+
+class TestFailureTracking:
+    @pytest.mark.asyncio
+    async def test_increment_failure_counter(self):
+        from flux.tasks.ai.dreaming import increment_failure_counter
+        from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+
+        provider = InMemoryProvider()
+        memory = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+
+        await increment_failure_counter(memory)
+        assert await memory.recall("_dream:failures") == 1
+
+        await increment_failure_counter(memory)
+        assert await memory.recall("_dream:failures") == 2
+
+    @pytest.mark.asyncio
+    async def test_reset_failure_counter(self):
+        from flux.tasks.ai.dreaming import reset_failure_counter
+        from flux.tasks.ai.memory.long_term_memory import LongTermMemory
+
+        provider = InMemoryProvider()
+        memory = LongTermMemory(provider=provider, agent="assistant", scope="user:1")
+        await memory.memorize("_dream:failures", 5)
+
+        await reset_failure_counter(memory)
+        assert await memory.recall("_dream:failures") == 0
+
+
+class TestDreamPrompts:
+    def test_orient_prompt_mentions_memory_keys(self):
+        from flux.tasks.ai.dreaming import ORIENT_PROMPT
+
+        assert "list_memory_keys" in ORIENT_PROMPT
+        assert "recall_memory" in ORIENT_PROMPT
+
+    def test_gather_signal_prompt_mentions_corrections(self):
+        from flux.tasks.ai.dreaming import GATHER_SIGNAL_PROMPT
+
+        assert "correction" in GATHER_SIGNAL_PROMPT.lower()
+        assert "decision" in GATHER_SIGNAL_PROMPT.lower()
+
+    def test_consolidate_prompt_mentions_merge(self):
+        from flux.tasks.ai.dreaming import CONSOLIDATE_PROMPT
+
+        assert "merge" in CONSOLIDATE_PROMPT.lower()
+        assert "contradict" in CONSOLIDATE_PROMPT.lower()
+        assert "provenance" in CONSOLIDATE_PROMPT.lower()
+
+    def test_prune_prompt_mentions_cap(self):
+        from flux.tasks.ai.dreaming import PRUNE_PROMPT
+
+        assert "100" in PRUNE_PROMPT
+        assert "stale" in PRUNE_PROMPT.lower()

--- a/tests/flux/tasks/ai/test_formatter_memory.py
+++ b/tests/flux/tasks/ai/test_formatter_memory.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 
 def _wm_messages_with_tools():
     return [
@@ -81,3 +83,30 @@ class TestOllamaFormatterMemory:
         assert "tool" in roles
         has_tool_calls = any("tool_calls" in m for m in messages if m.get("role") == "assistant")
         assert has_tool_calls
+
+
+class TestGeminiFormatterMemory:
+    def test_build_messages_reconstitutes_tool_roles(self):
+        pytest.importorskip("google.genai")
+        from flux.tasks.ai.gemini import GeminiFormatter
+
+        formatter = GeminiFormatter("gemini-test", max_tokens=4096)
+
+        wm = type("FakeWM", (), {"recall": lambda self: _wm_messages_with_tools()})()
+
+        contents, _ = formatter.build_messages("system prompt", "new question", wm)
+
+        has_function_call = any(
+            hasattr(c, "parts")
+            and any(hasattr(p, "function_call") and p.function_call for p in c.parts)
+            for c in contents
+            if hasattr(c, "parts")
+        )
+        assert has_function_call
+        has_function_response = any(
+            hasattr(c, "parts")
+            and any(hasattr(p, "function_response") and p.function_response for p in c.parts)
+            for c in contents
+            if hasattr(c, "parts")
+        )
+        assert has_function_response

--- a/tests/flux/tasks/ai/test_formatter_memory.py
+++ b/tests/flux/tasks/ai/test_formatter_memory.py
@@ -2,14 +2,22 @@ from __future__ import annotations
 
 import json
 
-import pytest
-
 
 def _wm_messages_with_tools():
     return [
         {"role": "user", "content": "find TODOs"},
-        {"role": "tool_call", "content": json.dumps({"calls": [{"id": "c1", "name": "grep", "arguments": {"pattern": "TODO"}}]})},
-        {"role": "tool_result", "content": json.dumps({"call_id": "c1", "name": "grep", "output": "file.py:10: TODO fix"})},
+        {
+            "role": "tool_call",
+            "content": json.dumps(
+                {"calls": [{"id": "c1", "name": "grep", "arguments": {"pattern": "TODO"}}]},
+            ),
+        },
+        {
+            "role": "tool_result",
+            "content": json.dumps(
+                {"call_id": "c1", "name": "grep", "output": "file.py:10: TODO fix"},
+            ),
+        },
         {"role": "assistant", "content": "Found 1 TODO"},
         {"role": "user", "content": "fix it"},
     ]
@@ -28,14 +36,16 @@ class TestAnthropicFormatterMemory:
 
         assistant_msgs = [m for m in messages if m.get("role") == "assistant"]
         has_tool_use = any(
-            isinstance(m.get("content"), list) and any(b.get("type") == "tool_use" for b in m["content"])
+            isinstance(m.get("content"), list)
+            and any(b.get("type") == "tool_use" for b in m["content"])
             for m in assistant_msgs
         )
         assert has_tool_use
 
         user_msgs = [m for m in messages if m.get("role") == "user"]
         has_tool_result = any(
-            isinstance(m.get("content"), list) and any(b.get("type") == "tool_result" for b in m["content"])
+            isinstance(m.get("content"), list)
+            and any(b.get("type") == "tool_result" for b in m["content"])
             for m in user_msgs
         )
         assert has_tool_result

--- a/tests/flux/tasks/ai/test_formatter_memory.py
+++ b/tests/flux/tasks/ai/test_formatter_memory.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def _wm_messages_with_tools():
+    return [
+        {"role": "user", "content": "find TODOs"},
+        {"role": "tool_call", "content": json.dumps({"calls": [{"id": "c1", "name": "grep", "arguments": {"pattern": "TODO"}}]})},
+        {"role": "tool_result", "content": json.dumps({"call_id": "c1", "name": "grep", "output": "file.py:10: TODO fix"})},
+        {"role": "assistant", "content": "Found 1 TODO"},
+        {"role": "user", "content": "fix it"},
+    ]
+
+
+class TestAnthropicFormatterMemory:
+    def test_build_messages_reconstitutes_tool_roles(self):
+        from unittest.mock import MagicMock
+        from flux.tasks.ai.anthropic import AnthropicFormatter
+
+        formatter = AnthropicFormatter(MagicMock(), "claude-test", 4096)
+        wm = MagicMock()
+        wm.recall.return_value = _wm_messages_with_tools()
+
+        messages, _ = formatter.build_messages("system", "new q", wm)
+
+        assistant_msgs = [m for m in messages if m.get("role") == "assistant"]
+        has_tool_use = any(
+            isinstance(m.get("content"), list) and any(b.get("type") == "tool_use" for b in m["content"])
+            for m in assistant_msgs
+        )
+        assert has_tool_use
+
+        user_msgs = [m for m in messages if m.get("role") == "user"]
+        has_tool_result = any(
+            isinstance(m.get("content"), list) and any(b.get("type") == "tool_result" for b in m["content"])
+            for m in user_msgs
+        )
+        assert has_tool_result
+
+
+class TestOpenAIFormatterMemory:
+    def test_build_messages_reconstitutes_tool_roles(self):
+        from unittest.mock import MagicMock
+        from flux.tasks.ai.openai import OpenAIFormatter
+
+        formatter = OpenAIFormatter(MagicMock(), "gpt-test")
+        wm = MagicMock()
+        wm.recall.return_value = _wm_messages_with_tools()
+
+        messages, _ = formatter.build_messages("system", "new q", wm)
+
+        roles = [m.get("role") for m in messages]
+        assert "tool" in roles
+        has_tool_calls = any("tool_calls" in m for m in messages if m.get("role") == "assistant")
+        assert has_tool_calls
+
+
+class TestOllamaFormatterMemory:
+    def test_build_messages_reconstitutes_tool_roles(self):
+        from flux.tasks.ai.ollama import OllamaFormatter
+
+        formatter = OllamaFormatter(None, "test-model")
+        wm = type("FakeWM", (), {"recall": lambda self: _wm_messages_with_tools()})()
+
+        messages, _ = formatter.build_messages("system", "new q", wm)
+
+        roles = [m.get("role") for m in messages]
+        assert "tool" in roles
+        has_tool_calls = any("tool_calls" in m for m in messages if m.get("role") == "assistant")
+        assert has_tool_calls

--- a/tests/flux/tasks/test_call_async.py
+++ b/tests/flux/tasks/test_call_async.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from flux.domain.execution_context import ExecutionContext
+from flux.tasks.call import call
+
+
+class TestCallAsyncMode:
+    @pytest.mark.asyncio
+    async def test_async_mode_returns_execution_id(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "execution_id": "exec_123",
+            "workflow_id": "wf_abc",
+            "workflow_name": "test_wf",
+            "state": "RUNNING",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_response
+
+        ctx = ExecutionContext(workflow_id="wf1", workflow_name="test", execution_id="exec_0")
+        token = ExecutionContext.set(ctx)
+        try:
+            with patch("httpx.Client", return_value=mock_client):
+                result = await call("my_workflow", {"key": "value"}, mode="async")
+        finally:
+            ExecutionContext.reset(token)
+
+        assert result == "exec_123"
+        mock_client.post.assert_called_once()
+        call_url = mock_client.post.call_args[0][0]
+        assert "/run/async" in call_url
+
+    @pytest.mark.asyncio
+    async def test_sync_mode_is_default(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "execution_id": "exec_123",
+            "workflow_id": "wf_abc",
+            "workflow_name": "test_wf",
+            "input": None,
+            "state": "COMPLETED",
+            "events": [],
+            "requests": [],
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_response
+
+        ctx = ExecutionContext(workflow_id="wf1", workflow_name="test", execution_id="exec_0")
+        token = ExecutionContext.set(ctx)
+        try:
+            with patch("httpx.Client", return_value=mock_client):
+                await call("my_workflow", None, mode="sync")
+        finally:
+            ExecutionContext.reset(token)
+
+        call_url = mock_client.post.call_args[0][0]
+        assert "/run/sync" in call_url

--- a/tests/flux/tasks/test_call_async.py
+++ b/tests/flux/tasks/test_call_async.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from flux.domain.execution_context import ExecutionContext
 from flux.tasks.call import call
+
+
+def _make_async_client(mock_response):
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    return mock_client
 
 
 class TestCallAsyncMode:
@@ -20,15 +28,12 @@ class TestCallAsyncMode:
         }
         mock_response.raise_for_status = MagicMock()
 
-        mock_client = MagicMock()
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_client.post.return_value = mock_response
+        mock_client = _make_async_client(mock_response)
 
         ctx = ExecutionContext(workflow_id="wf1", workflow_name="test", execution_id="exec_0")
         token = ExecutionContext.set(ctx)
         try:
-            with patch("httpx.Client", return_value=mock_client):
+            with patch("httpx.AsyncClient", return_value=mock_client):
                 result = await call("my_workflow", {"key": "value"}, mode="async")
         finally:
             ExecutionContext.reset(token)
@@ -52,15 +57,12 @@ class TestCallAsyncMode:
         }
         mock_response.raise_for_status = MagicMock()
 
-        mock_client = MagicMock()
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_client.post.return_value = mock_response
+        mock_client = _make_async_client(mock_response)
 
         ctx = ExecutionContext(workflow_id="wf1", workflow_name="test", execution_id="exec_0")
         token = ExecutionContext.set(ctx)
         try:
-            with patch("httpx.Client", return_value=mock_client):
+            with patch("httpx.AsyncClient", return_value=mock_client):
                 await call("my_workflow", None, mode="sync")
         finally:
             ExecutionContext.reset(token)


### PR DESCRIPTION
## Summary

### Core Infrastructure
- **`call` task async mode** — adds `mode` parameter (`Literal["sync", "async"]`). Async mode submits a workflow via `/run/async` and returns the `execution_id` immediately. Switched from sync `httpx.Client` to async `httpx.AsyncClient`.
- **Agent lifecycle hooks** — adds `on_complete` and `on_pause` parameters to `agent()`. Hooks fire with `(agent_id, value)` after the agent returns or when `PauseRequested` is raised. Fire-and-forget — failures logged, never affect return value. Supports both sync and async hooks via `inspect.isawaitable`.
- **`MemoryProvider` refactor** — renames `workflow` → `agent` across the protocol, both providers (InMemory, SqlAlchemy), and `MemoryEntry`. `LongTermMemory` now takes an explicit `agent: str` parameter instead of deriving from `ExecutionContext`.

### Working Memory Enhancements
- **Full tool interaction storage** — agent loop now stores `tool_call` (canonical JSON with call IDs, names, arguments) and `tool_result` (call_id, name, raw output) in working memory alongside `user` and `assistant` messages.
- **Formatter reconstitution** — all 4 formatters (Anthropic, OpenAI, Ollama, Gemini) reconstitute `tool_call`/`tool_result` roles from working memory into provider-specific message format via `_convert_memory_messages()`.
- **Two-tier compaction** — new `compact_model`, `compact_threshold`, `compact_preserve` parameters. Tier 1: mechanical tool result pruning (truncate old outputs to 200 chars). Tier 2: LLM summarization with structured 6-section prompt. Triggered inside `memorize()` with recursive guard.

### AI Dreaming
- **`dream()` hook factory** — returns an async hook that captures a working memory snapshot via `recall()` and submits the `agent_dream` workflow asynchronously.
- **`agent_dream` workflow** — four-phase memory consolidation pipeline (orient → gather signal → consolidate → prune). Reads working memory snapshot instead of raw execution events. Uses existing LTM tools (`recall_memory`, `store_memory`, `forget_memory`, `list_memory_keys`).
- **Failure gate** — max consecutive failure tracking in LTM (`_dream:failures` key). Skips after 3 failures, resets on success. Handles non-integer stored values gracefully.

### Other
- Bumps version to 0.22.0
- Adds `dreaming_agent_ollama.py` example demonstrating the full stack
- Updates all memory examples for the `agent` parameter

## Test plan
- [x] `call` async mode: submits to `/run/async`, returns execution_id (2 tests)
- [x] Agent hooks: on_complete/on_pause fire correctly, failures don't affect result, multiple hooks (5 tests)
- [x] LTM refactor: all memory tests updated for `agent` parameter (42 tests)
- [x] Working memory: new roles, compaction marks+skips, tool pruning, preserve window (11 tests)
- [x] Formatters: reconstitute tool_call/tool_result for Anthropic, OpenAI, Ollama (3 tests)
- [x] Dream factory: returns callable, submits WM snapshot, custom workflow, error handling (4 tests)
- [x] Dream phases: prompts validated, failure gate, workflow structure (14 tests)
- [x] Full test suite: 1183 passed, 0 failures
- [x] E2E server/worker: dreaming_agent registered, executed, dream hook fired async
- [x] E2E event inspection: 26 events showing full tool_call/tool_result storage in WM
- [x] E2E dream workflow: received WM snapshot, completed 4-phase consolidation
- [x] Regression: hello_world, system_tools_agent_ollama all pass via server/worker