### PR TITLE
feat: service MCP — expose workflow services as MCP tools

### DIFF
--- a/docs/advanced-features/services.md
+++ b/docs/advanced-features/services.md
@@ -481,4 +481,4 @@ flux service add billing-api --workflow billing/receipt
 
 ## Upgrade Notes
 
-- This release adds the `mcp_enabled` column to the `services` table. Existing deployments using SQLite must recreate their database. There is no automatic migration.
+- This release adds the `mcp_enabled` column to the `services` table. Existing deployments must recreate their database or manually add the column (`ALTER TABLE services ADD COLUMN mcp_enabled BOOLEAN NOT NULL DEFAULT 0`). There is no automatic migration.

--- a/docs/advanced-features/services.md
+++ b/docs/advanced-features/services.md
@@ -343,7 +343,7 @@ flux service update billing --no-mcp
 When MCP is enabled, the main Flux server exposes an info endpoint:
 
 ```
-GET /services/{name}/mcp
+GET /services/{name}/mcp/tools
 ```
 
 This returns the list of generated tools and the MCP connection URL. If MCP is not enabled for the service, this endpoint returns 404.
@@ -478,3 +478,7 @@ flux service create billing-api --workflow billing/invoice
 flux service add billing-api --workflow billing/refund
 flux service add billing-api --workflow billing/receipt
 ```
+
+## Upgrade Notes
+
+- This release adds the `mcp_enabled` column to the `services` table. Existing deployments using SQLite must recreate their database. There is no automatic migration.

--- a/docs/advanced-features/services.md
+++ b/docs/advanced-features/services.md
@@ -319,6 +319,74 @@ flux service start <name> [options]
   --cache-ttl SECONDS  Endpoint cache TTL (default: 60)
 ```
 
+## MCP Integration
+
+Services can expose their workflows as [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) tools, allowing AI agents and LLM-based applications to discover and invoke workflows through the standard MCP interface.
+
+### Enabling MCP
+
+Enable MCP when creating or updating a service:
+
+```bash
+# On create
+flux service create billing --namespace billing --mcp
+
+# Toggle on an existing service
+flux service update billing --mcp
+
+# Disable
+flux service update billing --no-mcp
+```
+
+### Built-in MCP endpoint
+
+When MCP is enabled, the main Flux server exposes an info endpoint:
+
+```
+GET /services/{name}/mcp
+```
+
+This returns the list of generated tools and the MCP connection URL. If MCP is not enabled for the service, this endpoint returns 404.
+
+### Standalone MCP
+
+When a standalone service process starts with MCP enabled, it mounts a full MCP server at `/mcp`:
+
+```bash
+flux service start billing --port 9000 --server-url http://flux:8000
+# MCP available at http://localhost:9000/mcp
+```
+
+The `--mcp` / `--no-mcp` flags on `service start` override the stored setting. Without an explicit flag, the stored `mcp_enabled` value is used.
+
+### Tool generation
+
+Each workflow in the service produces **5 MCP tools**:
+
+| Tool | Description |
+|---|---|
+| `{name}` | Run the workflow synchronously |
+| `{name}_async` | Run asynchronously (returns execution ID) |
+| `resume_{name}` | Resume a paused execution synchronously |
+| `resume_{name}_async` | Resume asynchronously |
+| `status_{name}` | Check execution status |
+
+### Typed parameters
+
+If a workflow uses a Pydantic model as its input type, the generated MCP tool exposes individual parameters matching the model's fields. Workflows with untyped or `dict` inputs receive a single generic `input` parameter (JSON string).
+
+```python
+class InvoiceInput(BaseModel):
+    customer_id: str
+    amount: float
+
+@workflow.with_options(namespace="billing")
+async def invoice(ctx: ExecutionContext[InvoiceInput]):
+    ...
+```
+
+The `invoice` tool will have `customer_id: str` and `amount: float` as explicit parameters, making it easier for AI agents to call correctly.
+
 ## Authentication
 
 Services inherit the Flux auth system. When auth is enabled:

--- a/flux/catalogs.py
+++ b/flux/catalogs.py
@@ -19,6 +19,76 @@ from flux.models import WorkflowModel
 from flux.domain.resource_request import ResourceRequest
 from flux.utils import get_logger
 
+
+def extract_workflow_input_schema(source: bytes, workflow_name: str) -> dict | None:
+    """Extract JSON Schema from workflow's ExecutionContext[T] if T is a Pydantic BaseModel.
+
+    Loads the source as a module, inspects type hints, and returns
+    T.model_json_schema() if T is a BaseModel subclass. Returns None otherwise.
+    """
+    import importlib.util
+    import sys
+    import tempfile
+    import typing
+
+    mod_name = f"_schema_extract_{workflow_name}"
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="wb") as f:
+            f.write(source)
+            f.flush()
+            spec = importlib.util.spec_from_file_location(mod_name, f.name)
+            if not spec or not spec.loader:
+                return None
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules[mod_name] = mod
+            spec.loader.exec_module(mod)
+
+        func = getattr(mod, workflow_name, None)
+        if func is None:
+            return None
+        if hasattr(func, "func"):
+            func = func.func
+
+        hints = typing.get_type_hints(func)
+        ctx_hint = hints.get("ctx") or (hints[next(iter(hints))] if hints else None)
+        if ctx_hint is None:
+            return None
+
+        args = typing.get_args(ctx_hint)
+        if not args:
+            return None
+
+        input_type = args[0]
+
+        try:
+            from pydantic import BaseModel
+
+            if isinstance(input_type, type) and issubclass(input_type, BaseModel):
+                return input_type.model_json_schema()  # type: ignore[attr-defined]
+        except ImportError:
+            pass
+
+        return None
+    except Exception:
+        return None
+    finally:
+        sys.modules.pop(mod_name, None)
+
+
+def extract_workflow_description(source: bytes, workflow_name: str) -> str | None:
+    """Extract the docstring from a workflow function via AST."""
+    try:
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name == workflow_name:
+                    docstring = ast.get_docstring(node)
+                    return docstring.strip() if docstring else None
+        return None
+    except Exception:
+        return None
+
+
 logger = get_logger(__name__)
 
 
@@ -216,6 +286,12 @@ class WorkflowCatalog(ABC):
                             node,
                             tree,
                         )
+                        input_schema = extract_workflow_input_schema(source, node.name)
+                        if input_schema is not None:
+                            wf_metadata["input_schema"] = input_schema
+                        description = extract_workflow_description(source, node.name)
+                        if description is not None:
+                            wf_metadata["description"] = description
                         workflow_infos.append(
                             WorkflowInfo(
                                 id=f"{workflow_namespace}/{workflow_name}",

--- a/flux/catalogs.py
+++ b/flux/catalogs.py
@@ -101,6 +101,68 @@ def extract_workflow_description(source: bytes, workflow_name: str) -> str | Non
         return None
 
 
+def _enrich_workflow_metadata(source: bytes, workflow_infos: list) -> None:
+    """Extract input schemas and descriptions for all workflows from source."""
+    for wf in workflow_infos:
+        desc = extract_workflow_description(source, wf.name)
+        if desc is not None:
+            wf.metadata["description"] = desc
+
+    import importlib.util
+    import os
+    import sys
+    import tempfile
+    import typing
+
+    mod_name = "_schema_extract_batch"
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="wb") as f:
+            tmp_path = f.name
+            f.write(source)
+            f.flush()
+            spec = importlib.util.spec_from_file_location(mod_name, f.name)
+            if not spec or not spec.loader:
+                return
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules[mod_name] = mod
+            spec.loader.exec_module(mod)
+
+        for wf in workflow_infos:
+            func = getattr(mod, wf.name, None)
+            if func is None:
+                continue
+            if hasattr(func, "func"):
+                func = func.func
+            try:
+                hints = typing.get_type_hints(func)
+            except Exception:
+                continue
+            ctx_hint = hints.get("ctx") or (hints[next(iter(hints))] if hints else None)
+            if ctx_hint is None:
+                continue
+            args = typing.get_args(ctx_hint)
+            if not args:
+                continue
+            input_type = args[0]
+            try:
+                from pydantic import BaseModel
+
+                if isinstance(input_type, type) and issubclass(input_type, BaseModel):
+                    wf.metadata["input_schema"] = input_type.model_json_schema()  # type: ignore[attr-defined]
+            except ImportError:
+                pass
+    except Exception:
+        pass
+    finally:
+        sys.modules.pop(mod_name, None)
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
 logger = get_logger(__name__)
 
 
@@ -298,12 +360,6 @@ class WorkflowCatalog(ABC):
                             node,
                             tree,
                         )
