### PR TITLE
feat: worker service principals — workers authenticate as RBAC principals

### DIFF
--- a/docs/advanced-features/authentication.md
+++ b/docs/advanced-features/authentication.md
@@ -72,6 +72,31 @@ default_user_roles = ["viewer"]
 
 Subsequent logins update `last_seen_at` and refresh `metadata` (display name, locale, etc.) but do not change roles. Roles are managed exclusively via the principals registry.
 
+### Worker service principals
+
+Workers are auto-provisioned as service account principals when they register. The registration flow:
+
+1. Worker sends `POST /workers/register` with the bootstrap token
+2. Server validates the bootstrap token and registers the worker
+3. Server creates (or finds) a service account principal with `subject=<worker-name>` and `external_issuer="flux"`
+4. Server assigns the `worker` role and generates an API key
+5. Worker receives the API key as its `session_token` and uses it for all subsequent calls
+
+The `worker` role grants:
+
+| Permission | Purpose |
+|-----------|---------|
+| `worker:*:*` | All worker-specific endpoints (pong, connect, claim, checkpoint, progress) |
+| `config:*:read` | Read agent configs at runtime |
+| `admin:secrets:read` | Read secrets for MCP auth |
+| `execution:*:read` | Read execution state |
+
+**Name binding:** Each worker endpoint verifies that the authenticated principal's subject matches the worker name in the URL path. Worker A cannot access `/workers/worker-B/pong`.
+
+**Eviction:** When the heartbeat reaper evicts a worker, its API key is revoked. When the worker reconnects and gets a 401, it re-registers with the bootstrap token, which provisions a fresh API key.
+
+**Auth-disabled mode:** When auth is disabled, worker endpoints are unprotected (consistent with all other endpoints). The name-binding check is skipped.
+
 ## RBAC
 
 Flux enforces RBAC at API and task level. Roles are collections of permissions.
@@ -83,6 +108,7 @@ Flux enforces RBAC at API and task level. Roles are collections of permissions.
 | `admin` | `*` — full access |
 | `operator` | Run and manage workflows, schedules, executions |
 | `viewer` | Read-only access |
+| `worker` | Worker endpoints, read configs/secrets/executions |
 
 ### Permission format
 
@@ -353,6 +379,12 @@ flux principals revoke-key <subject> --key-name <name>
 | `DELETE` | `/admin/principals/{id}` | `admin:principals:manage` |
 | `POST` | `/admin/principals/{id}/keys` | `admin:principals:manage` |
 | `DELETE` | `/admin/principals/{id}/keys/{name}` | `admin:principals:manage` |
+| `POST` | `/workers/register` | bootstrap_token |
+| `POST` | `/workers/{name}/pong` | `worker:*:*` |
+| `GET` | `/workers/{name}/connect` | `worker:*:*` |
+| `POST` | `/workers/{name}/claim/{id}` | `worker:*:*` |
+| `POST` | `/workers/{name}/checkpoint/{id}` | `worker:*:*` |
+| `POST` | `/workers/{name}/progress/{id}` | `worker:*:*` |
 
 ## Dev Environment
 

--- a/docs/advanced-features/observability.md
+++ b/docs/advanced-features/observability.md
@@ -55,7 +55,7 @@ FLUX_OBSERVABILITY__METRIC_EXPORT_INTERVAL=60
 
 ## Metrics
 
-Flux exposes 19 metric instruments accessible via the Prometheus `/metrics` endpoint at `http://localhost:8000/metrics`.
+Flux exposes 18 metric instruments accessible via the Prometheus `/metrics` endpoint at `http://localhost:8000/metrics`.
 
 ### Workflow Metrics
 

--- a/docs/advanced-features/observability.md
+++ b/docs/advanced-features/observability.md
@@ -55,7 +55,7 @@ FLUX_OBSERVABILITY__METRIC_EXPORT_INTERVAL=60
 
 ## Metrics
 
-Flux exposes 18 metric instruments accessible via the Prometheus `/metrics` endpoint at `http://localhost:8000/metrics`.
+Flux exposes 19 metric instruments accessible via the Prometheus `/metrics` endpoint at `http://localhost:8000/metrics`.
 
 ### Workflow Metrics
 
