### PR TITLE
fix: address 3 security review findings (path traversal + 2 hardcoded defaults)

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,8 +683,8 @@ retry_attempts = 3
 retry_delay = 1
 retry_backoff = 2
 
-[flux.security]
-encryption_key = "your-encryption-key"
+[flux.security.encryption]
+encryption_key = "your-encryption-key"  # generate with: openssl rand -hex 32
 
 [flux.mcp]
 name = "flux-workflows"
@@ -717,7 +717,7 @@ export FLUX_WORKERS__SERVER_URL=http://production:8000
 export FLUX_WORKERS__DEFAULT_TIMEOUT=600
 
 # Security settings
-export FLUX_SECURITY__ENCRYPTION_KEY=your-secret-key
+export FLUX_SECURITY__ENCRYPTION__ENCRYPTION_KEY=your-secret-key
 
 # MCP settings
 export FLUX_MCP__HOST=0.0.0.0

--- a/docs/advanced-features/agent-harness.md
+++ b/docs/advanced-features/agent-harness.md
@@ -344,6 +344,8 @@ Working memory is always on; there is no flag to disable it.
 
 `skills_dir`, `tools_file`, and `workflow_file` are paths on the machine running `flux agent create`. Because the workflow runs on a worker — potentially a different machine — these files are read and stored inline in the database at creation (and again on `update` if paths are supplied). The worker never reads them from the local filesystem.
 
+**Permission requirement.** When auth is enabled, shipping any of these inline payloads requires the `workflow:*:*:register` permission, not just `agent:*:create`. The contents are materialized on every worker that runs the agent, so the gate matches the one for registering workflow source code. Plain path-string `skills_dir` (referencing an existing directory on the worker host, not an inline bundle) does not trigger the elevated gate.
+
 ### Custom workflows
 
 The built-in template is `agents/agent_chat`. Most agents do not need anything else. For advanced flows, supply `workflow_file` with a custom workflow that follows the same contract:

--- a/docs/advanced-features/authentication.md
+++ b/docs/advanced-features/authentication.md
@@ -379,12 +379,22 @@ flux principals revoke-key <subject> --key-name <name>
 | `DELETE` | `/admin/principals/{id}` | `admin:principals:manage` |
 | `POST` | `/admin/principals/{id}/keys` | `admin:principals:manage` |
 | `DELETE` | `/admin/principals/{id}/keys/{name}` | `admin:principals:manage` |
-| `POST` | `/workers/register` | bootstrap_token |
+| `POST` | `/workers/register` | bootstrap_token (see below) |
 | `POST` | `/workers/{name}/pong` | `worker:*:*` |
 | `GET` | `/workers/{name}/connect` | `worker:*:*` |
 | `POST` | `/workers/{name}/claim/{id}` | `worker:*:*` |
 | `POST` | `/workers/{name}/checkpoint/{id}` | `worker:*:*` |
 | `POST` | `/workers/{name}/progress/{id}` | `worker:*:*` |
+
+### Worker bootstrap token
+
+`POST /workers/register` is gated by a long-lived shared secret rather than the auth-service permission system. Resolution order on the server:
+
+1. `FLUX_WORKERS__BOOTSTRAP_TOKEN` env var, or `[flux.workers] bootstrap_token` in flux.toml.
+2. Persisted file at `<home>/bootstrap-token` (mode 0600).
+3. Auto-generated on first server start, persisted to the path above, and logged at WARNING level.
+
+Retrieve the active token with `flux server bootstrap-token` (run on the server host). Force regeneration with `flux server bootstrap-token --rotate` — existing workers must re-register after rotation. Workers must be supplied an explicit token via env var, config, or CLI flag; auto-generation is server-only because workers typically run on different hosts. The server compares submitted tokens with `hmac.compare_digest`.
 
 ## Dev Environment
 

--- a/docs/advanced-features/authentication.md
+++ b/docs/advanced-features/authentication.md
@@ -394,7 +394,7 @@ flux principals revoke-key <subject> --key-name <name>
 2. Persisted file at `<home>/bootstrap-token` (mode 0600).
 3. Auto-generated on first server start, persisted to the path above, and logged at WARNING level.
 
-Retrieve the active token with `flux server bootstrap-token` (run on the server host). Force regeneration with `flux server bootstrap-token --rotate` — existing workers must re-register after rotation. Workers must be supplied an explicit token via env var, config, or CLI flag; auto-generation is server-only because workers typically run on different hosts. The server compares submitted tokens with `hmac.compare_digest`.
+Retrieve the active token with `flux server bootstrap-token` (run on the server host). Force regeneration of the persisted file-backed token with `flux server bootstrap-token --rotate`; the running server reads the token once at startup, so you must **restart the server** for the rotated value to take effect, and existing workers will need to re-register with the new token. If `FLUX_WORKERS__BOOTSTRAP_TOKEN` or `[flux.workers] bootstrap_token` is set, that configured value still wins over the rotated file until removed. Workers must be supplied an explicit token via env var, config, or CLI flag; auto-generation is server-only because workers typically run on different hosts. The server compares submitted tokens with `hmac.compare_digest`.
 
 ## Dev Environment
 

--- a/flux.toml
+++ b/flux.toml
@@ -16,7 +16,10 @@ database_url = "sqlite:///.flux/flux.db"                            # Database U
 # database_max_overflow = 20
 
 [flux.workers]
-bootstrap_token = "4298a036-a934-4add-8963-521294f06bf3"    # Token for bootstrapping workers
+# bootstrap_token = "<set explicitly OR omit to let the server auto-generate>"
+# When unset on the server, a fresh token is written to <home>/bootstrap-token
+# on first start; retrieve it via 'flux server bootstrap-token'. Workers must
+# always be supplied an explicit value (env var, flux.toml, or CLI flag).
 server_url = "http://localhost:8000"                        # Default server URL to connect to
 default_timeout = 30                                        # Default timeout for tasks in seconds
 retry_attempts = 0                                          # Default number of retry attempts for failed tasks

--- a/flux.toml
+++ b/flux.toml
@@ -26,7 +26,9 @@ module_cache_ttl = 300                                      # Seconds to cache c
 eviction_grace_period = 30                                  # Seconds to wait after marking worker stale before evicting
 
 [flux.security.encryption]
-encryption_key = "SUPER_SECRET_KEY"
+# encryption_key = "<generate with: openssl rand -hex 32>"
+# Required for the secrets store. Set via FLUX_SECURITY__ENCRYPTION__ENCRYPTION_KEY
+# in production; a missing key surfaces a clear error on first encrypt/decrypt.
 
 # Uncomment to enable API key authentication:
 # [flux.security.auth.api_keys]

--- a/flux/agents/template.py
+++ b/flux/agents/template.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 from flux.domain.execution_context import ExecutionContext
@@ -10,6 +11,34 @@ from flux.workflow import workflow
 
 from flux.agents.tools_resolver import resolve_builtin_tools
 from flux.agents.types import ChatResponseOutput
+
+
+def _materialize_skills_bundle(tmp: Path, skills_data: dict[str, Any]) -> None:
+    """Write a skills bundle into ``tmp``, rejecting any path that escapes it.
+
+    The bundle is sourced from agent definitions in the database and is therefore
+    treated as untrusted: each ``file_path`` must be a relative path that resolves
+    inside ``tmp`` after path normalization.
+    """
+    base = tmp.resolve()
+    for skill_name, files in skills_data.items():
+        if not isinstance(files, dict):
+            raise ValueError(
+                f"Skill '{skill_name}' bundle must be a mapping of file paths to contents.",
+            )
+        for file_path, content in files.items():
+            candidate = Path(file_path)
+            if candidate.is_absolute() or any(part == ".." for part in candidate.parts):
+                raise ValueError(
+                    f"Skill '{skill_name}' contains unsafe file path: {file_path!r}",
+                )
+            full_path = (base / candidate).resolve()
+            if not full_path.is_relative_to(base):
+                raise ValueError(
+                    f"Skill '{skill_name}' file path escapes bundle root: {file_path!r}",
+                )
+            full_path.parent.mkdir(parents=True, exist_ok=True)
+            full_path.write_text(content)
 
 
 @workflow.with_options(namespace="agents")
@@ -25,7 +54,6 @@ async def agent_chat(ctx: ExecutionContext[dict[str, Any]]):
     _skills_tmp_dir = None
     if agent_def.get("skills_dir"):
         import tempfile
-        from pathlib import Path
         from flux.tasks.ai.skills import SkillCatalog
 
         skills_data = agent_def["skills_dir"]
@@ -38,11 +66,7 @@ async def agent_chat(ctx: ExecutionContext[dict[str, Any]]):
         if isinstance(skills_data, dict):
             _skills_tmp_dir = tempfile.TemporaryDirectory(prefix="flux_skills_")
             tmp = Path(_skills_tmp_dir.name)
-            for skill_name, files in skills_data.items():
-                for file_path, content in files.items():
-                    full_path = tmp / file_path
-                    full_path.parent.mkdir(parents=True, exist_ok=True)
-                    full_path.write_text(content)
+            _materialize_skills_bundle(tmp, skills_data)
             skills = SkillCatalog.from_directory(str(tmp))
         else:
             skills = SkillCatalog.from_directory(str(skills_data))

--- a/flux/agents/template.py
+++ b/flux/agents/template.py
@@ -18,7 +18,7 @@ def _materialize_skills_bundle(tmp: Path, skills_data: dict[str, Any]) -> None:
 
     The bundle is sourced from agent definitions in the database and is therefore
     treated as untrusted: each ``file_path`` must be a relative path that resolves