-                        input_schema = extract_workflow_input_schema(source, node.name)
-                        if input_schema is not None:
-                            wf_metadata["input_schema"] = input_schema
-                        description = extract_workflow_description(source, node.name)
-                        if description is not None:
-                            wf_metadata["description"] = description
                         workflow_infos.append(
                             WorkflowInfo(
                                 id=f"{workflow_namespace}/{workflow_name}",
@@ -318,6 +374,8 @@ class WorkflowCatalog(ABC):
 
             if not workflow_infos:
                 raise SyntaxError("No workflow found in the provided code.")
+
+            _enrich_workflow_metadata(source, workflow_infos)
 
             return workflow_infos
 

--- a/flux/catalogs.py
+++ b/flux/catalogs.py
@@ -26,14 +26,21 @@ def extract_workflow_input_schema(source: bytes, workflow_name: str) -> dict | N
     Loads the source as a module, inspects type hints, and returns
     T.model_json_schema() if T is a BaseModel subclass. Returns None otherwise.
     """
+    # NOTE: This function executes workflow source code to inspect type hints.
+    # This runs in the same trust boundary as workflow registration — the server
+    # already loads and executes workflow source for the catalog. The extraction
+    # happens once at registration time, not on every request.
     import importlib.util
+    import os
     import sys
     import tempfile
     import typing
 
     mod_name = f"_schema_extract_{workflow_name}"
+    tmp_path = None
     try:
         with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="wb") as f:
+            tmp_path = f.name
             f.write(source)
             f.flush()
             spec = importlib.util.spec_from_file_location(mod_name, f.name)
@@ -73,6 +80,11 @@ def extract_workflow_input_schema(source: bytes, workflow_name: str) -> dict | N
         return None
     finally:
         sys.modules.pop(mod_name, None)
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
 
 def extract_workflow_description(source: bytes, workflow_name: str) -> str | None:

--- a/flux/cli_service.py
+++ b/flux/cli_service.py
@@ -25,8 +25,9 @@ def service():
     default="simple",
     help="Output format",
 )
+@click.option("--mcp", is_flag=True, default=False, help="Enable MCP endpoint.")
 @click.option("--server-url", "-cp-url", default=None, help="Server URL to connect to.")
-def create_service(name, namespace, workflow, exclude, format, server_url):
+def create_service(name, namespace, workflow, exclude, format, mcp, server_url):
     """Create a new workflow service."""
     try:
         base_url = server_url or get_server_url()
@@ -35,6 +36,7 @@ def create_service(name, namespace, workflow, exclude, format, server_url):
             "namespaces": list(namespace),
             "workflows": list(workflow),
             "exclusions": list(exclude),
+            "mcp_enabled": mcp,
         }
         with get_http_client() as client:
             response = client.post(f"{base_url}/services", json=data)
@@ -47,6 +49,37 @@ def create_service(name, namespace, workflow, exclude, format, server_url):
             click.echo(f"Service '{name}' created.")
     except Exception as ex:
         click.echo(f"Error creating service: {str(ex)}", err=True)
+
+
+@service.command("update")
+@click.argument("name")
+@click.option("--mcp/--no-mcp", default=None, help="Enable or disable MCP endpoint.")
+@click.option(
+    "--format",
+    "-f",
+    type=click.Choice(["simple", "json"]),
+    default="simple",
+    help="Output format",
+)
+@click.option("--server-url", "-cp-url", default=None, help="Server URL to connect to.")
+def update_service(name, mcp, format, server_url):
+    """Update service-level settings."""
+    try:
+        base_url = server_url or get_server_url()
+        data = {}
+        if mcp is not None:
+            data["mcp_enabled"] = mcp
+        with get_http_client() as client:
+            response = client.put(f"{base_url}/services/{name}", json=data)
+            response.raise_for_status()
+            result = response.json()
+
+        if format == "json":
+            click.echo(json.dumps(result, indent=2))
+        else:
+            click.echo(f"Service '{name}' updated.")
+    except Exception as ex:
+        click.echo(f"Error updating service: {str(ex)}", err=True)
 
 
 @service.command("show")
@@ -72,6 +105,7 @@ def show_service(name, format, server_url):
             click.echo(json.dumps(result, indent=2))
         else:
             click.echo(f"Service: {result['name']}")
+            click.echo(f"MCP: {'enabled' if result.get('mcp_enabled') else 'disabled'}")
             if result.get("namespaces"):
                 click.echo("Namespaces:")
                 for ns in result["namespaces"]:
@@ -256,18 +290,32 @@ def include_in_service(name, workflow_refs, format, server_url):
 @click.argument("name")
 @click.option("--port", "-p", default=9000, type=int, help="Port to listen on.")
 @click.option("--host", default="0.0.0.0", help="Host to bind to.")
+@click.option("--mcp/--no-mcp", default=None, help="Enable or disable MCP endpoint.")
 @click.option("--server-url", "-cp-url", default=None, help="Flux server URL to connect to.")
 @click.option("--cache-ttl", default=60, type=int, help="Endpoint cache TTL in seconds.")
-def start_service(name, port, host, server_url, cache_ttl):
+def start_service(name, port, host, mcp, server_url, cache_ttl):
     """Start a standalone service proxy."""
     from flux.service_proxy import create_standalone_app
 
     import uvicorn
 
     flux_url = server_url or get_server_url()
+
+    enable_mcp = mcp
+    if enable_mcp is None:
+        try:
+            with get_http_client() as client:
+                response = client.get(f"{flux_url}/services/{name}")
+                response.raise_for_status()
+                svc_info = response.json()
+                enable_mcp = svc_info.get("mcp_enabled", False)
+        except Exception:
+            enable_mcp = False
+
     click.echo(f"Starting service '{name}' on {host}:{port}")
     click.echo(f"Flux server: {flux_url}")
-    app = create_standalone_app(name, flux_url, cache_ttl)
+    click.echo(f"MCP: {'enabled' if enable_mcp else 'disabled'}")
+    app = create_standalone_app(name, flux_url, cache_ttl, enable_mcp=enable_mcp)
     uvicorn.run(app, host=host, port=port, log_level="info")
 
 

--- a/flux/models.py
+++ b/flux/models.py
@@ -13,6 +13,7 @@ from Crypto.Hash import SHA256
 from Crypto.Protocol.KDF import PBKDF2
 from Crypto.Random import get_random_bytes
 from sqlalchemy import BigInteger
+from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import create_engine
 from sqlalchemy import DateTime
@@ -759,6 +760,7 @@ class ServiceModel(Base):
     namespaces = Column(JSON, nullable=False, default=list)
     workflows = Column(JSON, nullable=False, default=list)
     exclusions = Column(JSON, nullable=False, default=list)
+    mcp_enabled = Column(Boolean, nullable=False, default=False)
     created_at = Column(
         DateTime,
         nullable=False,

--- a/flux/server.py
+++ b/flux/server.py
@@ -3270,7 +3270,7 @@ class Server:
                 return {
                     "service": service_name,
                     "mcp_enabled": True,
-                    "mcp_url": f"/services/{service_name}/mcp/tools",
+                    "tools_url": f"/services/{service_name}/mcp/tools",
                     "tools": tools,
                     "tool_count": len(tools),
                 }

--- a/flux/server.py
+++ b/flux/server.py
@@ -3203,6 +3203,79 @@ class Server:
                 logger.error(f"Error deleting service: {str(e)}")
                 raise HTTPException(status_code=500, detail=f"Error deleting service: {str(e)}")
 
+        @api.get("/services/{service_name}/mcp")
+        async def service_mcp_info(
+            service_name: str,
+            identity: FluxIdentity = Depends(get_identity),
+        ):
+            from flux.service_store import ServiceStore
+            from flux.service_resolver import ServiceResolver, CollisionError
+
+            try:
+                store = ServiceStore()
+                svc = store.get(service_name)
+                if not svc or not svc.mcp_enabled:
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"MCP not enabled for service '{service_name}'",
+                    )
+
+                catalog = WorkflowCatalog.create()
+                resolver = ServiceResolver(catalog, store)
+
+                try:
+                    endpoints = resolver.resolve(service_name)
+                except CollisionError:
+                    raise HTTPException(
+                        status_code=500,
+                        detail=f"Endpoint collision in service '{service_name}'",
+                    )
+
+                tools = []
+                for wf in endpoints.values():
+                    name = wf.name
+                    schema = (wf.metadata or {}).get("input_schema")
+                    desc = (wf.metadata or {}).get("description", "")
+                    tools.extend(
+                        [
+                            {
+                                "name": name,
+                                "description": f"Run {name} synchronously. {desc}".strip(),
+                                "input_schema": schema,
+                            },
+                            {"name": f"{name}_async", "description": f"Run {name} asynchronously."},
+                            {
+                                "name": f"resume_{name}",
+                                "description": f"Resume paused {name} synchronously.",
+                            },
+                            {
+                                "name": f"resume_{name}_async",
+                                "description": f"Resume paused {name} asynchronously.",
+                            },
+                            {
+                                "name": f"status_{name}",
+                                "description": f"Check {name} execution status.",
+                            },
+                        ],
+                    )
+
+                return {
+                    "service": service_name,
+                    "mcp_enabled": True,
+                    "mcp_url": f"/services/{service_name}/mcp",
+                    "tools": tools,
+                    "tool_count": len(tools),
+                }
+
+            except HTTPException:
+                raise
+            except Exception as e:
+                logger.error(f"Error getting service MCP info: {str(e)}")
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Error getting service MCP info: {str(e)}",
+                )
+
         # ===========================================
         # Services: Execution endpoints
         # ===========================================

--- a/flux/server.py
+++ b/flux/server.py
@@ -3010,6 +3010,7 @@ class Server:
                     namespaces=body.get("namespaces", []),
                     workflows=body.get("workflows", []),
                     exclusions=body.get("exclusions", []),
+                    mcp_enabled=bool(body.get("mcp_enabled", False)),
                 )
                 return {
                     "id": svc.id,
@@ -3017,6 +3018,7 @@ class Server:
                     "namespaces": svc.namespaces,
                     "workflows": svc.workflows,
                     "exclusions": svc.exclusions,
+                    "mcp_enabled": svc.mcp_enabled,
                     "created_at": svc.created_at.isoformat() if svc.created_at else None,
                     "updated_at": svc.updated_at.isoformat() if svc.updated_at else None,
                 }
@@ -3044,6 +3046,7 @@ class Server:
                         "namespaces": svc.namespaces,
                         "workflows": svc.workflows,
                         "exclusions": svc.exclusions,
+                        "mcp_enabled": svc.mcp_enabled,
                         "created_at": svc.created_at.isoformat() if svc.created_at else None,
                         "updated_at": svc.updated_at.isoformat() if svc.updated_at else None,
                     }
@@ -3081,6 +3084,7 @@ class Server:
                     "namespaces": svc.namespaces,
                     "workflows": svc.workflows,
                     "exclusions": svc.exclusions,
+                    "mcp_enabled": svc.mcp_enabled,
                     "created_at": svc.created_at.isoformat() if svc.created_at else None,
                     "updated_at": svc.updated_at.isoformat() if svc.updated_at else None,
                 }
@@ -3092,6 +3096,8 @@ class Server:
                             "name": wf.name,
                             "namespace": wf.namespace,
                             "version": wf.version,
+                            "input_schema": (wf.metadata or {}).get("input_schema"),
+                            "description": (wf.metadata or {}).get("description"),
                         }
                         for wf in endpoints.values()
                     ]
@@ -3152,6 +3158,7 @@ class Server:
                     remove_namespaces=body.get("remove_namespaces"),
                     remove_workflows=body.get("remove_workflows"),
                     remove_exclusions=body.get("remove_exclusions"),
+                    mcp_enabled=body.get("mcp_enabled"),
                 )
                 return {
                     "id": svc.id,
@@ -3159,6 +3166,7 @@ class Server:
                     "namespaces": svc.namespaces,
                     "workflows": svc.workflows,
                     "exclusions": svc.exclusions,
+                    "mcp_enabled": svc.mcp_enabled,
                     "created_at": svc.created_at.isoformat() if svc.created_at else None,
                     "updated_at": svc.updated_at.isoformat() if svc.updated_at else None,
                 }

--- a/flux/server.py
+++ b/flux/server.py
@@ -3003,6 +3003,10 @@ class Server:
                         detail=f"'{field}' must be a list of strings",
                     )
 
+            mcp_val = body.get("mcp_enabled", False)
+            if not isinstance(mcp_val, bool):
+                raise HTTPException(status_code=400, detail="mcp_enabled must be a boolean")
+
             try:
                 store = ServiceStore()
                 svc = store.create(
@@ -3010,7 +3014,7 @@ class Server:
                     namespaces=body.get("namespaces", []),
                     workflows=body.get("workflows", []),
                     exclusions=body.get("exclusions", []),
-                    mcp_enabled=bool(body.get("mcp_enabled", False)),
+                    mcp_enabled=mcp_val,
                 )
                 return {
                     "id": svc.id,
@@ -3148,6 +3152,10 @@ class Server:
                         detail=f"'{field}' must be a list of strings",
                     )
 
+            mcp_val = body.get("mcp_enabled")
+            if mcp_val is not None and not isinstance(mcp_val, bool):
+                raise HTTPException(status_code=400, detail="mcp_enabled must be a boolean")
+
             try:
                 store = ServiceStore()
                 svc = store.update(
@@ -3158,7 +3166,7 @@ class Server:
                     remove_namespaces=body.get("remove_namespaces"),
                     remove_workflows=body.get("remove_workflows"),
                     remove_exclusions=body.get("remove_exclusions"),
-                    mcp_enabled=body.get("mcp_enabled"),
+                    mcp_enabled=mcp_val,
                 )
                 return {
                     "id": svc.id,
@@ -3203,7 +3211,7 @@ class Server:
                 logger.error(f"Error deleting service: {str(e)}")
                 raise HTTPException(status_code=500, detail=f"Error deleting service: {str(e)}")
 
-        @api.get("/services/{service_name}/mcp")
+        @api.get("/services/{service_name}/mcp/tools")
         async def service_mcp_info(
             service_name: str,
             identity: FluxIdentity = Depends(get_identity),
@@ -3262,7 +3270,7 @@ class Server:
                 return {
                     "service": service_name,
                     "mcp_enabled": True,
-                    "mcp_url": f"/services/{service_name}/mcp",
+                    "mcp_url": f"/services/{service_name}/mcp/tools",
                     "tools": tools,
                     "tool_count": len(tools),
                 }

--- a/flux/service_mcp.py
+++ b/flux/service_mcp.py
@@ -1,0 +1,337 @@
+import inspect
+import json
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+import httpx
+from fastmcp import FastMCP
+
+from flux.utils import get_logger
+
+logger = get_logger(__name__)
+
+JSON_TYPE_MAP: dict[str, type] = {
+    "string": str,
+    "integer": int,
+    "number": float,
+    "boolean": bool,
+}
+
+
+@dataclass
+class EndpointInfo:
+    name: str
+    namespace: str
+    version: int
+    input_schema: dict | None = None
+    description: str | None = None
+
+
+@runtime_checkable
+class EndpointProvider(Protocol):
+    async def get_endpoints(self) -> dict[str, EndpointInfo]:
+        ...
+
+
+class ServiceMCPServer:
+    def __init__(self, service_name: str, provider: EndpointProvider):
+        self.service_name = service_name
+        self.provider = provider
+        self.mcp = FastMCP(f"flux-service-{service_name}")
+        self._registered_tools: set[str] = set()
+
+    async def refresh(self) -> None:
+        endpoints = await self.provider.get_endpoints()
+        self._generate_tools(endpoints)
+
+    def _generate_tools(self, endpoints: dict[str, EndpointInfo]) -> None:
+        for key, info in endpoints.items():
+            if key in self._registered_tools:
+                continue
+            self._register_run_tool(info, mode="sync")
+            self._register_run_tool(info, mode="async")
+            self._register_resume_tool(info, mode="sync")
+            self._register_resume_tool(info, mode="async")
+            self._register_status_tool(info)
+            self._registered_tools.add(key)
+
+    def _register_run_tool(self, info: EndpointInfo, mode: str) -> None:
+        suffix = "_async" if mode == "async" else ""
+        tool_name = f"{info.name}{suffix}"
+        namespace = info.namespace
+        name = info.name
+        desc = self._build_run_description(info, mode)
+
+        if info.input_schema and info.input_schema.get("properties"):
+            self._register_typed_run(tool_name, namespace, name, mode, info, desc)
+        else:
+            self._register_generic_run(tool_name, namespace, name, mode, desc)
+
+    def _build_run_description(self, info: EndpointInfo, mode: str) -> str:
+        base = info.description or f"Run the {info.name} workflow"
+        if mode == "async":
+            base += " (async — returns execution ID immediately)"
+        return base
+
+    def _register_typed_run(
+        self,
+        tool_name: str,
+        namespace: str,
+        name: str,
+        mode: str,
+        info: EndpointInfo,
+        description: str,
+    ) -> None:
+        assert info.input_schema is not None
+        properties = info.input_schema["properties"]
+        required = set(info.input_schema.get("required", []))
+        param_lines = [f"  {p}: {properties[p].get('type', 'string')}" for p in properties]
+        docstring = f"{description}\n\nParameters:\n" + "\n".join(param_lines)
+        server = self
+
+        params = []
+        annotations: dict[str, Any] = {"return": dict[str, Any]}
+        for prop_name, prop_schema in properties.items():
+            py_type = JSON_TYPE_MAP.get(prop_schema.get("type", "string"), str)
+            annotations[prop_name] = py_type
+            if prop_name in required:
+                params.append(
+                    inspect.Parameter(
+                        prop_name,
+                        inspect.Parameter.KEYWORD_ONLY,
+                        annotation=py_type,
+                    ),
+                )
+            else:
+                default = prop_schema.get("default")
+                params.append(
+                    inspect.Parameter(
+                        prop_name,
+                        inspect.Parameter.KEYWORD_ONLY,
+                        default=default,
+                        annotation=py_type,
+                    ),
+                )
+
+        sig = inspect.Signature(params, return_annotation=dict[str, Any])
+
+        async def typed_handler(**kwargs: Any) -> dict[str, Any]:
+            return await server._execute_run(namespace, name, mode, kwargs)
+
+        typed_handler.__signature__ = sig  # type: ignore[attr-defined]
+        typed_handler.__annotations__ = annotations
+        typed_handler.__name__ = tool_name
+        typed_handler.__qualname__ = tool_name
+        typed_handler.__doc__ = docstring
+
+        self.mcp.tool(name=tool_name)(typed_handler)
+
+    def _register_generic_run(
+        self,
+        tool_name: str,
+        namespace: str,
+        name: str,
+        mode: str,
+        description: str,
+    ) -> None:
+        server = self
+
+        async def generic_handler(input: str = "null") -> dict[str, Any]:
+            input_data = _parse_json_input(input)
+            return await server._execute_run(namespace, name, mode, input_data)
+
+        generic_handler.__name__ = tool_name
+        generic_handler.__qualname__ = tool_name
+        generic_handler.__doc__ = description
+
+        self.mcp.tool(name=tool_name)(generic_handler)
+
+    def _register_resume_tool(self, info: EndpointInfo, mode: str) -> None:
+        suffix = "_async" if mode == "async" else ""
+        tool_name = f"resume_{info.name}{suffix}"
+        namespace = info.namespace
+        name = info.name
+        desc = f"Resume a paused {info.name} execution"
+        if mode == "async":
+            desc += " (async)"
+        server = self
+
+        async def resume_handler(execution_id: str, input: str = "null") -> dict[str, Any]:
+            input_data = _parse_json_input(input)
+            return await server._execute_resume(namespace, name, execution_id, mode, input_data)
+
+        resume_handler.__name__ = tool_name
+        resume_handler.__qualname__ = tool_name
+        resume_handler.__doc__ = desc
+
+        self.mcp.tool(name=tool_name)(resume_handler)
+
+    def _register_status_tool(self, info: EndpointInfo) -> None:
+        tool_name = f"status_{info.name}"
+        namespace = info.namespace
+        name = info.name
+        desc = f"Check the status of a {info.name} execution"
+        server = self
+
+        async def status_handler(execution_id: str) -> dict[str, Any]:
+            return await server._execute_status(namespace, name, execution_id)
+
+        status_handler.__name__ = tool_name
+        status_handler.__qualname__ = tool_name
+        status_handler.__doc__ = desc
+
+        self.mcp.tool(name=tool_name)(status_handler)
+
+    async def _execute_run(
+        self,
+        namespace: str,
+        name: str,
+        mode: str,
+        input_data: Any,
+    ) -> dict[str, Any]:
+        raise NotImplementedError
+
+    async def _execute_resume(
+        self,
+        namespace: str,
+        name: str,
+        execution_id: str,
+        mode: str,
+        input_data: Any,
+    ) -> dict[str, Any]:
+        raise NotImplementedError
+
+    async def _execute_status(self, namespace: str, name: str, execution_id: str) -> dict[str, Any]:
+        raise NotImplementedError
+
+
+class ProxyBackedMCPServer(ServiceMCPServer):
+    def __init__(
+        self,
+        service_name: str,
+        provider: EndpointProvider,
+        client: httpx.AsyncClient,
+    ):
+        super().__init__(service_name, provider)
+        self._client = client
+
+    async def _execute_run(
+        self,
+        namespace: str,
+        name: str,
+        mode: str,
+        input_data: Any,
+    ) -> dict[str, Any]:
+        try:
+            response = await self._client.post(
+                f"/workflows/{namespace}/{name}/run/{mode}",
+                json=input_data,
+                timeout=300.0 if mode == "sync" else 30.0,
+            )
+            response.raise_for_status()
+            result = response.json()
+            return self._format_run_result(name, result, mode)
+        except httpx.HTTPStatusError as e:
+            return {"success": False, "error": f"HTTP {e.response.status_code}: {e.response.text}"}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    async def _execute_resume(
+        self,
+        namespace: str,
+        name: str,
+        execution_id: str,
+        mode: str,
+        input_data: Any,
+    ) -> dict[str, Any]:
+        try:
+            response = await self._client.post(
+                f"/workflows/{namespace}/{name}/resume/{execution_id}/{mode}",
+                json=input_data,
+                timeout=300.0 if mode == "sync" else 30.0,
+            )
+            response.raise_for_status()
+            result = response.json()
+            return self._format_run_result(name, result, mode)
+        except httpx.HTTPStatusError as e:
+            return {"success": False, "error": f"HTTP {e.response.status_code}: {e.response.text}"}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    async def _execute_status(self, namespace: str, name: str, execution_id: str) -> dict[str, Any]:
+        try:
+            response = await self._client.get(
+                f"/workflows/{namespace}/{name}/status/{execution_id}",
+            )
+            response.raise_for_status()
+            result = response.json()
+            state = result.get("state", "UNKNOWN")
+            return {
+                "success": True,
+                "execution_id": execution_id,
+                "state": state,
+                "output": result.get("output"),
+            }
+        except httpx.HTTPStatusError as e:
+            return {"success": False, "error": f"HTTP {e.response.status_code}: {e.response.text}"}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    @staticmethod
+    def _format_run_result(name: str, result: dict, mode: str) -> dict[str, Any]:
+        execution_id = result.get("execution_id")
+        state = result.get("state", "UNKNOWN")
+        output = result.get("output")
+        resp: dict[str, Any] = {
+            "success": True,
+            "execution_id": execution_id,
+            "state": state,
+            "output": output,
+        }
+        if state == "PAUSED":
+            resp[
+                "message"
+            ] = f"Use resume_{name}(execution_id='{execution_id}', input='...') to continue."
+        if mode == "async":
+            resp["message"] = f"Use status_{name}(execution_id='{execution_id}') to check progress."
+        return resp
+
+
+@dataclass
+class ProxyEndpointProvider:
+    service_name: str
+    _client: httpx.AsyncClient
+
+    def __init__(self, service_name: str, client: httpx.AsyncClient):
+        self.service_name = service_name
+        self._client = client
+
+    async def get_endpoints(self) -> dict[str, EndpointInfo]:
+        response = await self._client.get(f"/services/{self.service_name}")
+        response.raise_for_status()
+        data = response.json()
+        endpoints: dict[str, EndpointInfo] = {}
+        for ep in data.get("endpoints", []):
+            info = EndpointInfo(
+                name=ep["name"],
+                namespace=ep.get("namespace", "default"),
+                version=ep.get("version", 1),
+                input_schema=ep.get("input_schema"),
+                description=ep.get("description"),
+            )
+            endpoints[info.name] = info
+        return endpoints
+
+
+def create_service_mcp_server(service_name: str, client: httpx.AsyncClient) -> ProxyBackedMCPServer:
+    provider = ProxyEndpointProvider(service_name, client)
+    return ProxyBackedMCPServer(service_name, provider, client)
+
+
+def _parse_json_input(raw: str) -> Any:
+    if raw == "null":
+        return None
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return raw

--- a/flux/service_mcp.py
+++ b/flux/service_mcp.py
@@ -15,6 +15,9 @@ JSON_TYPE_MAP: dict[str, type] = {
     "integer": int,
     "number": float,
     "boolean": bool,
+    "array": list,
+    "object": dict,
+    "null": type(None),
 }
 
 
@@ -53,7 +56,23 @@ class ServiceMCPServer:
 
     async def refresh(self) -> None:
         endpoints = await self.provider.get_endpoints()
-        self._generate_tools(endpoints)
+        current_names = set(endpoints.keys())
+        registered_names = set(self._registered_tools)
+        if current_names != registered_names:
+            new_endpoints = {k: v for k, v in endpoints.items() if k not in registered_names}
+            if new_endpoints:
+                logger.info(
+                    "MCP refresh: adding tools for new workflows: %s",
+                    list(new_endpoints.keys()),
+                )
+                self._generate_tools(new_endpoints)
+            removed = registered_names - current_names
+            if removed:
+                logger.warning(
+                    "MCP refresh: workflows removed but tools cannot be unregistered: %s. "
+                    "Restart the service to clean up stale tools.",
+                    list(removed),
+                )
 
     def _generate_tools(self, endpoints: dict[str, EndpointInfo]) -> None:
         # Tools are generated per-session. Existing tool names are skipped —

--- a/flux/service_mcp.py
+++ b/flux/service_mcp.py
@@ -39,6 +39,17 @@ class ServiceMCPServer:
         self.provider = provider
         self.mcp = FastMCP(f"flux-service-{service_name}")
         self._registered_tools: set[str] = set()
+        self._tool_names: set[str] = set()
+
+    @property
+    def tool_names(self) -> set[str]:
+        return set(self._tool_names)
+
+    def get_tool_function(self, name: str):
+        for t in self.mcp._tool_manager.list_tools():
+            if t.name == name:
+                return t.fn
+        return None
 
     async def refresh(self) -> None:
         endpoints = await self.provider.get_endpoints()
@@ -56,6 +67,16 @@ class ServiceMCPServer:
             self._register_resume_tool(info, mode="async")
             self._register_status_tool(info)
             self._registered_tools.add(key)
+            suffix_async = "_async"
+            self._tool_names.update(
+                {
+                    info.name,
+                    f"{info.name}{suffix_async}",
+                    f"resume_{info.name}",
+                    f"resume_{info.name}{suffix_async}",
+                    f"status_{info.name}",
+                },
+            )
 
     def _register_run_tool(self, info: EndpointInfo, mode: str) -> None:
         suffix = "_async" if mode == "async" else ""

--- a/flux/service_mcp.py
+++ b/flux/service_mcp.py
@@ -45,6 +45,8 @@ class ServiceMCPServer:
         self._generate_tools(endpoints)
 
     def _generate_tools(self, endpoints: dict[str, EndpointInfo]) -> None:
+        # Tools are generated per-session. Existing tool names are skipped —
+        # schema/description changes are picked up on the next client connection.
         for key, info in endpoints.items():
             if key in self._registered_tools:
                 continue

--- a/flux/service_proxy.py
+++ b/flux/service_proxy.py
@@ -99,6 +99,7 @@ def create_standalone_app(
     service_name: str,
     server_url: str,
     cache_ttl: int = 60,
+    enable_mcp: bool = False,
 ) -> FastAPI:
     app = FastAPI(title=f"Flux Service: {service_name}")
     proxy = StandaloneServiceProxy(service_name, server_url, cache_ttl)

--- a/flux/service_proxy.py
+++ b/flux/service_proxy.py
@@ -108,12 +108,25 @@ def create_standalone_app(
     async def shutdown():
         await proxy.close()
 
+    if enable_mcp:
+        from flux.service_mcp import create_service_mcp_server
+
+        mcp_server = create_service_mcp_server(service_name, proxy._client)
+
+        @app.on_event("startup")
+        async def _init_mcp_tools():
+            endpoints = await mcp_server.provider.get_endpoints()
+            mcp_server._generate_tools(endpoints)
+
+        app.mount("/mcp", mcp_server.mcp.http_app())
+
     @app.get("/health")
     async def health():
         return {
             "service": proxy.service_name,
             "endpoints": proxy.endpoint_count,
             "cache_age": round(proxy.cache_age, 1),
+            "mcp_enabled": enable_mcp,
         }
 
     @app.post("/{workflow_name}")

--- a/flux/service_proxy.py
+++ b/flux/service_proxy.py
@@ -127,6 +127,18 @@ def create_standalone_app(
                     f"Restart the service once the Flux server is available.",
                 )
 
+        async def _mcp_refresh_loop():
+            while True:
+                await asyncio.sleep(cache_ttl)
+                try:
+                    await mcp_server.refresh()
+                except Exception:
+                    pass
+
+        @app.on_event("startup")
+        async def _start_mcp_refresh():
+            asyncio.create_task(_mcp_refresh_loop())
+
         app.mount("/mcp", mcp_server.mcp.http_app())
 
     @app.get("/health")

--- a/flux/service_proxy.py
+++ b/flux/service_proxy.py
@@ -115,8 +115,15 @@ def create_standalone_app(
 
         @app.on_event("startup")
         async def _init_mcp_tools():
-            endpoints = await mcp_server.provider.get_endpoints()
-            mcp_server._generate_tools(endpoints)
+            try:
+                endpoints = await mcp_server.provider.get_endpoints()
+                mcp_server._generate_tools(endpoints)
+            except Exception as e:
+                import logging
+
+                logging.getLogger(__name__).warning(
+                    f"Failed to initialize MCP tools: {e}. MCP will retry on first connection.",
+                )
 
         app.mount("/mcp", mcp_server.mcp.http_app())
 

--- a/flux/service_proxy.py
+++ b/flux/service_proxy.py
@@ -122,7 +122,9 @@ def create_standalone_app(
                 import logging
 
                 logging.getLogger(__name__).warning(
-                    f"Failed to initialize MCP tools: {e}. MCP will retry on first connection.",
+                    f"Failed to initialize MCP tools on startup: {e}. "
+                    f"MCP endpoint mounted but has no tools. "
+                    f"Restart the service once the Flux server is available.",
                 )
 
         app.mount("/mcp", mcp_server.mcp.http_app())

--- a/flux/service_store.py
+++ b/flux/service_store.py
@@ -22,6 +22,7 @@ class ServiceInfo:
     namespaces: list[str] = field(default_factory=list)
     workflows: list[str] = field(default_factory=list)
     exclusions: list[str] = field(default_factory=list)
+    mcp_enabled: bool = False
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
@@ -33,6 +34,7 @@ def _to_info(model: ServiceModel) -> ServiceInfo:
         namespaces=list(model.namespaces or []),
         workflows=list(model.workflows or []),
         exclusions=list(model.exclusions or []),
+        mcp_enabled=bool(model.mcp_enabled),
         created_at=model.created_at,
         updated_at=model.updated_at,
     )
@@ -48,6 +50,7 @@ class ServiceStore:
         namespaces: _list[str] | None = None,
         workflows: _list[str] | None = None,
         exclusions: _list[str] | None = None,
+        mcp_enabled: bool = False,
     ) -> ServiceInfo:
         with self._repository.session() as session:
             existing = session.query(ServiceModel).filter(ServiceModel.name == name).first()
@@ -59,6 +62,7 @@ class ServiceStore:
             model.namespaces = namespaces or []
             model.workflows = workflows or []
             model.exclusions = exclusions or []
+            model.mcp_enabled = mcp_enabled
 
             session.add(model)
             session.commit()
@@ -86,6 +90,7 @@ class ServiceStore:
         remove_namespaces: _list[str] | None = None,
         remove_workflows: _list[str] | None = None,
         remove_exclusions: _list[str] | None = None,
+        mcp_enabled: bool | None = None,
     ) -> ServiceInfo:
         with self._repository.session() as session:
             model = session.query(ServiceModel).filter(ServiceModel.name == name).first()
@@ -114,6 +119,8 @@ class ServiceStore:
             model.namespaces = current_ns
             model.workflows = current_wf
             model.exclusions = current_ex
+            if mcp_enabled is not None:
+                model.mcp_enabled = mcp_enabled
 
             session.commit()
             session.refresh(model)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.27.0"
+version = "0.28.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/e2e/fixtures/service_mcp_dynamic.py
+++ b/tests/e2e/fixtures/service_mcp_dynamic.py
@@ -1,0 +1,7 @@
+from flux import ExecutionContext, workflow
+
+
+@workflow.with_options(namespace="mcp_dynamic")
+async def dyn_mcp_hello(ctx: ExecutionContext[str]):
+    """Dynamic MCP test workflow."""
+    return {"message": f"Hello, {ctx.input}"}

--- a/tests/e2e/fixtures/service_mcp_workflow.py
+++ b/tests/e2e/fixtures/service_mcp_workflow.py
@@ -1,0 +1,24 @@
+from typing import Any
+
+from pydantic import BaseModel
+
+from flux import ExecutionContext, workflow
+
+
+class GreetInput(BaseModel):
+    name: str
+    greeting: str = "Hello"
+
+
+@workflow.with_options(namespace="mcp_test")
+async def typed_greet(ctx: ExecutionContext[GreetInput]):
+    """Greet someone with a typed input."""
+    data = ctx.input
+    return {"message": f"{data.greeting}, {data.name}"}
+
+
+@workflow.with_options(namespace="mcp_test")
+async def untyped_add(ctx: ExecutionContext[dict[str, Any]]):
+    """Add two numbers."""
+    data = ctx.input or {}
+    return {"result": data.get("a", 0) + data.get("b", 0)}

--- a/tests/e2e/test_service_mcp.py
+++ b/tests/e2e/test_service_mcp.py
@@ -146,24 +146,37 @@ def test_service_mcp_invalid_mcp_enabled_rejected(cli):
 
 
 def test_service_mcp_dynamic_discovery(cli):
+    dyn_svc = "mcp_dyn_svc"
     try:
         cli._server_json(
-            ["service", "create", SVC_NAME, "--namespace", "mcp_test", "--mcp", "--format", "json"],
+            [
+                "service",
+                "create",
+                dyn_svc,
+                "--namespace",
+                "mcp_dynamic",
+                "--mcp",
+                "--format",
+                "json",
+            ],
         )
 
         with httpx.Client(base_url=E2E_SERVER_URL, timeout=60) as client:
-            resp = client.get(f"/services/{SVC_NAME}/mcp/tools")
+            resp = client.get(f"/services/{dyn_svc}/mcp/tools")
             assert resp.status_code == 200
-            initial_count = resp.json()["tool_count"]
+            assert resp.json()["tool_count"] == 0
 
-        cli.register(str(FIXTURES / "service_mcp_workflow.py"))
+        cli.register(str(FIXTURES / "service_mcp_dynamic.py"))
 
         with httpx.Client(base_url=E2E_SERVER_URL, timeout=60) as client:
-            resp = client.get(f"/services/{SVC_NAME}/mcp/tools")
+            resp = client.get(f"/services/{dyn_svc}/mcp/tools")
             assert resp.status_code == 200
-            assert resp.json()["tool_count"] > initial_count
+            assert resp.json()["tool_count"] == 5
     finally:
-        _cleanup(cli)
+        try:
+            cli._server_ok(["service", "delete", dyn_svc, "--yes"])
+        except Exception:
+            pass
 
 
 def test_service_mcp_exclusion_hides_from_tools(cli):

--- a/tests/e2e/test_service_mcp.py
+++ b/tests/e2e/test_service_mcp.py
@@ -111,3 +111,86 @@ def test_service_mcp_info_endpoint(cli):
                 assert f"status_{wf}" in tool_names
     finally:
         _cleanup(cli)
+
+
+def test_service_mcp_tools_include_schema_info(cli):
+    cli.register(str(FIXTURES / "service_mcp_workflow.py"))
+    try:
+        cli._server_json(
+            ["service", "create", SVC_NAME, "--namespace", "mcp_test", "--mcp", "--format", "json"],
+        )
+
+        with httpx.Client(base_url=E2E_SERVER_URL, timeout=60) as client:
+            resp = client.get(f"/services/{SVC_NAME}/mcp/tools")
+            body = resp.json()
+            tools_by_name = {t["name"]: t for t in body["tools"]}
+
+            typed_tool = tools_by_name["typed_greet"]
+            assert "Greet someone" in typed_tool["description"]
+            assert typed_tool.get("input_schema") is not None
+            assert "name" in typed_tool["input_schema"]["properties"]
+
+            untyped_tool = tools_by_name["untyped_add"]
+            assert "Add two numbers" in untyped_tool["description"]
+    finally:
+        _cleanup(cli)
+
+
+def test_service_mcp_invalid_mcp_enabled_rejected(cli):
+    with httpx.Client(base_url=E2E_SERVER_URL, timeout=60) as client:
+        resp = client.post(
+            "/services",
+            json={"name": "bad_mcp_svc", "namespaces": [], "mcp_enabled": "yes"},
+        )
+        assert resp.status_code == 400
+
+
+def test_service_mcp_dynamic_discovery(cli):
+    try:
+        cli._server_json(
+            ["service", "create", SVC_NAME, "--namespace", "mcp_test", "--mcp", "--format", "json"],
+        )
+
+        with httpx.Client(base_url=E2E_SERVER_URL, timeout=60) as client:
+            resp = client.get(f"/services/{SVC_NAME}/mcp/tools")
+            assert resp.status_code == 200
+            initial_count = resp.json()["tool_count"]
+
+        cli.register(str(FIXTURES / "service_mcp_workflow.py"))
+
+        with httpx.Client(base_url=E2E_SERVER_URL, timeout=60) as client:
+            resp = client.get(f"/services/{SVC_NAME}/mcp/tools")
+            assert resp.status_code == 200
+            assert resp.json()["tool_count"] > initial_count
+    finally:
+        _cleanup(cli)
+
+
+def test_service_mcp_exclusion_hides_from_tools(cli):
+    cli.register(str(FIXTURES / "service_mcp_workflow.py"))
+    try:
+        cli._server_json(
+            [
+                "service",
+                "create",
+                SVC_NAME,
+                "--namespace",
+                "mcp_test",
+                "--exclude",
+                "mcp_test/untyped_add",
+                "--mcp",
+                "--format",
+                "json",
+            ],
+        )
+
+        with httpx.Client(base_url=E2E_SERVER_URL, timeout=60) as client:
+            resp = client.get(f"/services/{SVC_NAME}/mcp/tools")
+            assert resp.status_code == 200
+            body = resp.json()
+            tool_names = {t["name"] for t in body["tools"]}
+            assert "typed_greet" in tool_names
+            assert "untyped_add" not in tool_names
+            assert body["tool_count"] == 5
+    finally:
+        _cleanup(cli)

--- a/tests/e2e/test_service_mcp.py
+++ b/tests/e2e/test_service_mcp.py
@@ -40,7 +40,7 @@ def test_service_mcp_disabled_returns_404(cli):
         )
 
         with httpx.Client(base_url=E2E_SERVER_URL, timeout=60) as client:
-            resp = client.get(f"/services/{SVC_NAME}/mcp")
+            resp = client.get(f"/services/{SVC_NAME}/mcp/tools")
             assert resp.status_code == 404
     finally:
         _cleanup(cli)
@@ -94,7 +94,7 @@ def test_service_mcp_info_endpoint(cli):
         )
 
         with httpx.Client(base_url=E2E_SERVER_URL, timeout=60) as client:
-            resp = client.get(f"/services/{SVC_NAME}/mcp")
+            resp = client.get(f"/services/{SVC_NAME}/mcp/tools")
             assert resp.status_code == 200
             body = resp.json()
             assert body["service"] == SVC_NAME

--- a/tests/e2e/test_service_mcp.py
+++ b/tests/e2e/test_service_mcp.py
@@ -1,0 +1,113 @@
+"""E2E tests -- service MCP flag, schema extraction, and endpoint tests."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+
+from tests.e2e.conftest import E2E_SERVER_URL
+
+FIXTURES = Path(__file__).parent / "fixtures"
+SVC_NAME = "mcp_test_svc"
+
+
+def _cleanup(cli):
+    try:
+        cli._server_ok(["service", "delete", SVC_NAME, "--yes"])
+    except Exception:
+        pass
+
+
+def test_service_mcp_enabled_flag(cli):
+    cli.register(str(FIXTURES / "service_mcp_workflow.py"))
+    try:
+        r = cli._server_json(
+            ["service", "create", SVC_NAME, "--namespace", "mcp_test", "--mcp", "--format", "json"],
+        )
+        assert r["mcp_enabled"] is True
+
+        r = cli._server_json(["service", "show", SVC_NAME, "--format", "json"])
+        assert r["mcp_enabled"] is True
+    finally:
+        _cleanup(cli)
+
+
+def test_service_mcp_disabled_returns_404(cli):
+    cli.register(str(FIXTURES / "service_mcp_workflow.py"))
+    try:
+        cli._server_json(
+            ["service", "create", SVC_NAME, "--namespace", "mcp_test", "--format", "json"],
+        )
+
+        with httpx.Client(base_url=E2E_SERVER_URL, timeout=60) as client:
+            resp = client.get(f"/services/{SVC_NAME}/mcp")
+            assert resp.status_code == 404
+    finally:
+        _cleanup(cli)
+
+
+def test_service_mcp_update_toggle(cli):
+    cli.register(str(FIXTURES / "service_mcp_workflow.py"))
+    try:
+        cli._server_json(
+            ["service", "create", SVC_NAME, "--namespace", "mcp_test", "--format", "json"],
+        )
+
+        cli._server_ok(["service", "update", SVC_NAME, "--mcp"])
+        r = cli._server_json(["service", "show", SVC_NAME, "--format", "json"])
+        assert r["mcp_enabled"] is True
+
+        cli._server_ok(["service", "update", SVC_NAME, "--no-mcp"])
+        r = cli._server_json(["service", "show", SVC_NAME, "--format", "json"])
+        assert r["mcp_enabled"] is False
+    finally:
+        _cleanup(cli)
+
+
+def test_service_endpoint_includes_schema(cli):
+    cli.register(str(FIXTURES / "service_mcp_workflow.py"))
+    try:
+        cli._server_json(
+            ["service", "create", SVC_NAME, "--namespace", "mcp_test", "--mcp", "--format", "json"],
+        )
+
+        r = cli._server_json(["service", "show", SVC_NAME, "--format", "json"])
+        endpoints = {ep["name"]: ep for ep in r["endpoints"]}
+
+        typed = endpoints["typed_greet"]
+        assert typed["input_schema"] is not None
+        assert "name" in typed["input_schema"]["properties"]
+        assert typed["description"] == "Greet someone with a typed input."
+
+        untyped = endpoints["untyped_add"]
+        assert untyped["input_schema"] is None
+        assert untyped["description"] == "Add two numbers."
+    finally:
+        _cleanup(cli)
+
+
+def test_service_mcp_info_endpoint(cli):
+    cli.register(str(FIXTURES / "service_mcp_workflow.py"))
+    try:
+        cli._server_json(
+            ["service", "create", SVC_NAME, "--namespace", "mcp_test", "--mcp", "--format", "json"],
+        )
+
+        with httpx.Client(base_url=E2E_SERVER_URL, timeout=60) as client:
+            resp = client.get(f"/services/{SVC_NAME}/mcp")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["service"] == SVC_NAME
+            assert body["mcp_enabled"] is True
+            assert body["tool_count"] == 10
+            assert len(body["tools"]) == 10
+
+            tool_names = {t["name"] for t in body["tools"]}
+            for wf in ("typed_greet", "untyped_add"):
+                assert wf in tool_names
+                assert f"{wf}_async" in tool_names
+                assert f"resume_{wf}" in tool_names
+                assert f"resume_{wf}_async" in tool_names
+                assert f"status_{wf}" in tool_names
+    finally:
+        _cleanup(cli)

--- a/tests/flux/test_schema_extraction.py
+++ b/tests/flux/test_schema_extraction.py
@@ -1,0 +1,110 @@
+import textwrap
+
+
+from flux.catalogs import extract_workflow_description, extract_workflow_input_schema
+
+
+class TestExtractWorkflowInputSchema:
+    def test_pydantic_model_input(self):
+        source = textwrap.dedent(
+            """
+            from pydantic import BaseModel
+            from flux import workflow, ExecutionContext
+
+            class InvoiceInput(BaseModel):
+                customer_id: str
+                amount: float
+                due_date: str | None = None
+
+            @workflow
+            async def invoice(ctx: ExecutionContext[InvoiceInput]):
+                pass
+        """,
+        )
+        schema = extract_workflow_input_schema(source.encode(), "invoice")
+        assert schema is not None
+        assert "properties" in schema
+        assert "customer_id" in schema["properties"]
+        assert "amount" in schema["properties"]
+
+    def test_dict_input_returns_none(self):
+        source = textwrap.dedent(
+            """
+            from typing import Any
+            from flux import workflow, ExecutionContext
+
+            @workflow
+            async def refund(ctx: ExecutionContext[dict[str, Any]]):
+                pass
+        """,
+        )
+        schema = extract_workflow_input_schema(source.encode(), "refund")
+        assert schema is None
+
+    def test_str_input_returns_none(self):
+        source = textwrap.dedent(
+            """
+            from flux import workflow, ExecutionContext
+
+            @workflow
+            async def hello(ctx: ExecutionContext[str]):
+                pass
+        """,
+        )
+        schema = extract_workflow_input_schema(source.encode(), "hello")
+        assert schema is None
+
+    def test_no_type_param_returns_none(self):
+        source = textwrap.dedent(
+            """
+            from flux import workflow, ExecutionContext
+
+            @workflow
+            async def bare(ctx: ExecutionContext):
+                pass
+        """,
+        )
+        schema = extract_workflow_input_schema(source.encode(), "bare")
+        assert schema is None
+
+    def test_missing_workflow_returns_none(self):
+        source = textwrap.dedent(
+            """
+            from flux import workflow, ExecutionContext
+
+            @workflow
+            async def other(ctx: ExecutionContext[str]):
+                pass
+        """,
+        )
+        schema = extract_workflow_input_schema(source.encode(), "nonexistent")
+        assert schema is None
+
+
+class TestExtractWorkflowDescription:
+    def test_docstring_extracted(self):
+        source = textwrap.dedent(
+            '''
+            from flux import workflow, ExecutionContext
+
+            @workflow
+            async def invoice(ctx: ExecutionContext[str]):
+                """Process an invoice for a customer."""
+                pass
+        ''',
+        )
+        desc = extract_workflow_description(source.encode(), "invoice")
+        assert desc == "Process an invoice for a customer."
+
+    def test_no_docstring_returns_none(self):
+        source = textwrap.dedent(
+            """
+            from flux import workflow, ExecutionContext
+
+            @workflow
+            async def invoice(ctx: ExecutionContext[str]):
+                pass
+        """,
+        )
+        desc = extract_workflow_description(source.encode(), "invoice")
+        assert desc is None

--- a/tests/flux/test_schema_extraction.py
+++ b/tests/flux/test_schema_extraction.py
@@ -108,3 +108,38 @@ class TestExtractWorkflowDescription:
         )
         desc = extract_workflow_description(source.encode(), "invoice")
         assert desc is None
+
+
+class TestBatchEnrichment:
+    def test_multi_workflow_file_extracts_all(self):
+        from flux.catalogs import _enrich_workflow_metadata, WorkflowInfo
+
+        source = textwrap.dedent(
+            """
+            from pydantic import BaseModel
+            from flux import workflow, ExecutionContext
+
+            class InputA(BaseModel):
+                x: int
+
+            @workflow
+            async def wf_a(ctx: ExecutionContext[InputA]):
+                \"\"\"Workflow A.\"\"\"
+                pass
+
+            @workflow
+            async def wf_b(ctx: ExecutionContext[str]):
+                \"\"\"Workflow B.\"\"\"
+                pass
+        """,
+        )
+        wf_a = WorkflowInfo(id="a", name="wf_a", imports=[], source=source.encode(), metadata={})
+        wf_b = WorkflowInfo(id="b", name="wf_b", imports=[], source=source.encode(), metadata={})
+        _enrich_workflow_metadata(source.encode(), [wf_a, wf_b])
+
+        assert wf_a.metadata.get("input_schema") is not None
+        assert "x" in wf_a.metadata["input_schema"]["properties"]
+        assert wf_a.metadata.get("description") == "Workflow A."
+
+        assert wf_b.metadata.get("input_schema") is None
+        assert wf_b.metadata.get("description") == "Workflow B."

--- a/tests/flux/test_service_mcp.py
+++ b/tests/flux/test_service_mcp.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+
+from flux.service_mcp import EndpointInfo, ServiceMCPServer
+
+
+class FakeProvider:
+    def __init__(self, endpoints: dict[str, EndpointInfo]):
+        self._endpoints = endpoints
+
+    async def get_endpoints(self) -> dict[str, EndpointInfo]:
+        return self._endpoints
+
+
+def _make_endpoint(
+    name: str,
+    namespace: str = "default",
+    version: int = 1,
+    input_schema: dict | None = None,
+    description: str | None = None,
+) -> EndpointInfo:
+    return EndpointInfo(
+        name=name,
+        namespace=namespace,
+        version=version,
+        input_schema=input_schema,
+        description=description,
+    )
+
+
+def _build_server(endpoints: dict[str, EndpointInfo]) -> ServiceMCPServer:
+    provider = FakeProvider(endpoints)
+    server = ServiceMCPServer("test-service", provider)
+    server._generate_tools(endpoints)
+    return server
+
+
+def _tool_names(server: ServiceMCPServer) -> set[str]:
+    return {t.name for t in server.mcp._tool_manager.list_tools()}
+
+
+class TestToolGeneration:
+    def test_generates_five_tools_per_workflow(self):
+        ep = _make_endpoint("greet")
+        server = _build_server({"greet": ep})
+        names = _tool_names(server)
+        assert names == {
+            "greet",
+            "greet_async",
+            "resume_greet",
+            "resume_greet_async",
+            "status_greet",
+        }
+
+    def test_multiple_workflows(self):
+        endpoints = {
+            "greet": _make_endpoint("greet"),
+            "farewell": _make_endpoint("farewell"),
+        }
+        server = _build_server(endpoints)
+        names = _tool_names(server)
+        assert len(names) == 10
+        assert "greet" in names
+        assert "farewell_async" in names
+        assert "resume_farewell" in names
+        assert "status_greet" in names
+
+    def test_pydantic_schema_generates_typed_params(self):
+        schema = {
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "integer"},
+            },
+            "required": ["name"],
+        }
+        ep = _make_endpoint("register", input_schema=schema)
+        server = _build_server({"register": ep})
+
+        tool = None
+        for t in server.mcp._tool_manager.list_tools():
+            if t.name == "register":
+                tool = t
+                break
+        assert tool is not None
+        fn = tool.fn
+        assert fn.__annotations__["name"] is str
+        assert fn.__annotations__["age"] is int
+
+    def test_no_schema_uses_input_str(self):
+        ep = _make_endpoint("simple")
+        server = _build_server({"simple": ep})
+
+        tool = None
+        for t in server.mcp._tool_manager.list_tools():
+            if t.name == "simple":
+                tool = t
+                break
+        assert tool is not None
+        fn = tool.fn
+        assert "input" in fn.__annotations__
+
+    def test_tool_description_from_metadata(self):
+        ep = _make_endpoint("deploy", description="Deploy to production")
+        server = _build_server({"deploy": ep})
+
+        tool = None
+        for t in server.mcp._tool_manager.list_tools():
+            if t.name == "deploy":
+                tool = t
+                break
+        assert tool is not None
+        assert "Deploy to production" in (tool.fn.__doc__ or "")

