### PR TITLE
fix: triage and resolve 20 reported bugs across retry, graph, scheduling, observability, auth, and LLM providers

### DIFF
--- a/flux/catalogs.py
+++ b/flux/catalogs.py
@@ -596,7 +596,7 @@ class WorkflowCatalog(ABC):
         return None
 
     @staticmethod
-    def create() -> WorkflowCatalog:
+    def create() -> DatabaseWorkflowCatalog:
         return DatabaseWorkflowCatalog()
 
 

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -1480,12 +1480,11 @@ def schedule_history(schedule_id: str, limit: int, format: str, server_url: str 
         # rows live under "entries".
         entries = history.get("entries", []) if isinstance(history, dict) else history
 
-        if not entries:
-            click.echo("No execution history found.")
-            return
-
         if format == "json":
+            # Always emit valid JSON, even when there is no history.
             click.echo(json.dumps(history, indent=2))
+        elif not entries:
+            click.echo("No execution history found.")
         else:
             click.echo(f"Execution history for schedule '{schedule_id}':")
             click.echo()

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -1476,7 +1476,11 @@ def schedule_history(schedule_id: str, limit: int, format: str, server_url: str 
             response.raise_for_status()
             history = response.json()
 
-        if not history:
+        # The endpoint returns a ScheduleHistoryResponse object; the actual
+        # rows live under "entries".
+        entries = history.get("entries", []) if isinstance(history, dict) else history
+
+        if not entries:
             click.echo("No execution history found.")
             return
 
@@ -1485,24 +1489,17 @@ def schedule_history(schedule_id: str, limit: int, format: str, server_url: str 
         else:
             click.echo(f"Execution history for schedule '{schedule_id}':")
             click.echo()
-            for entry in history:
-                status_icon = (
-                    "✓"
-                    if entry["status"] == "completed"
-                    else "✗"
-                    if entry["status"] == "failed"
-                    else "⏸"
+            for entry in entries:
+                state = entry.get("state", "UNKNOWN")
+                status_icon = "✓" if state == "COMPLETED" else "✗" if state == "FAILED" else "⏸"
+                click.echo(
+                    f"{status_icon} {entry.get('execution_id', '?')} - {state}",
                 )
-                click.echo(f"{status_icon} {entry['scheduled_at']} - {entry['status'].upper()}")
 
-                if entry.get("execution_id"):
-                    click.echo(f"   Execution ID: {entry['execution_id']}")
                 if entry.get("started_at"):
                     click.echo(f"   Started: {entry['started_at']}")
                 if entry.get("completed_at"):
                     click.echo(f"   Completed: {entry['completed_at']}")
-                if entry.get("error_message"):
-                    click.echo(f"   Error: {entry['error_message']}")
                 click.echo()
 
     except httpx.HTTPStatusError as ex:

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -1499,6 +1499,8 @@ def schedule_history(schedule_id: str, limit: int, format: str, server_url: str 
                     click.echo(f"   Started: {entry['started_at']}")
                 if entry.get("completed_at"):
                     click.echo(f"   Completed: {entry['completed_at']}")
+                if entry.get("error"):
+                    click.echo(f"   Error: {entry['error']}")
                 click.echo()
 
     except httpx.HTTPStatusError as ex:

--- a/flux/config.py
+++ b/flux/config.py
@@ -77,7 +77,7 @@ class MCPConfig(BaseConfig):
         description="Default server URL to connect to",
     )
     transport: Literal["stdio", "streamable-http", "sse"] = Field(
-        default="sse",
+        default="streamable-http",
         description="Transport protocol for MCP (stdio, streamable-http, sse)",
     )
 
@@ -217,11 +217,11 @@ class FluxConfig(BaseSettings):
         3. pyproject.toml
         4. Default values
         """
-        # Try to load from flux.toml
-        config = cls._load_from_config()
+        # Lower precedence: pyproject.toml [tool.flux]
+        config = cls._load_from_pyproject()
 
-        # Try to load from pyproject.toml
-        config = {**config, **cls._load_from_pyproject()}
+        # Higher precedence: flux.toml overrides pyproject.toml
+        config = {**config, **cls._load_from_config()}
 
         # Pydantic-settings gives init kwargs higher priority than env vars.
         # To honour the documented precedence (env vars beat config files), drop

--- a/flux/models.py
+++ b/flux/models.py
@@ -533,6 +533,9 @@ class ExecutionContextModel(Base):
     exec_token = Column(String, nullable=True)
     scheduling_subject = Column(String, nullable=True)
     scheduling_principal_issuer = Column(String, nullable=True)
+    # Set when the execution was dispatched by a schedule; lets schedule
+    # history be scoped to the originating schedule rather than the workflow.
+    schedule_id = Column(String, nullable=True)
 
     # Relationship to events
     events = relationship(
@@ -550,6 +553,7 @@ class ExecutionContextModel(Base):
         Index("idx_execution_state", "state"),
         Index("idx_execution_worker_name", "worker_name"),
         Index("idx_execution_state_worker", "state", "worker_name"),
+        Index("idx_execution_schedule_id", "schedule_id"),
     )
 
     def __init__(
@@ -566,6 +570,7 @@ class ExecutionContextModel(Base):
         exec_token: str | None = None,
         scheduling_subject: str | None = None,
         scheduling_principal_issuer: str | None = None,
+        schedule_id: str | None = None,
     ):
         self.execution_id = execution_id
         self.workflow_id = workflow_id
@@ -579,6 +584,7 @@ class ExecutionContextModel(Base):
         self.exec_token = exec_token
         self.scheduling_subject = scheduling_subject
         self.scheduling_principal_issuer = scheduling_principal_issuer
+        self.schedule_id = schedule_id
 
     def to_plain(self) -> ExecutionContext:
         return ExecutionContext(

--- a/flux/observability/config.py
+++ b/flux/observability/config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 
@@ -12,6 +14,10 @@ class ObservabilityConfig(BaseModel):
     otlp_endpoint: str | None = Field(
         default=None,
         description="OTLP collector endpoint (e.g. http://localhost:4317)",
+    )
+    otlp_protocol: Literal["grpc", "http"] = Field(
+        default="grpc",
+        description="OTLP exporter protocol: 'grpc' or 'http' (HTTP/protobuf)",
     )
     prometheus_enabled: bool = Field(
         default=True,

--- a/flux/observability/provider.py
+++ b/flux/observability/provider.py
@@ -58,9 +58,14 @@ def _setup_providers_unlocked(config: ObservabilityConfig):
         readers.append(PrometheusMetricReader())
 
     if config.otlp_endpoint:
-        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
-            OTLPMetricExporter,
-        )
+        if config.otlp_protocol == "http":
+            from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+                OTLPMetricExporter,
+            )
+        else:
+            from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+                OTLPMetricExporter,
+            )
         from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 
         otlp_exporter = OTLPMetricExporter(endpoint=config.otlp_endpoint)
@@ -80,9 +85,14 @@ def _setup_providers_unlocked(config: ObservabilityConfig):
 
     span_exporters = []
     if config.otlp_endpoint:
-        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
-            OTLPSpanExporter,
-        )
+        if config.otlp_protocol == "http":
+            from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+                OTLPSpanExporter,
+            )
+        else:
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+                OTLPSpanExporter,
+            )
 
         span_exporters.append(OTLPSpanExporter(endpoint=config.otlp_endpoint))
 
@@ -97,9 +107,15 @@ def _setup_providers_unlocked(config: ObservabilityConfig):
     # Logging
     if config.otlp_endpoint:
         from opentelemetry._logs import set_logger_provider
-        from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
-            OTLPLogExporter,
-        )
+
+        if config.otlp_protocol == "http":
+            from opentelemetry.exporter.otlp.proto.http._log_exporter import (
+                OTLPLogExporter,
+            )
+        else:
+            from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
+                OTLPLogExporter,
+            )
         from opentelemetry.sdk._logs import LoggerProvider
         from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 

--- a/flux/schedule_manager.py
+++ b/flux/schedule_manager.py
@@ -5,8 +5,14 @@ from datetime import datetime, timezone
 from typing import Any
 
 
+from flux.domain.events import ExecutionEventType
 from flux.domain.schedule import Schedule
-from flux.models import ScheduleModel, RepositoryFactory, ExecutionContextModel
+from flux.models import (
+    ScheduleModel,
+    RepositoryFactory,
+    ExecutionContextModel,
+    ExecutionEventModel,
+)
 from flux.errors import ExecutionError
 
 
@@ -360,8 +366,9 @@ class DatabaseScheduleManager(ScheduleManager):
         """
         Get execution history for a schedule.
 
-        Since executions aren't directly linked to schedules in the database,
-        this returns executions for the workflow associated with the schedule.
+        Executions are linked to their originating schedule at dispatch time
+        (``executions.schedule_id``), so history is scoped to this schedule
+        rather than every execution of the underlying workflow.
 
         Args:
             schedule_id: The schedule ID
@@ -381,17 +388,46 @@ class DatabaseScheduleManager(ScheduleManager):
                 if not schedule:
                     raise ScheduleManagerError(f"Schedule with ID '{schedule_id}' not found")
 
-                # Query executions for this workflow using the repository
+                # Only executions dispatched by this schedule
                 query = session.query(ExecutionContextModel).filter(
-                    ExecutionContextModel.workflow_namespace == schedule.workflow_namespace,
-                    ExecutionContextModel.workflow_name == schedule.workflow_name,
+                    ExecutionContextModel.schedule_id == schedule_id,
                 )
 
                 # Get total count
                 total = query.count()
 
                 # Apply pagination
-                executions = query.offset(offset).limit(limit).all()
+                executions = (
+                    query.order_by(ExecutionContextModel.execution_id)
+                    .offset(offset)
+                    .limit(limit)
+                    .all()
+                )
+
+                # Derive started/completed timestamps from the event log.
+                exec_ids = [ex.execution_id for ex in executions]
+                started_at: dict[str, str] = {}
+                completed_at: dict[str, str] = {}
+                if exec_ids:
+                    terminal_types = {
+                        ExecutionEventType.WORKFLOW_COMPLETED,
+                        ExecutionEventType.WORKFLOW_FAILED,
+                        ExecutionEventType.WORKFLOW_CANCELLED,
+                    }
+                    events = (
+                        session.query(ExecutionEventModel)
+                        .filter(ExecutionEventModel.execution_id.in_(exec_ids))
+                        .order_by(ExecutionEventModel.id)
+                        .all()
+                    )
+                    for ev in events:
+                        if (
+                            ev.type == ExecutionEventType.WORKFLOW_STARTED
+                            and ev.execution_id not in started_at
+                        ):
+                            started_at[ev.execution_id] = ev.time.isoformat()
+                        elif ev.type in terminal_types:
+                            completed_at[ev.execution_id] = ev.time.isoformat()
 
                 # Return execution summaries
                 results = []
@@ -404,6 +440,8 @@ class DatabaseScheduleManager(ScheduleManager):
                             if hasattr(ex.state, "value")
                             else str(ex.state),
                             "worker_name": ex.worker_name,
+                            "started_at": started_at.get(ex.execution_id),
+                            "completed_at": completed_at.get(ex.execution_id),
                         },
                     )
 

--- a/flux/schedule_manager.py
+++ b/flux/schedule_manager.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from typing import Any
 
+from sqlalchemy import func
 
 from flux.domain.events import ExecutionEventType
 from flux.domain.schedule import Schedule
@@ -388,9 +389,26 @@ class DatabaseScheduleManager(ScheduleManager):
                 if not schedule:
                     raise ScheduleManagerError(f"Schedule with ID '{schedule_id}' not found")
 
-                # Only executions dispatched by this schedule
-                query = session.query(ExecutionContextModel).filter(
-                    ExecutionContextModel.schedule_id == schedule_id,
+                # Only executions dispatched by this schedule. The executions
+                # table has no timestamp column, so order by each execution's
+                # earliest event id (a monotonic autoincrement) DESC — newest
+                # runs first — instead of by the arbitrary execution_id string.
+                first_event = (
+                    session.query(
+                        ExecutionEventModel.execution_id.label("execution_id"),
+                        func.min(ExecutionEventModel.id).label("first_id"),
+                    )
+                    .group_by(ExecutionEventModel.execution_id)
+                    .subquery()
+                )
+
+                query = (
+                    session.query(ExecutionContextModel)
+                    .outerjoin(
+                        first_event,
+                        first_event.c.execution_id == ExecutionContextModel.execution_id,
+                    )
+                    .filter(ExecutionContextModel.schedule_id == schedule_id)
                 )
 
                 # Get total count
@@ -398,36 +416,45 @@ class DatabaseScheduleManager(ScheduleManager):
 
                 # Apply pagination
                 executions = (
-                    query.order_by(ExecutionContextModel.execution_id)
-                    .offset(offset)
-                    .limit(limit)
-                    .all()
+                    query.order_by(first_event.c.first_id.desc()).offset(offset).limit(limit).all()
                 )
 
-                # Derive started/completed timestamps from the event log.
+                # Derive started/completed timestamps (and the failure reason)
+                # from the event log. Only the few event types needed are
+                # fetched, as plain columns rather than full ORM rows, so a
+                # page never loads a workflow's entire event history.
                 exec_ids = [ex.execution_id for ex in executions]
                 started_at: dict[str, str] = {}
                 completed_at: dict[str, str] = {}
+                error: dict[str, str] = {}
                 if exec_ids:
                     terminal_types = {
                         ExecutionEventType.WORKFLOW_COMPLETED,
                         ExecutionEventType.WORKFLOW_FAILED,
                         ExecutionEventType.WORKFLOW_CANCELLED,
                     }
-                    events = (
-                        session.query(ExecutionEventModel)
-                        .filter(ExecutionEventModel.execution_id.in_(exec_ids))
+                    relevant_types = {ExecutionEventType.WORKFLOW_STARTED, *terminal_types}
+                    rows = (
+                        session.query(
+                            ExecutionEventModel.execution_id,
+                            ExecutionEventModel.type,
+                            ExecutionEventModel.time,
+                            ExecutionEventModel.value,
+                        )
+                        .filter(
+                            ExecutionEventModel.execution_id.in_(exec_ids),
+                            ExecutionEventModel.type.in_(relevant_types),
+                        )
                         .order_by(ExecutionEventModel.id)
                         .all()
                     )
-                    for ev in events:
-                        if (
-                            ev.type == ExecutionEventType.WORKFLOW_STARTED
-                            and ev.execution_id not in started_at
-                        ):
-                            started_at[ev.execution_id] = ev.time.isoformat()
-                        elif ev.type in terminal_types:
-                            completed_at[ev.execution_id] = ev.time.isoformat()
+                    for ev_exec_id, ev_type, ev_time, ev_value in rows:
+                        if ev_type == ExecutionEventType.WORKFLOW_STARTED:
+                            started_at.setdefault(ev_exec_id, ev_time.isoformat())
+                        elif ev_type in terminal_types:
+                            completed_at[ev_exec_id] = ev_time.isoformat()
+                            if ev_type == ExecutionEventType.WORKFLOW_FAILED and ev_value:
+                                error[ev_exec_id] = str(ev_value)
 
                 # Return execution summaries
                 results = []
@@ -442,6 +469,7 @@ class DatabaseScheduleManager(ScheduleManager):
                             "worker_name": ex.worker_name,
                             "started_at": started_at.get(ex.execution_id),
                             "completed_at": completed_at.get(ex.execution_id),
+                            "error": error.get(ex.execution_id),
                         },
                     )
 

--- a/flux/security/config.py
+++ b/flux/security/config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 if TYPE_CHECKING:
     from flux.config import EncryptionConfig
@@ -33,10 +33,28 @@ class APIKeyAuthConfig(_BaseConfig):
 class AuthConfig(_BaseConfig):
     oidc: OIDCConfig = Field(default_factory=OIDCConfig)
     api_keys: APIKeyAuthConfig = Field(default_factory=APIKeyAuthConfig)
+    enabled: bool = Field(
+        default=False,
+        description=(
+            "Master switch for authentication. Settable via "
+            "FLUX_SECURITY__AUTH__ENABLED. Enabling any provider implies it is "
+            "on; when on, at least one provider (oidc/api_keys) must be enabled."
+        ),
+    )
 
-    @property
-    def enabled(self) -> bool:
-        return self.oidc.enabled or self.api_keys.enabled
+    @model_validator(mode="after")
+    def _reconcile_enabled(self) -> AuthConfig:
+        provider_enabled = self.oidc.enabled or self.api_keys.enabled
+        if provider_enabled:
+            # Enabling a provider implies auth is on.
+            self.enabled = True
+        elif self.enabled:
+            raise ValueError(
+                "security.auth.enabled is true but no auth provider is "
+                "configured. Enable [flux.security.auth.oidc] or "
+                "[flux.security.auth.api_keys].",
+            )
+        return self
 
 
 def _make_encryption_config():

--- a/flux/security/config.py
+++ b/flux/security/config.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field, model_validator
 
 if TYPE_CHECKING:
     from flux.config import EncryptionConfig
+
+logger = logging.getLogger(__name__)
 
 
 class _BaseConfig(BaseModel):
@@ -46,7 +49,13 @@ class AuthConfig(_BaseConfig):
     def _reconcile_enabled(self) -> AuthConfig:
         provider_enabled = self.oidc.enabled or self.api_keys.enabled
         if provider_enabled:
-            # Enabling a provider implies auth is on.
+            # Enabling a provider implies auth is on. Surface the override so a
+            # deliberate enabled=false isn't silently flipped back.
+            if not self.enabled:
+                logger.warning(
+                    "security.auth.enabled was false but an auth provider is "
+                    "enabled; forcing security.auth.enabled=true.",
+                )
             self.enabled = True
         elif self.enabled:
             raise ValueError(

--- a/flux/server.py
+++ b/flux/server.py
@@ -18,6 +18,7 @@ from fastapi import Header
 from fastapi import HTTPException
 from fastapi import Query
 from fastapi import Request
+from fastapi import Response
 from fastapi import UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -289,6 +290,29 @@ class ScheduleHistoryResponse(BaseModel):
     total: int
     limit: int
     offset: int
+
+
+def _inject_trace_context(data_payload: str) -> str:
+    """Add the current OTel trace context to an SSE JSON payload, if enabled.
+
+    Workers use this to continue the server-side trace; without it resumed and
+    cancelled executions would start a disconnected trace.
+    """
+    from flux.observability import is_enabled
+
+    if not is_enabled():
+        return data_payload
+
+    import json as _json
+
+    from flux.observability.tracing import inject_trace_context
+
+    try:
+        event_data = _json.loads(data_payload)
+        event_data["trace_context"] = inject_trace_context()
+        return _json.dumps(event_data)
+    except Exception:
+        return data_payload
 
 
 class Server:
@@ -969,6 +993,19 @@ class Server:
                 schedule.workflow_name,
                 schedule.input_data,
             )
+
+            # Link the execution to its schedule so history can be scoped to
+            # this schedule rather than every execution of the workflow.
+            sched_link_session = self._get_db_session()
+            try:
+                from flux.models import ExecutionContextModel as _ECM_SCHED
+
+                sched_exec_row = sched_link_session.get(_ECM_SCHED, ctx.execution_id)
+                if sched_exec_row:
+                    sched_exec_row.schedule_id = schedule.id
+                    sched_link_session.commit()
+            finally:
+                sched_link_session.close()
 
             if auth_config.enabled and sa_principal is not None:
                 from flux.security.execution_token import mint_execution_token
@@ -1917,19 +1954,7 @@ class Server:
                                         payload_dict["exec_token"] = exec_token_for_dispatch
                                     data_payload = to_json(payload_dict)
 
-                                    from flux.observability import is_enabled
-
-                                    if is_enabled():
-                                        import json as _json
-
-                                        from flux.observability.tracing import inject_trace_context
-
-                                        try:
-                                            event_data = _json.loads(data_payload)
-                                            event_data["trace_context"] = inject_trace_context()
-                                            data_payload = _json.dumps(event_data)
-                                        except Exception:
-                                            pass
+                                    data_payload = _inject_trace_context(data_payload)
 
                                     yield {
                                         "id": f"{ctx.execution_id}_{uuid4().hex}",
@@ -1950,7 +1975,9 @@ class Server:
                                     yield {
                                         "id": f"{ctx.execution_id}_{uuid4().hex}",
                                         "event": "execution_cancelled",
-                                        "data": to_json({"context": ctx}),
+                                        "data": _inject_trace_context(
+                                            to_json({"context": ctx}),
+                                        ),
                                     }
 
                                     logger.debug(
@@ -1991,7 +2018,9 @@ class Server:
                                     yield {
                                         "id": f"{ctx.execution_id}_{uuid4().hex}",
                                         "event": "execution_resumed",
-                                        "data": to_json(resume_payload_dict),
+                                        "data": _inject_trace_context(
+                                            to_json(resume_payload_dict),
+                                        ),
                                     }
 
                                     logger.debug(
@@ -3483,7 +3512,7 @@ class Server:
         # ===========================================
 
         @api.get("/health", response_model=HealthResponse)
-        async def health():
+        async def health(response: Response):
             """Health check endpoint."""
             try:
                 logger.debug("Health check requested")
@@ -3501,11 +3530,16 @@ class Server:
                     version=version,
                 )
 
+                # Status-code-only probes must fail when the DB is unreachable.
+                if not db_healthy:
+                    response.status_code = 503
+
                 logger.debug(f"Health check result: {status}")
                 return result
 
             except Exception as e:
                 logger.error(f"Health check failed: {str(e)}")
+                response.status_code = 503
                 return HealthResponse(
                     status="unhealthy",
                     database=False,
@@ -3555,6 +3589,8 @@ class Server:
                             execution_id=e["execution_id"],
                             workflow_name=e["workflow_name"],
                             state=e["state"],
+                            started_at=e.get("started_at"),
+                            completed_at=e.get("completed_at"),
                         )
                         for e in entries
                     ],

--- a/flux/server.py
+++ b/flux/server.py
@@ -279,6 +279,7 @@ class ScheduleHistoryEntry(BaseModel):
     state: str
     started_at: str | None = None
     completed_at: str | None = None
+    error: str | None = None
 
 
 class ScheduleHistoryResponse(BaseModel):
@@ -994,19 +995,11 @@ class Server:
                 schedule.input_data,
             )
 
-            # Link the execution to its schedule so history can be scoped to
-            # this schedule rather than every execution of the workflow.
-            sched_link_session = self._get_db_session()
-            try:
-                from flux.models import ExecutionContextModel as _ECM_SCHED
-
-                sched_exec_row = sched_link_session.get(_ECM_SCHED, ctx.execution_id)
-                if sched_exec_row:
-                    sched_exec_row.schedule_id = schedule.id
-                    sched_link_session.commit()
-            finally:
-                sched_link_session.close()
-
+            # Link the execution to its schedule (so history can be scoped to
+            # this schedule) and, when auth is on, attach its execution token.
+            # Both writes share one session/commit so the row is updated in a
+            # single transaction rather than two independent ones.
+            exec_token = None
             if auth_config.enabled and sa_principal is not None:
                 from flux.security.execution_token import mint_execution_token
 
@@ -1016,18 +1009,21 @@ class Server:
                     execution_id=ctx.execution_id,
                     on_behalf_of=f"schedule:{schedule.name}",
                 )
-                sched_token_session = self._get_db_session()
-                try:
-                    from flux.models import ExecutionContextModel as _ECM5
 
-                    exec_row = sched_token_session.get(_ECM5, ctx.execution_id)
-                    if exec_row:
+            sched_link_session = self._get_db_session()
+            try:
+                from flux.models import ExecutionContextModel as _ECM_SCHED
+
+                exec_row = sched_link_session.get(_ECM_SCHED, ctx.execution_id)
+                if exec_row:
+                    exec_row.schedule_id = schedule.id
+                    if exec_token is not None and sa_principal is not None:
                         exec_row.exec_token = exec_token
                         exec_row.scheduling_subject = sa_principal.subject
                         exec_row.scheduling_principal_issuer = "flux"
-                        sched_token_session.commit()
-                finally:
-                    sched_token_session.close()
+                    sched_link_session.commit()
+            finally:
+                sched_link_session.close()
 
             # Update schedule tracking
             schedule.mark_run(scheduled_time)
@@ -3591,6 +3587,7 @@ class Server:
                             state=e["state"],
                             started_at=e.get("started_at"),
                             completed_at=e.get("completed_at"),
+                            error=e.get("error"),
                         )
                         for e in entries
                     ],