-    inside ``tmp`` after path normalization.
+    inside ``tmp`` after path normalization, and each ``content`` must be a string.
     """
     base = tmp.resolve()
     for skill_name, files in skills_data.items():
@@ -27,6 +27,29 @@ def _materialize_skills_bundle(tmp: Path, skills_data: dict[str, Any]) -> None:
                 f"Skill '{skill_name}' bundle must be a mapping of file paths to contents.",
             )
         for file_path, content in files.items():
+            if not isinstance(file_path, str):
+                raise ValueError(
+                    f"Skill '{skill_name}' bundle keys must be strings; got {type(file_path).__name__}.",
+                )
+            if not isinstance(content, str):
+                raise ValueError(
+                    f"Skill '{skill_name}' file {file_path!r} must have string content; "
+                    f"got {type(content).__name__}.",
+                )
+            # Belt-and-suspenders: reject by string shape AND by Path semantics. A
+            # Linux/macOS absolute path begins with '/'; a Windows absolute path may
+            # begin with a drive letter or backslash. Path.is_absolute() handles the
+            # platform conventions; the string checks catch pathological inputs that
+            # might escape Path's normalization.
+            if (
+                file_path.startswith("/")
+                or file_path.startswith("\\")
+                or (len(file_path) >= 2 and file_path[1] == ":")
+                or "\x00" in file_path
+            ):
+                raise ValueError(
+                    f"Skill '{skill_name}' contains unsafe file path: {file_path!r}",
+                )
             candidate = Path(file_path)
             if candidate.is_absolute() or any(part == ".." for part in candidate.parts):
                 raise ValueError(

--- a/flux/agents/types.py
+++ b/flux/agents/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -51,6 +52,23 @@ class AgentDefinition(BaseModel):
                     "long_term_memory.connection is required when long_term_memory is set",
                 )
         return self
+
+    def has_skills_bundle(self) -> bool:
+        """Return True if skills_dir carries an inline JSON bundle (vs a worker-side path)."""
+        if not self.skills_dir:
+            return False
+        try:
+            return isinstance(json.loads(self.skills_dir), dict)
+        except (json.JSONDecodeError, ValueError):
+            return False
+
+    def requires_code_upload_permission(self) -> bool:
+        """Return True if this definition ships content that escalates beyond ``agent:*:create``.
+
+        ``tools_file``/``workflow_file`` are exec'd on workers; an inline ``skills_dir`` bundle
+        ships arbitrary file content materialized on the worker filesystem.
+        """
+        return bool(self.tools_file or self.workflow_file or self.has_skills_bundle())
 
 
 class AgentPauseOutput(BaseModel):

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -1021,10 +1021,22 @@ def server_group():
     "--rotate",
     is_flag=True,
     default=False,
-    help="Generate a fresh token, persist it, and print it. Existing workers must re-register.",
+    help=(
+        "Generate a fresh token and persist it. The server caches the token at startup, "
+        "so you must restart it for the rotated value to take effect; existing workers "
+        "must then re-register. If FLUX_WORKERS__BOOTSTRAP_TOKEN or [flux.workers] "
+        "bootstrap_token is set, that override still wins until removed."
+    ),
 )
 def server_bootstrap_token(rotate: bool):
-    """Print the server's bootstrap token (or rotate it)."""
+    """Print the server's bootstrap token (or rotate it).
+
+    Reading: prints the configured token (env / config file) if set; else the
+    persisted file at <home>/bootstrap-token; else exits 1.
+
+    Rotating: writes a new token to the persisted file. The running server
+    keeps using its in-memory copy until restarted; configured overrides win.
+    """
     from flux.config import Configuration
     from flux.security import bootstrap_token as bt
 

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -1041,7 +1041,9 @@ def server_bootstrap_token(rotate: bool):
     from flux.security import bootstrap_token as bt
 
     settings = Configuration.get().settings
-    configured = settings.workers.bootstrap_token
+    # Mirror the resolver's normalization: a whitespace-only env/config value is
+    # treated as unset so it does not silently win over the persisted file.
+    configured = bt._normalize(settings.workers.bootstrap_token)
     home = settings.home
 
     if rotate:

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -1010,6 +1010,56 @@ def console(server_url: str | None = None):
     raise click.exceptions.Exit(1)
 
 
+@cli.group("server")
+def server_group():
+    """Server lifecycle commands (run on the server host)."""
+    pass
+
+
+@server_group.command("bootstrap-token")
+@click.option(
+    "--rotate",
+    is_flag=True,
+    default=False,
+    help="Generate a fresh token, persist it, and print it. Existing workers must re-register.",
+)
+def server_bootstrap_token(rotate: bool):
+    """Print the server's bootstrap token (or rotate it)."""
+    from flux.config import Configuration
+    from flux.security import bootstrap_token as bt
+
+    settings = Configuration.get().settings
+    configured = settings.workers.bootstrap_token
+    home = settings.home
+
+    if rotate:
+        if configured:
+            click.echo(
+                "Warning: bootstrap_token is set via env var or config; rotating the file "
+                "will not change the active token until that override is removed.",
+                err=True,
+            )
+        token = bt.rotate(home)
+        click.echo(token)
+        return
+
+    if configured:
+        click.echo(configured)
+        return
+
+    persisted = bt.read_persisted(home)
+    if persisted:
+        click.echo(persisted)
+        return
+
+    click.echo(
+        "No bootstrap token found. Start the server once to auto-generate one, "
+        "or set FLUX_WORKERS__BOOTSTRAP_TOKEN.",
+        err=True,
+    )
+    raise click.exceptions.Exit(1)
+
+
 @cli.group()
 def schedule():
     """Manage workflow schedules."""

--- a/flux/config.py
+++ b/flux/config.py
@@ -5,7 +5,6 @@ import re
 from pathlib import Path
 from threading import Lock
 from typing import Any, Literal
-from uuid import uuid4
 
 import tomli
 from pydantic import BaseModel
@@ -25,9 +24,14 @@ class BaseConfig(BaseModel):
 class WorkersConfig(BaseConfig):
     """Configuration for workflow executor."""
 