@@ -89,6 +89,7 @@ Flux exposes 18 metric instruments accessible via the Prometheus `/metrics` endp
 | `flux_worker_registrations_total` | Counter | `worker_name` | Registration events |
 | `flux_worker_disconnections_total` | Counter | `worker_name`, `reason` | Disconnection events |
 | `flux_worker_executions_active` | UpDownCounter | `worker_name` | Concurrent executions per worker |
+| `flux_worker_auth_events_total` | Counter | `worker_name`, `event` | Worker auth lifecycle (`principal_provisioned`, `key_revoked`, `identity_mismatch`) |
 | `flux_module_cache_total` | Counter | `result` | Module cache lookups (`hit`, `miss`) |
 
 ### Schedule Metrics
@@ -171,6 +172,9 @@ histogram_quantile(0.95, rate(flux_http_request_duration_seconds_bucket[5m]))
 
 # Connected workers
 flux_workers_active
+
+# Worker identity mismatch attempts (potential impersonation)
+rate(flux_worker_auth_events_total{event="identity_mismatch"}[5m])
 
 # Execution queue depth
 flux_execution_queue_depth

--- a/flux/observability/metrics.py
+++ b/flux/observability/metrics.py
@@ -115,6 +115,11 @@ class FluxMetrics:
             description="Concurrent executions per worker",
         )
 
+        self.worker_auth_events = meter.create_counter(
+            "flux_worker_auth_events_total",
+            description="Worker authentication lifecycle events",
+        )
+
         self.schedule_triggers = meter.create_counter(
             "flux_schedule_triggers_total",
             description="Schedule trigger events",
@@ -250,6 +255,12 @@ class FluxMetrics:
 
     def record_worker_execution_ended(self, worker_name: str):
         self.worker_executions_active.add(-1, {"worker_name": worker_name})
+
+    def record_worker_auth_event(self, worker_name: str, event: str):
+        self.worker_auth_events.add(
+            1,
+            {"worker_name": worker_name, "event": event},
+        )
 
     def record_schedule_trigger(self, schedule_name: str, outcome: str):
         self.schedule_triggers.add(1, {"schedule_name": schedule_name, "outcome": outcome})

--- a/flux/security/auth_service.py
+++ b/flux/security/auth_service.py
@@ -36,6 +36,12 @@ BUILT_IN_ROLES = {
         "execution:*:read",
         "schedule:*:read",
     ],
+    "worker": [
+        "worker:*:*",
+        "config:*:read",
+        "admin:secrets:read",
+        "execution:*:read",
+    ],
 }
 
 
@@ -413,6 +419,21 @@ class AuthService:
                 raise ValueError(f"API key '{key_name}' not found")
             session.delete(key)
             session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    async def revoke_all_api_keys(self, principal_id: str) -> int:
+        session = self._session_factory()
+        try:
+            keys = session.query(APIKeyModel).filter_by(principal_id=principal_id).all()
+            count = len(keys)
+            for key in keys:
+                session.delete(key)
+            session.commit()
+            return count
         except Exception:
             session.rollback()
             raise

--- a/flux/server.py
+++ b/flux/server.py
@@ -1912,6 +1912,8 @@ class Server:
                         "Connection": "keep-alive",
                     },
                 )
+            except HTTPException:
+                raise
             except Exception as e:
                 raise HTTPException(status_code=404, detail=str(e))
 

--- a/flux/server.py
+++ b/flux/server.py
@@ -1578,41 +1578,36 @@ class Server:
                     labels=registration.labels,
                 )
 
