### PR TITLE
feat: reasoning model support — capture, passthrough, working memory, effort config

### DIFF
--- a/docs/advanced-features/ai-agents.md
+++ b/docs/advanced-features/ai-agents.md
@@ -332,3 +332,9 @@ await agent(
     stream: bool = True,
 ) -> task
 ```
+
+## Reasoning Models
+
+For models that support chain-of-thought reasoning (Qwen3, DeepSeek-R1,
+Claude extended thinking, OpenAI o-series, Gemini thinking), see
+[Reasoning Models](reasoning-models.md).

--- a/docs/advanced-features/reasoning-models.md
+++ b/docs/advanced-features/reasoning-models.md
@@ -28,7 +28,7 @@ its response. Flux automatically:
 
 1. **Captures** the reasoning from the model response
 2. **Passes it back** on subsequent turns (required by Anthropic, OpenAI, Gemini)
-3. **Stores it** in working memory as a `thinking` role for pause/resume persistence
+3. **Stores it** in working memory as a `reasoning` role for pause/resume persistence
 
 ## Provider Support
 
@@ -41,16 +41,16 @@ its response. Flux automatically:
 
 ## Working Memory
 
-Reasoning is stored as `thinking` role messages in working memory, positioned
+Reasoning is stored as `reasoning` role messages in working memory, positioned
 before the associated assistant response or tool call. This preserves the
 reasoning context across pause/resume cycles.
 
 ```
 user       → "Find all Python files"
-thinking   → {"text": "I should use find_files...", "opaque": {...}}
+reasoning  → {"text": "I should use find_files...", "opaque": {...}}
 tool_call  → {"calls": [...]}
 tool_result → {"call_id": "...", "output": "..."}
