### PR TITLE
feat(service-mcp): add IdP auth support for standalone MCP endpoints

### DIFF
--- a/docs/advanced-features/services.md
+++ b/docs/advanced-features/services.md
@@ -366,7 +366,7 @@ Standalone MCP endpoints can validate bearer tokens from an external Identity Pr
 **CLI flags:**
 
 ```bash
-flux service start billing --port 9000 \
+flux service start billing --port 9000 --mcp \
   --mcp-issuer https://idp.example.com/realms/my-realm \
   --mcp-audience billing-api \
   --mcp-jwks-uri https://idp.example.com/realms/my-realm/protocol/openid-connect/certs

--- a/docs/advanced-features/services.md
+++ b/docs/advanced-features/services.md
@@ -359,6 +359,54 @@ flux service start billing --port 9000 --server-url http://flux:8000
 
 The `--mcp` / `--no-mcp` flags on `service start` override the stored setting. Without an explicit flag, the stored `mcp_enabled` value is used.
 
+### MCP Authentication
+
+Standalone MCP endpoints can validate bearer tokens from an external Identity Provider (IdP) and advertise the IdP via OAuth 2.0 Protected Resource Metadata ([RFC 9728](https://www.rfc-editor.org/rfc/rfc9728)). This enables MCP clients to discover the authorization server and obtain tokens through standard flows including Dynamic Client Registration (DCR) and PKCE.
+
+**CLI flags:**
+
+```bash
+flux service start billing --port 9000 \
+  --mcp-issuer https://idp.example.com/realms/my-realm \
+  --mcp-audience billing-api \
+  --mcp-jwks-uri https://idp.example.com/realms/my-realm/protocol/openid-connect/certs
+```
+
+| Flag | Description |
+|---|---|
+| `--mcp-issuer` | IdP issuer URL. Enables token validation and serves `/.well-known/oauth-protected-resource` pointing to this authorization server. |
+| `--mcp-audience` | Expected `aud` claim in JWT tokens. Optional. |
+| `--mcp-jwks-uri` | JWKS endpoint for token signature validation. Defaults to `{issuer}/.well-known/jwks.json` if omitted. |
+
+**Fallback to Flux OIDC config:**
+
+When no `--mcp-issuer` is provided, the service checks Flux's OIDC settings (`flux.security.auth.oidc`). If OIDC is enabled in the Flux config, the same issuer and audience are used for MCP auth automatically.
+
+```toml
+# flux.toml — MCP services inherit these settings when no --mcp-issuer is given
+[flux.security.auth.oidc]
+enabled = true
+issuer = "https://idp.example.com/realms/my-realm"
+audience = "flux-api"
+```
+
+**How it works:**
+
+1. MCP client connects to `/mcp` without a token and receives a `401`.
+2. Client fetches `/.well-known/oauth-protected-resource` from the service, which returns the `authorization_servers` list.
+3. Client follows the IdP's `/.well-known/oauth-authorization-server` metadata to discover endpoints (including DCR if supported).
+4. Client obtains an access token from the IdP and retries with `Authorization: Bearer <token>`.
+5. The service validates the token via the IdP's JWKS and grants access.
+
+**Supported IdPs** (any OAuth 2.0 / OIDC compliant provider):
+
+| Provider | Example issuer |
+|---|---|
+| Keycloak | `https://keycloak.example.com/realms/my-realm` |
+| Auth0 | `https://your-tenant.auth0.com/` |
+| Okta | `https://your-org.okta.com/oauth2/default` |
+| Entra ID | `https://login.microsoftonline.com/{tenant}/v2.0` |
+
 ### Tool generation
 
 Each workflow in the service produces **5 MCP tools**:

--- a/docs/advanced-features/services.md
+++ b/docs/advanced-features/services.md
@@ -376,7 +376,8 @@ flux service start billing --port 9000 --mcp \
 |---|---|
 | `--mcp-issuer` | IdP issuer URL. Enables token validation and serves `/.well-known/oauth-protected-resource` pointing to this authorization server. |
 | `--mcp-audience` | Expected `aud` claim in JWT tokens. Optional. |
-| `--mcp-jwks-uri` | JWKS endpoint for token signature validation. Defaults to `{issuer}/.well-known/jwks.json` if omitted. |
+| `--mcp-jwks-uri` | JWKS endpoint for token signature validation. If omitted, discovered from the issuer's `/.well-known/openid-configuration` metadata; falls back to `{issuer}/.well-known/jwks.json` if discovery is unavailable. |
+| `--mcp-base-url` | Public base URL for OAuth discovery metadata. Overrides the auto-constructed URL — use when the service sits behind TLS termination or a reverse proxy. |
 
 **Fallback to Flux OIDC config:**
 

--- a/flux/cli_service.py
+++ b/flux/cli_service.py
@@ -4,6 +4,7 @@ import json
 from typing import Any
 
 import click
+import httpx
 
 from flux.cli import cli, get_http_client, get_server_url
 