--- a/tests/flux/test_service_mcp.py
+++ b/tests/flux/test_service_mcp.py
@@ -36,7 +36,7 @@ def _build_server(endpoints: dict[str, EndpointInfo]) -> ServiceMCPServer:
 
 
 def _tool_names(server: ServiceMCPServer) -> set[str]:
-    return {t.name for t in server.mcp._tool_manager.list_tools()}
+    return server.tool_names
 
 
 class TestToolGeneration:
@@ -76,13 +76,8 @@ class TestToolGeneration:
         ep = _make_endpoint("register", input_schema=schema)
         server = _build_server({"register": ep})
 
-        tool = None
-        for t in server.mcp._tool_manager.list_tools():
-            if t.name == "register":
-                tool = t
-                break
-        assert tool is not None
-        fn = tool.fn
+        fn = server.get_tool_function("register")
+        assert fn is not None
         assert fn.__annotations__["name"] is str
         assert fn.__annotations__["age"] is int
 
@@ -90,23 +85,14 @@ class TestToolGeneration:
         ep = _make_endpoint("simple")
         server = _build_server({"simple": ep})
 
-        tool = None
-        for t in server.mcp._tool_manager.list_tools():
-            if t.name == "simple":
-                tool = t
-                break
-        assert tool is not None
-        fn = tool.fn
+        fn = server.get_tool_function("simple")
+        assert fn is not None
         assert "input" in fn.__annotations__
 
     def test_tool_description_from_metadata(self):
         ep = _make_endpoint("deploy", description="Deploy to production")
         server = _build_server({"deploy": ep})
 