-    bootstrap_token: str = Field(
-        default_factory=lambda: uuid4().hex,
-        description="Token for bootstrapping workers",
+    bootstrap_token: str | None = Field(
+        default=None,
+        description=(
+            "Token for bootstrapping workers. When unset on the server, one is "
+            "auto-generated and persisted at <home>/bootstrap-token on first start; "
+            "retrieve it with 'flux server bootstrap-token'. Workers must always "
+            "be supplied an explicit value."
+        ),
     )
 
     server_url: str = Field(

--- a/flux/security/bootstrap_token.py
+++ b/flux/security/bootstrap_token.py
@@ -20,6 +20,7 @@ filesystem with the server.
 from __future__ import annotations
 
 import logging
+import os
 import secrets
 import stat
 from pathlib import Path
@@ -43,10 +44,23 @@ def read_persisted(home: str | Path) -> str | None:
 
 
 def write(home: str | Path, token: str) -> Path:
-    """Persist ``token`` to ``<home>/bootstrap-token`` with mode 0600."""
+    """Persist ``token`` to ``<home>/bootstrap-token`` with mode 0600.
+
+    Creates the file atomically with restrictive permissions: ``os.open`` with
+    ``O_CREAT|O_TRUNC`` and ``mode=0600`` ensures the file never briefly exists
+    with the umask-derived permissions before the chmod. Falls back to a
+    second chmod for the case where the file already existed with wider mode.
+    """
     p = _path(home)
     p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(token)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    fd = os.open(str(p), flags, _FILE_MODE)
+    try:
+        os.write(fd, token.encode("utf-8"))
+    finally:
+        os.close(fd)
+    # If the file already existed with wider mode, os.open keeps the old mode.
+    # Tighten it explicitly.
     p.chmod(_FILE_MODE)
     return p
 

--- a/flux/security/bootstrap_token.py
+++ b/flux/security/bootstrap_token.py
@@ -1,0 +1,83 @@
+"""Bootstrap token: resolution, persistence, and rotation.
+
+The bootstrap token authenticates a worker's first call to ``POST /workers/register``.
+It is a long-lived shared secret between the server and any worker that wants to join.
+
+Resolution order (most specific wins):
+
+1. Caller-supplied value, typically from ``FLUX_WORKERS__BOOTSTRAP_TOKEN`` env var or
+   ``[flux.workers] bootstrap_token`` in flux.toml. Used as-is if non-empty.
+2. Persisted file at ``<home>/bootstrap-token`` (mode 0600). Used as-is if it exists
+   and is non-empty.
+3. Auto-generated via ``secrets.token_hex(32)``, persisted to the same path with mode
+   0600, and a one-line WARNING is logged so operators can capture it.
+
+Workers do NOT auto-generate; they must be supplied a token (env var, config, or CLI).
+Auto-generation is server-side only because worker hosts typically do not share a
+filesystem with the server.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+import stat
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+TOKEN_FILENAME = "bootstrap-token"
+_FILE_MODE = stat.S_IRUSR | stat.S_IWUSR  # 0600
+
+
+def _path(home: str | Path) -> Path:
+    return Path(home) / TOKEN_FILENAME
+
+
+def read_persisted(home: str | Path) -> str | None:
+    """Return the persisted bootstrap token if present, else None."""
+    p = _path(home)
+    if not p.exists():
+        return None
+    return p.read_text().strip() or None
+
+
+def write(home: str | Path, token: str) -> Path:
+    """Persist ``token`` to ``<home>/bootstrap-token`` with mode 0600."""
+    p = _path(home)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(token)
+    p.chmod(_FILE_MODE)
+    return p
+
+
+def generate() -> str:
+    return secrets.token_hex(32)
+
+
+def resolve_or_generate(home: str | Path, configured: str | None) -> tuple[str, bool]:
+    """Resolve the active bootstrap token; generate + persist on first call.
+
+    Returns ``(token, generated_now)`` where ``generated_now`` is True only when
+    this call wrote a brand-new token to disk.
+    """
+    if configured:
+        return configured, False
+    persisted = read_persisted(home)
+    if persisted:
+        return persisted, False
+    token = generate()
+    path = write(home, token)
+    logger.warning(
+        "Generated bootstrap token at %s. Workers must use this token to register; "
+        "retrieve via 'flux server bootstrap-token'.",
+        path,
+    )
+    return token, True
+
+
+def rotate(home: str | Path) -> str:
+    """Force-generate a new token and persist it. Returns the new token."""
+    token = generate()
+    write(home, token)
+    return token

--- a/flux/security/bootstrap_token.py
+++ b/flux/security/bootstrap_token.py
@@ -69,14 +69,31 @@ def generate() -> str:
     return secrets.token_hex(32)
 
 
+def _normalize(value: str | None) -> str | None:
+    """Strip whitespace; treat empty-after-strip as unset.
+
+    Mirrors ``read_persisted`` behavior so that a configured value like ``"   "``
+    or ``"\\n"`` is treated the same as no value at all, regardless of where it
+    came from (env var, flux.toml, CLI input).
+    """
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
 def resolve_or_generate(home: str | Path, configured: str | None) -> tuple[str, bool]:
     """Resolve the active bootstrap token; generate + persist on first call.
 
     Returns ``(token, generated_now)`` where ``generated_now`` is True only when
-    this call wrote a brand-new token to disk.
+    this call wrote a brand-new token to disk. Whitespace-only ``configured``
+    values are treated as unset (mirrors ``read_persisted``) so an operator
+    who exports ``FLUX_WORKERS__BOOTSTRAP_TOKEN=" "`` does not silently get an
+    unusable active token.
     """
-    if configured:
-        return configured, False
+    configured_norm = _normalize(configured)
+    if configured_norm:
+        return configured_norm, False
     persisted = read_persisted(home)
     if persisted:
         return persisted, False

--- a/flux/server.py
+++ b/flux/server.py
@@ -295,6 +295,10 @@ class Server:
         self._worker_offline_since: dict[str, float] = {}
         self._worker_evicted: dict[str, asyncio.Event] = {}
         self._worker_stale_since: dict[str, float] = {}
+        # Resolved by the FastAPI lifespan startup hook in _create_api so that
+        # merely constructing the app for tests / OpenAPI does not have the
+        # side effect of generating the persisted token file.
+        self._bootstrap_token: str | None = None
         self._worker_connection_gen: dict[str, int] = {}
 
         config = Configuration.get().settings.scheduling
@@ -994,6 +998,20 @@ class Server:
 
         @asynccontextmanager
         async def lifespan(app: FastAPI):
+            # Resolve / generate the bootstrap token here (not at module
+            # construction) so merely creating the FastAPI app for tests or
+            # OpenAPI generation does not have the side effect of creating
+            # <home>/bootstrap-token. FastAPI guarantees the startup half of
+            # lifespan runs before any request is dispatched.
+            from flux.security.bootstrap_token import resolve_or_generate
+
+            startup_settings = Configuration.get().settings
+            token, _ = resolve_or_generate(
+                home=startup_settings.home,
+                configured=startup_settings.workers.bootstrap_token,
+            )
+            self._bootstrap_token = token
+
             yield
             await self._stop_scheduler()
             await self._stop_reaper()
@@ -1033,15 +1051,6 @@ class Server:
         )
         auth_service.seed_built_in_roles()
         init_auth_service(auth_service)
-
-        from flux.security.bootstrap_token import resolve_or_generate
-
-        _settings = Configuration.get().settings
-        bootstrap_token, _ = resolve_or_generate(
-            home=_settings.home,
-            configured=_settings.workers.bootstrap_token,
-        )
-        self._bootstrap_token = bootstrap_token
 
         from flux.observability import get_metrics, is_enabled
 
@@ -1623,7 +1632,8 @@ class Server:
             try:
                 logger.debug(f"Worker registration request: {registration.name}")
                 token = self._extract_token(authorization)
-                if not token or not hmac.compare_digest(self._bootstrap_token, token):
+                expected = self._bootstrap_token
+                if not expected or not token or not hmac.compare_digest(expected, token):
                     logger.warning(f"Invalid bootstrap token for worker: {registration.name}")
                     raise HTTPException(
                         status_code=403,

--- a/flux/server.py
+++ b/flux/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hmac
 import re
 import time
 from typing import Any, Literal
@@ -1033,6 +1034,15 @@ class Server:
         auth_service.seed_built_in_roles()
         init_auth_service(auth_service)
 
+        from flux.security.bootstrap_token import resolve_or_generate
+
+        _settings = Configuration.get().settings
+        bootstrap_token, _ = resolve_or_generate(
+            home=_settings.home,
+            configured=_settings.workers.bootstrap_token,
+        )
+        self._bootstrap_token = bootstrap_token
+
         from flux.observability import get_metrics, is_enabled
 
         if is_enabled():
@@ -1613,8 +1623,7 @@ class Server:
             try:
                 logger.debug(f"Worker registration request: {registration.name}")
                 token = self._extract_token(authorization)
-                settings = Configuration.get().settings
-                if settings.workers.bootstrap_token != token:
+                if not token or not hmac.compare_digest(self._bootstrap_token, token):
                     logger.warning(f"Invalid bootstrap token for worker: {registration.name}")
                     raise HTTPException(
                         status_code=403,

--- a/flux/server.py
+++ b/flux/server.py
@@ -387,7 +387,14 @@ class Server:
             raise HTTPException(status_code=401, detail="Authorization header missing")
         if not authorization.startswith("Bearer "):
             raise HTTPException(status_code=401, detail="Invalid authorization format")
-        return authorization.split(" ")[1]
+        # Match flux.security.dependencies.get_identity: split exactly once so a
+        # token containing spaces parses correctly, and strip surrounding
+        # whitespace so a header like "Bearer  abc " yields "abc" rather than "".
+        parts = authorization.split(" ", 1)
+        token = parts[1].strip() if len(parts) == 2 else ""
+        if not token:
+            raise HTTPException(status_code=401, detail="Invalid authorization format")
+        return token
 
     def _verify_worker_identity(self, identity: FluxIdentity, name: str) -> None:
         auth_config = Configuration.get().settings.security.auth

--- a/flux/server.py
+++ b/flux/server.py
@@ -2383,16 +2383,19 @@ class Server:
 
             try:
                 definition = AgentDefinition(**agent_data)
-                if definition.tools_file or definition.workflow_file:
-                    if auth_service is not None:
-                        has_perm = await auth_service.is_authorized(
+                if definition.requires_code_upload_permission():
+                    from flux.security.dependencies import _get_auth_service
+
+                    upload_auth_service = _get_auth_service()
+                    if upload_auth_service is not None:
+                        has_perm = await upload_auth_service.is_authorized(
                             identity,
                             "workflow:*:*:register",
                         )
                         if not has_perm:
                             raise HTTPException(
                                 status_code=403,
-                                detail="tools_file/workflow_file require workflow:*:*:register permission",
+                                detail="tools_file/workflow_file/skills_dir bundles require workflow:*:*:register permission",
                             )
                 manager = AgentManager.current()
                 manager.create(definition)
@@ -2419,16 +2422,19 @@ class Server:
             try:
                 agent_data["name"] = name
                 definition = AgentDefinition(**agent_data)
-                if definition.tools_file or definition.workflow_file:
-                    if auth_service is not None:
-                        has_perm = await auth_service.is_authorized(
+                if definition.requires_code_upload_permission():
+                    from flux.security.dependencies import _get_auth_service
+
+                    upload_auth_service = _get_auth_service()
+                    if upload_auth_service is not None:
+                        has_perm = await upload_auth_service.is_authorized(
                             identity,
                             "workflow:*:*:register",
                         )
                         if not has_perm:
                             raise HTTPException(
                                 status_code=403,
-                                detail="tools_file/workflow_file require workflow:*:*:register permission",
+                                detail="tools_file/workflow_file/skills_dir bundles require workflow:*:*:register permission",
                             )
                 manager = AgentManager.current()
                 manager.update(definition)

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -82,6 +82,12 @@ class Worker:
         self.name = name
         self.labels = labels or {}
         config = Configuration.get().settings.workers
+        if not config.bootstrap_token:
+            raise RuntimeError(
+                "Worker bootstrap token is not configured. Set FLUX_WORKERS__BOOTSTRAP_TOKEN "
+                "or 'bootstrap_token' under [flux.workers] in flux.toml. Retrieve the server's "
+                "token by running 'flux server bootstrap-token' on the server host.",
+            )
         self.bootstrap_token = config.bootstrap_token
         self.base_url = f"{server_url or config.server_url}/workers"
         self.client = httpx.AsyncClient(timeout=config.default_timeout or None)

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -82,13 +82,19 @@ class Worker:
         self.name = name
         self.labels = labels or {}
         config = Configuration.get().settings.workers
-        if not config.bootstrap_token:
+        # Normalize so a whitespace-only token (e.g. an empty-after-strip env var)
+        # surfaces as "not configured" instead of being sent as `Bearer    ` and
+        # producing a confusing 403 from the server.
+        bootstrap_token = (
+            config.bootstrap_token.strip() if config.bootstrap_token is not None else None
+        )
+        if not bootstrap_token:
             raise RuntimeError(
                 "Worker bootstrap token is not configured. Set FLUX_WORKERS__BOOTSTRAP_TOKEN "
                 "or 'bootstrap_token' under [flux.workers] in flux.toml. Retrieve the server's "
                 "token by running 'flux server bootstrap-token' on the server host.",
             )
-        self.bootstrap_token = config.bootstrap_token
+        self.bootstrap_token = bootstrap_token
         self.base_url = f"{server_url or config.server_url}/workers"
         self.client = httpx.AsyncClient(timeout=config.default_timeout or None)
         self._running_workflows: dict[str, asyncio.Task] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.32.0"
+version = "0.32.1"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+"""Top-level test fixtures.
+
+Seeds Configuration values that production now requires explicit configuration
+for. The shipped flux.toml no longer hardcodes ``encryption_key`` or
+``bootstrap_token``, so any test that exercises a component consuming these
+settings (Worker, EncryptedType, secret managers, etc.) needs them seeded.
+Living here means the fixture covers tests/flux/, tests/security/,
+tests/examples/, and any future test directories.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from flux.config import Configuration
+
+
+@pytest.fixture(autouse=True)
+def _seed_required_config():
+    Configuration.get().override(
+        workers={"bootstrap_token": "test-bootstrap-token"},
+        security={"encryption": {"encryption_key": "test-encryption-key"}},
+    )
+    yield
+    Configuration.get().reset()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -552,6 +552,7 @@ def cli(tmp_path_factory):
         "FLUX_SERVER_PORT": str(E2E_PORT),
         "FLUX_DATABASE_URL": f"sqlite:///{db_path}",
         "FLUX_WORKERS__SERVER_URL": E2E_SERVER_URL,
+        "FLUX_WORKERS__BOOTSTRAP_TOKEN": "e2e-test-bootstrap-token",
         "FLUX_SECURITY__AUTH__ENABLED": "false",
         "FLUX_SECURITY__ENCRYPTION__ENCRYPTION_KEY": "e2e-test-encryption-key",
     }

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -553,6 +553,7 @@ def cli(tmp_path_factory):
         "FLUX_DATABASE_URL": f"sqlite:///{db_path}",
         "FLUX_WORKERS__SERVER_URL": E2E_SERVER_URL,
         "FLUX_SECURITY__AUTH__ENABLED": "false",
+        "FLUX_SECURITY__ENCRYPTION__ENCRYPTION_KEY": "e2e-test-encryption-key",
     }
 
     # -- start server -----------------------------------------------------

--- a/tests/e2e/test_agent_skills_path_traversal.py
+++ b/tests/e2e/test_agent_skills_path_traversal.py
@@ -10,6 +10,14 @@ companion API-gate (workflow:*:*:register requirement for inline skills_dir
 bundles). That path is covered by the route-level integration tests in
 ``tests/security/test_server_auth_routes.py`` which run the real FastAPI app
 through TestClient with mocked auth.