@@ -396,7 +397,8 @@ def _build_mcp_auth(
                 audience = audience or oidc.audience or None
             else:
                 return None, None
-        except Exception:
+        except Exception as ex:
+            click.echo(f"Warning: could not read Flux OIDC config: {ex}", err=True)
             return None, None
 
     if not jwks_uri:
@@ -430,7 +432,7 @@ def _discover_jwks_uri(issuer: str) -> str:
     """
     discovery_url = f"{issuer.rstrip('/')}/.well-known/openid-configuration"
     try:
-        with get_http_client() as client:
+        with httpx.Client(timeout=10.0) as client:
             response = client.get(discovery_url)
             response.raise_for_status()
             metadata = response.json()

--- a/flux/cli_service.py
+++ b/flux/cli_service.py
@@ -305,7 +305,15 @@ def include_in_service(name, workflow_refs, format, server_url):
     help="JWKS URI for MCP token validation (auto-discovered from issuer if omitted).",
 )
 def start_service(
-    name, port, host, mcp, server_url, cache_ttl, mcp_issuer, mcp_audience, mcp_jwks_uri,
+    name,
+    port,
+    host,
+    mcp,
+    server_url,
+    cache_ttl,
+    mcp_issuer,
+    mcp_audience,
+    mcp_jwks_uri,
 ):
     """Start a standalone service proxy."""
     from flux.service_proxy import create_standalone_app

--- a/flux/cli_service.py
+++ b/flux/cli_service.py
@@ -333,7 +333,7 @@ def start_service(
         except Exception:
             enable_mcp = False
 
-    mcp_auth = _build_mcp_auth(
+    mcp_auth, resolved_issuer = _build_mcp_auth(
         host=host,
         port=port,
         issuer=mcp_issuer,
@@ -345,7 +345,7 @@ def start_service(
     click.echo(f"Flux server: {flux_url}")
     click.echo(f"MCP: {'enabled' if enable_mcp else 'disabled'}")
     if mcp_auth:
-        click.echo(f"MCP auth: {mcp_issuer}")
+        click.echo(f"MCP auth: {resolved_issuer}")
     app = create_standalone_app(
         name,
         flux_url,
@@ -362,10 +362,10 @@ def _build_mcp_auth(
     issuer: str | None = None,
     audience: str | None = None,
     jwks_uri: str | None = None,
-):
+) -> tuple:
     """Build a FastMCP auth provider from explicit flags or Flux OIDC config.
 
-    Returns ``None`` when no auth is configured.
+    Returns ``(provider, resolved_issuer)`` or ``(None, None)``.
     """
     if not issuer:
         try:
@@ -377,9 +377,9 @@ def _build_mcp_auth(
                 issuer = oidc.issuer
                 audience = audience or oidc.audience or None
             else:
-                return None
+                return None, None
         except Exception:
-            return None
+            return None, None
 
     if not jwks_uri:
         jwks_uri = f"{issuer.rstrip('/')}/.well-known/jwks.json"
@@ -393,11 +393,12 @@ def _build_mcp_auth(
         issuer=issuer,
         audience=audience,
     )
-    return RemoteAuthProvider(
+    provider = RemoteAuthProvider(
         token_verifier=verifier,
         authorization_servers=[issuer],
         base_url=base_url,
     )
+    return provider, issuer
 
 
 @service.command("delete")

--- a/flux/cli_service.py
+++ b/flux/cli_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import click
 
@@ -302,7 +303,12 @@ def include_in_service(name, workflow_refs, format, server_url):
 @click.option(
     "--mcp-jwks-uri",
     default=None,
-    help="JWKS URI for MCP token validation (auto-discovered from issuer if omitted).",
+    help="JWKS URI for MCP token validation (discovered from issuer OIDC metadata if omitted).",
+)
+@click.option(
+    "--mcp-base-url",
+    default=None,
+    help="Public base URL for OAuth discovery metadata (overrides auto-constructed URL, useful behind TLS termination).",
 )
 def start_service(
     name,
@@ -314,6 +320,7 @@ def start_service(
     mcp_issuer,
     mcp_audience,
     mcp_jwks_uri,
+    mcp_base_url,
 ):
     """Start a standalone service proxy."""
     from flux.service_proxy import create_standalone_app
@@ -333,13 +340,23 @@ def start_service(
         except Exception:
             enable_mcp = False
 
-    mcp_auth, resolved_issuer = _build_mcp_auth(
-        host=host,
-        port=port,
-        issuer=mcp_issuer,
-        audience=mcp_audience,
-        jwks_uri=mcp_jwks_uri,
-    )
+    mcp_auth = None
+    resolved_issuer = None
+    has_auth_flags = any([mcp_issuer, mcp_audience, mcp_jwks_uri])
+    if enable_mcp:
+        mcp_auth, resolved_issuer = _build_mcp_auth(
+            host=host,
+            port=port,
+            issuer=mcp_issuer,
+            audience=mcp_audience,
+            jwks_uri=mcp_jwks_uri,
+            base_url=mcp_base_url,
+        )
+    elif has_auth_flags:
+        click.echo(
+            "Warning: --mcp-issuer/--mcp-audience/--mcp-jwks-uri ignored because MCP is disabled.",
+            err=True,
+        )
 
     click.echo(f"Starting service '{name}' on {host}:{port}")
     click.echo(f"Flux server: {flux_url}")
@@ -362,7 +379,8 @@ def _build_mcp_auth(
     issuer: str | None = None,
     audience: str | None = None,
     jwks_uri: str | None = None,
-) -> tuple:
+    base_url: str | None = None,
+) -> tuple[Any, str | None]:
     """Build a FastMCP auth provider from explicit flags or Flux OIDC config.
 
     Returns ``(provider, resolved_issuer)`` or ``(None, None)``.
@@ -382,11 +400,15 @@ def _build_mcp_auth(
             return None, None
 
     if not jwks_uri:
-        jwks_uri = f"{issuer.rstrip('/')}/.well-known/jwks.json"
+        jwks_uri = _discover_jwks_uri(issuer)
 
     from fastmcp.server.auth import JWTVerifier, RemoteAuthProvider
 
-    base_url = f"http://{host}:{port}" if host != "0.0.0.0" else f"http://localhost:{port}"
+    if not base_url:
+        if host in ("0.0.0.0", "::"):
+            base_url = f"http://localhost:{port}"
+        else:
+            base_url = f"http://{host}:{port}"
 
     verifier = JWTVerifier(
         jwks_uri=jwks_uri,
@@ -399,6 +421,34 @@ def _build_mcp_auth(
         base_url=base_url,
     )
     return provider, issuer
+
+
+def _discover_jwks_uri(issuer: str) -> str:
+    """Discover the JWKS URI from the issuer's OpenID Connect metadata.
+
+    Falls back to ``{issuer}/.well-known/jwks.json`` if discovery fails.
+    """
+    discovery_url = f"{issuer.rstrip('/')}/.well-known/openid-configuration"
+    try:
+        with get_http_client() as client:
+            response = client.get(discovery_url)
+            response.raise_for_status()
+            metadata = response.json()
+        discovered = metadata.get("jwks_uri")
+        if isinstance(discovered, str) and discovered:
+            return discovered
+        click.echo(
+            f"Warning: OIDC discovery at '{discovery_url}' did not return a valid 'jwks_uri'. "
+            f"Falling back to legacy JWKS URL.",
+            err=True,
+        )
+    except Exception as ex:
+        click.echo(
+            f"Warning: OIDC discovery failed for '{discovery_url}': {ex}. "
+            f"Falling back to legacy JWKS URL.",
+            err=True,
+        )
+    return f"{issuer.rstrip('/')}/.well-known/jwks.json"
 
 
 @service.command("delete")

--- a/flux/cli_service.py
+++ b/flux/cli_service.py
@@ -304,7 +304,9 @@ def include_in_service(name, workflow_refs, format, server_url):
     default=None,
     help="JWKS URI for MCP token validation (auto-discovered from issuer if omitted).",
 )
-def start_service(name, port, host, mcp, server_url, cache_ttl, mcp_issuer, mcp_audience, mcp_jwks_uri):
+def start_service(
+    name, port, host, mcp, server_url, cache_ttl, mcp_issuer, mcp_audience, mcp_jwks_uri,
+):
     """Start a standalone service proxy."""
     from flux.service_proxy import create_standalone_app
 
@@ -337,7 +339,11 @@ def start_service(name, port, host, mcp, server_url, cache_ttl, mcp_issuer, mcp_
     if mcp_auth:
         click.echo(f"MCP auth: {mcp_issuer}")
     app = create_standalone_app(
-        name, flux_url, cache_ttl, enable_mcp=enable_mcp, mcp_auth=mcp_auth,
+        name,
+        flux_url,
+        cache_ttl,
+        enable_mcp=enable_mcp,
+        mcp_auth=mcp_auth,
     )
     uvicorn.run(app, host=host, port=port, log_level="info")
 

--- a/flux/cli_service.py
+++ b/flux/cli_service.py
@@ -293,7 +293,18 @@ def include_in_service(name, workflow_refs, format, server_url):
 @click.option("--mcp/--no-mcp", default=None, help="Enable or disable MCP endpoint.")
 @click.option("--server-url", "-cp-url", default=None, help="Flux server URL to connect to.")
 @click.option("--cache-ttl", default=60, type=int, help="Endpoint cache TTL in seconds.")
-def start_service(name, port, host, mcp, server_url, cache_ttl):
+@click.option(
+    "--mcp-issuer",
+    default=None,
+    help="IdP issuer URL for MCP auth (enables token validation and OAuth discovery).",
+)
+@click.option("--mcp-audience", default=None, help="Expected JWT audience for MCP auth.")
+@click.option(
+    "--mcp-jwks-uri",
+    default=None,
+    help="JWKS URI for MCP token validation (auto-discovered from issuer if omitted).",
+)
+def start_service(name, port, host, mcp, server_url, cache_ttl, mcp_issuer, mcp_audience, mcp_jwks_uri):
     """Start a standalone service proxy."""
     from flux.service_proxy import create_standalone_app
 
@@ -312,11 +323,67 @@ def start_service(name, port, host, mcp, server_url, cache_ttl):
         except Exception:
             enable_mcp = False
 
+    mcp_auth = _build_mcp_auth(
+        host=host,
+        port=port,
+        issuer=mcp_issuer,
+        audience=mcp_audience,
+        jwks_uri=mcp_jwks_uri,
+    )
+
     click.echo(f"Starting service '{name}' on {host}:{port}")
     click.echo(f"Flux server: {flux_url}")
     click.echo(f"MCP: {'enabled' if enable_mcp else 'disabled'}")
-    app = create_standalone_app(name, flux_url, cache_ttl, enable_mcp=enable_mcp)
+    if mcp_auth:
+        click.echo(f"MCP auth: {mcp_issuer}")
+    app = create_standalone_app(
+        name, flux_url, cache_ttl, enable_mcp=enable_mcp, mcp_auth=mcp_auth,
+    )
     uvicorn.run(app, host=host, port=port, log_level="info")
+
+
+def _build_mcp_auth(
+    host: str,
+    port: int,
+    issuer: str | None = None,
+    audience: str | None = None,
+    jwks_uri: str | None = None,
+):
+    """Build a FastMCP auth provider from explicit flags or Flux OIDC config.
+
+    Returns ``None`` when no auth is configured.
+    """
+    if not issuer:
+        try:
+            from flux.config import FluxConfig
+
+            cfg = FluxConfig()
+            oidc = cfg.security.auth.oidc
+            if oidc.enabled and oidc.issuer:
+                issuer = oidc.issuer
+                audience = audience or oidc.audience or None
+            else:
+                return None
+        except Exception:
+            return None
+
+    if not jwks_uri:
+        jwks_uri = f"{issuer.rstrip('/')}/.well-known/jwks.json"
+
+    from fastmcp.server.auth import JWTVerifier, RemoteAuthProvider
+
+    base_url = f"http://{host}:{port}" if host != "0.0.0.0" else f"http://localhost:{port}"
+
+    verifier = JWTVerifier(
+        jwks_uri=jwks_uri,
+        issuer=issuer,
+        audience=audience,
+    )
+    return RemoteAuthProvider(
+        token_verifier=verifier,
+        authorization_servers=[issuer],
+        base_url=base_url,
+    )
 
 
 @service.command("delete")

--- a/flux/service_mcp.py
+++ b/flux/service_mcp.py
@@ -1,12 +1,17 @@
+from __future__ import annotations
+
 import inspect
 import json
 from dataclasses import dataclass
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import httpx
 from fastmcp import FastMCP
 
 from flux.utils import get_logger
+
+if TYPE_CHECKING:
+    from fastmcp.server.auth import AuthProvider
 
 logger = get_logger(__name__)
 
@@ -37,10 +42,15 @@ class EndpointProvider(Protocol):
 
 
 class ServiceMCPServer:
-    def __init__(self, service_name: str, provider: EndpointProvider):
+    def __init__(
+        self,
+        service_name: str,
+        provider: EndpointProvider,
+        auth: AuthProvider | None = None,
+    ):
         self.service_name = service_name
         self.provider = provider
-        self.mcp = FastMCP(f"flux-service-{service_name}")
+        self.mcp = FastMCP(f"flux-service-{service_name}", auth=auth)
         self._registered_tools: set[str] = set()
         self._tool_names: set[str] = set()
 
@@ -253,8 +263,9 @@ class ProxyBackedMCPServer(ServiceMCPServer):
         service_name: str,
         provider: EndpointProvider,
         client: httpx.AsyncClient,
+        auth: AuthProvider | None = None,
     ):
-        super().__init__(service_name, provider)
+        super().__init__(service_name, provider, auth=auth)
         self._client = client
 
     async def _execute_run(
@@ -365,9 +376,13 @@ class ProxyEndpointProvider:
         return endpoints
 
 
-def create_service_mcp_server(service_name: str, client: httpx.AsyncClient) -> ProxyBackedMCPServer:
+def create_service_mcp_server(
+    service_name: str,
+    client: httpx.AsyncClient,
+    auth: AuthProvider | None = None,
+) -> ProxyBackedMCPServer:
     provider = ProxyEndpointProvider(service_name, client)
-    return ProxyBackedMCPServer(service_name, provider, client)
+    return ProxyBackedMCPServer(service_name, provider, client, auth=auth)
 
 
 def _parse_json_input(raw: str) -> Any:

--- a/flux/service_mcp.py
+++ b/flux/service_mcp.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import inspect
 import json
 from dataclasses import dataclass
@@ -46,7 +44,7 @@ class ServiceMCPServer:
         self,
         service_name: str,
         provider: EndpointProvider,
-        auth: AuthProvider | None = None,
+        auth: "AuthProvider | None" = None,
     ):
         self.service_name = service_name
         self.provider = provider
@@ -263,7 +261,7 @@ class ProxyBackedMCPServer(ServiceMCPServer):
         service_name: str,
         provider: EndpointProvider,
         client: httpx.AsyncClient,
-        auth: AuthProvider | None = None,
+        auth: "AuthProvider | None" = None,
     ):
         super().__init__(service_name, provider, auth=auth)
         self._client = client
@@ -379,7 +377,7 @@ class ProxyEndpointProvider:
 def create_service_mcp_server(
     service_name: str,
     client: httpx.AsyncClient,
-    auth: AuthProvider | None = None,
+    auth: "AuthProvider | None" = None,
 ) -> ProxyBackedMCPServer:
     provider = ProxyEndpointProvider(service_name, client)
     return ProxyBackedMCPServer(service_name, provider, client, auth=auth)

--- a/flux/service_proxy.py
+++ b/flux/service_proxy.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any
 
 import httpx
 from fastapi import FastAPI, Query, Request
 from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -96,52 +101,67 @@ class StandaloneServiceProxy:
         await self._client.aclose()
 
 
+class MCPRouteMiddleware:
+    """ASGI middleware that intercepts ``/mcp`` and ``/.well-known/`` requests,
+    forwarding them to the FastMCP ASGI app before FastAPI's catch-all
+    ``/{workflow_name}`` route can match them.
+
+    Registered via ``app.add_middleware(MCPRouteMiddleware, mcp_app=...)``.
+    """
+
+    def __init__(self, app: Any, *, mcp_app: Any):
+        self.app = app
+        self.mcp_app = mcp_app
+
+    async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
+        if scope["type"] == "http" and self._is_mcp_route(scope.get("path", "")):
+            await self.mcp_app(scope, receive, send)
+        else:
+            await self.app(scope, receive, send)
+
+    @staticmethod
+    def _is_mcp_route(path: str) -> bool:
+        return path.startswith("/mcp") or path.startswith("/.well-known/")
+
+
 def create_standalone_app(
     service_name: str,
     server_url: str,
     cache_ttl: int = 60,
     enable_mcp: bool = False,
     mcp_auth: Any | None = None,
-) -> FastAPI | Any:
-    app = FastAPI(title=f"Flux Service: {service_name}")
+) -> FastAPI:
     proxy = StandaloneServiceProxy(service_name, server_url, cache_ttl)
 
