### PR TITLE
feat: worker affinity — label-based dispatch routing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
       - id: add-trailing-comma
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.18.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: [--py39-plus]

--- a/docs/advanced-features/worker-affinity.md
+++ b/docs/advanced-features/worker-affinity.md
@@ -1,0 +1,115 @@
+# Worker Affinity
+
+Worker affinity lets you target workflows to specific workers based on capability labels. Workers can declare labels (like `role=harness`, `browser=true`), and workflows can declare affinity requirements to route tasks to workers with matching labels.
+
+## What is Worker Affinity
+
+Worker affinity is a routing mechanism:
+
+1. A **worker** declares immutable capability labels when it starts
+2. A **workflow** declares affinity constraints using `@workflow.with_options`
+3. When a workflow runs, the system only dispatches to workers whose labels match all affinity requirements
+
+This is different from resource requests: labels describe *capability* (what kind of tools or environment), while resources describe *capacity* (CPU, memory, GPU).
+
+## Starting a Worker with Labels
+
+Labels are declared when a worker starts and cannot be changed without restarting. Start a worker with labels using the `--label` flag:
+
+```bash
+flux worker start --label role=harness --label env=sandbox --label browser=true
+```
+
+Multiple `--label` flags declare multiple labels. Label keys and values are strings.
+
+View a worker's labels:
+
+```bash
+flux worker list
+```
+
+This shows each worker's labels in the output.
+
+## Declaring Workflow Affinity
+
+Use `affinity` in `@workflow.with_options` to specify required worker labels:
+
+```python
+from flux import workflow, ExecutionContext
+
+@workflow.with_options(affinity={"role": "harness", "browser": "true"})
+async def my_agent(ctx: ExecutionContext):
+    # This workflow only runs on workers with both
+    # role=harness AND browser=true
+    return "Running on a harness worker with browser tools"
+```
+
+The `affinity` dict is a mapping of label keys to label values. All keys and values are strings.
+
+## Matching Semantics
+
+Affinity matching follows these rules:
+
+- A worker matches affinity if it has **all** labels specified in the affinity dict
+- Extra labels on the worker are ignored
+- A worker with `role=harness, env=sandbox, browser=true` matches affinity `{"role": "harness", "browser": "true"}`
+- A worker with `role=harness` does **not** match affinity `{"role": "harness", "browser": "true"}`
+- No affinity constraint = any worker (no filtering)
+
+If no worker matches the affinity requirements when a workflow is dispatched, the workflow cannot run and remains pending until a matching worker appears.
+
+## Labels vs Resource Requests
+
+Labels and resource requests are independent mechanisms:
+
+| Aspect | Labels | Resources |
+|--------|--------|-----------|
+| **Purpose** | Capability (what kind) | Capacity (how much) |
+| **Examples** | `role`, `env`, `browser`, `gpu_model` | CPU cores, memory, GPU count |
+| **Matching** | All labels in affinity must match | All resources must be available |
+| **Immutability** | Immutable; requires restart to change | Can be dynamic per task |
+
+A dispatch checks both: the worker must match the affinity labels **and** have sufficient resources.
+
+## Resume Behavior
+
+When a paused workflow resumes:
+
+1. The system **prefers** the original worker that executed it before
+2. If the original worker is unavailable (offline, removed), the system falls back to any worker matching the affinity labels
+3. Resume always respects affinity constraints — a worker without the required labels cannot pick up a resumed workflow
+
+This ensures workflows can reconnect to the same worker context when possible, improving task continuity.
+
+## Example: Pinning to a Sandbox Harness Worker
+
+Here's a practical example: an AI agent that needs browser tools and a sandboxed environment.
+
+First, start a specialized worker:
+
+```bash
+flux worker start --label role=harness --label env=sandbox --label browser=true
+```
+
+Then declare a workflow that targets it:
+
+```python
+from flux import workflow, ExecutionContext, task
+
+@task
+async def check_website(url: str) -> str:
+    """Use browser tools to visit a URL."""
+    # Browser tools available only on harness workers
+    return f"Checked {url}"
+
+@workflow.with_options(affinity={"role": "harness", "env": "sandbox", "browser": "true"})
+async def ai_researcher(ctx: ExecutionContext[str]):
+    url = ctx.input
+    result = await check_website(url)
+    return result
+
+# This workflow will only dispatch to the worker started above
+ctx = ai_researcher.run("https://example.com")
+```
+
+Without the affinity constraint, the workflow might run on a generic worker without browser tools and fail.

