### PR TITLE
fix(approvals): close decide/cancel-vs-pause races and SQLite decide race

### DIFF
--- a/flux/approvals.py
+++ b/flux/approvals.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import select
+from sqlalchemy import select, update as sa_update
 
 from flux.models import ApprovalRequestModel, ApprovalStatus, RepositoryFactory
 from flux.unit_of_work import UnitOfWork
@@ -175,38 +175,46 @@ class ApprovalManager:
         reason: str | None,
         uow: UnitOfWork,
     ) -> ApprovalRequestModel:
-        """Record a decision on a pending approval. Caller commits the UoW.
+        """Record a decision via atomic CAS. Loser raises ApprovalAlreadyDecided."""
+        new_status = ApprovalStatus.APPROVED if approved else ApprovalStatus.REJECTED
+        decided_at = datetime.now(timezone.utc)
 
-        Takes a row lock via with_for_update() — Postgres honors it as a real
-        FOR UPDATE; on SQLite, the UoW's transaction provides equivalent
-        serialization.
-
-        Raises ApprovalAlreadyDecided if the row isn't pending.
-        """
-        stmt = (
-            select(ApprovalRequestModel)
+        result = uow.session.execute(
+            sa_update(ApprovalRequestModel)
             .where(
                 ApprovalRequestModel.execution_id == execution_id,
                 ApprovalRequestModel.task_call_id == task_call_id,
+                ApprovalRequestModel.status == ApprovalStatus.PENDING,
             )
-            .with_for_update()
+            .values(
+                status=new_status,
+                approver_subject=approver_subject,
+                approver_provider=approver_provider,
+                reason=reason,
+                decided_at=decided_at,
+            ),
         )
-        row = uow.session.execute(stmt).scalar_one_or_none()
-        if row is None:
-            raise LookupError(
-                f"No approval found for execution={execution_id} task_call_id={task_call_id}",
-            )
-        if row.status != ApprovalStatus.PENDING:
-            raise ApprovalAlreadyDecided(row.status, row.decided_at)
 
-        row.status = ApprovalStatus.APPROVED if approved else ApprovalStatus.REJECTED
-        row.approver_subject = approver_subject
-        row.approver_provider = approver_provider
-        row.reason = reason
-        row.decided_at = datetime.now(timezone.utc)
+        if result.rowcount == 0:
+            existing = uow.session.execute(
+                select(ApprovalRequestModel).where(
+                    ApprovalRequestModel.execution_id == execution_id,
+                    ApprovalRequestModel.task_call_id == task_call_id,
+                ),
+            ).scalar_one_or_none()
+            if existing is None:
+                raise LookupError(
+                    f"No approval found for execution={execution_id} task_call_id={task_call_id}",
+                )
+            raise ApprovalAlreadyDecided(existing.status, existing.decided_at)
+
         uow.session.flush()
-        # Detach so attrs remain accessible after the caller's commit (which
-        # would otherwise expire managed instances).
+        row = uow.session.execute(
+            select(ApprovalRequestModel).where(
+                ApprovalRequestModel.execution_id == execution_id,
+                ApprovalRequestModel.task_call_id == task_call_id,
+            ),
+        ).scalar_one()
         uow.session.expunge(row)
         return row
 

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -23,6 +23,29 @@ if TYPE_CHECKING:
     from flux.unit_of_work import UnitOfWork
 
 
+_NO_DEMOTE_TO_PAUSED_FROM = frozenset(
+    {
+        ExecutionState.RESUMING,
+        ExecutionState.CANCELLING,
+    },
+)
+_TERMINAL_STATES = frozenset(
+    {
+        ExecutionState.COMPLETED,
+        ExecutionState.FAILED,
+        ExecutionState.CANCELLED,
+    },
+)
+
+
+def _accept_state_write(new: ExecutionState, db: ExecutionState) -> bool:
+    if new in _TERMINAL_STATES:
+        return True
+    if new == ExecutionState.PAUSED and db in _NO_DEMOTE_TO_PAUSED_FROM:
+        return False
+    return True
+
+
 class ContextManager(ABC):
     @abstractmethod
     def save(
@@ -156,13 +179,11 @@ class DatabaseContextManager(ContextManager):
         manage_transaction: bool,
     ) -> ExecutionContext:
         try:
-            model = session.get(
-                ExecutionContextModel,
-                ctx.execution_id,
-            )
+            model = self._lock_for_write(session, ctx.execution_id)
             if model:
+                if _accept_state_write(ctx.state, model.state):
+                    model.state = ctx.state
                 model.output = ctx.output
-                model.state = ctx.state
                 model.events.extend(self._get_additional_events(ctx, model))
             else:
                 session.add(ExecutionContextModel.from_plain(ctx))
@@ -176,17 +197,29 @@ class DatabaseContextManager(ContextManager):
 
     def update(self, ctx: ExecutionContext) -> ExecutionContext:
         with self.session() as session:
-            model = session.get(
-                ExecutionContextModel,
-                ctx.execution_id,
-            )
+            model = self._lock_for_write(session, ctx.execution_id)
             if not model:
                 raise ExecutionContextNotFoundError(ctx.execution_id)
+            if _accept_state_write(ctx.state, model.state):
+                model.state = ctx.state
             model.output = ctx.output
-            model.state = ctx.state
             model.events.extend(self._get_additional_events(ctx, model))
             session.commit()
             return ctx
+
+    @staticmethod
+    def _lock_for_write(
+        session: Session,
+        execution_id: str,
+    ) -> ExecutionContextModel | None:
+        from sqlalchemy import select
+
+        stmt = (
+            select(ExecutionContextModel)
+            .where(ExecutionContextModel.execution_id == execution_id)
+            .with_for_update()
+        )
+        return session.execute(stmt).scalar_one_or_none()
 
     def _worker_matches_workflow(self, worker: WorkerInfo, workflow: WorkflowModel) -> bool:
         if workflow.affinity is not None:

--- a/flux/domain/execution_context.py
+++ b/flux/domain/execution_context.py
@@ -296,17 +296,16 @@ class ExecutionContext(Generic[WorkflowInputType]):
         return self
 
     def start_resuming(self, input: Any | None = None) -> Self:
-        if self.is_paused:
-            self._state = ExecutionState.RESUMING
-            self.events.append(
-                ExecutionEvent(
-                    type=ExecutionEventType.WORKFLOW_RESUMING,
-                    source_id=self._current_worker,
-                    name=self.workflow_name,
-                    value=input,
-                    subject=None,
-                ),
-            )
+        self._state = ExecutionState.RESUMING
+        self.events.append(
+            ExecutionEvent(
+                type=ExecutionEventType.WORKFLOW_RESUMING,
+                source_id=self._current_worker,
+                name=self.workflow_name,
+                value=input,
+                subject=None,
+            ),
+        )
         return self
 
     def resume(self) -> Any:

--- a/flux/server.py
+++ b/flux/server.py
@@ -3425,12 +3425,6 @@ class Server:
                         else ExecutionEventType.TASK_REJECTED
                     )
                     decided_iso = updated.decided_at.isoformat() if updated.decided_at else None