-    @app.on_event("shutdown")
-    async def shutdown():
-        await proxy.close()
+    mcp_server = None
+    mcp_http_app = None
 
     if enable_mcp:
         from flux.service_mcp import create_service_mcp_server
 
         mcp_server = create_service_mcp_server(service_name, proxy._client, auth=mcp_auth)
+        mcp_http_app = mcp_server.mcp.http_app(path="/mcp")
 
-        @app.on_event("startup")
-        async def _init_mcp_tools():
-            try:
-                endpoints = await mcp_server.provider.get_endpoints()
-                mcp_server._generate_tools(endpoints)
-            except Exception as e:
-                import logging
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
+        try:
+            if mcp_server is not None and mcp_http_app is not None:
+                async with mcp_http_app.router.lifespan_context(mcp_http_app):
+                    await _init_mcp(mcp_server)
+                    refresh_task = asyncio.create_task(
+                        _mcp_refresh_loop(mcp_server, cache_ttl),
+                    )
+                    yield
+                    refresh_task.cancel()
+            else:
+                yield
+        finally:
+            await proxy.close()
 
-                logging.getLogger(__name__).warning(
-                    f"Failed to initialize MCP tools on startup: {e}. "
-                    f"MCP endpoint mounted but has no tools. "
-                    f"Restart the service once the Flux server is available.",
-                )
+    app = FastAPI(title=f"Flux Service: {service_name}", lifespan=lifespan)
 