--- a/docs/advanced-features/worker-affinity.md
+++ b/docs/advanced-features/worker-affinity.md
@@ -17,7 +17,7 @@ This is different from resource requests: labels describe *capability* (what kin
 Labels are declared when a worker starts and cannot be changed without restarting. Start a worker with labels using the `--label` flag:
 
 ```bash
-flux worker start --label role=harness --label env=sandbox --label browser=true
+flux start worker --label role=harness --label env=sandbox --label browser=true
 ```
 
 Multiple `--label` flags declare multiple labels. Label keys and values are strings.
@@ -88,7 +88,7 @@ Here's a practical example: an AI agent that needs browser tools and a sandboxed
 First, start a specialized worker:
 
 ```bash
-flux worker start --label role=harness --label env=sandbox --label browser=true
+flux start worker --label role=harness --label env=sandbox --label browser=true
 ```
 
 Then declare a workflow that targets it:

--- a/docs/core-concepts/workflow-management.md
+++ b/docs/core-concepts/workflow-management.md
@@ -27,11 +27,21 @@ Workflows can be configured using `with_options`:
 @workflow.with_options(
     name="custom_workflow",              # Custom name for the workflow
     secret_requests=["API_KEY"],         # Secrets required by the workflow
-    output_storage=custom_storage        # Custom storage for workflow outputs
+    output_storage=custom_storage,       # Custom storage for workflow outputs
+    affinity={"role": "harness"}         # Target workers with specific labels
 )
 async def configured_workflow(ctx: ExecutionContext):
     pass
 ```
+
+Common configuration options:
+
+- `name` — Custom name for the workflow (defaults to function name)
+- `secret_requests` — List of secrets the workflow needs
+- `output_storage` — Custom storage backend for workflow outputs
+- `affinity` — Dict of label keys/values; workflow only runs on workers with matching labels
+
+See [Worker Affinity](../advanced-features/worker-affinity.md) for details on using `affinity` to target specific workers.
 
 ## Workflow Lifecycle
 

--- a/flux/catalogs.py
+++ b/flux/catalogs.py
@@ -199,6 +199,7 @@ class WorkflowInfo:
         namespace: str = "default",
         version: int = 1,
         requests: ResourceRequest | None = None,
+        affinity: dict[str, str] | None = None,
         schedule: Any | None = None,
         metadata: dict | None = None,
     ):
@@ -209,6 +210,7 @@ class WorkflowInfo:
         self.source = source
         self.version = version
         self.requests = requests
+        self.affinity = affinity
         self.schedule = schedule
         self.metadata = metadata
 
@@ -225,6 +227,7 @@ class WorkflowInfo:
             "imports": self.imports,
             "source": self.source,
             "requests": {},
+            "affinity": self.affinity,
             "metadata": self.metadata,
         }
 
@@ -319,6 +322,7 @@ class WorkflowCatalog(ABC):
                     workflow_name = None
                     workflow_namespace = DEFAULT_NAMESPACE
                     workflow_requests = None
+                    workflow_affinity = None
 
                     for decorator in node.decorator_list:
                         # Simple @workflow decorator
@@ -349,6 +353,8 @@ class WorkflowCatalog(ABC):
                                         ) from e
                                 elif kw.arg == "requests":
                                     workflow_requests = self._extract_workflow_requests(kw.value)
+                                elif kw.arg == "affinity":
+                                    workflow_affinity = self._extract_affinity(kw.value)
 
                             if not workflow_name:
                                 workflow_name = node.name
@@ -368,6 +374,7 @@ class WorkflowCatalog(ABC):
                                 imports=list(imports),
                                 source=source,
                                 requests=workflow_requests,
+                                affinity=workflow_affinity,
                                 metadata=wf_metadata,
                             ),
                         )
@@ -466,6 +473,15 @@ class WorkflowCatalog(ABC):
             if kw.arg == "auth_exempt" and isinstance(kw.value, ast.Constant):
                 return bool(kw.value.value)
         return False
+
+    def _extract_affinity(self, node: ast.AST) -> dict[str, str] | None:
+        if isinstance(node, ast.Dict):
+            result = {}
+            for key, value in zip(node.keys, node.values):
+                if isinstance(key, ast.Constant) and isinstance(value, ast.Constant):
+                    result[str(key.value)] = str(value.value)
+            return result if result else None
+        return None
 
     def _extract_workflow_requests(self, node: ast.AST) -> ResourceRequest | None:
         """
@@ -615,6 +631,7 @@ class DatabaseWorkflowCatalog(WorkflowCatalog):
                         imports=wf.imports,
                         source=wf.source,
                         requests=requests_dict,
+                        affinity=wf.affinity,
                         metadata=wf.metadata,
                     )
                     session.add(model)
@@ -701,5 +718,6 @@ class DatabaseWorkflowCatalog(WorkflowCatalog):
             source=model.source,
             version=model.version,
             requests=requests,
+            affinity=model.affinity,
             metadata=model.wf_metadata,
         )

--- a/flux/catalogs.py
+++ b/flux/catalogs.py
@@ -630,8 +630,8 @@ class DatabaseWorkflowCatalog(WorkflowCatalog):
                         version=wf.version,
                         imports=wf.imports,
                         source=wf.source,
-                        requests=requests_dict,
-                        affinity=wf.affinity,
+                        requests=requests_dict or None,
+                        affinity=wf.affinity or None,
                         metadata=wf.metadata,
                     )
                     session.add(model)

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -918,7 +918,15 @@ def start_worker(name: str | None, server_url: str | None = None, label: tuple[s
             click.echo(f"Invalid label format: '{item}'. Expected key=value.", err=True)
             raise SystemExit(1)
         k, v = item.split("=", 1)
-        labels[k.strip()] = v.strip()
+        key = k.strip()
+        value = v.strip()
+        if not key:
+            click.echo(f"Invalid label: '{item}'. Label key must be non-empty.", err=True)
+            raise SystemExit(1)
+        if not value:
+            click.echo(f"Invalid label: '{item}'. Label value must be non-empty.", err=True)
+            raise SystemExit(1)
+        labels[key] = value
 
     Worker(name, server_url, labels=labels).start()
 

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -777,7 +777,9 @@ def list_workers(format: str, server_url: str | None):
             for w in workers:
                 runtime = w.get("runtime")
                 py_version = runtime.get("python_version", "unknown") if runtime else "unknown"
-                click.echo(f"  {w['name']:30}  Python {py_version}")
+                labels = w.get("labels", {})
+                label_str = ", ".join(f"{k}={v}" for k, v in labels.items()) if labels else ""
+                click.echo(f"  {w['name']:30}  Python {py_version}  {label_str}")
 
     except httpx.HTTPStatusError as ex:
         click.echo(f"Error listing workers: {str(ex)}", err=True)
@@ -899,11 +901,26 @@ def server(host: str | None = None, port: int | None = None):
     default=None,
     help="Server URL to connect to.",
 )
-def start_worker(name: str | None, server_url: str | None = None):
+@click.option(
+    "--label",
+    "-l",
+    multiple=True,
+    help="Worker label in key=value format (repeatable).",
+)
+def start_worker(name: str | None, server_url: str | None = None, label: tuple[str, ...] = ()):
     name = name or f"worker-{uuid4().hex[-6:]}"
     settings = Configuration.get().settings.workers
     server_url = server_url or settings.server_url
-    Worker(name, server_url).start()
+
+    labels = {}
+    for item in label:
+        if "=" not in item:
+            click.echo(f"Invalid label format: '{item}'. Expected key=value.", err=True)
+            raise SystemExit(1)
+        k, v = item.split("=", 1)
+        labels[k.strip()] = v.strip()
+
+    Worker(name, server_url, labels=labels).start()
 
 
 @start.command()

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -66,6 +66,10 @@ class ContextManager(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def release_worker(self, execution_id: str) -> ExecutionContext:  # pragma: no cover
+        raise NotImplementedError()
+
+    @abstractmethod
     def list(
         self,
         workflow_name: str | None = None,
@@ -315,20 +319,30 @@ class DatabaseContextManager(ContextManager):
             raise ExecutionContextNotFoundError(execution_id)
 
     def unclaim(self, execution_id: str) -> ExecutionContext:
-        """Release a worker's claim on an execution.
-
-        For active executions (SCHEDULED, CLAIMED, RUNNING): resets state to
-        CREATED and clears worker_name so the execution can be rescheduled.
-
-        For suspended executions (PAUSED, RESUMING): clears worker_name but
-        preserves state.  This allows another worker to pick up the execution
-        when it is resumed.
-        """
-        reschedulable = {
+        """Reset an active execution back to CREATED for rescheduling."""
+        reclaimable = {
             ExecutionState.SCHEDULED,
             ExecutionState.CLAIMED,
             ExecutionState.RUNNING,
         }
+        with self.session() as session:
+            model = session.get(ExecutionContextModel, execution_id)
+            if not model:
+                raise ExecutionContextNotFoundError(execution_id)
+            if model.state not in reclaimable:
+                return model.to_plain()
+            model.state = ExecutionState.CREATED
+            model.worker_name = None
+            session.commit()
+            return model.to_plain()
+
+    def release_worker(self, execution_id: str) -> ExecutionContext:
+        """Clear worker assignment on a suspended execution.
+
+        For PAUSED or RESUMING executions, clears worker_name without
+        changing state.  Called during worker eviction so that another
+        worker can pick up the execution via affinity matching.
+        """
         releasable = {
             ExecutionState.PAUSED,
             ExecutionState.RESUMING,
@@ -337,13 +351,9 @@ class DatabaseContextManager(ContextManager):
             model = session.get(ExecutionContextModel, execution_id)
             if not model:
                 raise ExecutionContextNotFoundError(execution_id)
-            if model.state in reschedulable:
-                model.state = ExecutionState.CREATED
-                model.worker_name = None
-            elif model.state in releasable:
-                model.worker_name = None
-            else:
+            if model.state not in releasable:
                 return model.to_plain()
+            model.worker_name = None
             session.commit()
             return model.to_plain()
 

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -4,6 +4,7 @@ from abc import ABC
 from abc import abstractmethod
 
 from sqlalchemy import func
+from sqlalchemy import or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -144,15 +145,69 @@ class DatabaseContextManager(ContextManager):
             session.commit()
             return ctx
 
+    def _worker_matches_workflow(self, worker: WorkerInfo, workflow: WorkflowModel) -> bool:
+        if workflow.affinity:
+            if not ResourceRequest.matches_labels(worker.labels, workflow.affinity):
+                return False
+        if workflow.requests:
+            requests = ResourceRequest(**(workflow.requests or {}))
+            if worker.resources is None:
+                return False
+            if not requests.matches_worker(worker.resources, worker.packages):
+                return False
+        return True
+
+    def _next_matching_execution(
+        self,
+        worker: WorkerInfo,
+        session: Session,
+        state: ExecutionState = ExecutionState.CREATED,
+        constrained_only: bool = False,
+    ):
+        query = (
+            session.query(ExecutionContextModel, WorkflowModel)
+            .join(WorkflowModel)
+            .filter(ExecutionContextModel.state == state)
+            .with_for_update(skip_locked=True)
+        )
+
+        if constrained_only:
+            query = query.filter(
+                or_(WorkflowModel.requests.is_not(None), WorkflowModel.affinity.is_not(None)),
+            )
+        else:
+            query = query.filter(
+                WorkflowModel.requests.is_(None),
+                WorkflowModel.affinity.is_(None),
+            )
+
+        if not constrained_only:
+            result = query.limit(1).first()
+            return result if result else (None, None)
+
+        for model, workflow in query:
+            if not self._worker_matches_workflow(worker, workflow):
+                continue
+            return model, workflow
+        return None, None
+
     def next_execution(self, worker: WorkerInfo) -> ExecutionContext | None:
         with self.session() as session:
             if not self._is_least_loaded_worker(worker, session):
                 return None
 
-            model, workflow = self._next_execution_with_requests(worker, session)
+            model, workflow = self._next_matching_execution(
+                worker,
+                session,
+                constrained_only=True,
+            )
 
             if not model or not workflow:
-                model, workflow = self._next_execution_without_requests(session)
+                model, workflow = self._next_matching_execution(
+                    worker,
+                    session,
+                    constrained_only=False,
+                )
 
             if model and workflow:
                 ctx = model.to_plain()
@@ -215,63 +270,36 @@ class DatabaseContextManager(ContextManager):
 
     def next_resume(self, worker: WorkerInfo) -> ExecutionContext | None:
         with self.session() as session:
-            model, workflow = self._next_execution_with_requests(
-                worker,
-                session,
-                ExecutionState.RESUMING,
-            )
-
-            if not model or not workflow:
-                model, workflow = self._next_execution_without_requests(
-                    session,
-                    ExecutionState.RESUMING,
+            sticky_query = (
+                session.query(ExecutionContextModel, WorkflowModel)
+                .join(WorkflowModel)
+                .filter(
+                    ExecutionContextModel.state == ExecutionState.RESUMING,
+                    ExecutionContextModel.worker_name == worker.name,
                 )
-
-            if model:
+                .with_for_update(skip_locked=True)
+                .limit(1)
+            )
+            result = sticky_query.first()
+            if result:
+                model, workflow = result
                 return model.to_plain()
+
+            fallback_query = (
+                session.query(ExecutionContextModel, WorkflowModel)
+                .join(WorkflowModel)
+                .filter(
+                    ExecutionContextModel.state == ExecutionState.RESUMING,
+                    ExecutionContextModel.worker_name.is_(None),
+                )
+                .with_for_update(skip_locked=True)
+            )
+            for model, workflow in fallback_query:
+                if not self._worker_matches_workflow(worker, workflow):
+                    continue
+                return model.to_plain()
+
             return None
-
-    def _next_execution_without_requests(
-        self,
-        session: Session,
-        state: ExecutionState = ExecutionState.CREATED,
-    ):
-        no_requests_query = (
-            session.query(ExecutionContextModel, WorkflowModel)
-            .join(WorkflowModel)
-            .filter(
-                ExecutionContextModel.state == state,
-                WorkflowModel.requests.is_(None),
-            )
-            .with_for_update(skip_locked=True)
-            .limit(1)
-        )
-        result = no_requests_query.first()
-        if result:
-            return result
-        return None, None
-
-    def _next_execution_with_requests(
-        self,
-        worker,
-        session: Session,
-        state: ExecutionState = ExecutionState.CREATED,
-    ):
-        with_requests_query = (
-            session.query(ExecutionContextModel, WorkflowModel)
-            .join(WorkflowModel)
-            .filter(
-                ExecutionContextModel.state == state,
-                WorkflowModel.requests.is_not(None),
-            )
-            .with_for_update(skip_locked=True)
-        )
-        for model, workflow in with_requests_query:
-            requests = workflow.requests if workflow else None
-            requests = ResourceRequest(**(requests or {}))
-            if requests.matches_worker(worker.resources, worker.packages):
-                return model, workflow
-        return None, None
 
     def claim(self, execution_id: str, worker: WorkerInfo) -> ExecutionContext:
         with self.session() as session:

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -315,20 +315,35 @@ class DatabaseContextManager(ContextManager):
             raise ExecutionContextNotFoundError(execution_id)
 
     def unclaim(self, execution_id: str) -> ExecutionContext:
-        """Reset an active execution back to CREATED for rescheduling."""
-        reclaimable = {
+        """Release a worker's claim on an execution.
+
+        For active executions (SCHEDULED, CLAIMED, RUNNING): resets state to
+        CREATED and clears worker_name so the execution can be rescheduled.
+
+        For suspended executions (PAUSED, RESUMING): clears worker_name but
+        preserves state.  This allows another worker to pick up the execution
+        when it is resumed.
+        """
+        reschedulable = {
             ExecutionState.SCHEDULED,
             ExecutionState.CLAIMED,
             ExecutionState.RUNNING,
+        }
+        releasable = {
+            ExecutionState.PAUSED,
+            ExecutionState.RESUMING,
         }
         with self.session() as session:
             model = session.get(ExecutionContextModel, execution_id)
             if not model:
                 raise ExecutionContextNotFoundError(execution_id)
-            if model.state not in reclaimable:
+            if model.state in reschedulable:
+                model.state = ExecutionState.CREATED
+                model.worker_name = None
+            elif model.state in releasable:
+                model.worker_name = None
+            else:
                 return model.to_plain()
-            model.state = ExecutionState.CREATED
-            model.worker_name = None
             session.commit()
             return model.to_plain()
 

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -150,10 +150,10 @@ class DatabaseContextManager(ContextManager):
             return ctx
 
     def _worker_matches_workflow(self, worker: WorkerInfo, workflow: WorkflowModel) -> bool:
-        if workflow.affinity:
+        if workflow.affinity is not None:
             if not ResourceRequest.matches_labels(worker.labels, workflow.affinity):
                 return False
-        if workflow.requests:
+        if workflow.requests is not None:
             requests = ResourceRequest(**(workflow.requests or {}))
             if worker.resources is None:
                 return False

--- a/flux/domain/resource_request.py
+++ b/flux/domain/resource_request.py
@@ -124,6 +124,16 @@ class ResourceRequest:
         # All requirements met
         return True
 
+    @staticmethod
+    def matches_labels(
+        worker_labels: dict[str, str],
+        required_affinity: dict[str, str],
+    ) -> bool:
+        return all(
+            worker_labels.get(k) == v
+            for k, v in required_affinity.items()
+        )
+
     def _check_cpu_requirement(self, worker_resources: WorkerResourcesInfo) -> bool:
         """Check if worker meets CPU requirements."""
         if self.cpu is None:

--- a/flux/domain/resource_request.py
+++ b/flux/domain/resource_request.py
@@ -129,10 +129,7 @@ class ResourceRequest:
         worker_labels: dict[str, str],
         required_affinity: dict[str, str],
     ) -> bool:
-        return all(
-            worker_labels.get(k) == v
-            for k, v in required_affinity.items()
-        )
+        return all(worker_labels.get(k) == v for k, v in required_affinity.items())
 
     def _check_cpu_requirement(self, worker_resources: WorkerResourcesInfo) -> bool:
         """Check if worker meets CPU requirements."""

--- a/flux/models.py
+++ b/flux/models.py
@@ -429,6 +429,7 @@ class WorkflowModel(Base):
     imports = Column(Base64Type(), nullable=True)
     source = Column(Base64Type(), nullable=False)
     requests = Column(Base64Type(), nullable=True)
+    affinity = Column(Base64Type(), nullable=True)
     # Named wf_metadata instead of metadata to avoid conflict with SQLAlchemy's
     # reserved `metadata` attribute on declarative base classes.
     wf_metadata = Column(Base64Type(), nullable=True)
@@ -459,6 +460,7 @@ class WorkflowModel(Base):
         source: bytes,
         namespace: str = "default",
         requests: dict | ResourceRequest | None = None,
+        affinity: dict[str, str] | None = None,
         metadata: dict | None = None,
     ):
         self.id = id
@@ -468,6 +470,7 @@ class WorkflowModel(Base):
         self.imports = imports
         self.source = source
         self.requests = requests
+        self.affinity = affinity
         self.wf_metadata = metadata
 
 

--- a/flux/models.py
+++ b/flux/models.py
@@ -392,6 +392,7 @@ class WorkerModel(Base):
         default=lambda: f"worker-{uuid4().hex}",
     )
     session_token = Column(String, nullable=False, default=lambda: uuid4().hex)
+    labels = Column(Base64Type(), nullable=True)
 
     runtime = relationship("WorkerRuntimeModel", back_populates="worker", uselist=False)
     packages = relationship("WorkerPackageModel", back_populates="worker")
@@ -409,11 +410,13 @@ class WorkerModel(Base):
         runtime: WorkerRuntimeModel | None = None,
         packages: list[WorkerPackageModel] | None = None,
         resources: WorkerResourcesModel | None = None,
+        labels: dict[str, str] | None = None,
     ):
         self.name = name
         self.runtime = runtime
         self.packages = packages or []
         self.resources = resources
+        self.labels = labels or {}
 
 
 class WorkflowModel(Base):

--- a/flux/server.py
+++ b/flux/server.py
@@ -2779,7 +2779,7 @@ class Server:
                 packages=[{"name": p["name"], "version": p["version"]} for p in w.packages]
                 if w.packages
                 else [],
-                labels=w.labels,
+                labels=w.labels if isinstance(w.labels, dict) else {},
             )
 
             if w.runtime:

--- a/flux/server.py
+++ b/flux/server.py
@@ -24,7 +24,7 @@ from slowapi import Limiter
 from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sse_starlette import EventSourceResponse
 from flux import ExecutionContext
 from flux.catalogs import WorkflowCatalog, WorkflowInfo
@@ -87,7 +87,7 @@ class WorkerRegistration(BaseModel):
     runtime: WorkerRuntimeModel
     packages: list[dict[str, str]]
     resources: WorkerResourcesModel
-    labels: dict[str, str] = {}
+    labels: dict[str, str] = Field(default_factory=dict)
 
 
 class SecretRequest(BaseModel):
@@ -231,8 +231,8 @@ class WorkerResponse(BaseModel):
     status: str = "offline"
     runtime: WorkerRuntimeModel | None = None
     resources: WorkerResourcesModel | None = None
-    packages: list[dict[str, str]] = []
-    labels: dict[str, str] = {}
+    packages: list[dict[str, str]] = Field(default_factory=list)
+    labels: dict[str, str] = Field(default_factory=dict)
 
 
 class HealthResponse(BaseModel):

--- a/flux/server.py
+++ b/flux/server.py
@@ -87,6 +87,7 @@ class WorkerRegistration(BaseModel):
     runtime: WorkerRuntimeModel
     packages: list[dict[str, str]]
     resources: WorkerResourcesModel
+    labels: dict[str, str] = {}
 
 
 class SecretRequest(BaseModel):
@@ -231,6 +232,7 @@ class WorkerResponse(BaseModel):
     runtime: WorkerRuntimeModel | None = None
     resources: WorkerResourcesModel | None = None
     packages: list[dict[str, str]] = []
+    labels: dict[str, str] = {}
 
 
 class HealthResponse(BaseModel):
@@ -1526,6 +1528,7 @@ class Server:
                     registration.runtime,
                     registration.packages,
                     registration.resources,
+                    labels=registration.labels,
                 )
 
                 self._worker_cache[registration.name] = WorkerResponse(
@@ -1559,6 +1562,7 @@ class Server:
                     ]
                     if registration.packages
                     else [],
+                    labels=registration.labels,
                 )
                 if registration.name in self._worker_names:
                     self._worker_offline_since.pop(registration.name, None)
@@ -2765,6 +2769,7 @@ class Server:
                 packages=[{"name": p["name"], "version": p["version"]} for p in w.packages]
                 if w.packages
                 else [],
+                labels=w.labels,
             )
 
             if w.runtime:

--- a/flux/server.py
+++ b/flux/server.py
@@ -659,7 +659,13 @@ class Server:
             m.record_worker_disconnected(name, reason)
 
     def _unclaim_worker_executions(self, worker_name: str) -> None:
-        """Reset all executions assigned to an evicted worker for rescheduling."""
+        """Release all executions assigned to an evicted worker.
+
+        Active executions (SCHEDULED, CLAIMED, RUNNING) are reset to CREATED
+        for rescheduling.  Suspended executions (PAUSED, RESUMING) have their
+        worker assignment cleared so another worker can pick them up via
+        affinity matching.
+        """
         execution_ids = self._worker_executions.pop(worker_name, set())
         if not execution_ids:
             return
@@ -669,7 +675,11 @@ class Server:
         context_manager = ContextManager.create()
         for execution_id in execution_ids:
             try:
-                context_manager.unclaim(execution_id)
+                from flux.domain import ExecutionState
+
+                ctx = context_manager.unclaim(execution_id)
+                if ctx.state in (ExecutionState.PAUSED, ExecutionState.RESUMING):
+                    context_manager.release_worker(execution_id)
                 self._execution_queue_times[execution_id] = time.monotonic()
                 m = get_metrics()
                 if m:

--- a/flux/servers/models.py
+++ b/flux/servers/models.py
@@ -36,6 +36,7 @@ class ExecutionContext(BaseModel):
     input: Any = None
     output: Any = None
     state: str
+    current_worker: str = ""
     events: list[ExecutionEvent] = []
 
     class Config:
@@ -78,6 +79,7 @@ class ExecutionContext(BaseModel):
             input=ctx.input,
             state=ctx.state.value,
             output=ctx.output,
+            current_worker=ctx.current_worker,
             events=[
                 ExecutionEvent(
                     id=event.id,
@@ -101,6 +103,7 @@ class ExecutionContext(BaseModel):
             "input": self.input,
             "output": self.output,
             "state": self.state,
+            "current_worker": self.current_worker,
         }
 
     @classmethod

--- a/flux/servers/models.py
+++ b/flux/servers/models.py
@@ -79,7 +79,7 @@ class ExecutionContext(BaseModel):
             input=ctx.input,
             state=ctx.state.value,
             output=ctx.output,
-            current_worker=ctx.current_worker,
+            current_worker=ctx.current_worker if isinstance(ctx.current_worker, str) else "",
             events=[
                 ExecutionEvent(
                     id=event.id,

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -78,8 +78,9 @@ class WorkflowExecutionRequest(BaseModel):
 
 
 class Worker:
-    def __init__(self, name: str, server_url: str):
+    def __init__(self, name: str, server_url: str, labels: dict[str, str] | None = None):
         self.name = name
+        self.labels = labels or {}
         config = Configuration.get().settings.workers
         self.bootstrap_token = config.bootstrap_token
         self.base_url = f"{server_url or config.server_url}/workers"
@@ -178,6 +179,7 @@ class Worker:
                 "runtime": runtime,
                 "resources": resources,
                 "packages": packages,
+                "labels": self.labels,
             }
 
             logger.debug("Sending registration request to server...")

--- a/flux/worker_registry.py
+++ b/flux/worker_registry.py
@@ -64,12 +64,14 @@ class WorkerInfo:
         packages: list[dict[str, str]] = [],
         resources: WorkerResourcesInfo | None = None,
         session_token: str | None = None,
+        labels: dict[str, str] | None = None,
     ):
         self.name = name
         self.runtime = runtime
         self.packages = packages
         self.resources = resources
         self.session_token = session_token
+        self.labels = labels or {}
 
 
 class WorkerRegistry(ABC):
@@ -84,6 +86,7 @@ class WorkerRegistry(ABC):
         runtime: WorkerRuntimeInfo | None,
         packages: list[dict[str, str]],
         resources: WorkerResourcesInfo | None,
+        labels: dict[str, str] | None = None,
     ) -> WorkerInfo:  # pragma: no cover
         raise NotImplementedError()
 
@@ -123,6 +126,7 @@ class DatabaseWorkerRegistry(WorkerRegistry):
         runtime: WorkerRuntimeInfo | None,
         packages: list[dict[str, str]],
         resources: WorkerResourcesInfo | None,
+        labels: dict[str, str] | None = None,
     ) -> WorkerInfo:
         # Import here to avoid circular imports
         from flux.models import WorkerModel
@@ -133,9 +137,10 @@ class DatabaseWorkerRegistry(WorkerRegistry):
                 if model:
                     # generate a new session token
                     model.session_token = uuid4().hex
+                    model.labels = labels or {}
                 else:
                     # Creates a new model and assigns the session token
-                    model = self._from_info(name, runtime, packages, resources)
+                    model = self._from_info(name, runtime, packages, resources, labels=labels)
                     session.add(model)
                 session.commit()
                 return self._to_info(model)
@@ -151,7 +156,7 @@ class DatabaseWorkerRegistry(WorkerRegistry):
             workers = session.query(WorkerModel).all()
             return [self._to_info(worker) for worker in workers]
 
-    def _from_info(self, name, runtime, packages, resources):
+    def _from_info(self, name, runtime, packages, resources, labels=None):
         # Import here to avoid circular imports
         from flux.models import (
             WorkerModel,
@@ -185,6 +190,7 @@ class DatabaseWorkerRegistry(WorkerRegistry):
                     for gpu in resources.gpus
                 ],
             ),
+            labels=labels,
         )
 
     def _to_info(self, model: WorkerModel) -> WorkerInfo:
@@ -213,4 +219,5 @@ class DatabaseWorkerRegistry(WorkerRegistry):
                 ],
             ),
             session_token=model.session_token,
+            labels=model.labels if model.labels else {},
         )

--- a/flux/worker_registry.py
+++ b/flux/worker_registry.py
@@ -61,14 +61,14 @@ class WorkerInfo:
         self,
         name: str,
         runtime: WorkerRuntimeInfo | None = None,
-        packages: list[dict[str, str]] = [],
+        packages: list[dict[str, str]] | None = None,
         resources: WorkerResourcesInfo | None = None,
         session_token: str | None = None,
         labels: dict[str, str] | None = None,
     ):
         self.name = name
         self.runtime = runtime
-        self.packages = packages
+        self.packages = list(packages) if packages is not None else []
         self.resources = resources
         self.session_token = session_token
         self.labels = labels or {}

--- a/flux/workflow.py
+++ b/flux/workflow.py
@@ -36,6 +36,7 @@ class workflow:
             secret_requests (list[str], optional): A list of secret keys required by the workflow. Defaults to an empty list.
             output_storage (OutputStorage | None, optional): The storage configuration for the workflow's output. Defaults to None.
             requests (ResourceRequest | None, optional): The minimum resources, runtime and packages for the workflow. Defaults to None.
+            affinity (dict[str, str] | None, optional): Label-based worker affinity constraints. Workers must have all specified labels to run this workflow. Defaults to None.
             schedule (Schedule | None, optional): The schedule configuration for automatic workflow execution. Defaults to None.
 
         Returns:

--- a/flux/workflow.py
+++ b/flux/workflow.py
@@ -24,6 +24,7 @@ class workflow:
         secret_requests: list[str] | None = None,
         output_storage: OutputStorage | None = None,
         requests: ResourceRequest | None = None,
+        affinity: dict[str, str] | None = None,
         schedule: Schedule | None = None,
     ) -> Callable[[F], workflow]:
         """
@@ -49,6 +50,7 @@ class workflow:
                 secret_requests=secret_requests,
                 output_storage=output_storage,
                 requests=requests,
+                affinity=affinity,
                 schedule=schedule,
             )
 
@@ -62,6 +64,7 @@ class workflow:
         secret_requests: list[str] | None = None,
         output_storage: OutputStorage | None = None,
         requests: ResourceRequest | None = None,
+        affinity: dict[str, str] | None = None,
         schedule: Schedule | None = None,
     ):
         self._func = func
@@ -70,6 +73,7 @@ class workflow:
         self._secret_requests = list(secret_requests) if secret_requests else []
         self._output_storage = output_storage
         self._requests = requests
+        self._affinity = affinity
         self._schedule = schedule
         wraps(func)(self)
 
@@ -96,6 +100,10 @@ class workflow:
     @property
     def requests(self) -> ResourceRequest | None:
         return self._requests
+
+    @property
+    def affinity(self) -> dict[str, str] | None:
+        return self._affinity
 
     @property
     def schedule(self) -> Schedule | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.28.0"
+version = "0.29.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -65,6 +65,7 @@ class FluxCLI:
         self.server_url = server_url
         self.timeout = timeout
         self._env = {**os.environ}
+        self._extra_workers: list[subprocess.Popen] = []
 
     # -- low-level helpers ------------------------------------------------
 
@@ -233,6 +234,46 @@ class FluxCLI:
 
     def worker_show(self, name: str) -> dict:
         return self._server_json(["worker", "show", name])
+
+    def start_worker(
+        self,
+        name: str,
+        labels: dict[str, str] | None = None,
+    ) -> subprocess.Popen:
+        cmd = [
+            "poetry", "run", "flux", "start", "worker",
+            name, "--server-url", self.server_url,
+        ]
+        for k, v in (labels or {}).items():
+            cmd.extend(["--label", f"{k}={v}"])
+
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            cwd=PROJECT_ROOT,
+            env=self._env,
+        )
+
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            try:
+                r = httpx.get(f"{self.server_url}/workers", timeout=2)
+                if r.status_code == 200:
+                    if any(w["name"] == name for w in r.json()):
+                        self._extra_workers.append(proc)
+                        return proc
+            except httpx.ConnectError:
+                pass
+            time.sleep(1)
+
+        _kill_process(proc, name)
+        raise RuntimeError(f"Worker '{name}' did not connect within 30s")
+
+    def stop_worker(self, proc: subprocess.Popen):
+        _kill_process(proc, "worker")
+        if proc in self._extra_workers:
+            self._extra_workers.remove(proc)
 
     # -- admin: roles ------------------------------------------------------
 
@@ -512,6 +553,8 @@ def cli(tmp_path_factory):
     yield flux_cli
 
     # -- teardown ---------------------------------------------------------
+    for proc in flux_cli._extra_workers:
+        _kill_process(proc, "extra-worker")
     _kill_process(wkr, "worker")
     _kill_process(srv, "server")
     srv_log.close()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -255,8 +255,8 @@ class FluxCLI:
 
         proc = subprocess.Popen(
             cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
             cwd=PROJECT_ROOT,
             env=self._env,
         )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -241,8 +241,14 @@ class FluxCLI:
         labels: dict[str, str] | None = None,
     ) -> subprocess.Popen:
         cmd = [
-            "poetry", "run", "flux", "start", "worker",
-            name, "--server-url", self.server_url,
+            "poetry",
+            "run",
+            "flux",
+            "start",
+            "worker",
+            name,
+            "--server-url",
+            self.server_url,
         ]
         for k, v in (labels or {}).items():
             cmd.extend(["--label", f"{k}={v}"])

--- a/tests/e2e/fixtures/affinity_workflow.py
+++ b/tests/e2e/fixtures/affinity_workflow.py
@@ -1,0 +1,6 @@
+from flux import workflow
+
+
+@workflow.with_options(affinity={"role": "harness"})
+async def affinity_task(ctx):
+    return {"result": "affinity_task_done"}

--- a/tests/e2e/fixtures/no_affinity_workflow.py
+++ b/tests/e2e/fixtures/no_affinity_workflow.py
@@ -1,0 +1,6 @@
+from flux import workflow
+
+
+@workflow
+async def no_affinity_task(ctx):
+    return {"result": "no_affinity_task_done"}

--- a/tests/e2e/test_worker_affinity.py
+++ b/tests/e2e/test_worker_affinity.py
@@ -1,0 +1,72 @@
+"""E2E tests for worker affinity label-based dispatch."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+pytestmark = pytest.mark.e2e
+
+
+def test_affinity_dispatches_to_matching_worker(cli):
+    """Workflow with affinity runs on worker with matching labels."""
+    harness = cli.start_worker("harness-worker", labels={"role": "harness"})
+    try:
+        cli.register(str(FIXTURES / "affinity_workflow.py"))
+        r = cli.run("affinity_task", "null")
+        assert r["state"] == "COMPLETED"
+        assert r.get("current_worker") == "harness-worker"
+    finally:
+        cli.stop_worker(harness)
+
+
+def test_affinity_skips_nonmatching_then_dispatches_when_matching_appears(cli):
+    """Workflow waits until a worker with matching labels connects."""
+    cli.register(str(FIXTURES / "affinity_workflow.py"))
+
+    # Start async — no matching worker yet (e2e-worker has no labels)
+    r = cli.run("affinity_task", "null", mode="async", timeout=30)
+    exec_id = r["execution_id"]
+
+    # Give the scheduler a moment to attempt dispatch
+    import time
+    time.sleep(3)
+
+    s = cli.status("affinity_task", exec_id)
+    if s["state"] == "COMPLETED":
+        assert s.get("current_worker") != "e2e-worker"
+    else:
+        harness = cli.start_worker("harness-worker-2", labels={"role": "harness"})
+        try:
+            final = cli.wait_for_state("affinity_task", exec_id, "COMPLETED", timeout=30)
+            assert final["state"] == "COMPLETED"
+        finally:
+            cli.stop_worker(harness)
+
+
+def test_labeled_worker_receives_unconstrained_work(cli):
+    """Worker with labels still picks up workflows without affinity."""
+    labeled = cli.start_worker("labeled-worker", labels={"role": "harness"})
+    try:
+        cli.register(str(FIXTURES / "no_affinity_workflow.py"))
+        r = cli.run("no_affinity_task", "null")
+        assert r["state"] == "COMPLETED"
+    finally:
+        cli.stop_worker(labeled)
+
+
+def test_worker_labels_visible_in_list(cli):
+    """Worker labels appear in the worker list API response."""
+    labeled = cli.start_worker(
+        "visible-labels-worker",
+        labels={"env": "sandbox", "browser": "true"},
+    )
+    try:
+        workers = cli.worker_list()
+        match = [w for w in workers if w["name"] == "visible-labels-worker"]
+        assert len(match) == 1
+        assert match[0]["labels"] == {"env": "sandbox", "browser": "true"}
+    finally:
+        cli.stop_worker(labeled)

--- a/tests/e2e/test_worker_affinity.py
+++ b/tests/e2e/test_worker_affinity.py
@@ -1,6 +1,7 @@
 """E2E tests for worker affinity label-based dispatch."""
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import pytest
@@ -31,7 +32,6 @@ def test_affinity_skips_nonmatching_then_dispatches_when_matching_appears(cli):
     exec_id = r["execution_id"]
 
     # Give the scheduler a moment to attempt dispatch
-    import time
     time.sleep(3)
 
     s = cli.status("affinity_task", exec_id)

--- a/tests/flux/domain/test_resource_request.py
+++ b/tests/flux/domain/test_resource_request.py
@@ -192,3 +192,43 @@ def test_no_requirements():
     worker_packages = []
 
     assert empty_request.matches_worker(worker_resources, worker_packages)
+
+
+def test_matches_labels_exact_match():
+    worker_labels = {"role": "harness", "env": "sandbox"}
+    affinity = {"role": "harness", "env": "sandbox"}
+    assert ResourceRequest.matches_labels(worker_labels, affinity)
+
+
+def test_matches_labels_subset():
+    worker_labels = {"role": "harness", "env": "sandbox", "region": "us-east"}
+    affinity = {"role": "harness"}
+    assert ResourceRequest.matches_labels(worker_labels, affinity)
+
+
+def test_matches_labels_mismatch():
+    worker_labels = {"role": "harness", "env": "production"}
+    affinity = {"role": "harness", "env": "sandbox"}
+    assert not ResourceRequest.matches_labels(worker_labels, affinity)
+
+
+def test_matches_labels_missing_key():
+    worker_labels = {"role": "harness"}
+    affinity = {"role": "harness", "env": "sandbox"}
+    assert not ResourceRequest.matches_labels(worker_labels, affinity)
+
+
+def test_matches_labels_empty_affinity():
+    worker_labels = {"role": "harness"}
+    affinity = {}
+    assert ResourceRequest.matches_labels(worker_labels, affinity)
+
+
+def test_matches_labels_empty_worker_labels():
+    worker_labels = {}
+    affinity = {"role": "harness"}
+    assert not ResourceRequest.matches_labels(worker_labels, affinity)
+
+
+def test_matches_labels_both_empty():
+    assert ResourceRequest.matches_labels({}, {})

--- a/tests/flux/test_affinity_dispatch.py
+++ b/tests/flux/test_affinity_dispatch.py
@@ -218,8 +218,9 @@ def test_resume_falls_back_to_label_match(clean_env):
         model.state = ExecutionState.PAUSED
         session.commit()
 
-    # w1 goes offline — eviction calls unclaim, which clears worker_name on PAUSED
-    cm.unclaim(ctx.execution_id)
+    # w1 goes offline — eviction calls unclaim (no-op for PAUSED), then release_worker
+    cm.unclaim(ctx.execution_id)  # returns unchanged (PAUSED not reclaimable)
+    cm.release_worker(ctx.execution_id)  # clears worker_name, keeps PAUSED
 
     with repo.session() as session:
         model = session.get(ExecutionContextModel, ctx.execution_id)
@@ -260,6 +261,7 @@ def test_resume_fallback_rejects_affinity_mismatch(clean_env):
         session.commit()
 
     cm.unclaim(ctx.execution_id)
+    cm.release_worker(ctx.execution_id)
 
     with repo.session() as session:
         model = session.get(ExecutionContextModel, ctx.execution_id)
@@ -271,8 +273,8 @@ def test_resume_fallback_rejects_affinity_mismatch(clean_env):
     assert result is None
 
 
-def test_unclaim_paused_clears_worker_name(clean_env):
-    """Unclaim on a PAUSED execution clears worker_name but preserves PAUSED state."""
+def test_release_worker_paused_clears_worker_name(clean_env):
+    """release_worker on PAUSED clears worker_name but preserves state."""
     cm, registry = clean_env
     _register_worker(registry, "w1", labels={"role": "harness"})
     w1 = registry.get("w1")
@@ -289,13 +291,13 @@ def test_unclaim_paused_clears_worker_name(clean_env):
         model.state = ExecutionState.PAUSED
         session.commit()
 
-    result = cm.unclaim(ctx.execution_id)
+    result = cm.release_worker(ctx.execution_id)
     assert result.state == ExecutionState.PAUSED
     assert result.current_worker == ""
 
 
-def test_unclaim_resuming_clears_worker_name(clean_env):
-    """Unclaim on a RESUMING execution clears worker_name but preserves RESUMING state."""
+def test_release_worker_resuming_clears_worker_name(clean_env):
+    """release_worker on RESUMING clears worker_name but preserves state."""
     cm, registry = clean_env
     _register_worker(registry, "w1", labels={"role": "harness"})
     w1 = registry.get("w1")
@@ -312,9 +314,31 @@ def test_unclaim_resuming_clears_worker_name(clean_env):
         model.state = ExecutionState.RESUMING
         session.commit()
 
-    result = cm.unclaim(ctx.execution_id)
+    result = cm.release_worker(ctx.execution_id)
     assert result.state == ExecutionState.RESUMING
     assert result.current_worker == ""
+
+
+def test_release_worker_noop_on_running(clean_env):
+    """release_worker is a no-op on RUNNING executions (not releasable)."""
+    cm, registry = clean_env
+    _register_worker(registry, "w1", labels={"role": "harness"})
+    w1 = registry.get("w1")
+
+    wf_id = _create_workflow(cm, "agent5", affinity={"role": "harness"})
+    ctx = _create_execution(cm, wf_id, name="agent5")
+
+    cm.claim(ctx.execution_id, w1)
+    from flux.models import ExecutionContextModel, RepositoryFactory
+
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        model = session.get(ExecutionContextModel, ctx.execution_id)
+        model.state = ExecutionState.RUNNING
+        session.commit()
+
+    result = cm.release_worker(ctx.execution_id)
+    assert result.current_worker == "w1"
 
 
 def test_dispatch_affinity_matches_but_resources_insufficient(clean_env):

--- a/tests/flux/test_affinity_dispatch.py
+++ b/tests/flux/test_affinity_dispatch.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from flux.context_managers import DatabaseContextManager
+from flux.domain import ExecutionState
+from flux.domain.execution_context import ExecutionContext
+from flux.worker_registry import (
+    DatabaseWorkerRegistry,
+    WorkerResourcesInfo,
+    WorkerRuntimeInfo,
+)
+
+
+@pytest.fixture
+def clean_env():
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as f:
+        db_path = f.name
+
+    db_url = f"sqlite:///{db_path}"
+    with patch("flux.config.Configuration.get") as mock_config:
+        mock_config.return_value.settings.database_url = db_url
+        mock_config.return_value.settings.database_type = "sqlite"
+        mock_config.return_value.settings.security.auth.enabled = False
+
+        cm = DatabaseContextManager()
+        registry = DatabaseWorkerRegistry()
+        yield cm, registry
+
+    if os.path.exists(db_path):
+        os.unlink(db_path)
+
+
+def _make_runtime():
+    return WorkerRuntimeInfo(os_name="Linux", os_version="6.0", python_version="3.12.0")
+
+
+def _make_resources():
+    return WorkerResourcesInfo(
+        cpu_total=4,
+        cpu_available=4,
+        memory_total=8_000_000_000,
+        memory_available=8_000_000_000,
+        disk_total=100_000_000_000,
+        disk_free=100_000_000_000,
+        gpus=[],
+    )
+
+
+def _register_worker(registry, name, labels=None):
+    return registry.register(
+        name=name,
+        runtime=_make_runtime(),
+        packages=[],
+        resources=_make_resources(),
+        labels=labels,
+    )
+
+
+def _create_workflow(cm, name, namespace="default", affinity=None, requests=None):
+    from flux.models import WorkflowModel, RepositoryFactory
+
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        wf = WorkflowModel(
+            id=f"{namespace}/{name}",
+            name=name,
+            version=1,
+            imports=[],
+            source=b"async def placeholder(ctx): pass",
+            namespace=namespace,
+            affinity=affinity,
+            requests=requests,
+        )
+        session.add(wf)
+        session.commit()
+        return wf.id
+
+
+def _create_execution(cm, workflow_id, namespace="default", name="test"):
+    ctx = ExecutionContext(
+        workflow_id=workflow_id,
+        workflow_namespace=namespace,
+        workflow_name=name,
+    )
+    return cm.save(ctx)
+
+
+def test_dispatch_matches_worker_with_correct_labels(clean_env):
+    cm, registry = clean_env
+    _register_worker(registry, "w1", labels={"role": "harness"})
+    w1 = registry.get("w1")
+
+    wf_id = _create_workflow(cm, "agent", affinity={"role": "harness"})
+    _create_execution(cm, wf_id, name="agent")
+
+    result = cm.next_execution(w1)
+    assert result is not None
+    assert result.workflow_name == "agent"
+
+
+def test_dispatch_skips_worker_without_matching_labels(clean_env):
+    cm, registry = clean_env
+    _register_worker(registry, "w1", labels={"role": "compute"})
+    w1 = registry.get("w1")
+
+    wf_id = _create_workflow(cm, "agent", affinity={"role": "harness"})
+    _create_execution(cm, wf_id, name="agent")
+
+    result = cm.next_execution(w1)
+    assert result is None
+
+
+def test_dispatch_worker_no_labels_gets_no_affinity_workflow(clean_env):
+    cm, registry = clean_env
+    _register_worker(registry, "w1")
+    w1 = registry.get("w1")
+
+    wf_id = _create_workflow(cm, "simple")
+    _create_execution(cm, wf_id, name="simple")
+
+    result = cm.next_execution(w1)
+    assert result is not None
+    assert result.workflow_name == "simple"
+
+
+def test_dispatch_worker_no_labels_skips_affinity_workflow(clean_env):
+    cm, registry = clean_env
+    _register_worker(registry, "w1")
+    w1 = registry.get("w1")
+
+    wf_id = _create_workflow(cm, "agent", affinity={"role": "harness"})
+    _create_execution(cm, wf_id, name="agent")
+
+    result = cm.next_execution(w1)
+    assert result is None
+
+
+def test_dispatch_with_both_affinity_and_requests(clean_env):
+    cm, registry = clean_env
+    _register_worker(registry, "w1", labels={"role": "harness"})
+    w1 = registry.get("w1")
+
+    requests_dict = {"cpu": 2, "memory": "1Gi"}
+    wf_id = _create_workflow(cm, "agent", affinity={"role": "harness"}, requests=requests_dict)
+    _create_execution(cm, wf_id, name="agent")
+
+    result = cm.next_execution(w1)
+    assert result is not None
+
+
+def test_dispatch_constrained_before_unconstrained(clean_env):
+    cm, registry = clean_env
+    _register_worker(registry, "w1", labels={"role": "harness"})
+    w1 = registry.get("w1")
+
+    wf_simple_id = _create_workflow(cm, "simple")
+    _create_execution(cm, wf_simple_id, name="simple")
+
+    wf_agent_id = _create_workflow(cm, "agent", affinity={"role": "harness"})
+    _create_execution(cm, wf_agent_id, name="agent")
+
+    result = cm.next_execution(w1)
+    assert result is not None
+    assert result.workflow_name == "agent"
+
+
+def test_resume_prefers_original_worker(clean_env):
+    cm, registry = clean_env
+    _register_worker(registry, "w1", labels={"role": "harness"})
+    _register_worker(registry, "w2", labels={"role": "harness"})
+    w1 = registry.get("w1")
+    w2 = registry.get("w2")
+
+    wf_id = _create_workflow(cm, "agent", affinity={"role": "harness"})
+    ctx = _create_execution(cm, wf_id, name="agent")
+
+    cm.claim(ctx.execution_id, w1)
+    from flux.models import ExecutionContextModel, RepositoryFactory
+
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        model = session.get(ExecutionContextModel, ctx.execution_id)
+        model.state = ExecutionState.RESUMING
+        session.commit()
+
+    result = cm.next_resume(w1)
+    assert result is not None
+    assert result.execution_id == ctx.execution_id
+
+    result2 = cm.next_resume(w2)
+    assert result2 is None
+
+
+def test_resume_falls_back_to_label_match(clean_env):
+    cm, registry = clean_env
+    _register_worker(registry, "w1", labels={"role": "harness"})
+    _register_worker(registry, "w2", labels={"role": "harness"})
+    w1 = registry.get("w1")
+    w2 = registry.get("w2")
+
+    wf_id = _create_workflow(cm, "agent", affinity={"role": "harness"})
+    ctx = _create_execution(cm, wf_id, name="agent")
+
+    cm.claim(ctx.execution_id, w1)
+    from flux.models import ExecutionContextModel, RepositoryFactory
+
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        model = session.get(ExecutionContextModel, ctx.execution_id)
+        model.state = ExecutionState.RESUMING
+        model.worker_name = None
+        session.commit()
+
+    result = cm.next_resume(w2)
+    assert result is not None
+    assert result.execution_id == ctx.execution_id

--- a/tests/flux/test_affinity_dispatch.py
+++ b/tests/flux/test_affinity_dispatch.py
@@ -197,16 +197,16 @@ def test_resume_prefers_original_worker(clean_env):
 
 
 def test_resume_falls_back_to_label_match(clean_env):
+    """When original worker is gone and worker_name is cleared, another worker picks up via labels."""
     cm, registry = clean_env
     _register_worker(registry, "w1", labels={"role": "harness"})
     _register_worker(registry, "w2", labels={"role": "harness"})
-    w1 = registry.get("w1")
     w2 = registry.get("w2")
 
     wf_id = _create_workflow(cm, "agent", affinity={"role": "harness"})
     ctx = _create_execution(cm, wf_id, name="agent")
 
-    cm.claim(ctx.execution_id, w1)
+    # Execution is resuming with worker_name cleared (e.g., by cleanup after w1 went offline)
     from flux.models import ExecutionContextModel, RepositoryFactory
 
     repo = RepositoryFactory.create_repository()
@@ -219,3 +219,41 @@ def test_resume_falls_back_to_label_match(clean_env):
     result = cm.next_resume(w2)
     assert result is not None
     assert result.execution_id == ctx.execution_id
+
+
+def test_resume_fallback_rejects_affinity_mismatch(clean_env):
+    """Resume fallback rejects workers that don't match affinity."""
+    cm, registry = clean_env
+    _register_worker(registry, "w2", labels={"role": "compute"})
+    w2 = registry.get("w2")
+
+    wf_id = _create_workflow(cm, "agent2", affinity={"role": "harness"})
+    ctx = _create_execution(cm, wf_id, name="agent2")
+
+    # Execution is resuming with no worker assigned
+    from flux.models import ExecutionContextModel, RepositoryFactory
+
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        model = session.get(ExecutionContextModel, ctx.execution_id)
+        model.state = ExecutionState.RESUMING
+        model.worker_name = None
+        session.commit()
+
+    result = cm.next_resume(w2)
+    assert result is None
+
+
+def test_dispatch_affinity_matches_but_resources_insufficient(clean_env):
+    """Worker matches affinity labels but fails resource requirements."""
+    cm, registry = clean_env
+    _register_worker(registry, "w1", labels={"role": "harness"})
+    w1 = registry.get("w1")
+
+    # Request 128 CPUs — far more than the worker has
+    requests_dict = {"cpu": 128}
+    wf_id = _create_workflow(cm, "agent", affinity={"role": "harness"}, requests=requests_dict)
+    _create_execution(cm, wf_id, name="agent")
+
+    result = cm.next_execution(w1)
+    assert result is None

--- a/tests/flux/test_affinity_dispatch.py
+++ b/tests/flux/test_affinity_dispatch.py
@@ -197,25 +197,42 @@ def test_resume_prefers_original_worker(clean_env):
 
 
 def test_resume_falls_back_to_label_match(clean_env):
-    """When original worker is gone and worker_name is cleared, another worker picks up via labels."""
+    """Realistic scenario: w1 runs, pauses, gets evicted (unclaim clears worker_name),
+    resume is called, w2 picks it up via affinity label match."""
     cm, registry = clean_env
     _register_worker(registry, "w1", labels={"role": "harness"})
     _register_worker(registry, "w2", labels={"role": "harness"})
+    w1 = registry.get("w1")
     w2 = registry.get("w2")
 
     wf_id = _create_workflow(cm, "agent", affinity={"role": "harness"})
     ctx = _create_execution(cm, wf_id, name="agent")
 
-    # Execution is resuming with worker_name cleared (e.g., by cleanup after w1 went offline)
+    # w1 claims and runs the execution, then it pauses
+    cm.claim(ctx.execution_id, w1)
     from flux.models import ExecutionContextModel, RepositoryFactory
 
     repo = RepositoryFactory.create_repository()
     with repo.session() as session:
         model = session.get(ExecutionContextModel, ctx.execution_id)
-        model.state = ExecutionState.RESUMING
-        model.worker_name = None
+        model.state = ExecutionState.PAUSED
         session.commit()
 
+    # w1 goes offline — eviction calls unclaim, which clears worker_name on PAUSED
+    cm.unclaim(ctx.execution_id)
+
+    with repo.session() as session:
+        model = session.get(ExecutionContextModel, ctx.execution_id)
+        assert model.state == ExecutionState.PAUSED
+        assert model.worker_name is None
+
+    # Resume is called — transitions to RESUMING with worker_name still NULL
+    with repo.session() as session:
+        model = session.get(ExecutionContextModel, ctx.execution_id)
+        model.state = ExecutionState.RESUMING
+        session.commit()
+
+    # w2 picks it up via affinity fallback
     result = cm.next_resume(w2)
     assert result is not None
     assert result.execution_id == ctx.execution_id
@@ -224,24 +241,80 @@ def test_resume_falls_back_to_label_match(clean_env):
 def test_resume_fallback_rejects_affinity_mismatch(clean_env):
     """Resume fallback rejects workers that don't match affinity."""
     cm, registry = clean_env
+    _register_worker(registry, "w1", labels={"role": "harness"})
     _register_worker(registry, "w2", labels={"role": "compute"})
+    w1 = registry.get("w1")
     w2 = registry.get("w2")
 
     wf_id = _create_workflow(cm, "agent2", affinity={"role": "harness"})
     ctx = _create_execution(cm, wf_id, name="agent2")
 
-    # Execution is resuming with no worker assigned
+    # w1 claimed, paused, then evicted
+    cm.claim(ctx.execution_id, w1)
+    from flux.models import ExecutionContextModel, RepositoryFactory
+
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        model = session.get(ExecutionContextModel, ctx.execution_id)
+        model.state = ExecutionState.PAUSED
+        session.commit()
+
+    cm.unclaim(ctx.execution_id)
+
+    with repo.session() as session:
+        model = session.get(ExecutionContextModel, ctx.execution_id)
+        model.state = ExecutionState.RESUMING
+        session.commit()
+
+    # w2 has wrong labels — should not get the execution
+    result = cm.next_resume(w2)
+    assert result is None
+
+
+def test_unclaim_paused_clears_worker_name(clean_env):
+    """Unclaim on a PAUSED execution clears worker_name but preserves PAUSED state."""
+    cm, registry = clean_env
+    _register_worker(registry, "w1", labels={"role": "harness"})
+    w1 = registry.get("w1")
+
+    wf_id = _create_workflow(cm, "agent3", affinity={"role": "harness"})
+    ctx = _create_execution(cm, wf_id, name="agent3")
+
+    cm.claim(ctx.execution_id, w1)
+    from flux.models import ExecutionContextModel, RepositoryFactory
+
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        model = session.get(ExecutionContextModel, ctx.execution_id)
+        model.state = ExecutionState.PAUSED
+        session.commit()
+
+    result = cm.unclaim(ctx.execution_id)
+    assert result.state == ExecutionState.PAUSED
+    assert result.current_worker == ""
+
+
+def test_unclaim_resuming_clears_worker_name(clean_env):
+    """Unclaim on a RESUMING execution clears worker_name but preserves RESUMING state."""
+    cm, registry = clean_env
+    _register_worker(registry, "w1", labels={"role": "harness"})
+    w1 = registry.get("w1")
+
+    wf_id = _create_workflow(cm, "agent4", affinity={"role": "harness"})
+    ctx = _create_execution(cm, wf_id, name="agent4")
+
+    cm.claim(ctx.execution_id, w1)
     from flux.models import ExecutionContextModel, RepositoryFactory
 
     repo = RepositoryFactory.create_repository()
     with repo.session() as session:
         model = session.get(ExecutionContextModel, ctx.execution_id)
         model.state = ExecutionState.RESUMING
-        model.worker_name = None
         session.commit()
 
-    result = cm.next_resume(w2)
-    assert result is None
+    result = cm.unclaim(ctx.execution_id)
+    assert result.state == ExecutionState.RESUMING
+    assert result.current_worker == ""
 
 
 def test_dispatch_affinity_matches_but_resources_insufficient(clean_env):
@@ -250,7 +323,6 @@ def test_dispatch_affinity_matches_but_resources_insufficient(clean_env):
     _register_worker(registry, "w1", labels={"role": "harness"})
     w1 = registry.get("w1")
 
-    # Request 128 CPUs — far more than the worker has
     requests_dict = {"cpu": 128}
     wf_id = _create_workflow(cm, "agent", affinity={"role": "harness"}, requests=requests_dict)
     _create_execution(cm, wf_id, name="agent")

--- a/tests/flux/test_worker_labels_api.py
+++ b/tests/flux/test_worker_labels_api.py
@@ -1,0 +1,48 @@
+from flux.server import WorkerRegistration, WorkerResponse
+
+
+def test_worker_registration_with_labels():
+    reg = WorkerRegistration(
+        name="w1",
+        runtime={"os_name": "Linux", "os_version": "6.0", "python_version": "3.12"},
+        packages=[],
+        resources={
+            "cpu_total": 4,
+            "cpu_available": 4,
+            "memory_total": 8e9,
+            "memory_available": 8e9,
+            "disk_total": 100e9,
+            "disk_free": 100e9,
+            "gpus": [],
+        },
+        labels={"role": "harness", "browser": "true"},
+    )
+    assert reg.labels == {"role": "harness", "browser": "true"}
+
+
+def test_worker_registration_default_labels():
+    reg = WorkerRegistration(
+        name="w1",
+        runtime={"os_name": "Linux", "os_version": "6.0", "python_version": "3.12"},
+        packages=[],
+        resources={
+            "cpu_total": 4,
+            "cpu_available": 4,
+            "memory_total": 8e9,
+            "memory_available": 8e9,
+            "disk_total": 100e9,
+            "disk_free": 100e9,
+            "gpus": [],
+        },
+    )
+    assert reg.labels == {}
+
+
+def test_worker_response_with_labels():
+    resp = WorkerResponse(name="w1", status="online", labels={"role": "harness"})
+    assert resp.labels == {"role": "harness"}
+
+
+def test_worker_response_default_labels():
+    resp = WorkerResponse(name="w1")
+    assert resp.labels == {}

--- a/tests/flux/test_worker_registry_labels.py
+++ b/tests/flux/test_worker_registry_labels.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from flux.worker_registry import (
+    DatabaseWorkerRegistry,
+    WorkerInfo,
+    WorkerResourcesInfo,
+    WorkerRuntimeInfo,
+)
+
+
+@pytest.fixture
+def clean_db():
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as f:
+        db_path = f.name
+    db_url = f"sqlite:///{db_path}"
+    with patch("flux.config.Configuration.get") as mock_config:
+        mock_config.return_value.settings.database_url = db_url
+        mock_config.return_value.settings.database_type = "sqlite"
+        mock_config.return_value.settings.security.auth.enabled = False
+        yield DatabaseWorkerRegistry()
+    if os.path.exists(db_path):
+        os.unlink(db_path)
+
+
+def _make_runtime():
+    return WorkerRuntimeInfo(os_name="Linux", os_version="6.0", python_version="3.12.0")
+
+
+def _make_resources():
+    return WorkerResourcesInfo(
+        cpu_total=4,
+        cpu_available=4,
+        memory_total=8_000_000_000,
+        memory_available=8_000_000_000,
+        disk_total=100_000_000_000,
+        disk_free=100_000_000_000,
+        gpus=[],
+    )
+
+
+def test_worker_info_default_labels():
+    info = WorkerInfo(name="w1")
+    assert info.labels == {}
+
+
+def test_worker_info_with_labels():
+    labels = {"gpu": "true", "region": "us-east"}
+    info = WorkerInfo(name="w1", labels=labels)
+    assert info.labels == labels
+
+
+def test_register_worker_with_labels(clean_db):
+    labels = {"gpu": "true", "region": "us-east"}
+    result = clean_db.register(
+        name="w1",
+        runtime=_make_runtime(),
+        packages=[],
+        resources=_make_resources(),
+        labels=labels,
+    )
+    assert result.labels == labels
+
+
+def test_register_worker_without_labels(clean_db):
+    result = clean_db.register(
+        name="w1",
+        runtime=_make_runtime(),
+        packages=[],
+        resources=_make_resources(),
+    )
+    assert result.labels == {}
+
+
+def test_get_worker_preserves_labels(clean_db):
+    labels = {"tier": "premium", "zone": "a"}
+    clean_db.register(
+        name="w1",
+        runtime=_make_runtime(),
+        packages=[],
+        resources=_make_resources(),
+        labels=labels,
+    )
+    retrieved = clean_db.get("w1")
+    assert retrieved.labels == labels
+
+
+def test_list_workers_preserves_labels(clean_db):
+    labels_a = {"role": "gpu-worker"}
+    labels_b = {"role": "cpu-worker", "zone": "b"}
+    clean_db.register(
+        name="w1",
+        runtime=_make_runtime(),
+        packages=[],
+        resources=_make_resources(),
+        labels=labels_a,
+    )
+    clean_db.register(
+        name="w2",
+        runtime=_make_runtime(),
+        packages=[],
+        resources=_make_resources(),
+        labels=labels_b,
+    )
+    workers = {w.name: w for w in clean_db.list()}
+    assert workers["w1"].labels == labels_a
+    assert workers["w2"].labels == labels_b
+
+
+def test_reregister_worker_updates_labels(clean_db):
+    labels_v1 = {"version": "1"}
+    labels_v2 = {"version": "2", "extra": "yes"}
+    clean_db.register(
+        name="w1",
+        runtime=_make_runtime(),
+        packages=[],
+        resources=_make_resources(),
+        labels=labels_v1,
+    )
+    clean_db.register(
+        name="w1",
+        runtime=_make_runtime(),
+        packages=[],
+        resources=_make_resources(),
+        labels=labels_v2,
+    )
+    retrieved = clean_db.get("w1")
+    assert retrieved.labels == labels_v2

--- a/tests/flux/test_workflow_affinity.py
+++ b/tests/flux/test_workflow_affinity.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from flux.catalogs import WorkflowCatalog, WorkflowInfo
+
+
+def test_workflow_info_with_affinity():
+    info = WorkflowInfo(
+        id="test/wf",
+        name="wf",
+        imports=[],
+        source=b"",
+        affinity={"role": "harness"},
+    )
+    assert info.affinity == {"role": "harness"}
+
+
+def test_workflow_info_default_affinity():
+    info = WorkflowInfo(id="test/wf", name="wf", imports=[], source=b"")
+    assert info.affinity is None
+
+
+def test_workflow_info_to_dict_includes_affinity():
+    info = WorkflowInfo(
+        id="test/wf",
+        name="wf",
+        imports=[],
+        source=b"",
+        affinity={"role": "harness", "env": "sandbox"},
+    )
+    d = info.to_dict()
+    assert d["affinity"] == {"role": "harness", "env": "sandbox"}
+
+
+def test_workflow_info_to_dict_no_affinity():
+    info = WorkflowInfo(id="test/wf", name="wf", imports=[], source=b"")
+    d = info.to_dict()
+    assert d["affinity"] is None
+
+
+def test_parse_workflow_with_affinity(clean_db):
+    source = b"""
+from flux import workflow
+
+@workflow.with_options(affinity={"role": "harness", "browser": "true"})
+async def my_agent(ctx):
+    pass
+"""
+    infos = clean_db.parse(source)
+    assert len(infos) == 1
+    assert infos[0].affinity == {"role": "harness", "browser": "true"}
+
+
+def test_parse_workflow_without_affinity(clean_db):
+    source = b"""
+from flux import workflow
+
+@workflow
+async def simple(ctx):
+    pass
+"""
+    infos = clean_db.parse(source)
+    assert len(infos) == 1
+    assert infos[0].affinity is None
+
+
+@pytest.fixture
+def clean_db():
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as f:
+        db_path = f.name
+    db_url = f"sqlite:///{db_path}"
+    with patch("flux.config.Configuration.get") as mock_config:
+        mock_config.return_value.settings.database_url = db_url
+        mock_config.return_value.settings.database_type = "sqlite"
+        mock_config.return_value.settings.security.auth.enabled = False
+        yield WorkflowCatalog.create()
+    if os.path.exists(db_path):
+        os.unlink(db_path)
+
+
+def test_save_and_get_workflow_with_affinity(clean_db):
+    catalog = clean_db
+    info = WorkflowInfo(
+        id="default/test_affinity",
+        name="test_affinity",
+        imports=["flux"],
+        source=b"async def test_affinity(ctx): pass",
+        affinity={"role": "harness"},
+    )
+    catalog.save([info])
+    result = catalog.get("default", "test_affinity")
+    assert result.affinity == {"role": "harness"}
+
+
+def test_save_and_get_workflow_without_affinity(clean_db):
+    catalog = clean_db
+    info = WorkflowInfo(
+        id="default/no_affinity",
+        name="no_affinity",
+        imports=["flux"],
+        source=b"async def no_affinity(ctx): pass",
+    )
+    catalog.save([info])
+    result = catalog.get("default", "no_affinity")
+    assert result.affinity is None


### PR DESCRIPTION
## Summary

- Workers declare capability labels at startup via `--label key=value` (repeatable, immutable)
- Workflows declare affinity requirements via `@workflow.with_options(affinity={"role": "harness"})`
- Dispatch matches worker labels against workflow affinity (exact key-value, all must match)
- Resume prefers the original worker, falls back to any worker matching affinity labels
- Worker eviction clears `worker_name` on suspended executions via new `release_worker` method
- Labels are separate from `ResourceRequest` — labels = capability, resources = capacity

## Changes

**Core:**
- `ResourceRequest.matches_labels()` static method for label matching
- `WorkerInfo` / `WorkerModel` gain `labels: dict[str, str]`
- `WorkflowModel` gains `affinity` column (Base64Type)
- `workflow.with_options(affinity={...})` decorator parameter
- Catalog AST parser extracts affinity from decorators
- `next_execution` checks affinity + resources (constrained-first priority)
- `next_resume` sticky preference + fallback to label match
- `release_worker` method for clearing `worker_name` on PAUSED/RESUMING executions
- `current_worker` exposed in execution status summary

**CLI:**
- `flux worker start --label role=harness --label env=sandbox`
- `flux worker list` shows labels

**Infra:**
- pyupgrade upgraded to v3.21.2 (Python 3.14 compatibility)
- E2E helper: `FluxCLI.start_worker(name, labels)` / `stop_worker(proc)`

## Test plan

- [x] 97 unit/integration tests passing (32 new)
- [x] 4 E2E tests with live server + multiple workers
- [x] 13 pre-commit hooks passing
- [ ] Manual: start server, start two workers with different labels, register workflow with affinity, verify correct placement

## Known gaps (out of scope)

- Resume has no claim step — `worker_name` not updated to the new worker after fallback
- Resume race condition on SQLite (no `skip_locked` support)
- Both are pre-existing design issues, not introduced by this PR