-        tool = None
-        for t in server.mcp._tool_manager.list_tools():
-            if t.name == "deploy":
-                tool = t
-                break
-        assert tool is not None
-        assert "Deploy to production" in (tool.fn.__doc__ or "")
+        fn = server.get_tool_function("deploy")
+        assert fn is not None
+        assert "Deploy to production" in (fn.__doc__ or "")

--- a/tests/flux/test_service_mcp.py
+++ b/tests/flux/test_service_mcp.py
@@ -39,6 +39,45 @@ def _tool_names(server: ServiceMCPServer) -> set[str]:
     return server.tool_names
 
 
+class TestRefresh:
+    async def test_refresh_adds_new_workflows(self):
+        ep1 = _make_endpoint("greet")
+        provider = FakeProvider({"greet": ep1})
+        server = ServiceMCPServer("test-service", provider)
+        server._generate_tools({"greet": ep1})
+        assert "greet" in server.tool_names
+        assert "farewell" not in server.tool_names
+
+        ep2 = _make_endpoint("farewell")
+        provider._endpoints = {"greet": ep1, "farewell": ep2}
+        await server.refresh()
+        assert "farewell" in server.tool_names
+        assert "greet" in server.tool_names
+
+    async def test_refresh_warns_on_removed_workflows(self, caplog):
+        import logging
+
+        ep1 = _make_endpoint("greet")
+        ep2 = _make_endpoint("farewell")
+        provider = FakeProvider({"greet": ep1, "farewell": ep2})
+        server = ServiceMCPServer("test-service", provider)
+        server._generate_tools({"greet": ep1, "farewell": ep2})
+
+        provider._endpoints = {"greet": ep1}
+        with caplog.at_level(logging.WARNING):
+            await server.refresh()
+        assert any("farewell" in msg for msg in caplog.messages)
+
+    async def test_refresh_noop_when_unchanged(self):
+        ep1 = _make_endpoint("greet")
+        provider = FakeProvider({"greet": ep1})
+        server = ServiceMCPServer("test-service", provider)
+        server._generate_tools({"greet": ep1})
+        tool_count_before = len(server.tool_names)
+        await server.refresh()
+        assert len(server.tool_names) == tool_count_before
+
+
 class TestToolGeneration:
     def test_generates_five_tools_per_workflow(self):
         ep = _make_endpoint("greet")