-        async def _mcp_refresh_loop():
-            while True:
-                await asyncio.sleep(cache_ttl)
-                try:
-                    await mcp_server.refresh()
-                except Exception:
-                    pass
-
-        @app.on_event("startup")
-        async def _start_mcp_refresh():
-            asyncio.create_task(_mcp_refresh_loop())
-
-        mcp_asgi_app = mcp_server.mcp.http_app(path="/mcp")
+    if enable_mcp and mcp_http_app is not None:
+        app.add_middleware(MCPRouteMiddleware, mcp_app=mcp_http_app)
 
     @app.get("/health")
     async def health():
@@ -271,68 +291,26 @@ def create_standalone_app(
 
         return JSONResponse(status_code=response.status_code, content=response.json())
 
-    if enable_mcp:
-        return _MCPDispatcher(app, mcp_asgi_app)
-
     return app
 
 
-class _MCPDispatcher:
-    """ASGI wrapper that routes /mcp requests to the FastMCP app before
-    FastAPI's catch-all ``/{workflow_name}`` can intercept them.
+async def _init_mcp(mcp_server: Any) -> None:
+    try:
+        endpoints = await mcp_server.provider.get_endpoints()
+        mcp_server._generate_tools(endpoints)
+    except Exception as e:
+        logger.warning(
+            "Failed to initialize MCP tools on startup: %s. "
+            "MCP endpoint mounted but has no tools. "
+            "Restart the service once the Flux server is available.",
+            e,
+        )
 
-    Manages both apps' lifespans so the MCP session manager is properly
-    initialised.
-    """
 
-    def __init__(self, main_app: Any, mcp_app: Any):
-        self.main_app = main_app
-        self.mcp_app = mcp_app
-        self._mcp_started = False
-
-    async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
-        if scope["type"] == "lifespan":
-            await self._handle_lifespan(scope, receive, send)
-        elif scope["type"] == "http" and self._is_mcp_route(scope.get("path", "")):
-            await self.mcp_app(scope, receive, send)
-        else:
-            await self.main_app(scope, receive, send)
-
-    @staticmethod
-    def _is_mcp_route(path: str) -> bool:
-        return path.startswith("/mcp") or path.startswith("/.well-known/")
-
-    async def _handle_lifespan(self, scope: dict, receive: Any, send: Any) -> None:
-        """Coordinate lifespan for both the FastAPI app and the MCP app."""
-        message = await receive()
-        if message["type"] != "lifespan.startup":
-            return
-
+async def _mcp_refresh_loop(mcp_server: Any, interval: int) -> None:
+    while True:
+        await asyncio.sleep(interval)
         try:
-            self._mcp_lifespan_cm = self.mcp_app.router.lifespan_context(self.mcp_app)
-            await self._mcp_lifespan_cm.__aenter__()
-            self._mcp_started = True
+            await mcp_server.refresh()
         except Exception:
             pass
-
-        await self.main_app(scope, self._wrap_receive(message), send)
-
-        if self._mcp_started:
-            try:
-                await self._mcp_lifespan_cm.__aexit__(None, None, None)
-            except Exception:
-                pass
-
-    @staticmethod
-    def _wrap_receive(first_message: dict) -> Any:
-        sent = False
-
-        async def _receive() -> dict:
-            nonlocal sent
-            if not sent:
-                sent = True
-                return first_message
-            while True:
-                await asyncio.sleep(3600)
-
-        return _receive

--- a/flux/service_proxy.py
+++ b/flux/service_proxy.py
@@ -121,7 +121,7 @@ class MCPRouteMiddleware:
 
     @staticmethod
     def _is_mcp_route(path: str) -> bool:
-        return path.startswith("/mcp") or path.startswith("/.well-known/")
+        return path == "/mcp" or path.startswith("/mcp/") or path.startswith("/.well-known/")
 
 
 def create_standalone_app(

--- a/flux/service_proxy.py
+++ b/flux/service_proxy.py
@@ -143,7 +143,7 @@ def create_standalone_app(
         mcp_http_app = mcp_server.mcp.http_app(path="/mcp")
 
     @asynccontextmanager
-    async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
+    async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
         try:
             if mcp_server is not None and mcp_http_app is not None:
                 async with mcp_http_app.router.lifespan_context(mcp_http_app):

--- a/flux/service_proxy.py
+++ b/flux/service_proxy.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
 from fastapi import FastAPI, Query, Request
 from fastapi.responses import JSONResponse
+
+if TYPE_CHECKING:
+    from flux.service_mcp import ServiceMCPServer
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +118,8 @@ class MCPRouteMiddleware:
         self.mcp_app = mcp_app
 
     async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
+        # Only intercept HTTP requests; WebSocket scopes intentionally fall
+        # through to FastAPI because MCP uses streamable HTTP transport.
         if scope["type"] == "http" and self._is_mcp_route(scope.get("path", "")):
             await self.mcp_app(scope, receive, send)
         else:
@@ -153,6 +159,8 @@ def create_standalone_app(
                     )
                     yield
                     refresh_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await refresh_task
             else:
                 yield
         finally:
@@ -294,20 +302,19 @@ def create_standalone_app(
     return app
 
 
-async def _init_mcp(mcp_server: Any) -> None:
+async def _init_mcp(mcp_server: ServiceMCPServer) -> None:
     try:
         endpoints = await mcp_server.provider.get_endpoints()
         mcp_server._generate_tools(endpoints)
     except Exception as e:
         logger.warning(
-            "Failed to initialize MCP tools on startup: %s. "
-            "MCP endpoint mounted but has no tools. "
-            "Restart the service once the Flux server is available.",
-            e,
+            f"Failed to initialize MCP tools on startup: {e}. "
+            f"MCP endpoint mounted but has no tools. "
+            f"Restart the service once the Flux server is available.",
         )
 
 
-async def _mcp_refresh_loop(mcp_server: Any, interval: int) -> None:
+async def _mcp_refresh_loop(mcp_server: ServiceMCPServer, interval: int) -> None:
     while True:
         await asyncio.sleep(interval)
         try:

--- a/flux/service_proxy.py
+++ b/flux/service_proxy.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import logging
 import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -13,10 +12,14 @@ import httpx
 from fastapi import FastAPI, Query, Request
 from fastapi.responses import JSONResponse
 
+from flux.utils import get_logger
+
 if TYPE_CHECKING:
+    from fastmcp.server.auth import AuthProvider
+
     from flux.service_mcp import ServiceMCPServer
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @dataclass(frozen=True)
@@ -135,7 +138,7 @@ def create_standalone_app(
     server_url: str,
     cache_ttl: int = 60,
     enable_mcp: bool = False,
-    mcp_auth: Any | None = None,
+    mcp_auth: AuthProvider | None = None,
 ) -> FastAPI:
     proxy = StandaloneServiceProxy(service_name, server_url, cache_ttl)
 
@@ -320,4 +323,4 @@ async def _mcp_refresh_loop(mcp_server: ServiceMCPServer, interval: int) -> None
         try:
             await mcp_server.refresh()
         except Exception:
-            pass
+            logger.debug("MCP refresh failed, will retry in %ds", interval, exc_info=True)

--- a/flux/service_proxy.py
+++ b/flux/service_proxy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 from dataclasses import dataclass
+from typing import Any
 
 import httpx
 from fastapi import FastAPI, Query, Request
@@ -100,7 +101,8 @@ def create_standalone_app(
     server_url: str,
     cache_ttl: int = 60,
     enable_mcp: bool = False,
-) -> FastAPI:
+    mcp_auth: Any | None = None,
+) -> FastAPI | Any:
     app = FastAPI(title=f"Flux Service: {service_name}")
     proxy = StandaloneServiceProxy(service_name, server_url, cache_ttl)
 
@@ -111,7 +113,7 @@ def create_standalone_app(
     if enable_mcp:
         from flux.service_mcp import create_service_mcp_server
 
-        mcp_server = create_service_mcp_server(service_name, proxy._client)
+        mcp_server = create_service_mcp_server(service_name, proxy._client, auth=mcp_auth)
 
         @app.on_event("startup")
         async def _init_mcp_tools():
@@ -139,7 +141,7 @@ def create_standalone_app(
         async def _start_mcp_refresh():
             asyncio.create_task(_mcp_refresh_loop())
 
-        app.mount("/mcp", mcp_server.mcp.http_app())
+        mcp_asgi_app = mcp_server.mcp.http_app(path="/mcp")
 
     @app.get("/health")
     async def health():
@@ -269,4 +271,68 @@ def create_standalone_app(
 
         return JSONResponse(status_code=response.status_code, content=response.json())
 
+    if enable_mcp:
+        return _MCPDispatcher(app, mcp_asgi_app)
+
     return app
+
+
+class _MCPDispatcher:
+    """ASGI wrapper that routes /mcp requests to the FastMCP app before
+    FastAPI's catch-all ``/{workflow_name}`` can intercept them.
+
+    Manages both apps' lifespans so the MCP session manager is properly
+    initialised.
+    """
+
+    def __init__(self, main_app: Any, mcp_app: Any):
+        self.main_app = main_app
+        self.mcp_app = mcp_app
+        self._mcp_started = False
+
+    async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
+        if scope["type"] == "lifespan":
+            await self._handle_lifespan(scope, receive, send)
+        elif scope["type"] == "http" and self._is_mcp_route(scope.get("path", "")):
+            await self.mcp_app(scope, receive, send)
+        else:
+            await self.main_app(scope, receive, send)
+
+    @staticmethod
+    def _is_mcp_route(path: str) -> bool:
+        return path.startswith("/mcp") or path.startswith("/.well-known/")
+
+    async def _handle_lifespan(self, scope: dict, receive: Any, send: Any) -> None:
+        """Coordinate lifespan for both the FastAPI app and the MCP app."""
+        message = await receive()
+        if message["type"] != "lifespan.startup":
+            return
+
+        try:
+            self._mcp_lifespan_cm = self.mcp_app.router.lifespan_context(self.mcp_app)
+            await self._mcp_lifespan_cm.__aenter__()
+            self._mcp_started = True
+        except Exception:
+            pass
+
+        await self.main_app(scope, self._wrap_receive(message), send)
+
+        if self._mcp_started:
+            try:
+                await self._mcp_lifespan_cm.__aexit__(None, None, None)
+            except Exception:
+                pass
+
+    @staticmethod
+    def _wrap_receive(first_message: dict) -> Any:
+        sent = False
+
+        async def _receive() -> dict:
+            nonlocal sent
+            if not sent:
+                sent = True
+                return first_message
+            while True:
+                await asyncio.sleep(3600)
+
+        return _receive

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.30.0"
+version = "0.31.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_service_mcp.py
+++ b/tests/flux/test_service_mcp.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -168,26 +168,31 @@ class TestToolGeneration:
 
 class TestAuthProvider:
     def test_no_auth_by_default(self):
-        ep = _make_endpoint("greet")
-        server = _build_server({"greet": ep})
-        assert server.mcp.auth is None
+        with patch("flux.service_mcp.FastMCP") as mock_cls:
+            ep = _make_endpoint("greet")
+            provider = FakeProvider({"greet": ep})
+            ServiceMCPServer("test-service", provider)
+            mock_cls.assert_called_once_with("flux-service-test-service", auth=None)
 
     def test_auth_provider_passed_to_fastmcp(self):
         fake_auth = MagicMock()
-        provider = FakeProvider({"greet": _make_endpoint("greet")})
-        server = ServiceMCPServer("test-service", provider, auth=fake_auth)
-        assert server.mcp.auth is fake_auth
+        with patch("flux.service_mcp.FastMCP") as mock_cls:
+            provider = FakeProvider({"greet": _make_endpoint("greet")})
+            ServiceMCPServer("test-service", provider, auth=fake_auth)
+            mock_cls.assert_called_once_with("flux-service-test-service", auth=fake_auth)
 
     def test_create_service_mcp_server_with_auth(self):
         fake_auth = MagicMock()
         fake_client = MagicMock()
-        server = create_service_mcp_server("svc", fake_client, auth=fake_auth)
-        assert server.mcp.auth is fake_auth
+        with patch("flux.service_mcp.FastMCP") as mock_cls:
+            create_service_mcp_server("svc", fake_client, auth=fake_auth)
+            mock_cls.assert_called_once_with("flux-service-svc", auth=fake_auth)
 
     def test_create_service_mcp_server_without_auth(self):
         fake_client = MagicMock()
-        server = create_service_mcp_server("svc", fake_client)
-        assert server.mcp.auth is None
+        with patch("flux.service_mcp.FastMCP") as mock_cls:
+            create_service_mcp_server("svc", fake_client)
+            mock_cls.assert_called_once_with("flux-service-svc", auth=None)
 
 
 class TestMCPRouteMiddleware:

--- a/tests/flux/test_service_mcp.py
+++ b/tests/flux/test_service_mcp.py
@@ -207,6 +207,11 @@ class TestMCPRouteMiddleware:
         assert MCPRouteMiddleware._is_mcp_route("/invoice") is False
         assert MCPRouteMiddleware._is_mcp_route("/invoice/status/abc") is False
 
+    def test_mcp_prefixed_workflow_is_not_mcp_route(self):
+        assert MCPRouteMiddleware._is_mcp_route("/mcp_billing") is False
+        assert MCPRouteMiddleware._is_mcp_route("/mcptest") is False
+        assert MCPRouteMiddleware._is_mcp_route("/mcp-workflow") is False
+
     @pytest.mark.asyncio
     async def test_http_mcp_routed_to_mcp_app(self):
         calls = {"main": [], "mcp": []}

--- a/tests/flux/test_service_mcp.py
+++ b/tests/flux/test_service_mcp.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock
 
-from flux.service_mcp import EndpointInfo, ServiceMCPServer
+import pytest
+
+from flux.service_mcp import EndpointInfo, ServiceMCPServer, create_service_mcp_server
+from flux.service_proxy import _MCPDispatcher
 
 
 class FakeProvider:
@@ -160,3 +164,92 @@ class TestToolGeneration:
         fn = server.get_tool_function("deploy")
         assert fn is not None
         assert "Deploy to production" in (fn.__doc__ or "")
+
+
+class TestAuthProvider:
+    def test_no_auth_by_default(self):
+        ep = _make_endpoint("greet")
+        server = _build_server({"greet": ep})
+        assert server.mcp.auth is None
+
+    def test_auth_provider_passed_to_fastmcp(self):
+        fake_auth = MagicMock()
+        provider = FakeProvider({"greet": _make_endpoint("greet")})
+        server = ServiceMCPServer("test-service", provider, auth=fake_auth)
+        assert server.mcp.auth is fake_auth
+
+    def test_create_service_mcp_server_with_auth(self):
+        fake_auth = MagicMock()
+        fake_client = MagicMock()
+        server = create_service_mcp_server("svc", fake_client, auth=fake_auth)
+        assert server.mcp.auth is fake_auth
+
+    def test_create_service_mcp_server_without_auth(self):
+        fake_client = MagicMock()
+        server = create_service_mcp_server("svc", fake_client)
+        assert server.mcp.auth is None
+
+
+class TestMCPDispatcherRouting:
+    def test_mcp_path_is_mcp_route(self):
+        assert _MCPDispatcher._is_mcp_route("/mcp") is True
+        assert _MCPDispatcher._is_mcp_route("/mcp/") is True
+        assert _MCPDispatcher._is_mcp_route("/mcp/something") is True
+
+    def test_well_known_is_mcp_route(self):
+        assert _MCPDispatcher._is_mcp_route("/.well-known/oauth-protected-resource") is True
+        assert _MCPDispatcher._is_mcp_route("/.well-known/oauth-authorization-server") is True
+
+    def test_health_is_not_mcp_route(self):
+        assert _MCPDispatcher._is_mcp_route("/health") is False
+
+    def test_workflow_is_not_mcp_route(self):
+        assert _MCPDispatcher._is_mcp_route("/invoice") is False
+        assert _MCPDispatcher._is_mcp_route("/invoice/status/abc") is False
+
+    @pytest.mark.asyncio
+    async def test_http_mcp_routed_to_mcp_app(self):
+        calls = {"main": [], "mcp": []}
+
+        async def main_app(scope, receive, send):
+            calls["main"].append(scope["path"])
+
+        async def mcp_app(scope, receive, send):
+            calls["mcp"].append(scope["path"])
+
+        dispatcher = _MCPDispatcher(main_app, mcp_app)
+        await dispatcher({"type": "http", "path": "/mcp"}, None, None)
+        assert calls["mcp"] == ["/mcp"]
+        assert calls["main"] == []
+
+    @pytest.mark.asyncio
+    async def test_http_well_known_routed_to_mcp_app(self):
+        calls = {"main": [], "mcp": []}
+
+        async def main_app(scope, receive, send):
+            calls["main"].append(scope["path"])
+
+        async def mcp_app(scope, receive, send):
+            calls["mcp"].append(scope["path"])
+
+        dispatcher = _MCPDispatcher(main_app, mcp_app)
+        await dispatcher(
+            {"type": "http", "path": "/.well-known/oauth-protected-resource"}, None, None,
+        )
+        assert calls["mcp"] == ["/.well-known/oauth-protected-resource"]
+        assert calls["main"] == []
+
+    @pytest.mark.asyncio
+    async def test_http_workflow_routed_to_main_app(self):
+        calls = {"main": [], "mcp": []}
+
+        async def main_app(scope, receive, send):
+            calls["main"].append(scope["path"])
+
+        async def mcp_app(scope, receive, send):
+            calls["mcp"].append(scope["path"])
+
+        dispatcher = _MCPDispatcher(main_app, mcp_app)
+        await dispatcher({"type": "http", "path": "/invoice"}, None, None)
+        assert calls["main"] == ["/invoice"]
+        assert calls["mcp"] == []

--- a/tests/flux/test_service_mcp.py
+++ b/tests/flux/test_service_mcp.py
@@ -234,7 +234,9 @@ class TestMCPRouteMiddleware:
 
         middleware = MCPRouteMiddleware(main_app, mcp_app=mcp_app)
         await middleware(
-            {"type": "http", "path": "/.well-known/oauth-protected-resource"}, None, None,
+            {"type": "http", "path": "/.well-known/oauth-protected-resource"},
+            None,
+            None,
         )
         assert calls["mcp"] == ["/.well-known/oauth-protected-resource"]
         assert calls["main"] == []

--- a/tests/flux/test_service_mcp.py
+++ b/tests/flux/test_service_mcp.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from flux.service_mcp import EndpointInfo, ServiceMCPServer, create_service_mcp_server
-from flux.service_proxy import _MCPDispatcher
+from flux.service_proxy import MCPRouteMiddleware
 
 
 class FakeProvider:
@@ -190,22 +190,22 @@ class TestAuthProvider:
         assert server.mcp.auth is None
 
 
-class TestMCPDispatcherRouting:
+class TestMCPRouteMiddleware:
     def test_mcp_path_is_mcp_route(self):
-        assert _MCPDispatcher._is_mcp_route("/mcp") is True
-        assert _MCPDispatcher._is_mcp_route("/mcp/") is True
-        assert _MCPDispatcher._is_mcp_route("/mcp/something") is True
+        assert MCPRouteMiddleware._is_mcp_route("/mcp") is True
+        assert MCPRouteMiddleware._is_mcp_route("/mcp/") is True
+        assert MCPRouteMiddleware._is_mcp_route("/mcp/something") is True
 
     def test_well_known_is_mcp_route(self):
-        assert _MCPDispatcher._is_mcp_route("/.well-known/oauth-protected-resource") is True
-        assert _MCPDispatcher._is_mcp_route("/.well-known/oauth-authorization-server") is True
+        assert MCPRouteMiddleware._is_mcp_route("/.well-known/oauth-protected-resource") is True
+        assert MCPRouteMiddleware._is_mcp_route("/.well-known/oauth-authorization-server") is True
 
     def test_health_is_not_mcp_route(self):
-        assert _MCPDispatcher._is_mcp_route("/health") is False
+        assert MCPRouteMiddleware._is_mcp_route("/health") is False
 
     def test_workflow_is_not_mcp_route(self):
-        assert _MCPDispatcher._is_mcp_route("/invoice") is False
-        assert _MCPDispatcher._is_mcp_route("/invoice/status/abc") is False
+        assert MCPRouteMiddleware._is_mcp_route("/invoice") is False
+        assert MCPRouteMiddleware._is_mcp_route("/invoice/status/abc") is False
 
     @pytest.mark.asyncio
     async def test_http_mcp_routed_to_mcp_app(self):
@@ -217,8 +217,8 @@ class TestMCPDispatcherRouting:
         async def mcp_app(scope, receive, send):
             calls["mcp"].append(scope["path"])
 
-        dispatcher = _MCPDispatcher(main_app, mcp_app)
-        await dispatcher({"type": "http", "path": "/mcp"}, None, None)
+        middleware = MCPRouteMiddleware(main_app, mcp_app=mcp_app)
+        await middleware({"type": "http", "path": "/mcp"}, None, None)
         assert calls["mcp"] == ["/mcp"]
         assert calls["main"] == []
 
@@ -232,8 +232,8 @@ class TestMCPDispatcherRouting:
         async def mcp_app(scope, receive, send):
             calls["mcp"].append(scope["path"])
 
-        dispatcher = _MCPDispatcher(main_app, mcp_app)
-        await dispatcher(
+        middleware = MCPRouteMiddleware(main_app, mcp_app=mcp_app)
+        await middleware(
             {"type": "http", "path": "/.well-known/oauth-protected-resource"}, None, None,
         )
         assert calls["mcp"] == ["/.well-known/oauth-protected-resource"]
@@ -249,7 +249,22 @@ class TestMCPDispatcherRouting:
         async def mcp_app(scope, receive, send):
             calls["mcp"].append(scope["path"])
 
-        dispatcher = _MCPDispatcher(main_app, mcp_app)
-        await dispatcher({"type": "http", "path": "/invoice"}, None, None)
+        middleware = MCPRouteMiddleware(main_app, mcp_app=mcp_app)
+        await middleware({"type": "http", "path": "/invoice"}, None, None)
         assert calls["main"] == ["/invoice"]
+        assert calls["mcp"] == []
+
+    @pytest.mark.asyncio
+    async def test_non_http_scope_passed_to_main_app(self):
+        calls = {"main": [], "mcp": []}
+
+        async def main_app(scope, receive, send):
+            calls["main"].append(scope["type"])
+
+        async def mcp_app(scope, receive, send):
+            calls["mcp"].append(scope["type"])
+
+        middleware = MCPRouteMiddleware(main_app, mcp_app=mcp_app)
+        await middleware({"type": "websocket", "path": "/mcp"}, None, None)
+        assert calls["main"] == ["websocket"]
         assert calls["mcp"] == []

--- a/tests/flux/test_service_proxy.py
+++ b/tests/flux/test_service_proxy.py
@@ -122,6 +122,20 @@ class TestMCPRouting:
             body_text = json.dumps(r.json()) if _is_json(r) else r.text
             assert "Workflow" not in body_text
 
+    @pytest.mark.parametrize(
+        "path",
+        ["/mcp_billing", "/mcptest", "/mcp-workflow"],
+        ids=["mcp_underscore", "mcptest", "mcp-hyphen"],
+    )
+    def test_mcp_prefixed_workflow_not_hijacked(self, path):
+        """Workflows whose names start with 'mcp' must NOT be intercepted."""
+        app = create_standalone_app("test-svc", UNREACHABLE_SERVER, enable_mcp=True)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            r = client.post(path)
+            # Should reach the workflow handler, not the MCP app.
+            # The workflow handler fails to connect (500/502) or can't resolve (404).
+            assert r.status_code in (404, 500, 502)
+
 
 def _is_json(response) -> bool:
     return "application/json" in response.headers.get("content-type", "")

--- a/tests/flux/test_service_proxy.py
+++ b/tests/flux/test_service_proxy.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from starlette.testclient import TestClient
+
+from flux.service_proxy import create_standalone_app
+
+UNREACHABLE_SERVER = "http://127.0.0.1:1"
+
+MCP_ACCEPT = "application/json, text/event-stream"
+
+
+class TestHealthRoute:
+    def test_health_without_mcp(self):
+        app = create_standalone_app("test-svc", UNREACHABLE_SERVER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            r = client.get("/health")
+            assert r.status_code == 200
+            body = r.json()
+            assert body["service"] == "test-svc"
+            assert body["mcp_enabled"] is False
+
+    def test_health_with_mcp(self):
+        app = create_standalone_app("test-svc", UNREACHABLE_SERVER, enable_mcp=True)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            r = client.get("/health")
+            assert r.status_code == 200
+            body = r.json()
+            assert body["mcp_enabled"] is True
+
+
+class TestWorkflowRoute:
+    """Workflow routes hit the proxy handler (which fails to connect to the
+    unreachable backend, producing 500/502).  The key assertion is that these
+    paths do NOT return an MCP-style response."""
+
+    def test_post_workflow_reaches_handler(self):
+        app = create_standalone_app("test-svc", UNREACHABLE_SERVER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            r = client.post("/invoice")
+            assert r.status_code in (404, 500, 502)
+
+    def test_resume_workflow_reaches_handler(self):
+        app = create_standalone_app("test-svc", UNREACHABLE_SERVER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            r = client.post("/invoice/resume/exec-123")
+            assert r.status_code in (404, 500, 502)
+
+    def test_status_workflow_reaches_handler(self):
+        app = create_standalone_app("test-svc", UNREACHABLE_SERVER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            r = client.get("/invoice/status/exec-123")
+            assert r.status_code in (404, 500, 502)
+
+
+class TestMCPRouting:
+    """Verify /mcp and /.well-known/ are routed to the FastMCP app,
+    not swallowed by the /{workflow_name} catch-all.
+
+    This is the exact bug that the MCPRouteMiddleware prevents.
+    """
+
+    def test_mcp_not_treated_as_workflow(self):
+        """POST /mcp must NOT return a 'Workflow mcp not found' error."""
+        app = create_standalone_app("test-svc", UNREACHABLE_SERVER, enable_mcp=True)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            r = client.post("/mcp")
+            body_text = json.dumps(r.json()) if _is_json(r) else r.text
+            assert "Workflow 'mcp' not found" not in body_text
+
+    def test_mcp_initialize(self):
+        """A valid MCP initialize request should get a JSON-RPC response."""
+        app = create_standalone_app("test-svc", UNREACHABLE_SERVER, enable_mcp=True)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            r = client.post(
+                "/mcp",
+                headers={"Accept": MCP_ACCEPT},
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "clientInfo": {"name": "test", "version": "0.1"},
+                    },
+                },
+            )
+            assert r.status_code == 200
+            body = _parse_sse_json(r.text)
+            assert body.get("jsonrpc") == "2.0"
+            assert "result" in body
+
+    def test_well_known_not_treated_as_workflow(self):
+        """GET /.well-known/... must NOT return a workflow-not-found error."""
+        app = create_standalone_app("test-svc", UNREACHABLE_SERVER, enable_mcp=True)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            r = client.get("/.well-known/oauth-protected-resource")
+            body_text = json.dumps(r.json()) if _is_json(r) else r.text
+            assert "Workflow" not in body_text
+
+    def test_mcp_disabled_falls_through_to_workflow_handler(self):
+        """Without MCP, /mcp should be treated as a workflow name."""
+        app = create_standalone_app("test-svc", UNREACHABLE_SERVER, enable_mcp=False)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            r = client.post("/mcp")
+            # Reaches the workflow handler — fails because backend is unreachable
+            assert r.status_code in (404, 500, 502)
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/mcp", "/mcp/", "/mcp/sse"],
+        ids=["mcp-root", "mcp-trailing-slash", "mcp-sse"],
+    )
+    def test_mcp_subpaths_routed_correctly(self, path):
+        """All /mcp/* subpaths should reach the FastMCP app."""
+        app = create_standalone_app("test-svc", UNREACHABLE_SERVER, enable_mcp=True)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            r = client.get(path)
+            body_text = json.dumps(r.json()) if _is_json(r) else r.text
+            assert "Workflow" not in body_text
+
+
+def _is_json(response) -> bool:
+    return "application/json" in response.headers.get("content-type", "")
+
+
+def _parse_sse_json(text: str) -> dict:
+    """Extract the first JSON object from an SSE stream."""
+    for line in text.splitlines():
+        if line.startswith("data: "):
+            return json.loads(line[len("data: ") :])
+    raise ValueError(f"No SSE data line found in: {text!r}")


### PR DESCRIPTION
## Summary

- Add configurable IdP/auth support to standalone service MCP endpoints so they can validate bearer tokens from an external Identity Provider and advertise it via [RFC 9728 Protected Resource Metadata](https://www.rfc-editor.org/rfc/rfc9728)
- MCP clients can discover the authorization server, perform Dynamic Client Registration (DCR) and PKCE, and present tokens — all through standard OAuth 2.1 flows
- Fix MCP routing bug where FastAPI's catch-all `/{workflow_name}` route intercepted `/mcp` requests before the MCP sub-app could handle them

### Changes

| File | What |
|------|------|
| `flux/service_mcp.py` | `ServiceMCPServer` and `create_service_mcp_server` accept optional `auth: AuthProvider` and forward it to FastMCP |
| `flux/service_proxy.py` | `create_standalone_app` accepts `mcp_auth`; `_MCPDispatcher` also routes `/.well-known/` to the MCP app for OAuth discovery |
| `flux/cli_service.py` | `--mcp-issuer`, `--mcp-audience`, `--mcp-jwks-uri` flags on `flux service start`; falls back to `flux.security.auth.oidc` config |
| `docs/advanced-features/services.md` | Documents MCP auth configuration, CLI flags, IdP examples, and the discovery flow |
| `tests/flux/test_service_mcp.py` | 11 new tests for auth plumbing and dispatcher routing |

### Usage

```bash
# Explicit IdP flags
flux service start billing --port 9000 \
  --mcp-issuer https://idp.example.com/realms/my-realm \
  --mcp-audience billing-api

# Or inherit from Flux OIDC config (flux.toml)
flux service start billing --port 9000
```

## Test plan

- [x] `TestAuthProvider` — verifies auth provider flows through `ServiceMCPServer` → `FastMCP`
- [x] `TestMCPDispatcherRouting` — verifies `/mcp`, `/.well-known/*` routed to MCP app; workflow paths to FastAPI
- [ ] Manual: start service with `--mcp-issuer` pointing at a real IdP, verify `/.well-known/oauth-protected-resource` returns correct metadata
- [ ] Manual: verify MCP client (e.g. Cursor) can complete the discovery → DCR → token → tool call flow


Made with [Cursor](https://cursor.com)