-thinking   → {"text": "Now I need to read each...", "opaque": {...}}
+reasoning  → {"text": "Now I need to read each...", "opaque": {...}}
 assistant  → "I found 3 Python files..."
 ```
 

--- a/docs/advanced-features/reasoning-models.md
+++ b/docs/advanced-features/reasoning-models.md
@@ -1,0 +1,76 @@
+# Reasoning Models
+
+Flux supports reasoning/chain-of-thought models that show their thinking process
+alongside tool calling. When enabled, the model's reasoning traces are captured,
+passed through on subsequent turns, and stored in working memory.
+
+## Quick Start
+
+```python
+from flux.tasks.ai import agent, system_tools
+from flux.tasks.ai.memory import working_memory
+
+assistant = await agent(
+    "You are a helpful assistant.",
+    model="ollama/qwen3",
+    tools=system_tools(workspace="/path/to/project"),
+    working_memory=working_memory(),
+    reasoning_effort="high",  # "low", "medium", "high"
+)
+
+answer = await assistant("Analyze the codebase")
+```
+
+## How It Works
+
+When `reasoning_effort` is set, the model produces a reasoning trace before
+its response. Flux automatically:
+
+1. **Captures** the reasoning from the model response
+2. **Passes it back** on subsequent turns (required by Anthropic, OpenAI, Gemini)
+3. **Stores it** in working memory as a `thinking` role for pause/resume persistence
+
+## Provider Support
+
+| Provider | Reasoning Field | Effort Mapping | Passback Required |
+|---|---|---|---|
+| Ollama | `message.thinking` | `think=True` for all levels | No |
+| Anthropic | `thinking` content blocks | Adaptive thinking with effort level | Yes (with signature) |
+| OpenAI | `message.reasoning_content` | `reasoning_effort` parameter | Yes (where available) |
+| Gemini | `part.thought=True` parts | `thinking_budget` in tokens | Yes |
+
+## Working Memory
+
+Reasoning is stored as `thinking` role messages in working memory, positioned
+before the associated assistant response or tool call. This preserves the
+reasoning context across pause/resume cycles.
+
+```
+user       → "Find all Python files"
+thinking   → {"text": "I should use find_files...", "opaque": {...}}
+tool_call  → {"calls": [...]}
+tool_result → {"call_id": "...", "output": "..."}
+thinking   → {"text": "Now I need to read each...", "opaque": {...}}
+assistant  → "I found 3 Python files..."
+```
+
+## Configuration
+
+`reasoning_effort` accepts:
+
+- `None` — reasoning disabled (default)
+- `"low"` — minimal reasoning
+- `"medium"` — balanced reasoning
+- `"high"` — deep reasoning
+
+The mapping to provider-specific settings is handled internally.
+Non-reasoning models silently ignore the parameter.
+
+## Supported Models
+
+| Provider | Models |
+|---|---|
+| Ollama | Qwen3, DeepSeek-R1, QwQ, Gemma 3 |
+| Anthropic | Claude Sonnet 4, Claude Opus 4 (adaptive thinking) |
+| OpenAI | o1, o3, o4-mini (via compatible endpoints) |
+| Gemini | Gemini 2.5 Flash, Gemini 2.5 Pro |

--- a/examples/ai/reasoning_agent_ollama.py
+++ b/examples/ai/reasoning_agent_ollama.py
@@ -1,0 +1,102 @@
+"""
+Reasoning Agent with Chain-of-Thought using Ollama.
+
+Demonstrates an agent that uses reasoning/thinking models to show its
+chain of thought while calling tools. The thinking traces are stored
+in working memory and visible in execution events.
+
+Prerequisites:
+    1. Install Ollama: https://ollama.ai
+    2. Pull a reasoning model: ollama pull qwen3
+    3. Start Ollama service: ollama serve
+
+Usage (in-process):
+    python examples/ai/reasoning_agent_ollama.py
+
+Usage (server/worker):
+    flux start server
+    flux start worker
+    flux workflow register examples/ai/reasoning_agent_ollama.py
+    flux workflow run reasoning_agent '{"message": "What files are in the workspace?", "reasoning_effort": "high"}'
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from flux import ExecutionContext, workflow
+from flux.config import Configuration
+from flux.tasks.ai import agent, system_tools
+from flux.tasks.ai.memory import working_memory
+
+
+@workflow
+async def reasoning_agent(ctx: ExecutionContext[dict[str, Any]]):
+    """Agent with reasoning/thinking enabled."""
+    input_data = ctx.input or {}
+    message = input_data.get("message", "List all files in the workspace")
+    model = input_data.get("model", "ollama/qwen3")
+    effort = input_data.get("reasoning_effort", "high")
+
+    flux_home = Path(Configuration.get().settings.home)
+    workspace = flux_home / "reasoning"
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    wm = working_memory(max_tokens=50_000)
+    tools = system_tools(workspace=str(workspace), timeout=30)
+
+    assistant = await agent(
+        "You are a helpful assistant. Think carefully before acting. "
+        "Use your tools to accomplish tasks.",
+        model=model,
+        name="reasoning_agent",
+        tools=tools,
+        working_memory=wm,
+        reasoning_effort=effort,
+        max_tool_calls=10,
+        stream=False,
+    )
+
+    answer = await assistant(message)
+
+    wm_messages = wm.recall()
+    thinking_messages = [m for m in wm_messages if m["role"] == "thinking"]
+
+    return {
+        "answer": answer,
+        "thinking_count": len(thinking_messages),
+        "thinking_traces": [m["content"] for m in thinking_messages],
+        "working_memory_roles": [m["role"] for m in wm_messages],
+    }
+
+
+if __name__ == "__main__":
+    import json
+
+    flux_home = Path(Configuration.get().settings.home)
+    workspace = flux_home / "reasoning"
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / "hello.py").write_text('def greet(name):\n    return f"Hello, {name}!"\n')
+    (workspace / "config.yaml").write_text("database: postgres\nport: 5432\n")
+
+    print(f"Workspace: {workspace}")
+    print("=" * 70)
+
+    result = reasoning_agent.run(
+        {
+            "message": "List all files and read hello.py. What does the greet function do?",
+            "reasoning_effort": "high",
+        },
+    )
+
+    if result.has_succeeded:
+        output = result.output
+        print(f"\nAnswer: {output['answer'][:300]}")
+        print(f"\nThinking traces ({output['thinking_count']}):")
+        for i, trace in enumerate(output["thinking_traces"]):
+            data = json.loads(trace)
+            text = data.get("text", "")
+            print(f"  {i + 1}. {text[:150]}...")
+        print(f"\nWM roles: {output['working_memory_roles']}")
+    elif result.has_failed:
+        print(f"Failed: {result.output}")

--- a/examples/ai/reasoning_agent_ollama.py
+++ b/examples/ai/reasoning_agent_ollama.py
@@ -17,37 +17,91 @@ Usage (server/worker):
     flux start server
     flux start worker
     flux workflow register examples/ai/reasoning_agent_ollama.py
-    flux workflow run reasoning_agent '{"message": "What files are in the workspace?", "reasoning_effort": "high"}'
+    flux workflow run reasoning_agent '{"question": "Compare Python and Rust for building web APIs"}'
 """
 from __future__ import annotations
 
-from pathlib import Path
+import asyncio
 from typing import Any
 
-from flux import ExecutionContext, workflow
-from flux.config import Configuration
-from flux.tasks.ai import agent, system_tools
+from flux import ExecutionContext, task, workflow
+from flux.tasks.ai import agent
 from flux.tasks.ai.memory import working_memory
+
+
+@task
+async def search_topic(topic: str) -> str:
+    """Search for information about a topic. Use this to research specific subjects."""
+    await asyncio.sleep(0.5)
+    knowledge = {
+        "python web frameworks": (
+            "Python has several popular web frameworks: FastAPI (async, high performance, "
+            "auto-generated docs), Django (batteries-included, ORM, admin panel), and "
+            "Flask (lightweight, flexible). FastAPI is the fastest-growing for APIs."
+        ),
+        "rust web frameworks": (
+            "Rust web frameworks include Actix Web (fastest benchmarks), Axum (built on "
+            "Tokio, ergonomic), and Rocket (easy to use, macro-based). Rust web servers "
+            "typically outperform Python by 10-50x in throughput."
+        ),
+        "python": (
+            "Python is a high-level, interpreted language known for readability and a vast "
+            "ecosystem. Widely used in web development, data science, AI/ML, and scripting. "
+            "GIL limits true parallelism but asyncio enables concurrent I/O."
+        ),
+        "rust": (
+            "Rust is a systems programming language focused on safety, speed, and concurrency. "
+            "No garbage collector, ownership model prevents memory bugs at compile time. "
+            "Growing adoption in web services, CLI tools, and infrastructure."
+        ),
+    }
+    topic_lower = topic.lower()
+    for key, value in knowledge.items():
+        if key in topic_lower:
+            return value
+    return f"Research results for '{topic}': General information about {topic}."
+
+
+@task
+async def get_statistics(subject: str) -> str:
+    """Get statistics and benchmarks about a technology or subject."""
+    await asyncio.sleep(0.5)
+    stats = {
+        "python": "Python: ~30% of developers use it (Stack Overflow 2025), 400k+ PyPI packages, avg API latency 50-200ms",
+        "rust": "Rust: ~13% of developers use it (Stack Overflow 2025), most admired language 8 years running, avg API latency 1-10ms",
+        "web api": "Web API benchmarks (TechEmpower 2025): Rust Actix ~700k req/s, Python FastAPI ~15k req/s, Go Gin ~300k req/s",
+    }
+    subject_lower = subject.lower()
+    for key, value in stats.items():
+        if key in subject_lower:
+            return value
+    return f"Statistics for '{subject}': No specific benchmarks available."
 
 
 @workflow
 async def reasoning_agent(ctx: ExecutionContext[dict[str, Any]]):
-    """Agent with reasoning/thinking enabled."""
+    """
+    Research assistant with reasoning/thinking enabled.
+
+    Input format:
+    {
+        "question": "Your research question",
+        "model": "ollama/qwen3",
+        "reasoning_effort": "high"
+    }
+    """
     input_data = ctx.input or {}
-    message = input_data.get("message", "List all files in the workspace")
+    question = input_data.get("question", "Compare Python and Rust for web development")
     model = input_data.get("model", "ollama/qwen3")
     effort = input_data.get("reasoning_effort", "high")
 
-    flux_home = Path(Configuration.get().settings.home)
-    workspace = flux_home / "reasoning"
-    workspace.mkdir(parents=True, exist_ok=True)
-
     wm = working_memory(max_tokens=50_000)
-    tools = system_tools(workspace=str(workspace), timeout=30)
+    tools = [search_topic, get_statistics]
 
     assistant = await agent(
-        "You are a helpful assistant. Think carefully before acting. "
-        "Use your tools to accomplish tasks.",
+        "You are a research assistant. Think carefully before acting. "
+        "Use search_topic to gather information and get_statistics for data. "
+        "Synthesize findings into a clear, balanced comparison.",
         model=model,
         name="reasoning_agent",
         tools=tools,
@@ -57,15 +111,16 @@ async def reasoning_agent(ctx: ExecutionContext[dict[str, Any]]):
         stream=False,
     )
 
-    answer = await assistant(message)
+    answer = await assistant(question)
 
     wm_messages = wm.recall()
-    thinking_messages = [m for m in wm_messages if m["role"] == "thinking"]
+    reasoning_messages = [m for m in wm_messages if m["role"] == "reasoning"]
 
     return {
+        "question": question,
         "answer": answer,
-        "thinking_count": len(thinking_messages),
-        "thinking_traces": [m["content"] for m in thinking_messages],
+        "thinking_count": len(reasoning_messages),
+        "thinking_traces": [m["content"] for m in reasoning_messages],
         "working_memory_roles": [m["role"] for m in wm_messages],
     }
 
@@ -73,25 +128,22 @@ async def reasoning_agent(ctx: ExecutionContext[dict[str, Any]]):
 if __name__ == "__main__":
     import json
 
-    flux_home = Path(Configuration.get().settings.home)
-    workspace = flux_home / "reasoning"
-    workspace.mkdir(parents=True, exist_ok=True)
-    (workspace / "hello.py").write_text('def greet(name):\n    return f"Hello, {name}!"\n')
-    (workspace / "config.yaml").write_text("database: postgres\nport: 5432\n")
-
-    print(f"Workspace: {workspace}")
+    print("=" * 70)
+    print("Reasoning Agent — Chain-of-Thought with Tool Calling")
     print("=" * 70)
 
     result = reasoning_agent.run(
         {
-            "message": "List all files and read hello.py. What does the greet function do?",
+            "question": "Compare Python and Rust for building web APIs. "
+            "Which is better for a startup building a real-time trading platform?",
             "reasoning_effort": "high",
         },
     )
 
     if result.has_succeeded:
         output = result.output
-        print(f"\nAnswer: {output['answer'][:300]}")
+        print(f"\nQuestion: {output['question']}")
+        print(f"\nAnswer:\n{output['answer'][:500]}")
         print(f"\nThinking traces ({output['thinking_count']}):")
         for i, trace in enumerate(output["thinking_traces"]):
             data = json.loads(trace)

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -40,6 +40,7 @@ async def agent(
     approval_mode: str = "default",
     on_complete: list[Callable] | None = None,
     on_pause: list[Callable] | None = None,
+    reasoning_effort: str | None = None,
 ) -> task:
     """Create a Flux @task that calls an LLM.
 
@@ -77,6 +78,8 @@ async def agent(
             Failures are logged but never affect the return value.
         on_pause: List of hook callables fired when the agent pauses (PauseRequested).
             Same signature as on_complete. Fired before the pause propagates.
+        reasoning_effort: Configure reasoning/thinking depth. "low", "medium", "high",
+            or None (disabled). Provider-specific mapping is applied internally.
 
     Returns:
         A Flux @task callable with signature (instruction: str, *, context: str = "") -> str | BaseModel
@@ -147,7 +150,11 @@ async def agent(
         from flux.tasks.ai.ollama import OllamaFormatter, _to_ollama_tools, build_ollama_provider
         from flux.tasks.ai.tool_executor import build_tool_schemas
 
-        llm_task, formatter = build_ollama_provider(model_name, response_format=response_format)
+        llm_task, formatter = build_ollama_provider(
+            model_name,
+            response_format=response_format,
+            reasoning_effort=reasoning_effort,
+        )
 
         tool_schemas = build_tool_schemas(tools) if tools else None
         ollama_tools = _to_ollama_tools(tool_schemas) if tool_schemas else None
@@ -186,7 +193,11 @@ async def agent(
         from flux.tasks.ai.openai import _to_openai_tools, build_openai_provider
         from flux.tasks.ai.tool_executor import build_tool_schemas
 
-        llm_task, formatter = build_openai_provider(model_name, response_format=response_format)
+        llm_task, formatter = build_openai_provider(
+            model_name,
+            response_format=response_format,
+            reasoning_effort=reasoning_effort,
+        )
 
         tool_schemas = build_tool_schemas(tools) if tools else None
         openai_tools = _to_openai_tools(tool_schemas) if tool_schemas else None
@@ -221,7 +232,11 @@ async def agent(
         from flux.tasks.ai.anthropic import _to_anthropic_tools, build_anthropic_provider
         from flux.tasks.ai.tool_executor import build_tool_schemas
 
-        llm_task, formatter = build_anthropic_provider(model_name, max_tokens=max_tokens)
+        llm_task, formatter = build_anthropic_provider(
+            model_name,
+            max_tokens=max_tokens,
+            reasoning_effort=reasoning_effort,
+        )
 
         tool_schemas = build_tool_schemas(tools) if tools else None
         anthropic_tools = _to_anthropic_tools(tool_schemas) if tool_schemas else None
@@ -260,6 +275,7 @@ async def agent(
             model_name,
             max_tokens=max_tokens,
             response_format=response_format,
+            reasoning_effort=reasoning_effort,
         )
 
         tool_schemas = build_tool_schemas(tools) if tools else None

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -84,6 +84,11 @@ async def agent(
     Returns:
         A Flux @task callable with signature (instruction: str, *, context: str = "") -> str | BaseModel
     """
+    if reasoning_effort is not None and reasoning_effort not in ("low", "medium", "high"):
+        raise ValueError(
+            f"reasoning_effort must be 'low', 'medium', 'high', or None, got: '{reasoning_effort}'",
+        )
+
     if skills is not None:
         from flux.tasks.ai.skills import build_skills_preamble, build_use_skill
 

--- a/flux/tasks/ai/agent_loop.py
+++ b/flux/tasks/ai/agent_loop.py
@@ -35,6 +35,21 @@ async def _fire_hooks(hooks: list[Any] | None, agent_name: str, value: Any) -> N
             logger.warning("Hook %s failed", hook, exc_info=True)
 
 
+async def _store_reasoning(working_memory: Any, response: Any) -> None:
+    if working_memory and hasattr(response, "reasoning") and response.reasoning:
+        import json
+
+        await working_memory.memorize(
+            "thinking",
+            json.dumps(
+                {
+                    "text": response.reasoning.text,
+                    "opaque": response.reasoning.opaque,
+                },
+            ),
+        )
+
+
 async def run_agent_loop(
     *,
     llm_task: TaskType,
@@ -94,6 +109,7 @@ async def run_agent_loop(
     result = await llm_task.with_options(name=f"llm_{call_counter}")(messages, **call_kwargs)
     call_counter += 1
     response = _ensure_llm_response(result)
+    await _store_reasoning(working_memory, response)
 
     always_approved: set[str] = set()
 
@@ -167,6 +183,7 @@ async def run_agent_loop(
         result = await llm_task.with_options(name=f"llm_{call_counter}")(messages, **call_kwargs)
         call_counter += 1
         response = _ensure_llm_response(result)
+        await _store_reasoning(working_memory, response)
 
         if (
             not response.tool_calls
@@ -186,6 +203,7 @@ async def run_agent_loop(
             )
             call_counter += 1
             response = _ensure_llm_response(result)
+            await _store_reasoning(working_memory, response)
 
     if response.tool_calls and tool_call_count >= max_tool_calls:
         messages.append(formatter.format_assistant_message(response))
@@ -198,6 +216,7 @@ async def run_agent_loop(
         result = await llm_task.with_options(name=f"llm_{call_counter}")(messages, **no_tool_kwargs)
         call_counter += 1
         response = _ensure_llm_response(result)
+        await _store_reasoning(working_memory, response)
 
     content = response.text
 

--- a/flux/tasks/ai/agent_loop.py
+++ b/flux/tasks/ai/agent_loop.py
@@ -39,12 +39,18 @@ async def _store_reasoning(working_memory: Any, response: Any) -> None:
     if working_memory and hasattr(response, "reasoning") and response.reasoning:
         import json
 
+        opaque = response.reasoning.opaque
+        try:
+            json.dumps(opaque)
+        except (TypeError, ValueError):
+            opaque = str(opaque) if opaque is not None else None
+
         await working_memory.memorize(
             "reasoning",
             json.dumps(
                 {
                     "text": response.reasoning.text,
-                    "opaque": response.reasoning.opaque,
+                    "opaque": opaque,
                 },
             ),
         )

--- a/flux/tasks/ai/agent_loop.py
+++ b/flux/tasks/ai/agent_loop.py
@@ -40,7 +40,7 @@ async def _store_reasoning(working_memory: Any, response: Any) -> None:
         import json
 
         await working_memory.memorize(
-            "thinking",
+            "reasoning",
             json.dumps(
                 {
                     "text": response.reasoning.text,

--- a/flux/tasks/ai/anthropic.py
+++ b/flux/tasks/ai/anthropic.py
@@ -54,18 +54,18 @@ class AnthropicFormatter(LLMFormatter):
         import json
 
         converted = []
-        pending_thinking: dict | None = None
+        pending_reasoning: dict | None = None
         for msg in memory_messages:
             role, content = msg["role"], msg["content"]
-            if role == "thinking":
+            if role == "reasoning":
                 data = json.loads(content)
-                pending_thinking = data.get("opaque")
+                pending_reasoning = data.get("opaque")
             elif role == "tool_call":
                 data = json.loads(content)
                 blocks: list[dict] = []
-                if pending_thinking is not None:
-                    blocks.append(pending_thinking)
-                    pending_thinking = None
+                if pending_reasoning is not None:
+                    blocks.append(pending_reasoning)
+                    pending_reasoning = None
                 blocks.extend(
                     {
                         "type": "tool_use",
@@ -91,9 +91,9 @@ class AnthropicFormatter(LLMFormatter):
                     },
                 )
             elif role == "assistant":
-                if pending_thinking is not None:
-                    blocks = [pending_thinking, {"type": "text", "text": content}]
-                    pending_thinking = None
+                if pending_reasoning is not None:
+                    blocks = [pending_reasoning, {"type": "text", "text": content}]
+                    pending_reasoning = None
                     converted.append({"role": "assistant", "content": blocks})
                 else:
                     converted.append({"role": "assistant", "content": content})

--- a/flux/tasks/ai/anthropic.py
+++ b/flux/tasks/ai/anthropic.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from flux.task import task
 from flux.tasks.ai.formatter import LLMFormatter
-from flux.tasks.ai.models import LLMResponse, ToolCall
+from flux.tasks.ai.models import LLMResponse, ReasoningContent, ToolCall
 
 try:
     from anthropic import AsyncAnthropic
@@ -16,6 +16,7 @@ except ImportError:
 def build_anthropic_provider(
     model_name: str,
     max_tokens: int = 4096,
+    reasoning_effort: str | None = None,
 ) -> tuple[task, LLMFormatter]:
     if AsyncAnthropic is None:
         raise ImportError(
@@ -32,25 +33,40 @@ def build_anthropic_provider(
         )
         return _to_llm_response(response)
 
-    formatter = AnthropicFormatter(client, model_name, max_tokens)
+    formatter = AnthropicFormatter(client, model_name, max_tokens, reasoning_effort)
     return anthropic_llm, formatter
 
 
 class AnthropicFormatter(LLMFormatter):
-    def __init__(self, client: Any, model_name: str, max_tokens: int) -> None:
+    def __init__(
+        self,
+        client: Any,
+        model_name: str,
+        max_tokens: int,
+        reasoning_effort: str | None = None,
+    ) -> None:
         self._client = client
         self._model_name = model_name
         self._max_tokens = max_tokens
+        self._reasoning_effort = reasoning_effort
 
     def _convert_memory_messages(self, memory_messages: list[dict]) -> list[dict]:
         import json
 
         converted = []
+        pending_thinking: dict | None = None
         for msg in memory_messages:
             role, content = msg["role"], msg["content"]
-            if role == "tool_call":
+            if role == "thinking":
                 data = json.loads(content)
-                blocks = [
+                pending_thinking = data.get("opaque")
+            elif role == "tool_call":
+                data = json.loads(content)
+                blocks: list[dict] = []
+                if pending_thinking is not None:
+                    blocks.append(pending_thinking)
+                    pending_thinking = None
+                blocks.extend(
                     {
                         "type": "tool_use",
                         "id": c["id"],
@@ -58,7 +74,7 @@ class AnthropicFormatter(LLMFormatter):
                         "input": c.get("arguments", {}),
                     }
                     for c in data["calls"]
-                ]
+                )
                 converted.append({"role": "assistant", "content": blocks})
             elif role == "tool_result":
                 data = json.loads(content)
@@ -74,7 +90,14 @@ class AnthropicFormatter(LLMFormatter):
                         ],
                     },
                 )
-            elif role in ("user", "assistant"):
+            elif role == "assistant":
+                if pending_thinking is not None:
+                    blocks = [pending_thinking, {"type": "text", "text": content}]
+                    pending_thinking = None
+                    converted.append({"role": "assistant", "content": blocks})
+                else:
+                    converted.append({"role": "assistant", "content": content})
+            elif role == "user":
                 converted.append({"role": role, "content": content})
         if not converted:
             return converted
@@ -112,10 +135,15 @@ class AnthropicFormatter(LLMFormatter):
             "system": system_prompt,
             "max_tokens": self._max_tokens,
         }
+        if self._reasoning_effort:
+            call_kwargs["thinking"] = {"type": "adaptive"}
+            call_kwargs["output_config"] = {"effort": self._reasoning_effort}
         return messages, call_kwargs
 
     def format_assistant_message(self, response: LLMResponse) -> dict:
         content: list[dict[str, Any]] = []
+        if response.reasoning and response.reasoning.opaque:
+            content.append(response.reasoning.opaque)
         if response.text:
             content.append({"type": "text", "text": response.text})
         for tc in response.tool_calls:
@@ -163,8 +191,18 @@ class AnthropicFormatter(LLMFormatter):
 def _to_llm_response(response: Any) -> LLMResponse:
     text_parts: list[str] = []
     tool_calls: list[ToolCall] = []
+    reasoning: ReasoningContent | None = None
     for block in response.content:
-        if block.type == "text":
+        if block.type == "thinking":
+            reasoning = ReasoningContent(
+                text=block.thinking,
+                opaque={
+                    "type": "thinking",
+                    "thinking": block.thinking,
+                    "signature": getattr(block, "signature", None),
+                },
+            )
+        elif block.type == "text":
             text_parts.append(block.text)
         elif block.type == "tool_use":
             tool_calls.append(
@@ -173,6 +211,7 @@ def _to_llm_response(response: Any) -> LLMResponse:
     return LLMResponse(
         text="\n".join(text_parts) if text_parts else "",
         tool_calls=tool_calls,
+        reasoning=reasoning,
     )
 
 

--- a/flux/tasks/ai/gemini.py
+++ b/flux/tasks/ai/gemini.py
@@ -99,7 +99,7 @@ class GeminiFormatter(LLMFormatter):
                         ],
                     ),
                 )
-            elif role == "thinking":
+            elif role == "reasoning":
                 data = json.loads(content)
                 opaque = data.get("opaque") or {}
                 thought_text = opaque.get("text", data.get("text", ""))
@@ -240,12 +240,12 @@ def _to_llm_response(response: Any) -> LLMResponse:
     candidates = getattr(response, "candidates", None)
     if candidates:
         parts = getattr(candidates[0].content, "parts", None) or []
-        thinking_parts: list[str] = []
+        reasoning_parts: list[str] = []
         text_parts: list[str] = []
         for part in parts:
             if getattr(part, "thought", False):
                 if part.text:
-                    thinking_parts.append(part.text)
+                    reasoning_parts.append(part.text)
             elif getattr(part, "function_call", None):
                 fc = part.function_call
                 tool_calls.append(
@@ -258,8 +258,8 @@ def _to_llm_response(response: Any) -> LLMResponse:
             elif getattr(part, "text", None):
                 text_parts.append(part.text)
 
-        if thinking_parts:
-            joined = "".join(thinking_parts)
+        if reasoning_parts:
+            joined = "".join(reasoning_parts)
             reasoning = ReasoningContent(
                 text=joined,
                 opaque={"text": joined, "thought": True},

--- a/flux/tasks/ai/gemini.py
+++ b/flux/tasks/ai/gemini.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from flux.task import task
 from flux.tasks.ai.formatter import LLMFormatter
-from flux.tasks.ai.models import LLMResponse, ToolCall
+from flux.tasks.ai.models import LLMResponse, ReasoningContent, ToolCall
 
 try:
     from google import genai
@@ -21,6 +21,7 @@ def build_gemini_provider(
     model_name: str,
     max_tokens: int = 4096,
     response_format: type[BaseModel] | None = None,
+    reasoning_effort: str | None = None,
 ) -> tuple[task, LLMFormatter]:
     if genai is None:
         raise ImportError(
@@ -47,7 +48,7 @@ def build_gemini_provider(
         )
         return _to_llm_response(response)
 
-    formatter = GeminiFormatter(model_name, max_tokens, response_format)
+    formatter = GeminiFormatter(model_name, max_tokens, response_format, reasoning_effort)
     return gemini_llm, formatter
 
 
@@ -57,10 +58,12 @@ class GeminiFormatter(LLMFormatter):
         model_name: str,
         max_tokens: int,
         response_format: type[BaseModel] | None = None,
+        reasoning_effort: str | None = None,
     ) -> None:
         self._model_name = model_name
         self._max_tokens = max_tokens
         self._response_format = response_format
+        self._reasoning_effort = reasoning_effort
 
     def _convert_memory_messages(self, memory_messages: list[dict]) -> list:
         import json
@@ -96,6 +99,16 @@ class GeminiFormatter(LLMFormatter):
                         ],
                     ),
                 )
+            elif role == "thinking":
+                data = json.loads(content)
+                opaque = data.get("opaque") or {}
+                thought_text = opaque.get("text", data.get("text", ""))
+                converted.append(
+                    _types.Content(
+                        role="model",
+                        parts=[_types.Part(text=thought_text, thought=True)],
+                    ),
+                )
             elif role in ("user", "assistant"):
                 converted.append(_to_content(role, content))
         return converted
@@ -120,6 +133,11 @@ class GeminiFormatter(LLMFormatter):
         if self._response_format:
             config_kwargs["response_mime_type"] = "application/json"
             config_kwargs["response_schema"] = self._response_format
+        if self._reasoning_effort:
+            budget_map = {"low": 1024, "medium": 4096, "high": 16384}
+            config_kwargs["thinking_config"] = types.ThinkingConfig(
+                thinking_budget=budget_map.get(self._reasoning_effort, 4096),
+            )
 
         config = types.GenerateContentConfig(**config_kwargs)
 
@@ -131,6 +149,9 @@ class GeminiFormatter(LLMFormatter):
 
     def format_assistant_message(self, response: LLMResponse) -> Any:
         parts = []
+        if response.reasoning and response.reasoning.opaque:
+            opaque = response.reasoning.opaque
+            parts.append(types.Part(text=opaque["text"], thought=True))
         if response.text:
             parts.append(types.Part(text=response.text))
         for tc in response.tool_calls:
@@ -213,18 +234,60 @@ def _to_content(role: str, text: str) -> Any:
 
 
 def _to_llm_response(response: Any) -> LLMResponse:
-    text = response.text or ""
+    reasoning: ReasoningContent | None = None
     tool_calls: list[ToolCall] = []
-    if response.function_calls:
-        for fc in response.function_calls:
-            tool_calls.append(
-                ToolCall(
-                    id=fc.name,
-                    name=fc.name,
-                    arguments=dict(fc.args),
-                ),
+
+    candidates = getattr(response, "candidates", None)
+    if candidates:
+        parts = getattr(candidates[0].content, "parts", None) or []
+        thinking_parts: list[str] = []
+        text_parts: list[str] = []
+        for part in parts:
+            if getattr(part, "thought", False):
+                if part.text:
+                    thinking_parts.append(part.text)
+            elif getattr(part, "function_call", None):
+                fc = part.function_call
+                tool_calls.append(
+                    ToolCall(
+                        id=fc.name,
+                        name=fc.name,
+                        arguments=dict(fc.args),
+                    ),
+                )
+            elif getattr(part, "text", None):
+                text_parts.append(part.text)
+
+        if thinking_parts:
+            joined = "".join(thinking_parts)
+            reasoning = ReasoningContent(
+                text=joined,
+                opaque={"text": joined, "thought": True},
             )
-    return LLMResponse(text=text, tool_calls=tool_calls)
+
+        text = "".join(text_parts) if text_parts else (response.text or "")
+        if not tool_calls and response.function_calls:
+            for fc in response.function_calls:
+                tool_calls.append(
+                    ToolCall(
+                        id=fc.name,
+                        name=fc.name,
+                        arguments=dict(fc.args),
+                    ),
+                )
+    else:
+        text = response.text or ""
+        if response.function_calls:
+            for fc in response.function_calls:
+                tool_calls.append(
+                    ToolCall(
+                        id=fc.name,
+                        name=fc.name,
+                        arguments=dict(fc.args),
+                    ),
+                )
+
+    return LLMResponse(text=text, tool_calls=tool_calls, reasoning=reasoning)
 
 
 def _to_gemini_tools(schemas: list[dict[str, Any]]) -> list:

--- a/flux/tasks/ai/models.py
+++ b/flux/tasks/ai/models.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel
 
 
@@ -9,6 +11,12 @@ class ToolCall(BaseModel):
     arguments: dict
 
 
+class ReasoningContent(BaseModel):
+    text: str | None = None
+    opaque: Any = None
+
+
 class LLMResponse(BaseModel):
     text: str = ""
     tool_calls: list[ToolCall] = []
+    reasoning: ReasoningContent | None = None

--- a/flux/tasks/ai/ollama.py
+++ b/flux/tasks/ai/ollama.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from flux.task import task
 from flux.tasks.ai.formatter import LLMFormatter
-from flux.tasks.ai.models import LLMResponse, ToolCall
+from flux.tasks.ai.models import LLMResponse, ReasoningContent, ToolCall
 from flux.tasks.ai.tool_executor import (
     extract_tool_calls_from_content,
     strip_tool_calls_from_content,
@@ -21,6 +21,7 @@ except ImportError:
 def build_ollama_provider(
     model_name: str,
     response_format: Any | None = None,
+    reasoning_effort: str | None = None,
 ) -> tuple[task, LLMFormatter]:
     if AsyncClient is None:
         raise ImportError(
@@ -38,20 +39,22 @@ def build_ollama_provider(
         response = await client.chat(messages=messages, **kwargs)
         return _to_llm_response(response, tool_names)
 
-    formatter = OllamaFormatter(client, model_name, response_format)
+    formatter = OllamaFormatter(model_name, client, response_format, reasoning_effort)
     return ollama_llm, formatter
 
 
 class OllamaFormatter(LLMFormatter):
     def __init__(
         self,
-        client: Any,
         model_name: str,
+        client: Any = None,
         response_format: Any | None = None,
+        reasoning_effort: str | None = None,
     ) -> None:
         self._client = client
         self._model_name = model_name
         self._response_format = response_format
+        self._reasoning_effort = reasoning_effort
         self._tool_names: set[str] = set()
 
     def set_tool_names(self, tool_names: set[str]) -> None:
@@ -76,6 +79,8 @@ class OllamaFormatter(LLMFormatter):
             elif role == "tool_result":
                 data = json.loads(content)
                 converted.append({"role": "tool", "content": data["output"]})
+            elif role == "thinking":
+                continue
             elif role in ("user", "assistant"):
                 converted.append({"role": role, "content": content})
         return converted
@@ -108,6 +113,9 @@ class OllamaFormatter(LLMFormatter):
 
         if self._tool_names:
             call_kwargs["tool_names"] = self._tool_names
+
+        if self._reasoning_effort is not None:
+            call_kwargs["think"] = True
 
         return messages, call_kwargs
 
@@ -190,7 +198,10 @@ def _to_llm_response(
             ]
             content = strip_tool_calls_from_content(content)
 
-    return LLMResponse(text=content, tool_calls=tool_calls)
+    thinking = message.get("thinking")
+    reasoning = ReasoningContent(text=thinking, opaque=None) if thinking else None
+
+    return LLMResponse(text=content, tool_calls=tool_calls, reasoning=reasoning)
 
 
 def _to_ollama_tools(schemas: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/flux/tasks/ai/ollama.py
+++ b/flux/tasks/ai/ollama.py
@@ -79,7 +79,7 @@ class OllamaFormatter(LLMFormatter):
             elif role == "tool_result":
                 data = json.loads(content)
                 converted.append({"role": "tool", "content": data["output"]})
-            elif role == "thinking":
+            elif role == "reasoning":
                 continue
             elif role in ("user", "assistant"):
                 converted.append({"role": role, "content": content})

--- a/flux/tasks/ai/openai.py
+++ b/flux/tasks/ai/openai.py
@@ -84,7 +84,7 @@ class OpenAIFormatter(LLMFormatter):
                         "content": data["output"],
                     },
                 )
-            elif role == "thinking":
+            elif role == "reasoning":
                 data = json.loads(content)
                 pending_reasoning = (data.get("opaque") or {}).get("reasoning_content")
                 continue

--- a/flux/tasks/ai/openai.py
+++ b/flux/tasks/ai/openai.py
@@ -86,7 +86,9 @@ class OpenAIFormatter(LLMFormatter):
                 )
             elif role == "reasoning":
                 data = json.loads(content)
-                pending_reasoning = (data.get("opaque") or {}).get("reasoning_content")
+                pending_reasoning = (data.get("opaque") or {}).get(
+                    "reasoning_content",
+                ) or data.get("text")
                 continue
             elif role == "assistant":
                 msg_out: dict[str, Any] = {"role": "assistant", "content": content}

--- a/flux/tasks/ai/openai.py
+++ b/flux/tasks/ai/openai.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from flux.task import task
 from flux.tasks.ai.formatter import LLMFormatter
-from flux.tasks.ai.models import LLMResponse, ToolCall
+from flux.tasks.ai.models import LLMResponse, ReasoningContent, ToolCall
 
 try:
     from openai import AsyncOpenAI
@@ -17,6 +17,7 @@ except ImportError:
 def build_openai_provider(
     model_name: str,
     response_format: Any | None = None,
+    reasoning_effort: str | None = None,
 ) -> tuple[task, LLMFormatter]:
     if AsyncOpenAI is None:
         raise ImportError(
@@ -33,7 +34,7 @@ def build_openai_provider(
         )
         return _to_llm_response(response)
 
-    formatter = OpenAIFormatter(client, model_name, response_format)
+    formatter = OpenAIFormatter(client, model_name, response_format, reasoning_effort)
     return openai_llm, formatter
 
 
@@ -43,13 +44,16 @@ class OpenAIFormatter(LLMFormatter):
         client: Any,
         model_name: str,
         response_format: Any | None = None,
+        reasoning_effort: str | None = None,
     ) -> None:
         self._client = client
         self._model_name = model_name
         self._response_format = response_format
+        self._reasoning_effort = reasoning_effort
 
     def _convert_memory_messages(self, memory_messages: list[dict]) -> list[dict]:
         converted = []
+        pending_reasoning = None
         for msg in memory_messages:
             role, content = msg["role"], msg["content"]
             if role == "tool_call":
@@ -80,7 +84,17 @@ class OpenAIFormatter(LLMFormatter):
                         "content": data["output"],
                     },
                 )
-            elif role in ("user", "assistant"):
+            elif role == "thinking":
+                data = json.loads(content)
+                pending_reasoning = (data.get("opaque") or {}).get("reasoning_content")
+                continue
+            elif role == "assistant":
+                msg_out: dict[str, Any] = {"role": "assistant", "content": content}
+                if pending_reasoning:
+                    msg_out["reasoning_content"] = pending_reasoning
+                    pending_reasoning = None
+                converted.append(msg_out)
+            elif role == "user":
                 converted.append({"role": role, "content": content})
         return converted
 
@@ -114,6 +128,9 @@ class OpenAIFormatter(LLMFormatter):
                 },
             }
 
+        if self._reasoning_effort:
+            call_kwargs["reasoning_effort"] = self._reasoning_effort
+
         return messages, call_kwargs
 
     def format_assistant_message(self, response: LLMResponse) -> dict:
@@ -130,6 +147,8 @@ class OpenAIFormatter(LLMFormatter):
                 }
                 for tc in response.tool_calls
             ]
+        if response.reasoning and response.reasoning.opaque:
+            msg["reasoning_content"] = response.reasoning.opaque.get("reasoning_content")
         return msg
 
     def format_tool_results(
@@ -180,7 +199,14 @@ def _to_llm_response(response: Any) -> LLMResponse:
                     arguments=json.loads(tc.function.arguments),
                 ),
             )
-    return LLMResponse(text=text, tool_calls=tool_calls)
+    reasoning: ReasoningContent | None = None
+    reasoning_text = getattr(message, "reasoning_content", None)
+    if reasoning_text:
+        reasoning = ReasoningContent(
+            text=reasoning_text,
+            opaque={"reasoning_content": reasoning_text},
+        )
+    return LLMResponse(text=text, tool_calls=tool_calls, reasoning=reasoning)
 
 
 def _to_openai_tools(schemas: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.22.0"
+version = "0.23.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/tasks/ai/test_openai_provider.py
+++ b/tests/flux/tasks/ai/test_openai_provider.py
@@ -182,6 +182,7 @@ def test_to_llm_response_text_only():
     message = MagicMock()
     message.content = "Hello world"
     message.tool_calls = None
+    message.reasoning_content = None
 
     response = MagicMock()
     response.choices = [MagicMock()]
@@ -205,6 +206,7 @@ def test_to_llm_response_with_tool_calls():
     message = MagicMock()
     message.content = "Let me search."
     message.tool_calls = [tc]
+    message.reasoning_content = None
 
     response = MagicMock()
     response.choices = [MagicMock()]
@@ -225,6 +227,7 @@ def test_to_llm_response_empty():
     message = MagicMock()
     message.content = None
     message.tool_calls = None
+    message.reasoning_content = None
 
     response = MagicMock()
     response.choices = [MagicMock()]
@@ -265,6 +268,7 @@ def test_llm_task_returns_llm_response():
         message = MagicMock()
         message.content = "Hello!"
         message.tool_calls = None
+        message.reasoning_content = None
 
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]

--- a/tests/flux/tasks/ai/test_openai_streaming.py
+++ b/tests/flux/tasks/ai/test_openai_streaming.py
@@ -66,6 +66,7 @@ def test_openai_no_streaming_when_disabled():
         message = MagicMock()
         message.content = "Hello world!"
         message.tool_calls = None
+        message.reasoning_content = None
 
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]

--- a/tests/flux/tasks/ai/test_reasoning.py
+++ b/tests/flux/tasks/ai/test_reasoning.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+
+from flux.tasks.ai.models import LLMResponse, ReasoningContent
+
+
+class TestReasoningContent:
+    def test_defaults_to_none(self):
+        rc = ReasoningContent()
+        assert rc.text is None
+        assert rc.opaque is None
+
+    def test_with_text_only(self):
+        rc = ReasoningContent(text="thinking about it")
+        assert rc.text == "thinking about it"
+        assert rc.opaque is None
+
+    def test_with_text_and_opaque(self):
+        rc = ReasoningContent(
+            text="step by step",
+            opaque={"signature": "abc123"},
+        )
+        assert rc.text == "step by step"
+        assert rc.opaque == {"signature": "abc123"}
+
+
+class TestLLMResponseReasoning:
+    def test_reasoning_defaults_to_none(self):
+        r = LLMResponse(text="hello")
+        assert r.reasoning is None
+
+    def test_reasoning_with_content(self):
+        r = LLMResponse(
+            text="answer",
+            reasoning=ReasoningContent(text="I thought about it"),
+        )
+        assert r.reasoning is not None
+        assert r.reasoning.text == "I thought about it"
+
+    def test_backward_compatible(self):
+        r = LLMResponse(text="hello", tool_calls=[])
+        assert r.text == "hello"
+        assert r.tool_calls == []
+        assert r.reasoning is None

--- a/tests/flux/tasks/ai/test_reasoning.py
+++ b/tests/flux/tasks/ai/test_reasoning.py
@@ -223,3 +223,89 @@ class TestAnthropicReasoning:
         _, kwargs = formatter.build_messages("system", "question", wm)
         assert "thinking" in kwargs
         assert kwargs["thinking"]["type"] == "adaptive"
+
+
+class TestOpenAIReasoning:
+    def test_to_llm_response_captures_reasoning_content(self):
+        from unittest.mock import MagicMock
+
+        from flux.tasks.ai.openai import _to_llm_response
+
+        message = MagicMock()
+        message.content = "The answer."
+        message.tool_calls = None
+        message.reasoning_content = "I reasoned step by step..."
+
+        response = MagicMock()
+        response.choices = [MagicMock(message=message)]
+
+        result = _to_llm_response(response)
+        assert result.reasoning is not None
+        assert result.reasoning.text == "I reasoned step by step..."
+        assert result.reasoning.opaque == {"reasoning_content": "I reasoned step by step..."}
+
+    def test_to_llm_response_no_reasoning(self):
+        from unittest.mock import MagicMock
+
+        from flux.tasks.ai.openai import _to_llm_response
+
+        message = MagicMock()
+        message.content = "Hello"
+        message.tool_calls = None
+        message.reasoning_content = None
+
+        response = MagicMock()
+        response.choices = [MagicMock(message=message)]
+
+        result = _to_llm_response(response)
+        assert result.reasoning is None
+
+    def test_format_assistant_message_includes_reasoning(self):
+        from unittest.mock import MagicMock
+
+        from flux.tasks.ai.openai import OpenAIFormatter
+
+        formatter = OpenAIFormatter(MagicMock(), "gpt-test")
+        response = LLMResponse(
+            text="answer",
+            reasoning=ReasoningContent(
+                text="step by step",
+                opaque={"reasoning_content": "step by step"},
+            ),
+        )
+        msg = formatter.format_assistant_message(response)
+        assert msg.get("reasoning_content") == "step by step"
+
+    def test_convert_memory_handles_thinking_role(self):
+        import json
+        from unittest.mock import MagicMock
+
+        from flux.tasks.ai.openai import OpenAIFormatter
+
+        formatter = OpenAIFormatter(MagicMock(), "gpt-test")
+        messages = [
+            {"role": "user", "content": "question"},
+            {
+                "role": "thinking",
+                "content": json.dumps(
+                    {
+                        "text": "reasoning",
+                        "opaque": {"reasoning_content": "reasoning"},
+                    },
+                ),
+            },
+            {"role": "assistant", "content": "answer"},
+        ]
+        converted = formatter._convert_memory_messages(messages)
+        assistant_msgs = [m for m in converted if m.get("role") == "assistant"]
+        assert any(m.get("reasoning_content") for m in assistant_msgs)
+
+    def test_reasoning_effort_in_call_kwargs(self):
+        from unittest.mock import MagicMock
+
+        from flux.tasks.ai.openai import OpenAIFormatter
+
+        formatter = OpenAIFormatter(MagicMock(), "gpt-test", reasoning_effort="medium")
+        wm = type("FakeWM", (), {"recall": lambda self: []})()
+        _, kwargs = formatter.build_messages("system", "question", wm)
+        assert kwargs.get("reasoning_effort") == "medium"

--- a/tests/flux/tasks/ai/test_reasoning.py
+++ b/tests/flux/tasks/ai/test_reasoning.py
@@ -88,12 +88,12 @@ class TestOllamaReasoning:
         formatter = OllamaFormatter("test-model")
         messages = [
             {"role": "user", "content": "hi"},
-            {"role": "thinking", "content": '{"text": "hmm", "opaque": null}'},
+            {"role": "reasoning", "content": '{"text": "hmm", "opaque": null}'},
             {"role": "assistant", "content": "hello"},
         ]
         converted = formatter._convert_memory_messages(messages)
         roles = [m["role"] for m in converted]
-        assert "thinking" not in roles
+        assert "reasoning" not in roles
         assert len(converted) == 2
 
     def test_reasoning_effort_adds_think_param(self):
@@ -194,7 +194,7 @@ class TestAnthropicReasoning:
         messages = [
             {"role": "user", "content": "question"},
             {
-                "role": "thinking",
+                "role": "reasoning",
                 "content": json.dumps(
                     {
                         "text": "reasoning...",
@@ -289,7 +289,7 @@ class TestOpenAIReasoning:
         messages = [
             {"role": "user", "content": "question"},
             {
-                "role": "thinking",
+                "role": "reasoning",
                 "content": json.dumps(
                     {
                         "text": "reasoning",
@@ -463,8 +463,8 @@ class TestAgentLoopReasoning:
             )
             messages = wm.recall()
             roles = [m["role"] for m in messages]
-            assert "thinking" in roles
-            thinking_msgs = [m for m in messages if m["role"] == "thinking"]
+            assert "reasoning" in roles
+            thinking_msgs = [m for m in messages if m["role"] == "reasoning"]
             assert len(thinking_msgs) >= 1
         finally:
             ExecutionContext.reset(token)
@@ -529,7 +529,7 @@ class TestAgentLoopReasoning:
             )
             messages = wm.recall()
             roles = [m["role"] for m in messages]
-            thinking_idx = roles.index("thinking")
+            thinking_idx = roles.index("reasoning")
             tool_call_idx = roles.index("tool_call")
             assert thinking_idx < tool_call_idx
         finally:

--- a/tests/flux/tasks/ai/test_reasoning.py
+++ b/tests/flux/tasks/ai/test_reasoning.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import pytest
 
-from flux.tasks.ai.models import LLMResponse, ReasoningContent
+from flux.domain.execution_context import ExecutionContext
+from flux.task import task
+from flux.tasks.ai.models import LLMResponse, ReasoningContent, ToolCall
 
 
 class TestReasoningContent:
@@ -392,3 +394,143 @@ class TestGeminiReasoning:
         parts = content.parts
         has_thought = any(getattr(p, "thought", False) for p in parts)
         assert not has_thought
+
+
+class TestAgentLoopReasoning:
+    @pytest.mark.asyncio
+    async def test_thinking_stored_in_working_memory(self):
+        from flux.tasks.ai.agent_loop import run_agent_loop
+        from flux.tasks.ai.memory.working_memory import WorkingMemory
+        from flux.tasks.ai.tool_executor import build_tool_schemas
+
+        call_count = 0
+
+        @task
+        async def fake_llm_reasoning(messages, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return LLMResponse(
+                    text="",
+                    tool_calls=[ToolCall(id="c1", name="my_tool", arguments={"x": 1})],
+                    reasoning=ReasoningContent(text="Let me think...", opaque=None),
+                )
+            return LLMResponse(
+                text="done",
+                reasoning=ReasoningContent(text="Final thought", opaque=None),
+            )
+
+        @task
+        async def my_tool(x: int) -> str:
+            """Test tool."""
+            return "result"
+
+        class FakeFormatter:
+            def build_messages(self, sys, user, wm):
+                return [{"role": "user", "content": user}], {}
+
+            def format_assistant_message(self, r):
+                return {"role": "assistant", "content": r.text}
+
+            def format_tool_results(self, tc, results):
+                return [{"role": "tool", "content": r["output"]} for r in results]
+
+            def format_user_message(self, text):
+                return {"role": "user", "content": text}
+
+            def remove_tools_from_kwargs(self, kw):
+                return kw
+
+            async def stream(self, messages, kwargs):
+                yield "hello"
+
+        tools = [my_tool]
+        schemas = build_tool_schemas(tools)
+
+        ctx = ExecutionContext(workflow_id="test", workflow_name="test")
+        token = ExecutionContext.set(ctx)
+        try:
+            wm = WorkingMemory()
+            await run_agent_loop(
+                llm_task=fake_llm_reasoning,
+                formatter=FakeFormatter(),
+                system_prompt="test",
+                instruction="test",
+                tools=tools,
+                tool_schemas=schemas,
+                working_memory=wm,
+                stream=False,
+            )
+            messages = wm.recall()
+            roles = [m["role"] for m in messages]
+            assert "thinking" in roles
+            thinking_msgs = [m for m in messages if m["role"] == "thinking"]
+            assert len(thinking_msgs) >= 1
+        finally:
+            ExecutionContext.reset(token)
+
+    @pytest.mark.asyncio
+    async def test_thinking_order_before_tool_call(self):
+        from flux.tasks.ai.agent_loop import run_agent_loop
+        from flux.tasks.ai.memory.working_memory import WorkingMemory
+        from flux.tasks.ai.tool_executor import build_tool_schemas
+
+        call_count = 0
+
+        @task
+        async def fake_llm(messages, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return LLMResponse(
+                    text="",
+                    tool_calls=[ToolCall(id="c1", name="my_tool", arguments={"x": 1})],
+                    reasoning=ReasoningContent(text="thinking first", opaque=None),
+                )
+            return LLMResponse(text="done")
+
+        @task
+        async def my_tool(x: int) -> str:
+            """Test tool."""
+            return "ok"
+
+        class FakeFormatter:
+            def build_messages(self, sys, user, wm):
+                return [{"role": "user", "content": user}], {}
+
+            def format_assistant_message(self, r):
+                return {"role": "assistant", "content": r.text}
+
+            def format_tool_results(self, tc, results):
+                return [{"role": "tool", "content": r["output"]} for r in results]
+
+            def format_user_message(self, text):
+                return {"role": "user", "content": text}
+
+            def remove_tools_from_kwargs(self, kw):
+                return kw
+
+        tools = [my_tool]
+        schemas = build_tool_schemas(tools)
+
+        ctx = ExecutionContext(workflow_id="test", workflow_name="test")
+        token = ExecutionContext.set(ctx)
+        try:
+            wm = WorkingMemory()
+            await run_agent_loop(
+                llm_task=fake_llm,
+                formatter=FakeFormatter(),
+                system_prompt="test",
+                instruction="test",
+                tools=tools,
+                tool_schemas=schemas,
+                working_memory=wm,
+                stream=False,
+            )
+            messages = wm.recall()
+            roles = [m["role"] for m in messages]
+            thinking_idx = roles.index("thinking")
+            tool_call_idx = roles.index("tool_call")
+            assert thinking_idx < tool_call_idx
+        finally:
+            ExecutionContext.reset(token)

--- a/tests/flux/tasks/ai/test_reasoning.py
+++ b/tests/flux/tasks/ai/test_reasoning.py
@@ -108,3 +108,118 @@ class TestOllamaReasoning:
         wm = type("FakeWM", (), {"recall": lambda self: []})()
         _, kwargs = formatter.build_messages("system", "question", wm)
         assert "think" not in kwargs
+
+
+class TestAnthropicReasoning:
+    def test_to_llm_response_captures_thinking(self):
+        from unittest.mock import MagicMock
+
+        from flux.tasks.ai.anthropic import _to_llm_response
+
+        thinking_block = MagicMock()
+        thinking_block.type = "thinking"
+        thinking_block.thinking = "Let me reason..."
+        thinking_block.signature = "sig_abc"
+
+        text_block = MagicMock()
+        text_block.type = "text"
+        text_block.text = "The answer."
+
+        response = MagicMock()
+        response.content = [thinking_block, text_block]
+
+        result = _to_llm_response(response)
+        assert result.reasoning is not None
+        assert result.reasoning.text == "Let me reason..."
+        assert result.reasoning.opaque["type"] == "thinking"
+        assert result.reasoning.opaque["signature"] == "sig_abc"
+
+    def test_to_llm_response_no_thinking(self):
+        from unittest.mock import MagicMock
+
+        from flux.tasks.ai.anthropic import _to_llm_response
+
+        text_block = MagicMock()
+        text_block.type = "text"
+        text_block.text = "Hello"
+
+        response = MagicMock()
+        response.content = [text_block]
+
+        result = _to_llm_response(response)
+        assert result.reasoning is None
+
+    def test_format_assistant_message_includes_thinking(self):
+        from unittest.mock import MagicMock
+
+        from flux.tasks.ai.anthropic import AnthropicFormatter
+
+        formatter = AnthropicFormatter(MagicMock(), "claude-test", 4096)
+        response = LLMResponse(
+            text="answer",
+            reasoning=ReasoningContent(
+                text="thinking...",
+                opaque={"type": "thinking", "thinking": "thinking...", "signature": "sig"},
+            ),
+        )
+        msg = formatter.format_assistant_message(response)
+        assert msg["role"] == "assistant"
+        content = msg["content"]
+        assert isinstance(content, list)
+        assert content[0]["type"] == "thinking"
+        assert content[0]["signature"] == "sig"
+
+    def test_format_assistant_message_omits_thinking_when_none(self):
+        from unittest.mock import MagicMock
+
+        from flux.tasks.ai.anthropic import AnthropicFormatter
+
+        formatter = AnthropicFormatter(MagicMock(), "claude-test", 4096)
+        response = LLMResponse(text="answer")
+        msg = formatter.format_assistant_message(response)
+        content = msg["content"]
+        has_thinking = any(isinstance(c, dict) and c.get("type") == "thinking" for c in content)
+        assert not has_thinking
+
+    def test_convert_memory_merges_thinking_with_next_message(self):
+        import json
+        from unittest.mock import MagicMock
+
+        from flux.tasks.ai.anthropic import AnthropicFormatter
+
+        formatter = AnthropicFormatter(MagicMock(), "claude-test", 4096)
+        messages = [
+            {"role": "user", "content": "question"},
+            {
+                "role": "thinking",
+                "content": json.dumps(
+                    {
+                        "text": "reasoning...",
+                        "opaque": {
+                            "type": "thinking",
+                            "thinking": "reasoning...",
+                            "signature": "sig",
+                        },
+                    },
+                ),
+            },
+            {"role": "assistant", "content": "answer"},
+        ]
+        converted = formatter._convert_memory_messages(messages)
+        assert len(converted) == 2
+        assistant_msg = converted[1]
+        assert assistant_msg["role"] == "assistant"
+        content = assistant_msg["content"]
+        assert isinstance(content, list)
+        assert content[0]["type"] == "thinking"
+
+    def test_reasoning_effort_adds_thinking_config(self):
+        from unittest.mock import MagicMock
+
+        from flux.tasks.ai.anthropic import AnthropicFormatter
+
+        formatter = AnthropicFormatter(MagicMock(), "claude-test", 4096, reasoning_effort="medium")
+        wm = type("FakeWM", (), {"recall": lambda self: []})()
+        _, kwargs = formatter.build_messages("system", "question", wm)
+        assert "thinking" in kwargs
+        assert kwargs["thinking"]["type"] == "adaptive"

--- a/tests/flux/tasks/ai/test_reasoning.py
+++ b/tests/flux/tasks/ai/test_reasoning.py
@@ -42,3 +42,69 @@ class TestLLMResponseReasoning:
         assert r.text == "hello"
         assert r.tool_calls == []
         assert r.reasoning is None
+
+
+class TestOllamaReasoning:
+    def test_to_llm_response_captures_thinking(self):
+        from flux.tasks.ai.ollama import _to_llm_response
+
+        response = {
+            "message": {
+                "content": "The answer is 42.",
+                "thinking": "Let me think step by step...",
+            },
+        }
+        result = _to_llm_response(response)
+        assert result.reasoning is not None
+        assert result.reasoning.text == "Let me think step by step..."
+        assert result.reasoning.opaque is None
+
+    def test_to_llm_response_no_thinking(self):
+        from flux.tasks.ai.ollama import _to_llm_response
+
+        response = {"message": {"content": "Hello"}}
+        result = _to_llm_response(response)
+        assert result.reasoning is None
+
+    def test_format_assistant_message_no_reasoning_injection(self):
+        from flux.tasks.ai.ollama import OllamaFormatter
+
+        formatter = OllamaFormatter("test-model")
+        response = LLMResponse(
+            text="answer",
+            reasoning=ReasoningContent(text="thinking"),
+        )
+        msg = formatter.format_assistant_message(response)
+        assert msg["role"] == "assistant"
+        assert msg["content"] == "answer"
+        assert "thinking" not in msg
+
+    def test_convert_memory_skips_thinking_role(self):
+        from flux.tasks.ai.ollama import OllamaFormatter
+
+        formatter = OllamaFormatter("test-model")
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "thinking", "content": '{"text": "hmm", "opaque": null}'},
+            {"role": "assistant", "content": "hello"},
+        ]
+        converted = formatter._convert_memory_messages(messages)
+        roles = [m["role"] for m in converted]
+        assert "thinking" not in roles
+        assert len(converted) == 2
+
+    def test_reasoning_effort_adds_think_param(self):
+        from flux.tasks.ai.ollama import OllamaFormatter
+
+        formatter = OllamaFormatter("test-model", reasoning_effort="high")
+        wm = type("FakeWM", (), {"recall": lambda self: []})()
+        _, kwargs = formatter.build_messages("system", "question", wm)
+        assert kwargs.get("think") is True
+
+    def test_reasoning_effort_none_no_think_param(self):
+        from flux.tasks.ai.ollama import OllamaFormatter
+
+        formatter = OllamaFormatter("test-model")
+        wm = type("FakeWM", (), {"recall": lambda self: []})()
+        _, kwargs = formatter.build_messages("system", "question", wm)
+        assert "think" not in kwargs

--- a/tests/flux/tasks/ai/test_reasoning.py
+++ b/tests/flux/tasks/ai/test_reasoning.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 
 from flux.tasks.ai.models import LLMResponse, ReasoningContent
 
@@ -309,3 +310,85 @@ class TestOpenAIReasoning:
         wm = type("FakeWM", (), {"recall": lambda self: []})()
         _, kwargs = formatter.build_messages("system", "question", wm)
         assert kwargs.get("reasoning_effort") == "medium"
+
+
+class TestGeminiReasoning:
+    def test_to_llm_response_captures_thought_parts(self):
+        pytest.importorskip("google.genai")
+        from unittest.mock import MagicMock
+
+        from flux.tasks.ai.gemini import _to_llm_response
+
+        thought_part = MagicMock()
+        thought_part.thought = True
+        thought_part.text = "Let me think..."
+        thought_part.function_call = None
+
+        text_part = MagicMock()
+        text_part.thought = False
+        text_part.text = "The answer."
+        text_part.function_call = None
+
+        candidate = MagicMock()
+        candidate.content.parts = [thought_part, text_part]
+
+        response = MagicMock()
+        response.candidates = [candidate]
+        response.text = "The answer."
+        response.function_calls = None
+
+        result = _to_llm_response(response)
+        assert result.reasoning is not None
+        assert result.reasoning.text == "Let me think..."
+        assert result.reasoning.opaque == {"text": "Let me think...", "thought": True}
+
+    def test_to_llm_response_no_thought(self):
+        pytest.importorskip("google.genai")
+        from unittest.mock import MagicMock
+
+        from flux.tasks.ai.gemini import _to_llm_response
+
+        text_part = MagicMock()
+        text_part.thought = False
+        text_part.text = "Hello"
+        text_part.function_call = None
+
+        candidate = MagicMock()
+        candidate.content.parts = [text_part]
+
+        response = MagicMock()
+        response.candidates = [candidate]
+        response.text = "Hello"
+        response.function_calls = None
+
+        result = _to_llm_response(response)
+        assert result.reasoning is None
+
+    def test_format_assistant_message_includes_thought(self):
+        pytest.importorskip("google.genai")
+
+        from flux.tasks.ai.gemini import GeminiFormatter
+
+        formatter = GeminiFormatter("gemini-test", max_tokens=4096)
+        response = LLMResponse(
+            text="answer",
+            reasoning=ReasoningContent(
+                text="thinking...",
+                opaque={"text": "thinking...", "thought": True},
+            ),
+        )
+        content = formatter.format_assistant_message(response)
+        parts = content.parts
+        has_thought = any(getattr(p, "thought", False) for p in parts)
+        assert has_thought
+
+    def test_format_assistant_message_omits_when_none(self):
+        pytest.importorskip("google.genai")
+        from flux.tasks.ai.gemini import GeminiFormatter
+
+        formatter = GeminiFormatter("gemini-test", max_tokens=4096)
+        response = LLMResponse(text="answer")
+        content = formatter.format_assistant_message(response)
+        parts = content.parts
+        has_thought = any(getattr(p, "thought", False) for p in parts)
+        assert not has_thought


### PR DESCRIPTION
## Summary

- Adds `ReasoningContent` model (text + opaque blob) on `LLMResponse`
- Captures reasoning from all 4 providers:
  - Ollama: `message.thinking` field
  - Anthropic: `thinking` content blocks with signature
  - OpenAI: `reasoning_content` (best-effort via compatible endpoints)
  - Gemini: `part.thought=True` parts
- Passes reasoning back on subsequent turns via `format_assistant_message`
- Stores reasoning as `thinking` role in working memory for pause/resume
- Adds `reasoning_effort` parameter to `agent()` — "low", "medium", "high"
- Formatters reconstitute `thinking` role from working memory
- Adds reasoning agent example and dedicated documentation page
- Bumps version to 0.23.0

## Test plan
- [x] ReasoningContent and LLMResponse model tests (6 tests)
- [x] Ollama: capture thinking, skip passthrough, think param (6 tests)
- [x] Anthropic: capture thinking blocks, inject with signature, merge in memory (6 tests)
- [x] OpenAI: capture reasoning_content, inject, handle in memory (5 tests)
- [x] Gemini: capture thought parts, inject, thinking_config (4 tests)
- [x] Agent loop: thinking stored in WM, correct ordering (2 tests)
- [x] Full test suite passes
- [x] Manual E2E: reasoning_agent with Ollama qwen3