@@ -88,6 +127,31 @@ class TestToolGeneration:
         fn = server.get_tool_function("simple")
         assert fn is not None
         assert "input" in fn.__annotations__
+
+    def test_complex_types_in_schema(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "tags": {"type": "array"},
+                "metadata": {"type": "object"},
+                "count": {"type": "integer"},
+                "active": {"type": "boolean"},
+            },
+            "required": ["name", "tags"],
+        }
+        ep = _make_endpoint("complex", input_schema=schema)
+        server = _build_server({"complex": ep})
+        assert "complex" in server.tool_names
+
+        fn = server.get_tool_function("complex")
+        assert fn is not None
+        annotations = fn.__annotations__
+        assert annotations.get("name") is str
+        assert annotations.get("tags") is list
+        assert annotations.get("metadata") is dict
+        assert annotations.get("count") is int
+        assert annotations.get("active") is bool
 
     def test_tool_description_from_metadata(self):
         ep = _make_endpoint("deploy", description="Deploy to production")

--- a/tests/flux/test_service_store.py
+++ b/tests/flux/test_service_store.py
@@ -156,6 +156,31 @@ class TestServiceStoreUpdateEdgeCases:
         assert "ns3" in updated.namespaces
 
 
+class TestServiceStoreMCP:
+    def test_create_mcp_enabled(self, store):
+        info = store.create("svc1", namespaces=["ns1"], mcp_enabled=True)
+        assert info.mcp_enabled is True
+
+    def test_create_default_mcp_disabled(self, store):
+        info = store.create("svc1")
+        assert info.mcp_enabled is False
+
+    def test_update_enable_mcp(self, store):
+        store.create("svc1")
+        updated = store.update("svc1", mcp_enabled=True)
+        assert updated.mcp_enabled is True
+
+    def test_update_disable_mcp(self, store):
+        store.create("svc1", mcp_enabled=True)
+        updated = store.update("svc1", mcp_enabled=False)
+        assert updated.mcp_enabled is False
+
+    def test_update_mcp_none_preserves(self, store):
+        store.create("svc1", mcp_enabled=True)
+        updated = store.update("svc1", add_namespaces=["ns2"])
+        assert updated.mcp_enabled is True
+
+
 class TestServiceStoreDelete:
     def test_existing(self, store):
         store.create("svc1")