-                if auth_service is not None and auth_config.enabled:
-                    try:
-                        principal = principal_registry.find(
+                if auth_service is not None and auth_config.api_keys.enabled:
+                    principal = principal_registry.find(
+                        subject=registration.name,
+                        external_issuer="flux",
+                    )
+                    if not principal:
+                        principal = principal_registry.create(
+                            type="service_account",
                             subject=registration.name,
                             external_issuer="flux",
                         )
-                        if not principal:
-                            principal = principal_registry.create(
-                                type="service_account",
-                                subject=registration.name,
-                                external_issuer="flux",
-                            )
-                        existing_roles = principal_registry.get_roles(principal.id)
-                        if "worker" not in existing_roles:
-                            principal_registry.assign_role(principal.id, "worker")
-                        await auth_service.revoke_all_api_keys(principal.id)
-                        api_key = await auth_service.create_api_key(
-                            principal.id,
-                            key_name=f"worker-{registration.name}",
-                        )
-                        result.session_token = api_key
+                    if not principal.enabled:
+                        principal_registry.set_enabled(principal.id, True)
+                    existing_roles = principal_registry.get_roles(principal.id)
+                    if "worker" not in existing_roles:
+                        principal_registry.assign_role(principal.id, "worker")
+                    await auth_service.revoke_all_api_keys(principal.id)
+                    api_key = await auth_service.create_api_key(
+                        principal.id,
+                        key_name=f"worker-{registration.name}",
+                    )
+                    result.session_token = api_key
 
-                        from flux.observability import get_metrics as _gm_prov
+                    from flux.observability import get_metrics as _gm_prov
 
-                        _m_prov = _gm_prov()
-                        if _m_prov:
-                            _m_prov.record_worker_auth_event(
-                                registration.name,
-                                "principal_provisioned",
-                            )
-                    except Exception as provision_err:
-                        logger.warning(
-                            f"Failed to provision service principal for worker "
-                            f"{registration.name}: {provision_err}. "
-                            f"Worker will use legacy session token.",
+                    _m_prov = _gm_prov()
+                    if _m_prov:
+                        _m_prov.record_worker_auth_event(
+                            registration.name,
+                            "principal_provisioned",
                         )
 
                 self._worker_cache[registration.name] = WorkerResponse(

--- a/flux/server.py
+++ b/flux/server.py
@@ -1541,7 +1541,7 @@ class Server:
                     labels=registration.labels,
                 )
 
-                if auth_config.enabled:
+                if auth_service is not None and auth_config.enabled:
                     try:
                         principal = principal_registry.find(
                             subject=registration.name,

--- a/flux/server.py
+++ b/flux/server.py
@@ -383,6 +383,11 @@ class Server:
     def _verify_worker_identity(self, identity: FluxIdentity, name: str) -> None:
         auth_config = Configuration.get().settings.security.auth
         if auth_config.enabled and identity.subject != name:
+            from flux.observability import get_metrics as _gm_bind
+
+            _m_bind = _gm_bind()
+            if _m_bind:
+                _m_bind.record_worker_auth_event(name, "identity_mismatch")
             raise HTTPException(
                 status_code=403,
                 detail=f"Worker identity mismatch: authenticated as '{identity.subject}', "
@@ -673,6 +678,15 @@ class Server:
                         if principal:
                             await _auth_svc.revoke_all_api_keys(principal.id)
                             logger.info(f"Revoked API key for evicted worker {name}")
+
+                            from flux.observability import get_metrics as _gm_evict
+
+                            _m_evict = _gm_evict()
+                            if _m_evict:
+                                _m_evict.record_worker_auth_event(
+                                    name,
+                                    "key_revoked",
+                                )
                     except Exception as e:
                         logger.warning(f"Failed to revoke API key for worker {name}: {e}")
 
@@ -1585,6 +1599,15 @@ class Server:
                             key_name=f"worker-{registration.name}",
                         )
                         result.session_token = api_key
+
+                        from flux.observability import get_metrics as _gm_prov
+
+                        _m_prov = _gm_prov()
+                        if _m_prov:
+                            _m_prov.record_worker_auth_event(
+                                registration.name,
+                                "principal_provisioned",
+                            )
                     except Exception as provision_err:
                         logger.warning(
                             f"Failed to provision service principal for worker "

--- a/flux/server.py
+++ b/flux/server.py
@@ -1541,6 +1541,34 @@ class Server:
                     labels=registration.labels,
                 )
 
+                if auth_config.enabled:
+                    try:
+                        principal = principal_registry.find(
+                            subject=registration.name,
+                            external_issuer="flux",
+                        )
+                        if not principal:
+                            principal = principal_registry.create(
+                                type="service_account",
+                                subject=registration.name,
+                                external_issuer="flux",
+                            )
+                        existing_roles = principal_registry.get_roles(principal.id)
+                        if "worker" not in existing_roles:
+                            principal_registry.assign_role(principal.id, "worker")
+                        await auth_service.revoke_all_api_keys(principal.id)
+                        api_key = await auth_service.create_api_key(
+                            principal.id,
+                            key_name=f"worker-{registration.name}",
+                        )
+                        result.session_token = api_key
+                    except Exception as provision_err:
+                        logger.warning(
+                            f"Failed to provision service principal for worker "
+                            f"{registration.name}: {provision_err}. "
+                            f"Worker will use legacy session token.",
+                        )
+
                 self._worker_cache[registration.name] = WorkerResponse(
                     name=registration.name,
                     status="online" if registration.name in self._worker_names else "offline",

--- a/flux/server.py
+++ b/flux/server.py
@@ -659,6 +659,28 @@ class Server:
         if m:
             m.record_worker_disconnected(name, reason)
 
+        if reason == "evicted":
+            from flux.security.dependencies import _get_auth_service
+            from flux.security.principals import PrincipalRegistry
+
+            _auth_svc = _get_auth_service()
+            if _auth_svc is not None:
+
+                async def _revoke_worker_key():
+                    try:
+                        registry = PrincipalRegistry.create()
+                        principal = registry.find(subject=name, external_issuer="flux")
+                        if principal:
+                            await _auth_svc.revoke_all_api_keys(principal.id)
+                            logger.info(f"Revoked API key for evicted worker {name}")
+                    except Exception as e:
+                        logger.warning(f"Failed to revoke API key for worker {name}: {e}")
+
+                try:
+                    asyncio.create_task(_revoke_worker_key())
+                except RuntimeError:
+                    logger.warning(f"Cannot revoke API key for {name}: no event loop")
+
     def _unclaim_worker_executions(self, worker_name: str) -> None:
         """Release all executions assigned to an evicted worker.
 

--- a/flux/server.py
+++ b/flux/server.py
@@ -381,8 +381,6 @@ class Server:
         return authorization.split(" ")[1]
 
     def _verify_worker_identity(self, identity: FluxIdentity, name: str) -> None:
-        from flux.config import Configuration
-
         auth_config = Configuration.get().settings.security.auth
         if auth_config.enabled and identity.subject != name:
             raise HTTPException(
@@ -1907,6 +1905,8 @@ class Server:
                     event.set()
 
                 return ctx.summary()
+            except HTTPException:
+                raise
             except Exception as e:
                 logger.error(f"Error claiming execution {execution_id} by worker {name}: {str(e)}")
                 raise HTTPException(status_code=404, detail=str(e))

--- a/flux/server.py
+++ b/flux/server.py
@@ -668,7 +668,7 @@ class Server:
 
                 async def _revoke_worker_key():
                     try:
-                        registry = PrincipalRegistry.create()
+                        registry = PrincipalRegistry(session_factory=self._get_db_session)
                         principal = registry.find(subject=name, external_issuer="flux")
                         if principal:
                             await _auth_svc.revoke_all_api_keys(principal.id)

--- a/flux/server.py
+++ b/flux/server.py
@@ -380,13 +380,16 @@ class Server:
             raise HTTPException(status_code=401, detail="Invalid authorization format")
         return authorization.split(" ")[1]
 
-    def _get_worker(self, name: str, authorization: str | None) -> WorkerInfo:
-        token = self._extract_token(authorization)
-        registry = WorkerRegistry.create()
-        worker = registry.get(name)
-        if worker.session_token != token:
-            raise HTTPException(status_code=403, detail="Invalid token")
-        return worker
+    def _verify_worker_identity(self, identity: FluxIdentity, name: str) -> None:
+        from flux.config import Configuration
+
+        auth_config = Configuration.get().settings.security.auth
+        if auth_config.enabled and identity.subject != name:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Worker identity mismatch: authenticated as '{identity.subject}', "
+                f"but accessing endpoint for '{name}'",
+            )
 
     def _get_version(self) -> str:
         import importlib.metadata
@@ -1635,10 +1638,13 @@ class Server:
                 )
 
         @api.post("/workers/{name}/pong")
-        async def workers_pong(name: str, authorization: str = Header(None)):
+        async def workers_pong(
+            name: str,
+            identity: FluxIdentity = Depends(require_permission("worker:*:*")),
+        ):
             """Receive heartbeat pong from a worker."""
             try:
-                self._get_worker(name, authorization)
+                self._verify_worker_identity(identity, name)
                 self._worker_last_pong[name] = time.monotonic()
                 self._worker_stale_since.pop(name, None)
                 logger.debug(f"Pong received from worker {name}")
@@ -1649,10 +1655,15 @@ class Server:
                 raise HTTPException(status_code=500, detail=str(e))
 
         @api.get("/workers/{name}/connect")
-        async def workers_connect(name: str, authorization: str = Header(None)):
+        async def workers_connect(
+            name: str,
+            identity: FluxIdentity = Depends(require_permission("worker:*:*")),
+        ):
             try:
                 logger.debug(f"Worker connection request: {name}")
-                worker = self._get_worker(name, authorization)
+                self._verify_worker_identity(identity, name)
+                registry = WorkerRegistry.create()
+                worker = registry.get(name)
                 logger.info(f"Worker connected: {name}")
 
                 worker_event = asyncio.Event()
@@ -1867,10 +1878,16 @@ class Server:
                 raise HTTPException(status_code=404, detail=str(e))
 
         @api.post("/workers/{name}/claim/{execution_id}")
-        async def workers_claim(name: str, execution_id: str, authorization: str = Header(None)):
+        async def workers_claim(
+            name: str,
+            execution_id: str,
+            identity: FluxIdentity = Depends(require_permission("worker:*:*")),
+        ):
             try:
                 logger.debug(f"Worker {name} claiming execution: {execution_id}")
-                worker = self._get_worker(name, authorization)
+                self._verify_worker_identity(identity, name)
+                registry = WorkerRegistry.create()
+                worker = registry.get(name)
                 context_manager = ContextManager.create()
                 ctx = context_manager.claim(execution_id, worker)
                 self._worker_executions.setdefault(name, set()).add(execution_id)
@@ -1899,7 +1916,7 @@ class Server:
             name: str,
             execution_id: str,
             context: ExecutionContextDTO = Body(...),
-            authorization: str = Header(None),
+            identity: FluxIdentity = Depends(require_permission("worker:*:*")),
         ):
             try:
                 logger.debug(
@@ -1907,7 +1924,7 @@ class Server:
                 )
                 logger.debug(f"Execution state: {context.state}")
 
-                self._get_worker(name, authorization)
+                self._verify_worker_identity(identity, name)
                 self._worker_last_pong[name] = time.monotonic()
 
                 context_manager = ContextManager.create()
@@ -1943,9 +1960,9 @@ class Server:
             name: str,
             execution_id: str,
             events: list = Body(...),
-            authorization: str = Header(None),
+            identity: FluxIdentity = Depends(require_permission("worker:*:*")),
         ):
-            self._get_worker(name, authorization)
+            self._verify_worker_identity(identity, name)
             self._worker_last_pong[name] = time.monotonic()
 
             buffer = self._progress_buffers.get(execution_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.29.0"
+version = "0.30.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/observability/test_metrics.py
+++ b/tests/flux/observability/test_metrics.py
@@ -141,6 +141,17 @@ class TestFluxMetrics:
         metric = self._get_metric(reader, "flux_worker_executions_active")
         assert metric is not None
 
+    def test_record_worker_auth_event(self):
+        m, reader = self._create_metrics()
+        m.record_worker_auth_event("worker-1", "principal_provisioned")
+
+        metric = self._get_metric(reader, "flux_worker_auth_events_total")
+        assert metric is not None
+        dp = metric.data.data_points[0]
+        assert dp.attributes["worker_name"] == "worker-1"
+        assert dp.attributes["event"] == "principal_provisioned"
+        assert dp.value == 1
+
     def test_record_schedule_trigger(self):
         m, reader = self._create_metrics()
         m.record_schedule_trigger("nightly", "success")

--- a/tests/security/test_auth_service.py
+++ b/tests/security/test_auth_service.py
@@ -2,10 +2,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from flux.security.auth_service import AuthService
+from flux.security.auth_service import AuthService, BUILT_IN_ROLES
 from flux.security.identity import FluxIdentity
 from flux.security.config import AuthConfig, OIDCConfig, APIKeyAuthConfig
-from flux.security.models import RoleModel
+from flux.security.models import RoleModel, APIKeyModel
 from flux.security.errors import AuthenticationError
 
 
@@ -230,3 +230,61 @@ def test_collect_required_permissions_visited_set_uses_tuple_key():
     # Both should appear — they're separate entities despite sharing a short name
     assert "workflow:billing:process:run" in perms
     assert "workflow:analytics:process:run" in perms
+
+
+class TestBuiltInWorkerRole:
+    def test_worker_role_exists(self):
+        assert "worker" in BUILT_IN_ROLES
+
+    def test_worker_role_permissions(self):
+        perms = BUILT_IN_ROLES["worker"]
+        assert "worker:*:*" in perms
+        assert "config:*:read" in perms
+        assert "admin:secrets:read" in perms
+        assert "execution:*:read" in perms
+        assert len(perms) == 4
+
+
+class TestRevokeAllApiKeys:
+    @pytest.mark.asyncio
+    async def test_revoke_all_api_keys_deletes_all(self):
+        config = AuthConfig()
+        session = MagicMock()
+        key1 = MagicMock(spec=APIKeyModel)
+        key2 = MagicMock(spec=APIKeyModel)
+        session.query.return_value.filter_by.return_value.all.return_value = [key1, key2]
+        service = AuthService(config=config, session_factory=lambda: session)
+
+        count = await service.revoke_all_api_keys("principal-1")
+
+        assert count == 2
+        session.delete.assert_any_call(key1)
+        session.delete.assert_any_call(key2)
+        session.commit.assert_called_once()
+        session.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_revoke_all_api_keys_returns_zero_when_none(self):
+        config = AuthConfig()
+        session = MagicMock()
+        session.query.return_value.filter_by.return_value.all.return_value = []
+        service = AuthService(config=config, session_factory=lambda: session)
+
+        count = await service.revoke_all_api_keys("principal-1")
+
+        assert count == 0
+        session.delete.assert_not_called()
+        session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_revoke_all_api_keys_rolls_back_on_error(self):
+        config = AuthConfig()
+        session = MagicMock()
+        session.query.return_value.filter_by.return_value.all.side_effect = RuntimeError("db error")
+        service = AuthService(config=config, session_factory=lambda: session)
+
+        with pytest.raises(RuntimeError, match="db error"):
+            await service.revoke_all_api_keys("principal-1")
+
+        session.rollback.assert_called_once()
+        session.close.assert_called_once()

--- a/tests/security/test_integration.py
+++ b/tests/security/test_integration.py
@@ -141,7 +141,7 @@ class TestFullAuthorizationFlow:
         auth_service.seed_built_in_roles()
         auth_service.seed_built_in_roles()
         roles = await auth_service.list_roles()
-        assert sum(1 for r in roles if r.built_in) == 3
+        assert sum(1 for r in roles if r.built_in) == 4
 
     @pytest.mark.asyncio
     async def test_authorize_nested_workflows(self, auth_service):

--- a/tests/security/test_worker_auth.py
+++ b/tests/security/test_worker_auth.py
@@ -165,7 +165,7 @@ class TestWorkerNameBinding:
                     "/workers/worker-A/pong",
                     headers={"Authorization": "Bearer fake-token"},
                 )
-                assert resp.status_code != 403
+                assert resp.status_code == 200
         finally:
             settings.security.auth.api_keys.enabled = original
 

--- a/tests/security/test_worker_auth.py
+++ b/tests/security/test_worker_auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -182,3 +183,52 @@ class TestWorkerNameBinding:
         finally:
             settings.security.auth.oidc.enabled = original_oidc
             settings.security.auth.api_keys.enabled = original_keys
+
+
+@pytest.mark.asyncio
+async def test_eviction_revokes_api_key():
+    """When a worker is evicted, _disconnect_worker schedules key revocation."""
+    server = Server(host="localhost", port=8000)
+
+    mock_principal = MagicMock()
+    mock_principal.id = "principal-123"
+
+    mock_registry = MagicMock()
+    mock_registry.find.return_value = mock_principal
+
+    mock_auth = MagicMock()
+    mock_auth.revoke_all_api_keys = AsyncMock(return_value=1)
+
+    with (
+        patch(
+            "flux.security.dependencies._get_auth_service",
+            return_value=mock_auth,
+        ),
+        patch(
+            "flux.security.principals.PrincipalRegistry.create",
+            return_value=mock_registry,
+        ),
+    ):
+        server._disconnect_worker("test-worker", reason="evicted")
+        await asyncio.sleep(0.1)
+
+    mock_registry.find.assert_called_once_with(subject="test-worker", external_issuer="flux")
+    mock_auth.revoke_all_api_keys.assert_called_once_with("principal-123")
+
+
+@pytest.mark.asyncio
+async def test_disconnect_without_eviction_does_not_revoke():
+    """Normal disconnect (not eviction) should NOT revoke the API key."""
+    server = Server(host="localhost", port=8000)
+
+    mock_auth = MagicMock()
+    mock_auth.revoke_all_api_keys = AsyncMock()
+
+    with patch(
+        "flux.security.dependencies._get_auth_service",
+        return_value=mock_auth,
+    ):
+        server._disconnect_worker("test-worker", reason="disconnect")
+        await asyncio.sleep(0.1)
+
+    mock_auth.revoke_all_api_keys.assert_not_called()

--- a/tests/security/test_worker_auth.py
+++ b/tests/security/test_worker_auth.py
@@ -205,12 +205,12 @@ async def test_eviction_revokes_api_key():
             return_value=mock_auth,
         ),
         patch(
-            "flux.security.principals.PrincipalRegistry.create",
+            "flux.security.principals.PrincipalRegistry",
             return_value=mock_registry,
         ),
     ):
         server._disconnect_worker("test-worker", reason="evicted")
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(0)
 
     mock_registry.find.assert_called_once_with(subject="test-worker", external_issuer="flux")
     mock_auth.revoke_all_api_keys.assert_called_once_with("principal-123")
@@ -229,6 +229,6 @@ async def test_disconnect_without_eviction_does_not_revoke():
         return_value=mock_auth,
     ):
         server._disconnect_worker("test-worker", reason="disconnect")
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(0)
 
     mock_auth.revoke_all_api_keys.assert_not_called()

--- a/tests/security/test_worker_auth.py
+++ b/tests/security/test_worker_auth.py
@@ -117,12 +117,8 @@ def _mock_auth(identity: FluxIdentity):
     async def mock_is_authorized(ident, permission):
         return True
 
-    async def mock_resolve_permissions(ident):
-        return {"worker:*:*", "config:*:read", "admin:secrets:read", "execution:*:read"}
-
     mock_service.authenticate = mock_authenticate
     mock_service.is_authorized = mock_is_authorized
-    mock_service.resolve_permissions = mock_resolve_permissions
 
     return patch(
         "flux.security.dependencies._get_auth_service",

--- a/tests/security/test_worker_auth.py
+++ b/tests/security/test_worker_auth.py
@@ -1,5 +1,12 @@
-from unittest.mock import AsyncMock
+from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from flux.server import Server
+from flux.security.identity import FluxIdentity
 from flux.worker import WorkflowExecutionRequest
 
 
@@ -88,3 +95,94 @@ class TestWorkerSetsExecTokenOnContext:
         }
         request = WorkflowExecutionRequest.from_json(data, checkpoint=AsyncMock())
         assert request.context.exec_token is None
+
+
+@pytest.fixture
+def server_app():
+    server = Server(host="localhost", port=8000)
+    return server._create_api()
+
+
+@pytest.fixture
+def client(server_app):
+    return TestClient(server_app)
+
+
+def _mock_auth(identity: FluxIdentity):
+    mock_service = MagicMock()
+
+    async def mock_authenticate(token):
+        return identity
+
+    async def mock_is_authorized(ident, permission):
+        return True
+
+    async def mock_resolve_permissions(ident):
+        return {"worker:*:*", "config:*:read", "admin:secrets:read", "execution:*:read"}
+
+    mock_service.authenticate = mock_authenticate
+    mock_service.is_authorized = mock_is_authorized
+    mock_service.resolve_permissions = mock_resolve_permissions
+
+    return patch(
+        "flux.security.dependencies._get_auth_service",
+        return_value=mock_service,
+    )
+
+
+class TestWorkerNameBinding:
+    def test_pong_rejects_identity_mismatch(self, client):
+        identity = FluxIdentity(
+            subject="worker-A",
+            roles=frozenset({"worker"}),
+        )
+        from flux.config import Configuration
+
+        settings = Configuration.get().settings
+        original = settings.security.auth.api_keys.enabled
+        settings.security.auth.api_keys.enabled = True
+        try:
+            with _mock_auth(identity):
+                resp = client.post(
+                    "/workers/worker-B/pong",
+                    headers={"Authorization": "Bearer fake-token"},
+                )
+                assert resp.status_code == 403
+                assert "mismatch" in resp.json()["detail"].lower()
+        finally:
+            settings.security.auth.api_keys.enabled = original
+
+    def test_pong_allows_identity_match(self, client):
+        identity = FluxIdentity(
+            subject="worker-A",
+            roles=frozenset({"worker"}),
+        )
+        from flux.config import Configuration
+
+        settings = Configuration.get().settings
+        original = settings.security.auth.api_keys.enabled
+        settings.security.auth.api_keys.enabled = True
+        try:
+            with _mock_auth(identity):
+                resp = client.post(
+                    "/workers/worker-A/pong",
+                    headers={"Authorization": "Bearer fake-token"},
+                )
+                assert resp.status_code != 403
+        finally:
+            settings.security.auth.api_keys.enabled = original
+
+    def test_pong_skips_name_check_when_auth_disabled(self, client):
+        from flux.config import Configuration
+
+        settings = Configuration.get().settings
+        original_oidc = settings.security.auth.oidc.enabled
+        original_keys = settings.security.auth.api_keys.enabled
+        settings.security.auth.oidc.enabled = False
+        settings.security.auth.api_keys.enabled = False
+        try:
+            resp = client.post("/workers/any-name/pong")
+            assert resp.status_code != 403
+        finally:
+            settings.security.auth.oidc.enabled = original_oidc
+            settings.security.auth.api_keys.enabled = original_keys


### PR DESCRIPTION
## Summary

- Workers are now auto-provisioned as service account principals with API keys on registration, replacing the custom session-token system
- All 5 worker endpoints (`pong`, `connect`, `claim`, `checkpoint`, `progress`) migrated from `_get_worker()` to `require_permission("worker:*:*")` with name-binding checks
- New `worker` built-in role with permissions: `worker:*:*`, `config:*:read`, `admin:secrets:read`, `execution:*:read`
- API key revocation on worker eviction — re-connecting workers must re-register
- `revoke_all_api_keys(principal_id)` method added to AuthService

## Motivation

Workers previously authenticated using a custom two-token system (`bootstrap_token` → `session_token`) with a dedicated `_get_worker()` method that bypassed the standard `AuthService` → `require_permission()` pipeline. This meant:

- Workers couldn't access permission-gated endpoints when auth was enabled
- No RBAC for workers — every worker had identical implicit privileges
- Two separate auth code paths to maintain
- Worker tokens weren't real principals — no audit trail, no role management

## Design

**Registration flow:**
1. Worker sends `POST /workers/register` with bootstrap token (unchanged)
2. Server validates bootstrap token, registers worker in WorkerRegistry
3. Server auto-provisions a service account principal (`subject=worker-name`, `external_issuer="flux"`)
4. Server assigns the `worker` role and generates an API key
5. Worker receives the API key as `session_token` — uses it as Bearer for all calls
6. All worker endpoints authenticate through `AuthService` → `APIKeyProvider` → `FluxIdentity`

**Name binding:** Each worker endpoint verifies `identity.subject == name` in the URL path, preventing worker A from impersonating worker B.

**Eviction:** When the heartbeat reaper evicts a worker, its API key is revoked via `asyncio.create_task` (fire-and-forget). Re-connecting workers get 401 and fall back to re-registration.

**Auth-disabled mode:** `require_permission()` is a no-op; name-binding check is skipped. Workers use legacy UUID tokens. Consistent with all other endpoints.

## What does NOT change

- `flux/worker.py` — worker code is unchanged (still registers, gets token, uses as Bearer)
- `WorkerModel` / DB schema — no schema changes (`session_token` field now holds an API key string instead of a UUID)
- Bootstrap token flow — still gates who can register

## Test plan

- [x] Unit tests: worker role in BUILT_IN_ROLES, revoke_all_api_keys, name-binding (match/mismatch/auth-disabled), eviction revocation
- [x] 1610 unit tests pass (ignoring pre-existing unrelated observability failure)
- [x] E2E tests pass (task, admin, worker affinity suites verified)
- [x] Pre-commit passes on all files

## Files changed

| File | Change |
|------|--------|
| `flux/security/auth_service.py` | Add `worker` built-in role + `revoke_all_api_keys` method |
| `flux/server.py` | Auto-provision on registration, migrate 5 endpoints, remove `_get_worker`, eviction revokes key |
| `docs/advanced-features/authentication.md` | Document worker service principals + worker role |
| `tests/security/test_auth_service.py` | Tests for worker role + revoke_all_api_keys |
| `tests/security/test_integration.py` | Fix stale built-in role count (3→4) |
| `tests/security/test_worker_auth.py` | Tests for name-binding + eviction revocation |