+
+Workflow registration is module-scoped (one registration shared by all three
+tests) to dodge a pre-existing bug in Flux's worker module cache: after
+``test_agent_harness_server_modes`` registers a stub ``agents/agent_chat`` at
+some version N then deletes it, the worker keeps the compiled stub cached
+under key ``agents:agent_chat:N``. Per-test re-registration would bump the
+version on each call and eventually land back on the cached version, causing
+the test to silently run the stub instead of the real template.
 """
 
 from __future__ import annotations
@@ -17,6 +25,14 @@ from __future__ import annotations
 import json
 
 import httpx
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _register_agent_chat(cli):
+    """Register the real agents/agent_chat exactly once for this module."""
+    cli.register("flux/agents/template.py")
+    yield
 
 
 def _create_agent(cli, name: str, skills_dir: str) -> httpx.Response:
@@ -38,8 +54,6 @@ def _delete_agent(cli, name: str) -> None:
 
 def test_skills_dir_bundle_with_dotdot_path_fails_workflow(cli):
     """Malicious bundle with a `..` segment must fail the workflow at materialize-time."""
-    cli.register("flux/agents/template.py")
-
     name = "e2e_skills_dotdot"
     bundle = json.dumps({"a": {"../../../../tmp/flux_pwn_dotdot.txt": "rooted"}})
 
@@ -66,8 +80,6 @@ def test_skills_dir_bundle_with_dotdot_path_fails_workflow(cli):
 
 def test_skills_dir_bundle_with_absolute_path_fails_workflow(cli):
     """Malicious bundle with an absolute path must fail the workflow at materialize-time."""
-    cli.register("flux/agents/template.py")
-
     name = "e2e_skills_absolute"
     bundle = json.dumps({"a": {"/tmp/flux_pwn_absolute.txt": "rooted"}})
 
@@ -92,8 +104,6 @@ def test_skills_dir_bundle_with_absolute_path_fails_workflow(cli):
 
 def test_skills_dir_bundle_with_safe_paths_succeeds(cli):
     """A well-formed skills bundle must pause at turn 0 (no LLM call) like a normal agent."""
-    cli.register("flux/agents/template.py")
-
     name = "e2e_skills_safe"
     bundle = json.dumps(
         {

--- a/tests/e2e/test_agent_skills_path_traversal.py
+++ b/tests/e2e/test_agent_skills_path_traversal.py
@@ -1,0 +1,118 @@
+"""E2E: agent_chat must reject skills_dir bundles that escape the temp dir.
+
+Exercises the worker-side path-traversal validation added for the security
+review (Vuln 1). Creates agents via POST /admin/agents with both safe and
+malicious skills_dir JSON payloads, runs the real agent_chat template against
+the live worker, and verifies the workflow state.
+
+The shared E2E session disables auth, so this file does not exercise the
+companion API-gate (workflow:*:*:register requirement for inline skills_dir
+bundles). That path is covered by the route-level integration tests in
+``tests/security/test_server_auth_routes.py`` which run the real FastAPI app
+through TestClient with mocked auth.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+
+def _create_agent(cli, name: str, skills_dir: str) -> httpx.Response:
+    return httpx.post(
+        f"{cli.server_url}/admin/agents",
+        json={
+            "name": name,
+            "model": "ollama/qwen3:latest",
+            "system_prompt": "skills bundle test agent",
+            "skills_dir": skills_dir,
+        },
+        timeout=10,
+    )
+
+
+def _delete_agent(cli, name: str) -> None:
+    httpx.delete(f"{cli.server_url}/admin/agents/{name}", timeout=10)
+
+
+def test_skills_dir_bundle_with_dotdot_path_fails_workflow(cli):
+    """Malicious bundle with a `..` segment must fail the workflow at materialize-time."""
+    cli.register("flux/agents/template.py")
+
+    name = "e2e_skills_dotdot"
+    bundle = json.dumps({"a": {"../../../../tmp/flux_pwn_dotdot.txt": "rooted"}})
+
+    r = _create_agent(cli, name, bundle)
+    assert r.status_code == 200, f"Failed to create agent: {r.text}"
+
+    try:
+        result = cli.run("agents/agent_chat", f'{{"agent": "{name}"}}', mode="async")
+        exec_id = result["execution_id"]
+
+        final = cli.wait_for_state("agents/agent_chat", exec_id, "FAILED", timeout=30)
+        assert (
+            final["state"] == "FAILED"
+        ), f"Expected FAILED (path-traversal rejected); got {final['state']}"
+
+        detailed = cli.execution_show(exec_id, detailed=True)
+        rendered = json.dumps(detailed)
+        assert (
+            "unsafe file path" in rendered or "escapes bundle root" in rendered
+        ), f"Expected path-traversal error in execution events; got: {rendered[:1000]}"
+    finally:
+        _delete_agent(cli, name)
+
+
+def test_skills_dir_bundle_with_absolute_path_fails_workflow(cli):
+    """Malicious bundle with an absolute path must fail the workflow at materialize-time."""
+    cli.register("flux/agents/template.py")
+
+    name = "e2e_skills_absolute"
+    bundle = json.dumps({"a": {"/tmp/flux_pwn_absolute.txt": "rooted"}})
+
+    r = _create_agent(cli, name, bundle)
+    assert r.status_code == 200, f"Failed to create agent: {r.text}"
+
+    try:
+        result = cli.run("agents/agent_chat", f'{{"agent": "{name}"}}', mode="async")
+        exec_id = result["execution_id"]
+
+        final = cli.wait_for_state("agents/agent_chat", exec_id, "FAILED", timeout=30)
+        assert final["state"] == "FAILED"
+
+        detailed = cli.execution_show(exec_id, detailed=True)
+        rendered = json.dumps(detailed)
+        assert (
+            "unsafe file path" in rendered
+        ), f"Expected 'unsafe file path' in execution events; got: {rendered[:1000]}"
+    finally:
+        _delete_agent(cli, name)
+
+
+def test_skills_dir_bundle_with_safe_paths_succeeds(cli):
+    """A well-formed skills bundle must pause at turn 0 (no LLM call) like a normal agent."""
+    cli.register("flux/agents/template.py")
+
+    name = "e2e_skills_safe"
+    bundle = json.dumps(
+        {
+            "greeter": {
+                "greeter/SKILL.md": "---\nname: greeter\ndescription: greets people\n---\nSay hi.\n",
+            },
+        },
+    )
+
+    r = _create_agent(cli, name, bundle)
+    assert r.status_code == 200, f"Failed to create agent: {r.text}"
+
+    try:
+        result = cli.run("agents/agent_chat", f'{{"agent": "{name}"}}', mode="async")
+        exec_id = result["execution_id"]
+
+        final = cli.wait_for_state("agents/agent_chat", exec_id, "PAUSED", timeout=30)
+        assert (
+            final["state"] == "PAUSED"
+        ), f"Expected PAUSED (safe bundle materialized); got {final['state']}"
+    finally:
+        _delete_agent(cli, name)