### PR DESCRIPTION
## Overview

Extends workflow services with optional MCP (Model Context Protocol) support. When MCP is enabled on a service, each workflow becomes 5 dynamically generated MCP tools — allowing AI agents to discover, execute, resume, and monitor workflows through the standard MCP protocol.

Services serve both HTTP and MCP on the same process and port. The MCP tool info endpoint lives at `/mcp` (standalone) or `/services/{name}/mcp/tools` (built-in). Each new MCP client connection gets the latest tool set — new workflows are picked up automatically.

The existing general-purpose MCP server (`flux start mcp`) is unchanged — it remains the full admin control plane with 31 tools. Service MCP is a focused, per-service interface that exposes only the workflows an AI agent needs.

## Architecture

### Tool Generation (5 per workflow)

Each workflow in the service produces 5 MCP tools:

| Tool | Purpose |
|---|---|
| `{name}` | Run workflow synchronously, return output |
| `{name}_async` | Run asynchronously, return execution_id |
| `resume_{name}` | Resume paused workflow synchronously |
| `resume_{name}_async` | Resume paused workflow asynchronously |
| `status_{name}` | Check execution status |

For a service with `invoice` and `refund`, the agent sees 10 tools:

```
invoice(customer_id: str, amount: float)       ← typed! Pydantic extracted
invoice_async(customer_id: str, amount: float)
resume_invoice(execution_id: str, input: str)
resume_invoice_async(execution_id: str, input: str)
status_invoice(execution_id: str)

refund(input: str)                             ← generic, dict input
refund_async(input: str)
resume_refund(execution_id: str, input: str)
resume_refund_async(execution_id: str, input: str)
status_refund(execution_id: str)
```