--- a/flux/task.py
+++ b/flux/task.py
@@ -272,7 +272,7 @@ class task:
                     },
                 )
 
-            with span_cm:
+            with span_cm as span:
                 try:
                     output = None
                     cache_hit = False
@@ -316,6 +316,11 @@ class task:
 
                 except Exception as ex:
                     task_failed = True
+                    if span is not None:
+                        from opentelemetry.trace import Status, StatusCode
+
+                        span.set_status(Status(StatusCode.ERROR, str(ex)))
+                        span.record_exception(ex)
                     output = await self.__handle_exception(
                         ctx,
                         ex,
@@ -570,6 +575,9 @@ class task:
         kwargs: dict,
     ):
         attempt = 0
+        # current_delay persists across iterations so retry_backoff actually
+        # compounds: attempt 1 waits retry_delay, attempt 2 retry_delay*backoff, …
+        current_delay = self.retry_delay
         while attempt < self.retry_max_attempts:
             attempt += 1
 
@@ -579,7 +587,6 @@ class task:
             if _m:
                 _m.record_task_retry(ctx.workflow_namespace, ctx.workflow_name, self.name)
 
-            current_delay = self.retry_delay
             retry_args = {
                 "current_attempt": attempt,
                 "max_attempts": self.retry_max_attempts,
@@ -589,10 +596,6 @@ class task:
 
             try:
                 await asyncio.sleep(current_delay)
-                current_delay = min(
-                    current_delay * self.retry_backoff,
-                    600,
-                )
 
                 ctx.events.append(
                     ExecutionEvent(
@@ -602,7 +605,21 @@ class task:
                         value=retry_args,
                     ),
                 )
-                output = await maybe_awaitable(self._func(*args, **kwargs))
+                if self.timeout > 0:
+                    try:
+                        output = await asyncio.wait_for(
+                            maybe_awaitable(self._func(*args, **kwargs)),
+                            timeout=self.timeout,
+                        )
+                    except TimeoutError as ex:
+                        raise ExecutionTimeoutError(
+                            "Task",
+                            self.name,
+                            task_id,
+                            self.timeout,
+                        ) from ex
+                else:
+                    output = await maybe_awaitable(self._func(*args, **kwargs))
                 ctx.events.append(
                     ExecutionEvent(
                         type=ExecutionEventType.TASK_RETRY_COMPLETED,
@@ -639,3 +656,4 @@ class task:
                         self.retry_delay,
                         self.retry_backoff,
                     )
+                current_delay = min(current_delay * self.retry_backoff, 600)

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -71,7 +71,7 @@ async def agent(
         max_concurrent_tools: Maximum number of tools to run concurrently when
             the LLM emits multiple tool calls in a single turn. None means
             unlimited. Defaults to None.
-        max_tokens: Maximum tokens in the LLM response (used by Anthropic and Google, ignored by others).
+        max_tokens: Maximum tokens in the LLM response (used by OpenAI, Anthropic, and Google; ignored by Ollama).
         stream: If True, enable streaming responses. Automatically disabled when response_format is set.
         on_complete: List of hook callables fired after the agent returns.
             Signature: ``async (agent_id: str, value: Any) -> None``. Sync hooks are also supported.
@@ -202,6 +202,7 @@ async def agent(
             model_name,
             response_format=response_format,
             reasoning_effort=reasoning_effort,
+            max_tokens=max_tokens,
         )
 
         tool_schemas = build_tool_schemas(tools) if tools else None
@@ -241,6 +242,7 @@ async def agent(
             model_name,
             max_tokens=max_tokens,
             reasoning_effort=reasoning_effort,
+            response_format=response_format,
         )
 
         tool_schemas = build_tool_schemas(tools) if tools else None

--- a/flux/tasks/ai/agent_loop.py
+++ b/flux/tasks/ai/agent_loop.py
@@ -140,6 +140,11 @@ async def run_agent_loop(
 
     messages, call_kwargs = formatter.build_messages(sys_prompt, user_content, working_memory)
 
+    if response_format and not tools:
+        # Let providers with native structured-output support enforce the
+        # schema at the API level rather than relying only on the prompt.
+        formatter.apply_structured_output(response_format, call_kwargs)
+
     if tool_schemas:
         call_kwargs["tools"] = tool_schemas
 

--- a/flux/tasks/ai/anthropic.py
+++ b/flux/tasks/ai/anthropic.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -12,11 +13,17 @@ try:
 except ImportError:
     AsyncAnthropic = None  # type: ignore[assignment,misc]
 
+# Synthetic tool used to force Anthropic to emit schema-valid structured
+# output. Anthropic has no response_format parameter, so a forced tool call
+# is the API-level way to constrain the response shape.
+_STRUCTURED_TOOL_NAME = "respond_with_structured_output"
+
 
 def build_anthropic_provider(
     model_name: str,
     max_tokens: int = 4096,
     reasoning_effort: str | None = None,
+    response_format: Any | None = None,
 ) -> tuple[task, LLMFormatter]:
     if AsyncAnthropic is None:
         raise ImportError(
@@ -33,7 +40,13 @@ def build_anthropic_provider(
         )
         return _to_llm_response(response)
 
-    formatter = AnthropicFormatter(client, model_name, max_tokens, reasoning_effort)
+    formatter = AnthropicFormatter(
+        client,
+        model_name,
+        max_tokens,
+        reasoning_effort,
+        response_format,
+    )
     return anthropic_llm, formatter
 
 
@@ -44,15 +57,33 @@ class AnthropicFormatter(LLMFormatter):
         model_name: str,
         max_tokens: int,
         reasoning_effort: str | None = None,
+        response_format: Any | None = None,
     ) -> None:
         self._client = client
         self._model_name = model_name
         self._max_tokens = max_tokens
         self._reasoning_effort = reasoning_effort
+        self._response_format = response_format
+
+    def apply_structured_output(self, response_format: Any, call_kwargs: dict) -> None:
+        # Force a single tool call whose input_schema is the requested model;
+        # the API then guarantees schema-valid output.
+        call_kwargs["tools"] = [
+            {
+                "name": _STRUCTURED_TOOL_NAME,
+                "description": (
+                    "Return the final answer as structured data matching the "
+                    "required schema. You must call this tool to respond."
+                ),
+                "input_schema": response_format.model_json_schema(),
+            },
+        ]
+        call_kwargs["tool_choice"] = {"type": "tool", "name": _STRUCTURED_TOOL_NAME}
+        # Forced tool use is incompatible with extended thinking.
+        call_kwargs.pop("thinking", None)
+        call_kwargs.pop("output_config", None)
 
     def _convert_memory_messages(self, memory_messages: list[dict]) -> list[dict]:
-        import json
-
         converted = []
         pending_reasoning: dict | None = None
         for msg in memory_messages:
@@ -220,9 +251,14 @@ def _to_llm_response(response: Any) -> LLMResponse:
         elif block.type == "text":
             text_parts.append(block.text)
         elif block.type == "tool_use":
-            tool_calls.append(
-                ToolCall(id=block.id, name=block.name, arguments=block.input),
-            )
+            if block.name == _STRUCTURED_TOOL_NAME:
+                # Surface the forced structured-output tool as plain text so
+                # the agent loop validates it like any other final answer.
+                text_parts.append(json.dumps(block.input))
+            else:
+                tool_calls.append(
+                    ToolCall(id=block.id, name=block.name, arguments=block.input),
+                )
     return LLMResponse(
         text="\n".join(text_parts) if text_parts else "",
         tool_calls=tool_calls,

--- a/flux/tasks/ai/anthropic.py
+++ b/flux/tasks/ai/anthropic.py
@@ -67,7 +67,13 @@ class AnthropicFormatter(LLMFormatter):
 
     def apply_structured_output(self, response_format: Any, call_kwargs: dict) -> None:
         # Force a single tool call whose input_schema is the requested model;
-        # the API then guarantees schema-valid output.
+        # the API then guarantees schema-valid output. This commandeers the
+        # "tools"/"tool_choice" kwargs, so it is mutually exclusive with caller
+        # tool use — the agent loop guarantees this by only invoking us when no
+        # tools are configured. Assert it so a future caller change fails loud.
+        assert "tools" not in call_kwargs, (
+            "apply_structured_output cannot be combined with tool use"
+        )
         call_kwargs["tools"] = [
             {
                 "name": _STRUCTURED_TOOL_NAME,

--- a/flux/tasks/ai/formatter.py
+++ b/flux/tasks/ai/formatter.py
@@ -55,3 +55,15 @@ class LLMFormatter(ABC):
         on_reasoning_token: Any,
     ) -> Any:
         raise NotImplementedError
+
+    def apply_structured_output(
+        self,
+        response_format: Any,
+        call_kwargs: dict,
+    ) -> None:
+        """Configure provider-native structured output, if supported.
+
+        Default is a no-op: providers without native enforcement rely on the
+        schema the agent loop appends to the prompt. Providers that can
+        enforce the schema at the API level override this method.
+        """

--- a/flux/tasks/ai/ollama.py
+++ b/flux/tasks/ai/ollama.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import AsyncIterator
 from typing import Any
 from uuid import uuid4
@@ -12,6 +13,8 @@ from flux.tasks.ai.tool_executor import (
     extract_tool_calls_from_content,
     strip_tool_calls_from_content,
 )
+
+logger = logging.getLogger("flux.tasks.ai.ollama")
 
 try:
     from ollama import AsyncClient
@@ -113,12 +116,22 @@ class OllamaFormatter(LLMFormatter):
             schema_json = json.dumps(self._response_format.model_json_schema())
             messages[-1]["content"] += f"\n\nRespond with JSON matching this schema:\n{schema_json}"
             call_kwargs["format"] = "json"
+        elif self._response_format and self._tool_names:
+            logger.warning(
+                "Ollama: response_format is ignored when tools are in use; "
+                "the model output will not be constrained to the schema.",
+            )
 
         if self._tool_names:
             call_kwargs["tool_names"] = self._tool_names
 
         if self._reasoning_effort is not None:
-            call_kwargs["think"] = True
+            # Preserve effort granularity for models that accept a level;
+            # fall back to a boolean for models that only support on/off.
+            if self._reasoning_effort in ("low", "medium", "high"):
+                call_kwargs["think"] = self._reasoning_effort
+            else:
+                call_kwargs["think"] = True
 
         return messages, call_kwargs
 

--- a/flux/tasks/ai/openai.py
+++ b/flux/tasks/ai/openai.py
@@ -18,6 +18,7 @@ def build_openai_provider(
     model_name: str,
     response_format: Any | None = None,
     reasoning_effort: str | None = None,
+    max_tokens: int | None = None,
 ) -> tuple[task, LLMFormatter]:
     if AsyncOpenAI is None:
         raise ImportError(
@@ -34,7 +35,13 @@ def build_openai_provider(
         )
         return _to_llm_response(response)
 
-    formatter = OpenAIFormatter(client, model_name, response_format, reasoning_effort)
+    formatter = OpenAIFormatter(
+        client,
+        model_name,
+        response_format,
+        reasoning_effort,
+        max_tokens,
+    )
     return openai_llm, formatter
 
 
@@ -47,11 +54,13 @@ class OpenAIFormatter(LLMFormatter):
         model_name: str,
         response_format: Any | None = None,
         reasoning_effort: str | None = None,
+        max_tokens: int | None = None,
     ) -> None:
         self._client = client
         self._model_name = model_name
         self._response_format = response_format
         self._reasoning_effort = reasoning_effort
+        self._max_tokens = max_tokens
 
     def _convert_memory_messages(self, memory_messages: list[dict]) -> list[dict]:
         converted = []
@@ -122,6 +131,9 @@ class OpenAIFormatter(LLMFormatter):
             ]
 
         call_kwargs: dict[str, Any] = {"model": self._model_name}
+
+        if self._max_tokens:
+            call_kwargs["max_completion_tokens"] = self._max_tokens
 
         if self._response_format:
             call_kwargs["response_format"] = {

--- a/flux/tasks/ai/openai.py
+++ b/flux/tasks/ai/openai.py
@@ -132,22 +132,27 @@ class OpenAIFormatter(LLMFormatter):
 
         call_kwargs: dict[str, Any] = {"model": self._model_name}
 
+        # max_completion_tokens is the unified token cap in the OpenAI v2 SDK;
+        # it is accepted by both reasoning and non-reasoning models.
         if self._max_tokens:
             call_kwargs["max_completion_tokens"] = self._max_tokens
-
-        if self._response_format:
-            call_kwargs["response_format"] = {
-                "type": "json_schema",
-                "json_schema": {
-                    "name": self._response_format.__name__,
-                    "schema": self._response_format.model_json_schema(),
-                },
-            }
 
         if self._reasoning_effort:
             call_kwargs["reasoning_effort"] = self._reasoning_effort
 
         return messages, call_kwargs
+
+    def apply_structured_output(self, response_format: Any, call_kwargs: dict) -> None:
+        # OpenAI enforces structured output natively via response_format. Wired
+        # through this hook (rather than build_messages) so every provider
+        # exposes structured output the same way to the agent loop.
+        call_kwargs["response_format"] = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": response_format.__name__,
+                "schema": response_format.model_json_schema(),
+            },
+        }
 
     def format_assistant_message(self, response: LLMResponse) -> dict:
         msg: dict[str, Any] = {"role": "assistant", "content": response.text or None}

--- a/flux/tasks/builtins.py
+++ b/flux/tasks/builtins.py
@@ -23,7 +23,7 @@ async def uuid4() -> uuid.UUID:
 
 
 @task
-async def choice(options: list[Any]) -> int:
+async def choice(options: list[Any]) -> Any:
     return random.choice(options)
 
 

--- a/flux/tasks/graph.py
+++ b/flux/tasks/graph.py
@@ -26,12 +26,17 @@ class Graph:
         def __hash__(self):
             return hash(self.name)
 
+    # Name constants only — never store these in an instance's _nodes, or the
+    # mutable upstream/state would be shared across every Graph in the process.
     START = Node(name="START", action=default_action)
     END = Node(name="END", action=default_action)
 
     def __init__(self, name: str):
         self._name = name
-        self._nodes: dict[str, Graph.Node] = {"START": Graph.START, "END": Graph.END}
+        self._nodes: dict[str, Graph.Node] = {
+            "START": Graph.Node(name="START", action=default_action),
+            "END": Graph.Node(name="END", action=default_action),
+        }
 
     def start_with(self, node: str) -> Graph:
         self.add_edge(Graph.START.name, node)
@@ -90,7 +95,31 @@ class Graph:
         if len(visited) != len(self._nodes):
             raise ValueError("Not all nodes are connected.")
 
+        self.__detect_cycle()
+
         return self
+
+    def __detect_cycle(self) -> None:
+        # Colour-based DFS over downstream edges: a GREY node reached again
+        # means a back-edge, i.e. a cycle. Without this a cyclic graph would
+        # pass validation and blow up at runtime with RecursionError.
+        white, grey, black = 0, 1, 2
+        color: dict[str, int] = dict.fromkeys(self._nodes, white)
+
+        def visit(name: str) -> None:
+            color[name] = grey
+            for dnode in self.__get_downstream(self._nodes[name]):
+                if color[dnode.name] == grey:
+                    raise ValueError(
+                        f"Graph contains a cycle involving node '{dnode.name}'.",
+                    )
+                if color[dnode.name] == white:
+                    visit(dnode.name)
+            color[name] = black
+
+        for node_name in self._nodes:
+            if color[node_name] == white:
+                visit(node_name)
 
     @task.with_options(name="graph_{self._name}")
     async def __call__(self, input: Any | None = None):
@@ -100,7 +129,7 @@ class Graph:
 
     async def __execute_node(self, name: str, input: Any | None = None):
         node = self._nodes[name]
-        if self.__can_execute(node):
+        if await self.__can_execute(node):
             upstream_outputs = (
                 [input]
                 if name == Graph.START.name

--- a/flux/tasks/graph.py
+++ b/flux/tasks/graph.py
@@ -102,24 +102,33 @@ class Graph:
     def __detect_cycle(self) -> None:
         # Colour-based DFS over downstream edges: a GREY node reached again
         # means a back-edge, i.e. a cycle. Without this a cyclic graph would
-        # pass validation and blow up at runtime with RecursionError.
+        # pass validation and blow up at runtime with RecursionError. Uses an
+        # explicit stack so deep linear graphs don't hit the recursion limit.
         white, grey, black = 0, 1, 2
         color: dict[str, int] = dict.fromkeys(self._nodes, white)
 
-        def visit(name: str) -> None:
-            color[name] = grey
-            for dnode in self.__get_downstream(self._nodes[name]):
-                if color[dnode.name] == grey:
-                    raise ValueError(
-                        f"Graph contains a cycle involving node '{dnode.name}'.",
-                    )
-                if color[dnode.name] == white:
-                    visit(dnode.name)
-            color[name] = black
-
-        for node_name in self._nodes:
-            if color[node_name] == white:
-                visit(node_name)
+        for root in self._nodes:
+            if color[root] != white:
+                continue
+            # Each entry is (name, exiting): exiting=True is the post-order
+            # sentinel pushed beneath a node's children to mark it black.
+            stack: list[tuple[str, bool]] = [(root, False)]
+            while stack:
+                name, exiting = stack.pop()
+                if exiting:
+                    color[name] = black
+                    continue
+                if color[name] != white:
+                    continue
+                color[name] = grey
+                stack.append((name, True))
+                for dnode in self.__get_downstream(self._nodes[name]):
+                    if color[dnode.name] == grey:
+                        raise ValueError(
+                            f"Graph contains a cycle involving node '{dnode.name}'.",
+                        )
+                    if color[dnode.name] == white:
+                        stack.append((dnode.name, False))
 
     @task.with_options(name="graph_{self._name}")
     async def __call__(self, input: Any | None = None):

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -113,19 +113,6 @@ class Worker:
         logger.debug(f"Worker name: {self.name}")
         logger.debug(f"Server URL: {self.base_url}")
 
-        # systemd/Docker/k8s stop containers with SIGTERM, not SIGINT. Route it
-        # through the same KeyboardInterrupt path so the worker drains and runs
-        # its shutdown finally-block instead of being hard-killed.
-        def _handle_sigterm(_signum, _frame):
-            logger.info("Worker received SIGTERM, shutting down...")
-            raise KeyboardInterrupt
-
-        try:
-            signal.signal(signal.SIGTERM, _handle_sigterm)
-        except ValueError:
-            # signal.signal only works on the main thread; ignore otherwise.
-            logger.debug("Could not install SIGTERM handler (not main thread)")
-
         obs_config = Configuration.get().settings.observability
         if obs_config.enabled:
             from flux.observability import setup as setup_observability
@@ -135,8 +122,8 @@ class Worker:
 
         try:
             asyncio.run(self._run())
-        except KeyboardInterrupt:
-            logger.info("Worker interrupted by user")
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            logger.info("Worker shutdown requested")
         finally:
             try:
                 from flux.observability import shutdown as shutdown_observability
@@ -153,6 +140,27 @@ class Worker:
         On reconnect, skips registration and reuses the existing session token.
         If the server rejects the token (401/403), falls back to full re-registration.
         """
+        # systemd/Docker/k8s stop containers with SIGTERM, not SIGINT. Register
+        # cooperative loop-level handlers so a stop signal cancels the worker at
+        # an await boundary — letting in-flight checkpoints and shutdown
+        # finally-blocks run — instead of raising KeyboardInterrupt at an
+        # arbitrary bytecode point mid-coroutine.
+        loop = asyncio.get_running_loop()
+        main_task = asyncio.current_task()
+
+        def _request_shutdown(signame: str) -> None:
+            logger.info(f"Worker received {signame}, shutting down...")
+            if main_task is not None:
+                main_task.cancel()
+
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            try:
+                loop.add_signal_handler(sig, _request_shutdown, sig.name)
+            except (NotImplementedError, RuntimeError, ValueError):
+                # Unsupported on Windows / outside the main thread; the default
+                # SIGINT->KeyboardInterrupt behaviour still applies there.
+                logger.debug(f"Could not install {sig.name} handler via event loop")
+
         backoff = 1
         while True:
             try:

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -5,6 +5,7 @@ import base64
 import importlib
 import platform
 import random
+import signal
 import sys
 import time
 from collections.abc import Awaitable
@@ -111,6 +112,19 @@ class Worker:
         logger.info("Worker starting up...")
         logger.debug(f"Worker name: {self.name}")
         logger.debug(f"Server URL: {self.base_url}")
+
+        # systemd/Docker/k8s stop containers with SIGTERM, not SIGINT. Route it
+        # through the same KeyboardInterrupt path so the worker drains and runs
+        # its shutdown finally-block instead of being hard-killed.
+        def _handle_sigterm(_signum, _frame):
+            logger.info("Worker received SIGTERM, shutting down...")
+            raise KeyboardInterrupt
+
+        try:
+            signal.signal(signal.SIGTERM, _handle_sigterm)
+        except ValueError:
+            # signal.signal only works on the main thread; ignore otherwise.
+            logger.debug("Could not install SIGTERM handler (not main thread)")
 
         obs_config = Configuration.get().settings.observability
         if obs_config.enabled:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.34.0"
+version = "0.35.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/observability/test_config.py
+++ b/tests/flux/observability/test_config.py
@@ -9,10 +9,22 @@ class TestObservabilityConfig:
         assert config.enabled is False
         assert config.service_name == "flux"
         assert config.otlp_endpoint is None
+        assert config.otlp_protocol == "grpc"
         assert config.prometheus_enabled is True
         assert config.trace_sample_rate == 1.0
         assert config.metric_export_interval == 60
         assert config.resource_attributes == {}
+
+    def test_otlp_protocol_http(self):
+        config = ObservabilityConfig(otlp_protocol="http")
+        assert config.otlp_protocol == "http"
+
+    def test_otlp_protocol_rejects_unknown(self):
+        import pytest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ObservabilityConfig(otlp_protocol="thrift")
 
     def test_custom_values(self):
         config = ObservabilityConfig(

--- a/tests/flux/tasks/ai/test_anthropic_provider.py
+++ b/tests/flux/tasks/ai/test_anthropic_provider.py
@@ -331,3 +331,55 @@ def test_format_assistant_message_empty_response():
 
         assert msg["role"] == "assistant"
         assert msg["content"] == []
+
+
+def test_apply_structured_output_forces_tool():
+    """Anthropic enforces structured output via a forced tool call rather than
+    only a prompt instruction."""
+    from pydantic import BaseModel
+
+    class Answer(BaseModel):
+        value: int
+
+    with patch("flux.tasks.ai.anthropic.AsyncAnthropic"):
+        from flux.tasks.ai.anthropic import (
+            _STRUCTURED_TOOL_NAME,
+            build_anthropic_provider,
+        )
+
+        _, formatter = build_anthropic_provider(
+            "claude-sonnet-4-20250514",
+            response_format=Answer,
+        )
+
+        call_kwargs: dict = {"model": "claude-sonnet-4-20250514", "max_tokens": 4096}
+        formatter.apply_structured_output(Answer, call_kwargs)
+
+        assert call_kwargs["tool_choice"] == {
+            "type": "tool",
+            "name": _STRUCTURED_TOOL_NAME,
+        }
+        assert call_kwargs["tools"][0]["name"] == _STRUCTURED_TOOL_NAME
+        assert call_kwargs["tools"][0]["input_schema"] == Answer.model_json_schema()
+
+
+def test_structured_tool_call_surfaces_as_text():
+    """A forced structured-output tool call is surfaced as JSON text so the
+    agent loop can validate it like any final answer."""
+    import json
+
+    from flux.tasks.ai.anthropic import _STRUCTURED_TOOL_NAME, _to_llm_response
+
+    structured_block = MagicMock()
+    structured_block.type = "tool_use"
+    structured_block.id = "tu_1"
+    structured_block.name = _STRUCTURED_TOOL_NAME
+    structured_block.input = {"value": 42}
+
+    response = MagicMock()
+    response.content = [structured_block]
+
+    result = _to_llm_response(response)
+
+    assert result.tool_calls == []
+    assert json.loads(result.text) == {"value": 42}

--- a/tests/flux/tasks/ai/test_openai_provider.py
+++ b/tests/flux/tasks/ai/test_openai_provider.py
@@ -353,7 +353,7 @@ def test_stream_yields_tokens():
     asyncio.run(run())
 
 
-def test_build_messages_with_response_format():
+def test_apply_structured_output_sets_response_format():
     with patch("flux.tasks.ai.openai.AsyncOpenAI"):
         from pydantic import BaseModel
 
@@ -365,8 +365,11 @@ def test_build_messages_with_response_format():
 
         _, formatter = build_openai_provider("gpt-4o", response_format=MyFormat)
 
-        messages, kwargs = formatter.build_messages("You are helpful.", "Hello")
+        # response_format is wired through the apply_structured_output hook
+        # (symmetric with the other providers), not build_messages.
+        _, kwargs = formatter.build_messages("You are helpful.", "Hello")
+        assert "response_format" not in kwargs
 
-        assert kwargs["model"] == "gpt-4o"
+        formatter.apply_structured_output(MyFormat, kwargs)
         assert kwargs["response_format"]["type"] == "json_schema"
         assert kwargs["response_format"]["json_schema"]["name"] == "MyFormat"

--- a/tests/flux/tasks/ai/test_openai_provider.py
+++ b/tests/flux/tasks/ai/test_openai_provider.py
@@ -41,6 +41,19 @@ def test_build_messages_basic():
             {"role": "user", "content": "Hello"},
         ]
         assert kwargs["model"] == "gpt-4o"
+        # No max_tokens configured ⇒ not sent.
+        assert "max_completion_tokens" not in kwargs
+
+
+def test_build_messages_passes_max_tokens():
+    with patch("flux.tasks.ai.openai.AsyncOpenAI"):
+        from flux.tasks.ai.openai import build_openai_provider
+
+        _, formatter = build_openai_provider("gpt-4o", max_tokens=512)
+
+        _, kwargs = formatter.build_messages("sys", "Hello")
+
+        assert kwargs["max_completion_tokens"] == 512
 
 
 def test_build_messages_with_working_memory():

--- a/tests/flux/tasks/ai/test_reasoning.py
+++ b/tests/flux/tasks/ai/test_reasoning.py
@@ -99,7 +99,17 @@ class TestOllamaReasoning:
     def test_reasoning_effort_adds_think_param(self):
         from flux.tasks.ai.ollama import OllamaFormatter
 
+        # A recognised effort level is passed through verbatim so models that
+        # support graded reasoning keep the distinction.
         formatter = OllamaFormatter("test-model", reasoning_effort="high")
+        wm = type("FakeWM", (), {"recall": lambda self: []})()
+        _, kwargs = formatter.build_messages("system", "question", wm)
+        assert kwargs.get("think") == "high"
+
+    def test_reasoning_effort_unknown_falls_back_to_bool(self):
+        from flux.tasks.ai.ollama import OllamaFormatter
+
+        formatter = OllamaFormatter("test-model", reasoning_effort="enabled")
         wm = type("FakeWM", (), {"recall": lambda self: []})()
         _, kwargs = formatter.build_messages("system", "question", wm)
         assert kwargs.get("think") is True

--- a/tests/flux/tasks/test_graph.py
+++ b/tests/flux/tasks/test_graph.py
@@ -1,0 +1,96 @@
+"""Tests for Graph cycle detection and conditional-edge evaluation."""
+
+from __future__ import annotations
+
+import pytest
+
+from flux import ExecutionContext
+from flux.task import task
+from flux.tasks import Graph
+from flux.workflow import workflow
+
+
+@task
+async def _passthrough(value=None):
+    return value
+
+
+@task
+async def _double(value) -> int:
+    return value * 2
+
+
+async def _always(_value) -> bool:
+    return True
+
+
+async def _never(_value) -> bool:
+    return False
+
+
+def test_validate_detects_cycle():
+    g = Graph("cyclic")
+    g.add_node("a", _passthrough)
+    g.add_node("b", _passthrough)
+    g.add_edge("a", "b")
+    g.add_edge("b", "a")
+    g.start_with("a")
+    g.end_with("b")
+
+    with pytest.raises(ValueError, match="cycle"):
+        g.validate()
+
+
+def test_validate_accepts_acyclic_graph():
+    g = Graph("acyclic")
+    g.add_node("a", _passthrough)
+    g.add_node("b", _passthrough)
+    g.add_edge("a", "b")
+    g.start_with("a")
+    g.end_with("b")
+
+    assert g.validate() is g
+
+
+@workflow
+async def _gated_true_wf(ctx: ExecutionContext[int]):
+    g = (
+        Graph("gated_true")
+        .add_node("a", _passthrough)
+        .add_node("b", _double)
+        .add_edge("a", "b", _always)
+        .start_with("a")
+        .end_with("b")
+    )
+    return await g(ctx.input)
+
+
+@workflow
+async def _gated_false_wf(ctx: ExecutionContext[int]):
+    g = (
+        Graph("gated_false")
+        .add_node("a", _passthrough)
+        .add_node("b", _double)
+        .add_edge("a", "b", _never)
+        .start_with("a")
+        .end_with("b")
+    )
+    return await g(ctx.input)
+
+
+def test_conditional_edge_true_runs_downstream():
+    ctx = _gated_true_wf.run(7)
+    assert ctx.has_finished and ctx.has_succeeded
+    ran = any("_double" in str(e.name) for e in ctx.events)
+    assert ran, "downstream node should run when the edge condition is true"
+    assert ctx.output == 14
+
+
+def test_conditional_edge_false_skips_downstream():
+    # __can_execute is async; before the fix it was never awaited, so the
+    # condition coroutine was always truthy and the downstream node ran
+    # regardless. A false condition must now prevent it.
+    ctx = _gated_false_wf.run(7)
+    assert ctx.has_finished and ctx.has_succeeded
+    ran = any("_double" in str(e.name) for e in ctx.events)
+    assert not ran, "downstream node ran despite a false edge condition"

--- a/tests/flux/test_config.py
+++ b/tests/flux/test_config.py
@@ -275,6 +275,25 @@ def test_shipped_flux_toml_does_not_hardcode_bootstrap_token():
     )
 
 
+def test_flux_config_flux_toml_overrides_pyproject():
+    """flux.toml must take precedence over pyproject.toml [tool.flux]."""
+    with patch.object(FluxConfig, "_load_from_config") as mock_flux_toml:
+        with patch.object(FluxConfig, "_load_from_pyproject") as mock_pyproject:
+            mock_flux_toml.return_value = {"log_level": "DEBUG"}
+            mock_pyproject.return_value = {"log_level": "ERROR"}
+
+            config = FluxConfig.load()
+
+            assert config.log_level == "DEBUG"
+
+
+def test_mcp_config_transport_default_matches_cli():
+    """MCPConfig.transport default must match the `flux start mcp` CLI default."""
+    from flux.config import MCPConfig
+
+    assert MCPConfig().transport == "streamable-http"
+
+
 @pytest.fixture
 def reset_configuration():
     """Fixture to reset the Configuration singleton before and after each test."""

--- a/tests/flux/test_retry_backoff.py
+++ b/tests/flux/test_retry_backoff.py
@@ -1,0 +1,79 @@
+"""Regression tests for task retry backoff and per-retry timeout."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+from flux import ExecutionContext
+from flux.domain.events import ExecutionEventType
+from flux.task import task
+from flux.workflow import workflow
+
+
+def test_retry_backoff_compounds(monkeypatch):
+    """retry_backoff must actually compound the delay across retries.
+
+    Previously current_delay was reset to retry_delay every iteration, so the
+    backoff multiplier never affected runtime behaviour.
+    """
+    real_sleep = asyncio.sleep
+
+    async def fast_sleep(_delay, *args, **kwargs):
+        # Keep the test fast; the assertion is on the recorded event metadata.
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+
+    calls = {"n": 0}
+
+    @task.with_options(retry_max_attempts=4, retry_delay=1, retry_backoff=3)
+    async def flaky():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ValueError("boom")
+        return "ok"
+
+    @workflow
+    async def backoff_wf(ctx: ExecutionContext):
+        return await flaky()
+
+    ctx = backoff_wf.run()
+
+    assert ctx.has_finished and ctx.has_succeeded
+    assert ctx.output == "ok"
+
+    retry_delays = [
+        e.value["current_delay"]
+        for e in ctx.events
+        if e.type == ExecutionEventType.TASK_RETRY_STARTED
+    ]
+    # First retry waits retry_delay, second waits retry_delay * retry_backoff.
+    assert retry_delays == [1, 3]
+
+
+def test_timeout_applies_to_retry_attempts():
+    """A task that hangs on a retry must be killed by its configured timeout
+    rather than hanging forever.
+    """
+    calls = {"n": 0}
+
+    @task.with_options(retry_max_attempts=3, retry_delay=1, retry_backoff=1, timeout=1)
+    async def hangs_on_retry():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ValueError("first attempt fails fast")
+        # Retry attempts hang — the timeout must cut them off.
+        await asyncio.sleep(3600)
+
+    @workflow
+    async def timeout_wf(ctx: ExecutionContext):
+        return await hangs_on_retry()
+
+    start = time.monotonic()
+    ctx = timeout_wf.run()
+    elapsed = time.monotonic() - start
+
+    assert ctx.has_finished and ctx.has_failed
+    # Without the fix the first retry would hang indefinitely.
+    assert elapsed < 30

--- a/tests/flux/test_schedule_manager_namespace.py
+++ b/tests/flux/test_schedule_manager_namespace.py
@@ -24,9 +24,10 @@ def _reset_config_singleton():
     DatabaseRepository._engines.clear()
 
 
-def test_schedule_history_scoped_by_namespace(tmp_path, monkeypatch):
-    """Two workflows with the same short name in different namespaces must
-    not share execution history via the schedule manager's query path.
+def test_schedule_history_scoped_by_schedule(tmp_path, monkeypatch):
+    """Schedule history is scoped to the originating schedule: executions of
+    the same workflow that were not dispatched by this schedule (manual runs,
+    other schedules, same-named workflows in other namespaces) must not leak.
     """
     monkeypatch.setenv("FLUX_DATABASE_URL", f"sqlite:///{tmp_path}/sched.db")
     from flux.models import DatabaseRepository
@@ -72,7 +73,7 @@ def test_schedule_history_scoped_by_namespace(tmp_path, monkeypatch):
         s.flush()
         sched_id = sm.id
 
-        # Insert one execution for billing/process
+        # Execution dispatched by this schedule — the only one that should appear
         s.add(
             ExecutionContextModel(
                 execution_id="e_billing",
@@ -81,9 +82,21 @@ def test_schedule_history_scoped_by_namespace(tmp_path, monkeypatch):
                 workflow_name="process",
                 input=None,
                 state=ExecutionState.COMPLETED,
+                schedule_id=sched_id,
             ),
         )
-        # Insert one execution for analytics/process — this MUST NOT leak into the billing query
+        # A manual run of the same workflow — no schedule_id, MUST NOT leak in
+        s.add(
+            ExecutionContextModel(
+                execution_id="e_manual",
+                workflow_id=billing_wf.id,
+                workflow_namespace="billing",
+                workflow_name="process",
+                input=None,
+                state=ExecutionState.COMPLETED,
+            ),
+        )
+        # An execution of the same-named workflow in another namespace
         s.add(
             ExecutionContextModel(
                 execution_id="e_analytics",

--- a/tests/flux/test_server_cancellation.py
+++ b/tests/flux/test_server_cancellation.py
@@ -440,7 +440,7 @@ class TestHealthEndpoint:
 
         response = test_client.get("/health")
 
-        assert response.status_code == 200
+        assert response.status_code == 503
         data = response.json()
         assert data["status"] == "unhealthy"
         assert data["database"] is False
@@ -530,7 +530,7 @@ class TestAPIEdgeCases:
 
         response = test_client.get("/health")
 
-        assert response.status_code == 200
+        assert response.status_code == 503
         data = response.json()
         assert data["status"] == "unhealthy"
 

--- a/tests/security/test_config.py
+++ b/tests/security/test_config.py
@@ -24,6 +24,22 @@ class TestAuthConfig:
         )
         assert config.enabled is False
 
+    def test_auth_enabled_is_a_settable_field(self):
+        # enabled is a real field (so FLUX_SECURITY__AUTH__ENABLED is honoured),
+        # not a derived read-only property.
+        config = AuthConfig(enabled=True, api_keys=APIKeyAuthConfig(enabled=True))
+        assert config.enabled is True
+
+    def test_auth_enabled_without_provider_is_rejected(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="no auth provider"):
+            AuthConfig(enabled=True)
+
+    def test_auth_can_be_explicitly_disabled(self):
+        config = AuthConfig(enabled=False)
+        assert config.enabled is False
+
     def test_oidc_defaults(self):
         config = OIDCConfig()
         assert config.roles_claim == "roles"

--- a/tests/security/test_server_auth_routes.py
+++ b/tests/security/test_server_auth_routes.py
@@ -54,7 +54,9 @@ class TestWorkflowExecutionsAuthEnforcement:
 
             settings = Configuration.get().settings
             original = settings.security.auth.api_keys.enabled
+            original_enabled = settings.security.auth.enabled
             settings.security.auth.api_keys.enabled = True
+            settings.security.auth.enabled = True
             try:
                 resp = client.get(
                     "/workflows/default/some_workflow/executions",
@@ -64,6 +66,7 @@ class TestWorkflowExecutionsAuthEnforcement:
                 assert resp.status_code in (401, 403)
             finally:
                 settings.security.auth.api_keys.enabled = original
+                settings.security.auth.enabled = original_enabled
 
     def test_executions_endpoint_allows_when_auth_disabled(self, client):
         """When auth is disabled, the endpoint should not require permissions."""

--- a/tests/security/test_worker_auth.py
+++ b/tests/security/test_worker_auth.py
@@ -137,7 +137,9 @@ class TestWorkerNameBinding:
 
         settings = Configuration.get().settings
         original = settings.security.auth.api_keys.enabled
+        original_enabled = settings.security.auth.enabled
         settings.security.auth.api_keys.enabled = True
+        settings.security.auth.enabled = True
         try:
             with _mock_auth(identity):
                 resp = client.post(
@@ -148,6 +150,7 @@ class TestWorkerNameBinding:
                 assert "mismatch" in resp.json()["detail"].lower()
         finally:
             settings.security.auth.api_keys.enabled = original
+            settings.security.auth.enabled = original_enabled
 
     def test_pong_allows_identity_match(self, client):
         identity = FluxIdentity(
@@ -158,7 +161,9 @@ class TestWorkerNameBinding:
 
         settings = Configuration.get().settings
         original = settings.security.auth.api_keys.enabled
+        original_enabled = settings.security.auth.enabled
         settings.security.auth.api_keys.enabled = True
+        settings.security.auth.enabled = True
         try:
             with _mock_auth(identity):
                 resp = client.post(
@@ -168,6 +173,7 @@ class TestWorkerNameBinding:
                 assert resp.status_code == 200
         finally:
             settings.security.auth.api_keys.enabled = original
+            settings.security.auth.enabled = original_enabled
 
     def test_pong_skips_name_check_when_auth_disabled(self, client):
         from flux.config import Configuration
@@ -175,14 +181,17 @@ class TestWorkerNameBinding:
         settings = Configuration.get().settings
         original_oidc = settings.security.auth.oidc.enabled
         original_keys = settings.security.auth.api_keys.enabled
+        original_enabled = settings.security.auth.enabled
         settings.security.auth.oidc.enabled = False
         settings.security.auth.api_keys.enabled = False
+        settings.security.auth.enabled = False
         try:
             resp = client.post("/workers/any-name/pong")
             assert resp.status_code != 403
         finally:
             settings.security.auth.oidc.enabled = original_oidc
             settings.security.auth.api_keys.enabled = original_keys
+            settings.security.auth.enabled = original_enabled
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Retry/task execution:
- retry_backoff now compounds across attempts instead of resetting each loop
- task timeout is applied to retry attempts, not just the first call

Graph:
- conditional edges are now awaited (were always-truthy coroutines)
- validate() detects cycles instead of failing at runtime with RecursionError
- START/END are per-instance nodes (were shared class-level mutable state)

Built-ins:
- choice() return annotation corrected to Any

Scheduling:
- flux schedule history CLI no longer crashes on non-empty results
- ScheduleHistoryResponse started_at/completed_at populated from the event log
- history is scoped to the originating schedule via executions.schedule_id

Observability:
- failed task spans set ERROR status
- trace context propagated to resumed/cancelled executions, not just scheduled
- OTLP exporter protocol (grpc/http) is configurable

Health/server:
- /health returns HTTP 503 when the database is unreachable

Configuration:
- flux.toml now correctly takes precedence over pyproject.toml
- FLUX_SECURITY__AUTH__ENABLED is a real settable field; enabling auth
  without a configured provider is now rejected
- MCPConfig.transport default aligned with the CLI ("streamable-http")

Worker lifecycle:
- SIGTERM is handled for graceful shutdown under systemd/Docker/k8s

LLM providers:
- Ollama warns when response_format is dropped due to tools
- Ollama reasoning_effort preserves low/medium/high granularity
- Anthropic structured output is API-enforced via a forced tool call
- OpenAI provider honors max_tokens