-                    # Transition the workflow back to RESUMING *before* the
-                    # TASK_APPROVED/REJECTED event so ``is_paused`` (which
-                    # checks the last event) still sees WORKFLOW_PAUSED. This
-                    # is a no-op when the ctx is not currently paused — for
-                    # instance, in the transient window where a worker has
-                    # already started replaying the task.
                     exec_ctx.start_resuming()
                     exec_ctx.events.append(
                         ExecutionEvent(

--- a/tests/flux/test_approval_decide_race.py
+++ b/tests/flux/test_approval_decide_race.py
@@ -1,0 +1,123 @@
+"""Concurrent-decide race tests for ApprovalManager.decide."""
+
+from __future__ import annotations
+
+import threading
+import uuid
+
+import pytest
+
+from flux.approvals import ApprovalAlreadyDecided, ApprovalManager
+from flux.unit_of_work import UnitOfWork
+
+
+def _seed(execution_id: str, task_call_id: str = "deploy_1") -> None:
+    with UnitOfWork() as uow:
+        ApprovalManager().create(
+            execution_id,
+            task_call_id,
+            workflow_namespace="default",
+            workflow_name="release",
+            task_name="deploy",
+            uow=uow,
+        )
+        uow.commit()
+
+
+def _decide(
+    execution_id: str,
+    task_call_id: str,
+    *,
+    approver: str,
+    approved: bool,
+    barrier: threading.Barrier | None,
+    out: list,
+) -> None:
+    if barrier is not None:
+        barrier.wait()
+    try:
+        with UnitOfWork() as uow:
+            ApprovalManager().decide(
+                execution_id,
+                task_call_id,
+                approver_subject=approver,
+                approver_provider="oidc",
+                approved=approved,
+                reason=None,
+                uow=uow,
+            )
+            uow.commit()
+        out.append(("ok", approver))
+    except ApprovalAlreadyDecided as e:
+        out.append(("loser", approver, e.current_status.value))
+    except Exception as e:
+        out.append(("error", approver, type(e).__name__, str(e)))
+
+
+def test_concurrent_decide_yields_one_winner_and_one_clean_409(isolated_db):
+    eid = f"exec-{uuid.uuid4().hex[:8]}"
+    _seed(eid)
+
+    barrier = threading.Barrier(2)
+    out: list = []
+    t1 = threading.Thread(
+        target=_decide,
+        kwargs={
+            "execution_id": eid,
+            "task_call_id": "deploy_1",
+            "approver": "alice",
+            "approved": True,
+            "barrier": barrier,
+            "out": out,
+        },
+    )
+    t2 = threading.Thread(
+        target=_decide,
+        kwargs={
+            "execution_id": eid,
+            "task_call_id": "deploy_1",
+            "approver": "bob",
+            "approved": False,
+            "barrier": barrier,
+            "out": out,
+        },
+    )
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    statuses = [r[0] for r in out]
+    assert statuses.count("ok") == 1, out
+    assert statuses.count("loser") == 1, out
+    assert "error" not in statuses, out
+
+
+def test_serial_decide_after_decision_raises_already_decided(isolated_db):
+    eid = f"exec-{uuid.uuid4().hex[:8]}"
+    _seed(eid)
+    mgr = ApprovalManager()
+    with UnitOfWork() as uow:
+        mgr.decide(
+            eid,
+            "deploy_1",
+            approver_subject="alice",
+            approver_provider="oidc",
+            approved=True,
+            reason=None,
+            uow=uow,
+        )
+        uow.commit()
+    with pytest.raises(ApprovalAlreadyDecided) as exc:
+        with UnitOfWork() as uow:
+            mgr.decide(
+                eid,
+                "deploy_1",
+                approver_subject="bob",
+                approver_provider="oidc",
+                approved=False,
+                reason=None,
+                uow=uow,
+            )
+            uow.commit()
+    assert exc.value.current_status.value == "approved"

--- a/tests/flux/test_state_precedence.py
+++ b/tests/flux/test_state_precedence.py
@@ -1,0 +1,155 @@
+"""State-precedence regression tests for save/update vs decide/cancel races."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from flux.context_managers import ContextManager, DatabaseContextManager
+from flux.domain import ExecutionContext, ExecutionState
+from flux.domain.events import ExecutionEvent, ExecutionEventType
+
+
+def _make_ctx(state: ExecutionState = ExecutionState.RUNNING) -> ExecutionContext:
+    ctx: ExecutionContext = ExecutionContext(
+        workflow_id="wf-precedence",
+        workflow_namespace="default",
+        workflow_name="precedence",
+        input=None,
+    )
+    ctx._state = state
+    return ctx
+
+
+def _set_db_state(execution_id: str, state: ExecutionState) -> None:
+    cm = cast(DatabaseContextManager, ContextManager.create())
+    with cm.session() as session:
+        from flux.models import ExecutionContextModel
+
+        row = session.get(ExecutionContextModel, execution_id)
+        assert row is not None
+        row.state = state
+        session.commit()
+
+
+# --- start_resuming -------------------------------------------------------
+
+
+def test_start_resuming_transitions_even_when_not_paused():
+    ctx = _make_ctx(ExecutionState.RUNNING)
+    ctx.start_resuming()
+    assert ctx.state == ExecutionState.RESUMING
+    assert any(e.type == ExecutionEventType.WORKFLOW_RESUMING for e in ctx.events)
+
+
+def test_start_resuming_from_paused_still_works():
+    ctx = _make_ctx(ExecutionState.RUNNING)
+    ctx.events.append(
+        ExecutionEvent(
+            type=ExecutionEventType.WORKFLOW_PAUSED,
+            source_id="wf",
+            name="precedence",
+            value=None,
+        ),
+    )
+    ctx._state = ExecutionState.PAUSED
+    ctx.start_resuming()
+    assert ctx.state == ExecutionState.RESUMING
+
+
+# --- save() state precedence ---------------------------------------------
+
+
+def test_save_does_not_demote_resuming_to_paused(isolated_db):
+    ctx = _make_ctx(ExecutionState.RUNNING)
+    cm = ContextManager.create()
+    cm.save(ctx)
+    _set_db_state(ctx.execution_id, ExecutionState.RESUMING)
+
+    ctx.pause("wf", "approval", output=None)
+    assert ctx.state == ExecutionState.PAUSED
+    cm.save(ctx)
+
+    fetched = cm.get(ctx.execution_id)
+    assert fetched.state == ExecutionState.RESUMING
+    paused_events = [e for e in fetched.events if e.type == ExecutionEventType.WORKFLOW_PAUSED]
+    assert len(paused_events) == 1
+
+
+def test_save_does_not_demote_cancelling_to_paused(isolated_db):
+    ctx = _make_ctx(ExecutionState.RUNNING)
+    cm = ContextManager.create()
+    cm.save(ctx)
+    _set_db_state(ctx.execution_id, ExecutionState.CANCELLING)
+
+    ctx.pause("wf", "stale", output=None)
+    cm.save(ctx)
+
+    fetched = cm.get(ctx.execution_id)
+    assert fetched.state == ExecutionState.CANCELLING
+
+
+def test_save_allows_paused_from_resume_claimed(isolated_db):
+    ctx = _make_ctx(ExecutionState.RUNNING)
+    cm = ContextManager.create()
+    cm.save(ctx)
+    _set_db_state(ctx.execution_id, ExecutionState.RESUME_CLAIMED)
+
+    ctx.pause("wf", "next-pause-point", output=None)
+    cm.save(ctx)
+
+    fetched = cm.get(ctx.execution_id)
+    assert fetched.state == ExecutionState.PAUSED
+
+
+def test_save_terminal_always_wins_over_resuming(isolated_db):
+    ctx = _make_ctx(ExecutionState.RUNNING)
+    cm = ContextManager.create()
+    cm.save(ctx)
+    _set_db_state(ctx.execution_id, ExecutionState.RESUMING)
+
+    ctx.complete("wf", output={"value": 1})
+    cm.save(ctx)
+
+    fetched = cm.get(ctx.execution_id)
+    assert fetched.state == ExecutionState.COMPLETED
+
+
+def test_save_normal_pause_still_works(isolated_db):
+    ctx = _make_ctx(ExecutionState.RUNNING)
+    cm = ContextManager.create()
+    cm.save(ctx)
+
+    ctx.pause("wf", "name", output=None)
+    cm.save(ctx)
+
+    fetched = cm.get(ctx.execution_id)
+    assert fetched.state == ExecutionState.PAUSED
+
+
+# --- update() state precedence -------------------------------------------
+
+
+def test_update_does_not_demote_resuming_to_paused(isolated_db):
+    ctx = _make_ctx(ExecutionState.RUNNING)
+    cm = ContextManager.create()
+    cm.save(ctx)
+    _set_db_state(ctx.execution_id, ExecutionState.RESUMING)
+
+    ctx.pause("wf", "stale", output=None)
+    cm.update(ctx)
+
+    fetched = cm.get(ctx.execution_id)
+    assert fetched.state == ExecutionState.RESUMING
+
+
+def test_update_does_not_demote_cancelling_to_paused(isolated_db):
+    ctx = _make_ctx(ExecutionState.RUNNING)
+    cm = ContextManager.create()
+    cm.save(ctx)
+    _set_db_state(ctx.execution_id, ExecutionState.CANCELLING)
+
+    ctx.pause("wf", "stale", output=None)
+    cm.update(ctx)
+
+    fetched = cm.get(ctx.execution_id)
+    assert fetched.state == ExecutionState.CANCELLING


### PR DESCRIPTION
## Summary

Fixes three of the deeper findings from the systematic review of #66:

- **C1 / H4** — When an operator decided / cancelled an execution before the worker had checkpointed `WORKFLOW_PAUSED`, the worker's later `PAUSED` checkpoint silently overwrote the `RESUMING` / `CANCELLING` state set by the control-plane handler. `next_resume` and `next_cancellation` filter on state, so the row was never re-claimed and the workflow wedged forever.
- **C3** — `ApprovalManager.decide()` relied on `with_for_update()` for row locking, which is silently a no-op on SQLite. Two operators racing the same row could both succeed (last-writer-wins) or surface as a 500 ``OperationalError: database is locked`` instead of the intended `409 already_decided`.
- **M1** — `start_resuming()` was a silent no-op when the ctx wasn't currently paused; the decide handler relied on this and quietly failed to transition. Now always transitions, with the new state-precedence guard taking care of races.

Stacked on `feat/approval-as-task-primitive` (#66).

## Changes

- **`flux/domain/execution_context.py`** — `start_resuming()` always sets `state=RESUMING` and emits `WORKFLOW_RESUMING` (drops the silent `if self.is_paused` guard).
- **`flux/context_managers.py`** — `save()` and `update()` lock the row with `FOR UPDATE` and apply a precedence guard: a write of `PAUSED` is rejected when the DB row is in `RESUMING` / `CANCELLING`. Events still flush; only the state column is preserved. Terminal states (`COMPLETED` / `FAILED` / `CANCELLED`) always win.
- **`flux/approvals.py`** — `decide()` is now an atomic CAS (`UPDATE ... WHERE status=PENDING` + `rowcount` check) instead of `SELECT` + `UPDATE`. Race-safe on SQLite and PostgreSQL.
- **`flux/server.py`** — drops a now-stale comment in `_decide_approval` that explained the silent-no-op behavior.

## Test plan

- [x] **New regression tests:**
  - `tests/flux/test_state_precedence.py` (8 tests) — verifies `start_resuming` always transitions; `save`/`update` block `PAUSED` from `RESUMING`/`CANCELLING`; terminal states always win; legitimate `PAUSED` writes still succeed; allows `PAUSED` from `RESUME_CLAIMED` (legitimate worker progression).
  - `tests/flux/test_approval_decide_race.py` (2 tests) — drives two threads through `ApprovalManager.decide` on the same row with a barrier; asserts exactly one `ok` and one `loser`. Plus the serial after-decision assertion.
- [x] **Pre-commit (all files)**: clean
- [x] **Unit suite**: 2229 passed (5:20)
- [x] **E2E (no ollama)**: 101 passed, 0 failed (38:42)

## Notes

The state-precedence guard intentionally only blocks `PAUSED` writes from `RESUMING` / `CANCELLING`. It does **not** block from `RESUME_SCHEDULED` / `RESUME_CLAIMED` — those are part of the legitimate worker progression during a resume cycle (the worker's next checkpoint as it pauses again is the right write).