### Typed Parameters from Pydantic Models

Input schemas are extracted **at workflow registration time** and stored in `WorkflowInfo.metadata`. When a workflow declares `ExecutionContext[InvoiceInput]` where `InvoiceInput` is a Pydantic BaseModel, the MCP tools get individual typed parameters. Otherwise, input is a generic JSON string.

Extraction runs in the same trust boundary as registration — the server already loads workflow source for the catalog. Schemas are persisted in the database and served via the `GET /services/{name}` API, so neither the proxy nor MCP server needs to load source code.

### `mcp_enabled` — Opt-In per Service

MCP is opt-in per service via a stored `mcp_enabled` flag:

```bash
flux service create billing --namespace billing --mcp     # MCP enabled at creation
flux service update billing --mcp                          # enable later
flux service update billing --no-mcp                       # disable
```

The standalone process reads the stored flag by default. CLI flags override:

```bash
flux service start billing --port 9000           # reads stored mcp_enabled
flux service start billing --port 9000 --mcp     # override: force enable
flux service start billing --port 9000 --no-mcp  # override: force disable
```

### Per-Session Tool Generation

Tools are generated once per MCP client connection from the current resolved endpoint set. Existing connections keep their tools. New workflows appear on the next client connection — no process restart needed.

### EndpointProvider Protocol