--- a/tests/e2e/test_server_bootstrap_token.py
+++ b/tests/e2e/test_server_bootstrap_token.py
@@ -1,0 +1,163 @@
+"""E2E: ``flux server bootstrap-token`` reflects the active token, and the
+server rejects worker registrations with a wrong or missing bootstrap token.
+
+The shared E2E session sets ``FLUX_WORKERS__BOOTSTRAP_TOKEN`` explicitly so
+the configured-value precedence path is what we exercise here. The command
+is local-only (reads from on-disk file or local Configuration) and is not
+piped through the running server.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import httpx
+
+from tests.e2e.conftest import PROJECT_ROOT
+
+
+def _valid_registration_body(name: str) -> dict:
+    """Build a body matching the WorkerRegistration / WorkerResourcesModel schemas."""
+    return {
+        "name": name,
+        "runtime": {"os_name": "Linux", "os_version": "0.0", "python_version": "3.12"},
+        "packages": [],
+        "resources": {
+            "cpu_total": 1.0,
+            "cpu_available": 1.0,
+            "memory_total": 1024.0,
+            "memory_available": 1024.0,
+            "disk_total": 1024.0,
+            "disk_free": 1024.0,
+            "gpus": [],
+        },
+        "labels": {},
+    }
+
+
+def test_server_bootstrap_token_prints_configured_value(cli):
+    """When FLUX_WORKERS__BOOTSTRAP_TOKEN is set in the env, the CLI prints it."""
+    result = subprocess.run(
+        ["poetry", "run", "flux", "server", "bootstrap-token"],
+        cwd=PROJECT_ROOT,
+        env=cli._env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"command failed: {result.stderr}"
+    assert result.stdout.strip() == cli._env["FLUX_WORKERS__BOOTSTRAP_TOKEN"]
+
+
+def test_workers_register_rejects_wrong_bootstrap_token(cli):
+    """An attacker who guesses a token must get 403 from /workers/register."""
+    resp = httpx.post(
+        f"{cli.server_url}/workers/register",
+        json=_valid_registration_body("rogue-worker-1"),
+        headers={"Authorization": "Bearer not-the-real-token"},
+        timeout=10,
+    )
+    assert (
+        resp.status_code == 403
+    ), f"expected 403 for wrong bootstrap token; got {resp.status_code}: {resp.text}"
+    assert "Invalid bootstrap token" in resp.text
+
+
+def test_workers_register_rejects_missing_bootstrap_token(cli):
+    """No Authorization header must be rejected (401 by the extractor, before
+    the bootstrap-token compare even runs)."""
+    resp = httpx.post(
+        f"{cli.server_url}/workers/register",
+        json=_valid_registration_body("rogue-worker-2"),
+        timeout=10,
+    )
+    assert resp.status_code in (
+        401,
+        403,
+    ), f"missing token must be rejected; got {resp.status_code}: {resp.text}"
+
+
+def test_workers_register_rejects_non_bearer_scheme(cli):
+    """Authorization header that is not Bearer must be rejected by the extractor."""
+    resp = httpx.post(
+        f"{cli.server_url}/workers/register",
+        json=_valid_registration_body("rogue-worker-3"),
+        headers={"Authorization": "Basic not-a-bearer"},
+        timeout=10,
+    )
+    assert resp.status_code == 401
+
+
+def test_workers_register_rejects_token_with_correct_prefix(cli):
+    """A token sharing a prefix with the real one must still be rejected.
+
+    Regression for the constant-time-compare fix: we use hmac.compare_digest
+    so a partial match yields the same 403 as any other mismatch.
+    """
+    token = cli._env["FLUX_WORKERS__BOOTSTRAP_TOKEN"]
+    near_match = token[: len(token) // 2] + "X" * (len(token) - len(token) // 2)
+    resp = httpx.post(
+        f"{cli.server_url}/workers/register",
+        json=_valid_registration_body("rogue-worker-5"),
+        headers={"Authorization": f"Bearer {near_match}"},
+        timeout=10,
+    )
+    assert resp.status_code == 403
+
+
+def test_workers_register_accepts_correct_bootstrap_token(cli):
+    """The real configured token must be accepted by /workers/register."""
+    token = cli._env["FLUX_WORKERS__BOOTSTRAP_TOKEN"]
+    resp = httpx.post(
+        f"{cli.server_url}/workers/register",
+        json=_valid_registration_body("transient-e2e-worker"),
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10,
+    )
+    assert (
+        resp.status_code == 200
+    ), f"expected 200 for correct bootstrap token; got {resp.status_code}: {resp.text}"
+
+
+def test_server_bootstrap_token_rotate_writes_new_file(cli, tmp_path):
+    """`flux server bootstrap-token --rotate` must write a fresh token file.
+
+    Runs in an isolated home dir (not the live E2E session's) to avoid
+    desynchronizing the running server's token from the worker's. We override
+    ``home`` and unset the configured token so the file path is what gets used.
+    """
+    isolated_env = {**cli._env}
+    isolated_env["FLUX_HOME"] = str(tmp_path)
+    isolated_env.pop("FLUX_WORKERS__BOOTSTRAP_TOKEN", None)
+
+    result = subprocess.run(
+        ["poetry", "run", "flux", "server", "bootstrap-token", "--rotate"],
+        cwd=PROJECT_ROOT,
+        env=isolated_env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"rotate failed: {result.stderr}"
+    new_token = result.stdout.strip().splitlines()[-1]
+    assert len(new_token) == 64
+    persisted = (tmp_path / "bootstrap-token").read_text().strip()
+    assert persisted == new_token
+
+
+def test_server_bootstrap_token_no_token_anywhere_errors(cli, tmp_path):
+    """If neither configured nor persisted, the CLI must error out (not crash)."""
+    isolated_env = {**cli._env}
+    isolated_env["FLUX_HOME"] = str(tmp_path)
+    isolated_env.pop("FLUX_WORKERS__BOOTSTRAP_TOKEN", None)
+
+    result = subprocess.run(
+        ["poetry", "run", "flux", "server", "bootstrap-token"],
+        cwd=PROJECT_ROOT,
+        env=isolated_env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 1
+    assert "No bootstrap token found" in (result.stdout + result.stderr)

--- a/tests/flux/agents/test_template.py
+++ b/tests/flux/agents/test_template.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from flux.agents.template import agent_chat
+from pathlib import Path
+
+import pytest
+
+from flux.agents.template import _materialize_skills_bundle, agent_chat
 
 
 def test_template_exists():
@@ -11,3 +15,39 @@ def test_template_exists():
 
 def test_template_is_workflow():
     assert hasattr(agent_chat, "__wrapped__") or callable(agent_chat)
+
+
+def test_materialize_skills_bundle_writes_relative_paths(tmp_path: Path):
+    bundle = {"my-skill": {"SKILL.md": "hello", "nested/file.md": "world"}}
+    _materialize_skills_bundle(tmp_path, bundle)
+    assert (tmp_path / "SKILL.md").read_text() == "hello"
+    assert (tmp_path / "nested/file.md").read_text() == "world"
+
+
+def test_materialize_skills_bundle_rejects_absolute_path(tmp_path: Path):
+    bundle = {"my-skill": {"/etc/cron.d/pwn": "rooted"}}
+    with pytest.raises(ValueError, match="unsafe file path"):
+        _materialize_skills_bundle(tmp_path, bundle)
+
+
+def test_materialize_skills_bundle_rejects_dotdot(tmp_path: Path):
+    bundle = {"my-skill": {"../../../etc/passwd": "rooted"}}
+    with pytest.raises(ValueError, match="unsafe file path"):
+        _materialize_skills_bundle(tmp_path, bundle)
+
+
+def test_materialize_skills_bundle_rejects_escape_via_symlink_resolution(tmp_path: Path):
+    inner = tmp_path / "bundle"
+    inner.mkdir()
+    sibling = tmp_path / "outside"
+    sibling.mkdir()
+    (inner / "link").symlink_to(sibling)
+    bundle = {"my-skill": {"link/escape.txt": "rooted"}}
+    with pytest.raises(ValueError, match="escapes bundle root"):
+        _materialize_skills_bundle(inner, bundle)
+
+
+def test_materialize_skills_bundle_rejects_non_mapping_files(tmp_path: Path):
+    bundle = {"my-skill": "not a dict"}
+    with pytest.raises(ValueError, match="must be a mapping"):
+        _materialize_skills_bundle(tmp_path, bundle)

--- a/tests/flux/agents/test_types.py
+++ b/tests/flux/agents/test_types.py
@@ -146,6 +146,58 @@ class TestAgentDefinition:
         assert agent.name == "coder"
         assert agent.tools == ["shell", "read_file"]
 
+    def test_has_skills_bundle_detects_inline_json_dict(self):
+        agent = AgentDefinition(
+            name="x",
+            model="openai/gpt-4o",
+            system_prompt="x",
+            skills_dir='{"my-skill": {"SKILL.md": "..."}}',
+        )
+        assert agent.has_skills_bundle() is True
+        assert agent.requires_code_upload_permission() is True
+
+    def test_has_skills_bundle_false_for_path_string(self):
+        agent = AgentDefinition(
+            name="x",
+            model="openai/gpt-4o",
+            system_prompt="x",
+            skills_dir="/var/lib/flux/skills",
+        )
+        assert agent.has_skills_bundle() is False
+        assert agent.requires_code_upload_permission() is False
+
+    def test_has_skills_bundle_false_for_json_non_dict(self):
+        agent = AgentDefinition(
+            name="x",
+            model="openai/gpt-4o",
+            system_prompt="x",
+            skills_dir='["a", "b"]',
+        )
+        assert agent.has_skills_bundle() is False
+
+    def test_has_skills_bundle_false_when_none(self):
+        agent = AgentDefinition(name="x", model="openai/gpt-4o", system_prompt="x")
+        assert agent.has_skills_bundle() is False
+        assert agent.requires_code_upload_permission() is False
+
+    def test_requires_code_upload_permission_for_tools_file(self):
+        agent = AgentDefinition(
+            name="x",
+            model="openai/gpt-4o",
+            system_prompt="x",
+            tools_file="from flux import task",
+        )
+        assert agent.requires_code_upload_permission() is True
+
+    def test_requires_code_upload_permission_for_workflow_file(self):
+        agent = AgentDefinition(
+            name="x",
+            model="openai/gpt-4o",
+            system_prompt="x",
+            workflow_file="from flux import workflow",
+        )
+        assert agent.requires_code_upload_permission() is True
+
 
 class TestChatResponseOutput:
     def test_chat_response(self):

--- a/tests/flux/conftest.py
+++ b/tests/flux/conftest.py
@@ -6,7 +6,6 @@ import pytest
 from tests.flux.fixtures.config_fixtures import *  # noqa: F403,F401
 from tests.flux.fixtures.database_fixtures import *  # noqa: F403,F401
 
-from flux.config import Configuration
 from flux.models import DatabaseRepository
 
 
@@ -15,20 +14,3 @@ def _reset_db_engine_cache():
     """Clear cached database engines between tests to prevent cross-test contamination."""
     DatabaseRepository._engines.clear()
     yield
-
-
-@pytest.fixture(autouse=True)
-def _seed_required_config():
-    """Provide values for fields that production now requires explicit configuration for.
-
-    The shipped flux.toml no longer hardcodes ``encryption_key`` or
-    ``bootstrap_token``, so tests that exercise components consuming these
-    settings (Worker, EncryptedType, etc.) need them seeded. We override the
-    Configuration singleton before each test and reset after.
-    """
-    Configuration.get().override(
-        workers={"bootstrap_token": "test-bootstrap-token"},
-        security={"encryption": {"encryption_key": "test-encryption-key"}},
-    )
-    yield
-    Configuration.get().reset()

--- a/tests/flux/conftest.py
+++ b/tests/flux/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from tests.flux.fixtures.config_fixtures import *  # noqa: F403,F401
 from tests.flux.fixtures.database_fixtures import *  # noqa: F403,F401
 
+from flux.config import Configuration
 from flux.models import DatabaseRepository
 
 
@@ -14,3 +15,20 @@ def _reset_db_engine_cache():
     """Clear cached database engines between tests to prevent cross-test contamination."""
     DatabaseRepository._engines.clear()
     yield
+
+
+@pytest.fixture(autouse=True)
+def _seed_required_config():
+    """Provide values for fields that production now requires explicit configuration for.
+
+    The shipped flux.toml no longer hardcodes ``encryption_key`` or
+    ``bootstrap_token``, so tests that exercise components consuming these
+    settings (Worker, EncryptedType, etc.) need them seeded. We override the
+    Configuration singleton before each test and reset after.
+    """
+    Configuration.get().override(
+        workers={"bootstrap_token": "test-bootstrap-token"},
+        security={"encryption": {"encryption_key": "test-encryption-key"}},
+    )
+    yield
+    Configuration.get().reset()

--- a/tests/flux/test_cli_server.py
+++ b/tests/flux/test_cli_server.py
@@ -1,0 +1,156 @@
+"""Tests for the `flux server` CLI group (server lifecycle commands)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from flux.cli import cli
+from flux.security import bootstrap_token as bt
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _patched_settings(home: Path, configured: str | None = None):
+    """Build a settings-like mock that the CLI sees when reading Configuration.
+
+    We patch ``flux.config.Configuration.get`` to return an object whose
+    ``settings.home`` and ``settings.workers.bootstrap_token`` match the
+    test inputs.
+    """
+    workers = type("W", (), {"bootstrap_token": configured})()
+    settings = type("S", (), {"home": str(home), "workers": workers})()
+    config = type("C", (), {"settings": settings})()
+    return config
+
+
+class TestServerBootstrapToken:
+    def test_prints_configured_value_when_set(self, runner, tmp_path: Path):
+        with patch(
+            "flux.config.Configuration.get",
+            return_value=_patched_settings(tmp_path, configured="explicit-token"),
+        ):
+            result = runner.invoke(cli, ["server", "bootstrap-token"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "explicit-token"
+
+    def test_prints_persisted_value_when_no_config(self, runner, tmp_path: Path):
+        bt.write(tmp_path, "persisted-token")
+        with patch("flux.config.Configuration.get", return_value=_patched_settings(tmp_path)):
+            result = runner.invoke(cli, ["server", "bootstrap-token"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "persisted-token"
+
+    def test_errors_when_no_token_anywhere(self, runner, tmp_path: Path):
+        with patch("flux.config.Configuration.get", return_value=_patched_settings(tmp_path)):
+            result = runner.invoke(cli, ["server", "bootstrap-token"])
+        assert result.exit_code == 1
+        assert "No bootstrap token found" in result.output
+
+    def test_rotate_writes_new_token_and_prints_it(self, runner, tmp_path: Path):
+        bt.write(tmp_path, "original")
+        with patch("flux.config.Configuration.get", return_value=_patched_settings(tmp_path)):
+            result = runner.invoke(cli, ["server", "bootstrap-token", "--rotate"])
+        assert result.exit_code == 0
+        new = result.output.strip().splitlines()[-1]
+        assert new != "original"
+        assert len(new) == 64
+        assert bt.read_persisted(tmp_path) == new
+
+    def test_rotate_warns_when_configured_overrides(self, runner, tmp_path: Path):
+        with patch(
+            "flux.config.Configuration.get",
+            return_value=_patched_settings(tmp_path, configured="env-supplied"),
+        ):
+            result = runner.invoke(cli, ["server", "bootstrap-token", "--rotate"])
+        assert result.exit_code == 0
+        assert "Warning" in result.output
+        # The new token must still be written even if config overrides it
+        assert bt.read_persisted(tmp_path) is not None
+
+    def test_configured_takes_precedence_over_persisted(self, runner, tmp_path: Path):
+        bt.write(tmp_path, "stale-on-disk")
+        with patch(
+            "flux.config.Configuration.get",
+            return_value=_patched_settings(tmp_path, configured="active-from-env"),
+        ):
+            result = runner.invoke(cli, ["server", "bootstrap-token"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "active-from-env"
+
+    def test_help_does_not_crash(self, runner):
+        """`flux server bootstrap-token --help` must work without runtime imports failing."""
+        result = runner.invoke(cli, ["server", "bootstrap-token", "--help"])
+        assert result.exit_code == 0
+        assert "bootstrap-token" in result.output or "Print" in result.output
+        assert "--rotate" in result.output
+
+    def test_server_group_help_lists_subcommand(self, runner):
+        """`flux server --help` must list bootstrap-token as a subcommand."""
+        result = runner.invoke(cli, ["server", "--help"])
+        assert result.exit_code == 0
+        assert "bootstrap-token" in result.output
+
+    def test_rotate_creates_home_dir_when_missing(self, runner, tmp_path: Path):
+        """`--rotate` must work even if <home> doesn't exist yet."""
+        nested = tmp_path / "fresh-home"
+        assert not nested.exists()
+        with patch("flux.config.Configuration.get", return_value=_patched_settings(nested)):
+            result = runner.invoke(cli, ["server", "bootstrap-token", "--rotate"])
+        assert result.exit_code == 0
+        token = result.output.strip().splitlines()[-1]
+        assert (nested / bt.TOKEN_FILENAME).read_text() == token
+
+    def test_rotate_replaces_corrupted_persisted_file(self, runner, tmp_path: Path):
+        """If the persisted file is empty/whitespace, --rotate still produces a fresh value."""
+        bt.write(tmp_path, "   \n  ")
+        with patch("flux.config.Configuration.get", return_value=_patched_settings(tmp_path)):
+            result = runner.invoke(cli, ["server", "bootstrap-token", "--rotate"])
+        assert result.exit_code == 0
+        token = result.output.strip().splitlines()[-1]
+        assert len(token) == 64
+        assert bt.read_persisted(tmp_path) == token
+
+    def test_persisted_with_trailing_whitespace_is_normalized(self, runner, tmp_path: Path):
+        """Operator-edited file with trailing newline still yields the bare token."""
+        (tmp_path / bt.TOKEN_FILENAME).write_text("hand-edited-token\n")
+        with patch("flux.config.Configuration.get", return_value=_patched_settings(tmp_path)):
+            result = runner.invoke(cli, ["server", "bootstrap-token"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "hand-edited-token"
+
+    def test_rotate_warning_does_not_pollute_token_output(self, tmp_path: Path):
+        """The warning goes to stderr; stdout must contain ONLY the token.
+
+        Click 8.2+ removed the ``mix_stderr=False`` argument to ``invoke``,
+        so we spawn a real subprocess to inspect stdout and stderr separately.
+        """
+        import os
+        import subprocess
+        import sys
+        from tests.e2e.conftest import PROJECT_ROOT
+
+        env = {
+            **os.environ,
+            "FLUX_HOME": str(tmp_path),
+            "FLUX_WORKERS__BOOTSTRAP_TOKEN": "env-supplied",
+        }
+        result = subprocess.run(
+            [sys.executable, "-m", "flux.cli", "server", "bootstrap-token", "--rotate"],
+            cwd=PROJECT_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0
+        stdout_lines = [line for line in result.stdout.splitlines() if line.strip()]
+        assert len(stdout_lines) == 1
+        assert len(stdout_lines[0]) == 64
+        assert "Warning" in result.stderr

--- a/tests/flux/test_cli_server.py
+++ b/tests/flux/test_cli_server.py
@@ -125,6 +125,27 @@ class TestServerBootstrapToken:
         assert result.exit_code == 0
         assert result.output.strip() == "hand-edited-token"
 
+    def test_whitespace_only_configured_falls_through_to_persisted(self, runner, tmp_path: Path):
+        """A whitespace-only env/config value must not suppress the persisted-file fallback."""
+        bt.write(tmp_path, "persisted-token")
+        with patch(
+            "flux.config.Configuration.get",
+            return_value=_patched_settings(tmp_path, configured="   \n\t  "),
+        ):
+            result = runner.invoke(cli, ["server", "bootstrap-token"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "persisted-token"
+
+    def test_padded_configured_is_stripped_before_print(self, runner, tmp_path: Path):
+        """Leading/trailing whitespace on configured value must be stripped."""
+        with patch(
+            "flux.config.Configuration.get",
+            return_value=_patched_settings(tmp_path, configured="  padded-token  "),
+        ):
+            result = runner.invoke(cli, ["server", "bootstrap-token"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "padded-token"
+
     def test_rotate_warning_does_not_pollute_token_output(self, tmp_path: Path):
         """The warning goes to stderr; stdout must contain ONLY the token.
 
@@ -134,7 +155,11 @@ class TestServerBootstrapToken:
         import os
         import subprocess
         import sys
-        from tests.e2e.conftest import PROJECT_ROOT
+
+        # Compute the repo root locally rather than importing from
+        # tests.e2e.conftest, which has import-time side effects (binds a
+        # socket to pick an E2E port).
+        project_root = Path(__file__).resolve().parents[2]
 
         env = {
             **os.environ,
@@ -143,7 +168,7 @@ class TestServerBootstrapToken:
         }
         result = subprocess.run(
             [sys.executable, "-m", "flux.cli", "server", "bootstrap-token", "--rotate"],
-            cwd=PROJECT_ROOT,
+            cwd=project_root,
             env=env,
             capture_output=True,
             text=True,

--- a/tests/flux/test_config.py
+++ b/tests/flux/test_config.py
@@ -35,7 +35,7 @@ def test_base_config_to_dict():
 def test_executor_config_defaults():
     """Test default values for ExecutorConfig."""
     config = WorkersConfig()
-    assert config.bootstrap_token is not None
+    assert config.bootstrap_token is None
     assert config.server_url == "http://localhost:8000"
     assert config.default_timeout == 0
     assert config.retry_attempts == 3
@@ -254,6 +254,25 @@ def test_shipped_flux_toml_does_not_hardcode_encryption_key():
     assert (
         "encryption_key" not in encryption
     ), f"flux.toml must not hardcode encryption_key; got: {encryption.get('encryption_key')!r}"
+
+
+def test_shipped_flux_toml_does_not_hardcode_bootstrap_token():
+    """Regression: flux.toml must NOT ship a literal bootstrap_token.
+
+    A previous default UUID was published to the public repo and baked into
+    the Docker image, allowing anyone to register a rogue worker against a
+    default-deployed Flux server. Server-side, the token is auto-generated
+    and persisted at <home>/bootstrap-token; workers must be supplied an
+    explicit value via env var or config.
+    """
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[2]
+    shipped = FluxConfig._load_from_toml(str(repo_root / "flux.toml"), ["flux"])
+    workers = shipped.get("workers", {})
+    assert (
+        "bootstrap_token" not in workers
+    ), f"flux.toml must not hardcode bootstrap_token; got: {workers.get('bootstrap_token')!r}"
 
 
 @pytest.fixture

--- a/tests/flux/test_config.py
+++ b/tests/flux/test_config.py
@@ -237,6 +237,25 @@ def test_flux_config_load_from_config():
         mock_load.assert_called_once_with("flux.toml", ["flux"])
 
 
+def test_shipped_flux_toml_does_not_hardcode_encryption_key():
+    """Regression: flux.toml must NOT ship a literal encryption_key.
+
+    A previous default of "SUPER_SECRET_KEY" was published to a public repo
+    and baked into the Docker image, providing zero confidentiality for
+    encrypted secrets in any deployment that did not override it. The shipped
+    config must leave encryption_key unset so operators are forced to supply
+    one via env var or their own config.
+    """
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[2]
+    shipped = FluxConfig._load_from_toml(str(repo_root / "flux.toml"), ["flux"])
+    encryption = shipped.get("security", {}).get("encryption", {})
+    assert (
+        "encryption_key" not in encryption
+    ), f"flux.toml must not hardcode encryption_key; got: {encryption.get('encryption_key')!r}"
+
+
 @pytest.fixture
 def reset_configuration():
     """Fixture to reset the Configuration singleton before and after each test."""

--- a/tests/flux/test_secret_managers.py
+++ b/tests/flux/test_secret_managers.py
@@ -5,20 +5,7 @@ import json
 
 import pytest
 
-from flux.config import Configuration
 from flux.secret_managers import SecretManager
-
-
-@pytest.fixture(autouse=True)
-def _set_encryption_key():
-    """Provide an encryption key for the SecretModel.value column.
-
-    The shipped flux.toml no longer hardcodes an encryption_key (operators
-    must supply one in production), so these tests must seed one explicitly.
-    """
-    Configuration.get().override(security={"encryption": {"encryption_key": "test-encryption-key"}})
-    yield
-    Configuration.get().reset()
 
 
 async def test_save_and_get_secret():

--- a/tests/flux/test_secret_managers.py
+++ b/tests/flux/test_secret_managers.py
@@ -5,7 +5,20 @@ import json
 
 import pytest
 
+from flux.config import Configuration
 from flux.secret_managers import SecretManager
+
+
+@pytest.fixture(autouse=True)
+def _set_encryption_key():
+    """Provide an encryption key for the SecretModel.value column.
+
+    The shipped flux.toml no longer hardcodes an encryption_key (operators
+    must supply one in production), so these tests must seed one explicitly.
+    """
+    Configuration.get().override(security={"encryption": {"encryption_key": "test-encryption-key"}})
+    yield
+    Configuration.get().reset()
 
 
 async def test_save_and_get_secret():

--- a/tests/flux/test_worker.py
+++ b/tests/flux/test_worker.py
@@ -38,6 +38,32 @@ def worker(mock_config):
     return Worker(name="test-worker", server_url="http://localhost:8000")
 
 
+def test_worker_init_fails_fast_when_bootstrap_token_missing():
+    """A worker started without a configured bootstrap_token must fail at __init__,
+    not silently send 'Bearer None' to the server.
+    """
+    mock_settings = MagicMock()
+    mock_settings.workers.bootstrap_token = None
+    mock_settings.workers.server_url = "http://localhost:8000"
+
+    with patch.object(Configuration, "get") as mock_get:
+        mock_get.return_value = MagicMock(settings=mock_settings)
+        with pytest.raises(RuntimeError, match="Worker bootstrap token is not configured"):
+            Worker(name="test-worker", server_url="http://localhost:8000")
+
+
+def test_worker_init_fails_fast_when_bootstrap_token_empty():
+    """Empty-string bootstrap_token must also be rejected (treated as unset)."""
+    mock_settings = MagicMock()
+    mock_settings.workers.bootstrap_token = ""
+    mock_settings.workers.server_url = "http://localhost:8000"
+
+    with patch.object(Configuration, "get") as mock_get:
+        mock_get.return_value = MagicMock(settings=mock_settings)
+        with pytest.raises(RuntimeError, match="Worker bootstrap token is not configured"):
+            Worker(name="test-worker", server_url="http://localhost:8000")
+
+
 @pytest.fixture
 def sample_workflow_definition():
     """Create a sample workflow definition for testing."""

--- a/tests/flux/test_worker.py
+++ b/tests/flux/test_worker.py
@@ -64,6 +64,30 @@ def test_worker_init_fails_fast_when_bootstrap_token_empty():
             Worker(name="test-worker", server_url="http://localhost:8000")
 
 
+def test_worker_init_fails_fast_when_bootstrap_token_whitespace_only():
+    """Whitespace-only bootstrap_token must be rejected, not sent as 'Bearer    '."""
+    mock_settings = MagicMock()
+    mock_settings.workers.bootstrap_token = "   \n\t  "
+    mock_settings.workers.server_url = "http://localhost:8000"
+
+    with patch.object(Configuration, "get") as mock_get:
+        mock_get.return_value = MagicMock(settings=mock_settings)
+        with pytest.raises(RuntimeError, match="Worker bootstrap token is not configured"):
+            Worker(name="test-worker", server_url="http://localhost:8000")
+
+
+def test_worker_init_strips_bootstrap_token_padding():
+    """A token with leading/trailing whitespace is stripped before use."""
+    mock_settings = MagicMock()
+    mock_settings.workers.bootstrap_token = "  real-token  "
+    mock_settings.workers.server_url = "http://localhost:8000"
+
+    with patch.object(Configuration, "get") as mock_get:
+        mock_get.return_value = MagicMock(settings=mock_settings)
+        worker = Worker(name="test-worker", server_url="http://localhost:8000")
+        assert worker.bootstrap_token == "real-token"
+
+
 @pytest.fixture
 def sample_workflow_definition():
     """Create a sample workflow definition for testing."""

--- a/tests/security/test_bootstrap_token.py
+++ b/tests/security/test_bootstrap_token.py
@@ -183,3 +183,37 @@ def test_resolve_or_generate_then_rotate_then_resolve_uses_new_token(tmp_path: P
     final, generated = bt.resolve_or_generate(tmp_path, configured=None)
     assert final == rotated
     assert generated is False
+
+
+def test_resolve_or_generate_treats_whitespace_only_configured_as_unset(tmp_path: Path):
+    """A whitespace-only env/config value must not become the active token."""
+    bt.write(tmp_path, "real-persisted")
+    token, generated = bt.resolve_or_generate(tmp_path, configured="   \n\t  ")
+    assert token == "real-persisted"
+    assert generated is False
+
+
+def test_resolve_or_generate_strips_padded_configured(tmp_path: Path):
+    """A configured value with leading/trailing whitespace is normalized."""
+    token, generated = bt.resolve_or_generate(tmp_path, configured="  real-token  ")
+    assert token == "real-token"
+    assert generated is False
+    # Configured value won; file should NOT have been written.
+    assert not (tmp_path / bt.TOKEN_FILENAME).exists()
+
+
+def test_resolve_or_generate_whitespace_falls_through_to_generation(tmp_path: Path):
+    """When configured is whitespace and no file exists, we still generate."""
+    token, generated = bt.resolve_or_generate(tmp_path, configured="   ")
+    assert generated is True
+    assert len(token) == 64
+    assert (tmp_path / bt.TOKEN_FILENAME).read_text() == token
+
+
+def test_normalize_helper_returns_none_for_blank_inputs():
+    assert bt._normalize(None) is None
+    assert bt._normalize("") is None
+    assert bt._normalize("   ") is None
+    assert bt._normalize("\n\t  ") is None
+    assert bt._normalize("ok") == "ok"
+    assert bt._normalize("  spaced  ") == "spaced"

--- a/tests/security/test_bootstrap_token.py
+++ b/tests/security/test_bootstrap_token.py
@@ -1,0 +1,185 @@
+"""Tests for the bootstrap token resolver and persistence helpers."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from flux.security import bootstrap_token as bt
+
+
+def test_generate_returns_64_char_hex():
+    token = bt.generate()
+    assert isinstance(token, str)
+    assert len(token) == 64
+    int(token, 16)
+
+
+def test_generate_returns_unique_values():
+    assert bt.generate() != bt.generate()
+
+
+def test_read_persisted_returns_none_when_missing(tmp_path: Path):
+    assert bt.read_persisted(tmp_path) is None
+
+
+def test_write_creates_file_with_0600_mode(tmp_path: Path):
+    path = bt.write(tmp_path, "secret-token")
+    assert path.read_text() == "secret-token"
+    if os.name != "nt":
+        mode = path.stat().st_mode & 0o777
+        assert mode == stat.S_IRUSR | stat.S_IWUSR, f"expected 0600, got {oct(mode)}"
+
+
+def test_write_creates_parent_directory(tmp_path: Path):
+    nested = tmp_path / "a" / "b" / "c"
+    bt.write(nested, "x")
+    assert (nested / bt.TOKEN_FILENAME).read_text() == "x"
+
+
+def test_read_persisted_round_trips_write(tmp_path: Path):
+    bt.write(tmp_path, "round-trip-token")
+    assert bt.read_persisted(tmp_path) == "round-trip-token"
+
+
+def test_read_persisted_strips_whitespace(tmp_path: Path):
+    bt.write(tmp_path, "whitespace-token\n  ")
+    assert bt.read_persisted(tmp_path) == "whitespace-token"
+
+
+def test_read_persisted_returns_none_for_empty_file(tmp_path: Path):
+    bt.write(tmp_path, "")
+    assert bt.read_persisted(tmp_path) is None
+
+
+def test_resolve_or_generate_uses_configured(tmp_path: Path):
+    token, generated = bt.resolve_or_generate(tmp_path, configured="explicit-token")
+    assert token == "explicit-token"
+    assert generated is False
+    assert not (
+        tmp_path / bt.TOKEN_FILENAME
+    ).exists(), "configured value must NOT trigger file generation"
+
+
+def test_resolve_or_generate_reads_persisted_when_no_configured(tmp_path: Path):
+    bt.write(tmp_path, "persisted-token")
+    token, generated = bt.resolve_or_generate(tmp_path, configured=None)
+    assert token == "persisted-token"
+    assert generated is False
+
+
+def test_resolve_or_generate_creates_when_neither_configured_nor_persisted(tmp_path: Path):
+    token, generated = bt.resolve_or_generate(tmp_path, configured=None)
+    assert generated is True
+    assert len(token) == 64
+    assert (tmp_path / bt.TOKEN_FILENAME).read_text() == token
+
+
+def test_resolve_or_generate_treats_empty_string_configured_as_unset(tmp_path: Path):
+    token, generated = bt.resolve_or_generate(tmp_path, configured="")
+    assert generated is True
+
+
+def test_rotate_writes_new_token_and_returns_it(tmp_path: Path):
+    bt.write(tmp_path, "original")
+    new = bt.rotate(tmp_path)
+    assert new != "original"
+    assert len(new) == 64
+    assert bt.read_persisted(tmp_path) == new
+
+
+def test_resolve_or_generate_logs_warning_on_first_generation(tmp_path: Path, caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="flux.security.bootstrap_token"):
+        bt.resolve_or_generate(tmp_path, configured=None)
+    assert any(
+        "Generated bootstrap token" in record.message for record in caplog.records
+    ), f"expected a WARNING about generation; got: {[r.message for r in caplog.records]}"
+
+
+def test_resolve_or_generate_does_not_log_when_using_configured(tmp_path: Path, caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="flux.security.bootstrap_token"):
+        bt.resolve_or_generate(tmp_path, configured="op-supplied")
+    assert not any("Generated bootstrap token" in record.message for record in caplog.records)
+
+
+@pytest.mark.parametrize("home_kind", ["str", "Path"])
+def test_resolve_or_generate_accepts_str_or_path(tmp_path: Path, home_kind: str):
+    home = str(tmp_path) if home_kind == "str" else tmp_path
+    token, _ = bt.resolve_or_generate(home, configured=None)
+    assert token
+
+
+def test_read_persisted_returns_none_for_whitespace_only_file(tmp_path: Path):
+    bt.write(tmp_path, "   \n\t  ")
+    assert bt.read_persisted(tmp_path) is None
+
+
+def test_read_persisted_returns_token_with_internal_punctuation(tmp_path: Path):
+    bt.write(tmp_path, "abc-123-def")
+    assert bt.read_persisted(tmp_path) == "abc-123-def"
+
+
+def test_write_clobbers_existing_file_and_resets_mode(tmp_path: Path):
+    p = bt.write(tmp_path, "first")
+    if os.name != "nt":
+        p.chmod(0o644)
+    bt.write(tmp_path, "second")
+    assert p.read_text() == "second"
+    if os.name != "nt":
+        mode = p.stat().st_mode & 0o777
+        assert mode == stat.S_IRUSR | stat.S_IWUSR
+
+
+def test_resolve_or_generate_creates_home_dir_if_missing(tmp_path: Path):
+    nested = tmp_path / "does" / "not" / "exist"
+    assert not nested.exists()
+    token, generated = bt.resolve_or_generate(nested, configured=None)
+    assert generated is True
+    assert (nested / bt.TOKEN_FILENAME).read_text() == token
+
+
+def test_resolve_or_generate_preserves_persisted_with_trailing_newline(tmp_path: Path):
+    """Operators may hand-edit the file; trailing whitespace must be tolerated."""
+    (tmp_path / bt.TOKEN_FILENAME).write_text("manual-token\n")
+    token, generated = bt.resolve_or_generate(tmp_path, configured=None)
+    assert token == "manual-token"
+    assert generated is False
+
+
+def test_resolve_or_generate_idempotent_when_persisted(tmp_path: Path):
+    """Calling twice returns the same token; the file is not rewritten."""
+    first, _ = bt.resolve_or_generate(tmp_path, configured=None)
+    mtime1 = (tmp_path / bt.TOKEN_FILENAME).stat().st_mtime
+    second, generated = bt.resolve_or_generate(tmp_path, configured=None)
+    assert first == second
+    assert generated is False
+    assert (tmp_path / bt.TOKEN_FILENAME).stat().st_mtime == mtime1
+
+
+def test_rotate_creates_home_dir_if_missing(tmp_path: Path):
+    nested = tmp_path / "fresh"
+    token = bt.rotate(nested)
+    assert (nested / bt.TOKEN_FILENAME).read_text() == token
+
+
+def test_rotate_yields_unique_tokens(tmp_path: Path):
+    a = bt.rotate(tmp_path)
+    b = bt.rotate(tmp_path)
+    assert a != b
+    assert bt.read_persisted(tmp_path) == b
+
+
+def test_resolve_or_generate_then_rotate_then_resolve_uses_new_token(tmp_path: Path):
+    """End-to-end: generate, rotate, resolve again — final value matches rotated."""
+    bt.resolve_or_generate(tmp_path, configured=None)
+    rotated = bt.rotate(tmp_path)
+    final, generated = bt.resolve_or_generate(tmp_path, configured=None)
+    assert final == rotated
+    assert generated is False

--- a/tests/security/test_server_auth_routes.py
+++ b/tests/security/test_server_auth_routes.py
@@ -906,3 +906,133 @@ class TestAgentAdminEndpointsRBAC:
             resp.status_code not in (401, 403)
         ), f"agent:*:delete should allow the endpoint; got {resp.status_code} (perms checked: {perms})"
         assert "agent:*:delete" in perms
+
+
+class TestAgentCodeUploadGate:
+    """POST/PUT /admin/agents must escalate to workflow:*:*:register when the body
+    ships executable content (tools_file, workflow_file) or an inline skills_dir bundle
+    that gets materialized on worker filesystems.
+    """
+
+    def _post_agent(self, client, body, granted_permissions):
+        """Call POST /admin/agents with auth enabled and only the listed permissions granted."""
+        from flux.config import Configuration
+        from flux.security.identity import FluxIdentity
+
+        permissions_checked: list[str] = []
+        identity = FluxIdentity(subject="limited-user", roles=frozenset({"role-x"}))
+
+        async def mock_authenticate(token):
+            return identity
+
+        async def mock_is_authorized(ident, permission):
+            permissions_checked.append(permission)
+            return permission in granted_permissions
+
+        mock_auth_service = MagicMock()
+        mock_auth_service.authenticate = mock_authenticate
+        mock_auth_service.is_authorized = mock_is_authorized
+
+        settings = Configuration.get().settings
+        orig_keys = settings.security.auth.api_keys.enabled
+        settings.security.auth.api_keys.enabled = True
+        try:
+            with patch(
+                "flux.security.dependencies._get_auth_service",
+                return_value=mock_auth_service,
+            ):
+                resp = client.post(
+                    "/admin/agents",
+                    json=body,
+                    headers={"Authorization": "Bearer fake-token"},
+                )
+        finally:
+            settings.security.auth.api_keys.enabled = orig_keys
+        return resp, permissions_checked
+
+    def _base_body(self, **overrides):
+        body = {
+            "name": "evil",
+            "model": "openai/gpt-4o",
+            "system_prompt": "x",
+        }
+        body.update(overrides)
+        return body
+
+    def test_skills_dir_bundle_blocked_without_register_permission(self, client):
+        """A caller with only agent:*:create must NOT be able to ship an inline skills_dir bundle."""
+        body = self._base_body(
+            skills_dir='{"a": {"../../etc/passwd": "rooted"}}',
+        )
+        resp, perms = self._post_agent(
+            client,
+            body,
+            granted_permissions={"agent:*:create"},
+        )
+        assert (
+            resp.status_code == 403
+        ), f"Inline skills_dir bundle must require workflow:*:*:register; got {resp.status_code}"
+        assert "workflow:*:*:register" in perms
+        assert "skills_dir" in resp.json().get("detail", "")
+
+    def test_tools_file_still_blocked_without_register_permission(self, client):
+        """Regression: tools_file gate keeps working under the renamed helper."""
+        body = self._base_body(tools_file="from flux import task")
+        resp, perms = self._post_agent(
+            client,
+            body,
+            granted_permissions={"agent:*:create"},
+        )
+        assert resp.status_code == 403
+        assert "workflow:*:*:register" in perms
+
+    def test_workflow_file_still_blocked_without_register_permission(self, client):
+        """Regression: workflow_file gate keeps working under the renamed helper."""
+        body = self._base_body(workflow_file="from flux import workflow")
+        resp, perms = self._post_agent(
+            client,
+            body,
+            granted_permissions={"agent:*:create"},
+        )
+        assert resp.status_code == 403
+        assert "workflow:*:*:register" in perms
+
+    def test_skills_dir_path_string_does_not_require_register_permission(self, client):
+        """A plain path string in skills_dir is NOT a code-upload — it must not trigger the gate."""
+        body = self._base_body(skills_dir="/var/lib/flux/skills")
+        resp, perms = self._post_agent(
+            client,
+            body,
+            granted_permissions={"agent:*:create"},
+        )
+        # The gate must not be tripped (no 403 referencing the upload restriction).
+        # The endpoint may still 500 because no AgentManager is registered in this
+        # test harness — what we're asserting is the absence of the upload gate.
+        assert (
+            "workflow:*:*:register" not in perms
+        ), f"Path-only skills_dir must NOT trigger workflow:*:*:register; perms checked: {perms}"
+
+    def test_no_dangerous_fields_does_not_require_register_permission(self, client):
+        """Plain agent definition (no executable content) must not trigger the gate."""
+        body = self._base_body()
+        resp, perms = self._post_agent(
+            client,
+            body,
+            granted_permissions={"agent:*:create"},
+        )
+        assert "workflow:*:*:register" not in perms
+
+    def test_skills_dir_bundle_allowed_with_register_permission(self, client):
+        """When workflow:*:*:register is granted, the bundle path is allowed past the gate."""
+        body = self._base_body(
+            skills_dir='{"a": {"SKILL.md": "harmless"}}',
+        )
+        resp, perms = self._post_agent(
+            client,
+            body,
+            granted_permissions={"agent:*:create", "workflow:*:*:register"},
+        )
+        # Permission was checked and granted; any non-403 response means the gate
+        # did not block the request.
+        assert resp.status_code != 403
+        assert "workflow:*:*:register" in perms


### PR DESCRIPTION
## Summary

Closes three high-severity findings from the deep security review. Each commit is self-contained with unit + E2E coverage; the final commit bumps the version and tightens worker startup.

| Finding | Severity | Fix |
|---|---|---|
| Path traversal + missing API gate on agent `skills_dir` bundles | HIGH | Worker validates resolved paths stay under temp dir; API gate now requires `workflow:*:*:register` for inline skill bundles, matching `tools_file`/`workflow_file` |
| Hardcoded `encryption_key = "SUPER_SECRET_KEY"` in shipped `flux.toml` | HIGH | Comment out the literal; operators must supply via env or local config; `_get_key()` already raises on missing |
| Hardcoded `bootstrap_token = "4298a036-..."` in shipped `flux.toml` | HIGH | TeamCity-style auto-generate + persist at `<home>/bootstrap-token` (0600); new `flux server bootstrap-token [--rotate]` CLI; `/workers/register` now uses `hmac.compare_digest` |

### Code change shape
- **+1174 / −29** across 23 files
- New: `flux/security/bootstrap_token.py`, `flux server` CLI group
- Modified: `flux.toml`, `flux/agents/template.py`, `flux/agents/types.py`, `flux/cli.py`, `flux/config.py`, `flux/server.py`, `flux/worker.py`
- Docs: `docs/advanced-features/agent-harness.md` (skills_dir permission gate), `docs/advanced-features/authentication.md` (bootstrap token resolution), README config-path bug fixes

### Tests
- **+47 unit tests** — resolver (26), CLI (12), agent-bundle helpers (5), AgentDefinition methods (6), Worker fail-fast (2), config regressions (2)
- **+11 integration tests** (`tests/security/test_server_auth_routes.py`) — `/admin/agents` upload-permission gate
- **+11 E2E tests** — agent skills path traversal (3), `flux server bootstrap-token` + `/workers/register` (8)
- Full unit suite: **1997 passing**

### Migration

Deployments that relied on the public defaults must:
1. Set `FLUX_SECURITY__ENCRYPTION__ENCRYPTION_KEY` (any data encrypted with the public placeholder remains decryptable only with that placeholder)
2. Either set `FLUX_WORKERS__BOOTSTRAP_TOKEN` or capture the auto-generated token from the first-start log / ``flux server bootstrap-token``

## Test plan

- [x] `poetry run pytest tests/flux/ tests/security/ -q --ignore=tests/e2e` — 1997 passing
- [x] `poetry run pytest tests/e2e/test_admin.py::test_secrets_lifecycle tests/e2e/test_server_bootstrap_token.py tests/e2e/test_agent_skills_path_traversal.py` — 12 passing
- [x] `poetry run pre-commit run --all-files` (per-file on changed files) — clean
- [ ] Reviewer: confirm migration notes are sufficient and CI green