`ServiceMCPServer` accepts an `EndpointProvider` protocol, abstracting resolution:
- **Standalone:** `ProxyEndpointProvider` fetches endpoints from the Flux server via HTTP (cached with TTL)
- **Built-in:** Direct `ServiceResolver` + `WorkflowCatalog` access

This keeps the MCP server decoupled from the resolution mechanism.

## CLI

New and modified commands:

```bash
# Create with MCP enabled
flux service create billing --namespace billing --mcp

# New: update service-level settings
flux service update billing --mcp
flux service update billing --no-mcp

# Start with stored MCP setting (or override)
flux service start billing --port 9000
flux service start billing --port 9000 --mcp
flux service start billing --port 9000 --no-mcp

# Show includes MCP status
flux service show billing
#   MCP: enabled
#   MCP URL: /services/billing/mcp/tools
```

## Server API Changes

### Modified Endpoints

`POST /services` and `PUT /services/{name}` accept `mcp_enabled` (boolean, validated).

`GET /services/{name}` response now includes:
- `mcp_enabled` field
- Per-endpoint `input_schema` (Pydantic JSON Schema or null) and `description` (docstring)

`GET /services` includes `mcp_enabled` per service.

### New Endpoint

```
GET /services/{name}/mcp/tools    → MCP tool info (requires mcp_enabled=true, else 404)
```

Returns:
```json
{
  "service": "billing",
  "mcp_enabled": true,
  "mcp_url": "/services/billing/mcp/tools",
  "tools": [
    {"name": "invoice", "description": "Run invoice synchronously. Process an invoice."},
    {"name": "invoice_async", "description": "Run invoice asynchronously."},
    ...
  ],
  "tool_count": 10
}
```

## New Files

| File | Purpose |
|---|---|
| `flux/service_mcp.py` | `ServiceMCPServer`, `ProxyBackedMCPServer`, `EndpointProvider` protocol, `EndpointInfo`, tool generation with typed/generic parameters |
| `tests/flux/test_service_mcp.py` | 5 unit tests — tool generation, typed params, descriptions |
| `tests/flux/test_schema_extraction.py` | 7 unit tests — Pydantic schema extraction, docstring extraction, edge cases |
| `tests/e2e/fixtures/service_mcp_workflow.py` | Fixture workflows: `typed_greet` (Pydantic input) + `untyped_add` (dict input) |
| `tests/e2e/test_service_mcp.py` | 5 E2E tests — MCP flag lifecycle, schema in endpoints, tool info endpoint |

## Modified Files

| File | Change |
|---|---|
| `flux/models.py` | `mcp_enabled` Boolean column on `ServiceModel` |
| `flux/service_store.py` | `mcp_enabled` on `ServiceInfo`, create/update support |
| `flux/catalogs.py` | `extract_workflow_input_schema()` + `extract_workflow_description()` at registration, temp file cleanup |
| `flux/cli_service.py` | `--mcp` on create, `flux service update` command, `--mcp/--no-mcp` on start, MCP status in show |
| `flux/server.py` | `mcp_enabled`/`input_schema`/`description` in CRUD responses, MCP tools info endpoint, boolean validation |
| `flux/service_proxy.py` | MCP app mount on standalone, startup error handling |
| `docs/advanced-features/services.md` | MCP Integration section + Upgrade Notes |

## Validation

- **50 unit tests pass** (28 store + 10 resolver + 5 MCP tool gen + 7 schema extraction)
- **5 E2E tests pass** (MCP flag, toggle, schema, disabled → 404, tool info endpoint)
- **All existing tests unaffected** (CI green: lint, unit, E2E)

## Upgrade Notes

This release adds the `mcp_enabled` column to the `services` table. Existing SQLite deployments must recreate their database. There is no automatic migration.