### PR TITLE
fix: derive task_id deterministically so completed tasks replay across processes

### DIFF
--- a/flux/task.py
+++ b/flux/task.py
@@ -6,11 +6,13 @@ from flux.domain.events import ExecutionEvent, ExecutionEventType
 from flux.errors import ExecutionError, ExecutionTimeoutError, PauseRequested, RetryError
 from flux.output_storage import InlineOutputStorage, OutputStorage, OutputStorageReference
 from flux.secret_managers import SecretManager
-from flux.utils import get_func_args, make_hashable, maybe_awaitable
+from flux.utils import get_func_args, make_deterministic, maybe_awaitable
 
 
 import asyncio
+import hashlib
 import inspect
+import json
 import time
 from functools import wraps
 from typing import Any, TypeVar
@@ -137,11 +139,28 @@ class task:
             **kwargs,
         )
 
+    @staticmethod
+    def _compute_task_id(full_name: str, task_args: dict, args: tuple, kwargs: dict) -> str:
+        """Deterministic, cross-process-stable id for a task call.
+
+        This is the source_id the replay short-circuit matches on and the
+        approval gate's call_id, so it must be identical in every process. SHA256
+        over a canonical form — builtin hash() is per-process randomized (the
+        same defect was already fixed for event ids; see flux/domain/events.py).
+        """
+        canonical = json.dumps(
+            make_deterministic([full_name, task_args, args, kwargs]),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+        return f"{full_name}_{digest}"
+
     async def __call__(self, *args, **kwargs) -> Any:
         task_args = get_func_args(self._func, args)
         full_name = self.name.format(**task_args)
 
-        task_id = f"{full_name}_{abs(hash((full_name, make_hashable(task_args), make_hashable(args), make_hashable(kwargs))))}"
+        task_id = self._compute_task_id(full_name, task_args, args, kwargs)
 
         ctx = await ExecutionContext.get()
 

--- a/flux/utils.py
+++ b/flux/utils.py
@@ -111,7 +111,9 @@ def make_deterministic(item):
     elif isinstance(item, AsyncGeneratorType):
         frame, code = item.ag_frame, item.ag_code
     if code is not None:
-        fn_qualname = getattr(code, "co_qualname", code.co_name)
+        qual = getattr(code, "co_qualname", code.co_name)
+        module = frame.f_globals.get("__name__", "") if frame is not None else ""
+        fn_qualname = f"{module}.{qual}" if module else qual
         if frame is not None:
             try:
                 argcount = code.co_argcount + code.co_kwonlyargcount
@@ -146,7 +148,10 @@ def make_deterministic(item):
     if isinstance(obj_dict, dict):
         return {"__object__": qualname, "fields": make_deterministic(obj_dict)}
 
-    slot_names = [s for cls in type(item).__mro__ for s in getattr(cls, "__slots__", ())]
+    slot_names = []
+    for cls in type(item).__mro__:
+        slots = getattr(cls, "__slots__", ())
+        slot_names.extend((slots,) if isinstance(slots, str) else slots)
     if slot_names:
         slots = {s: getattr(item, s) for s in slot_names if hasattr(item, s)}
         return {"__object__": qualname, "fields": make_deterministic(slots)}

--- a/flux/utils.py
+++ b/flux/utils.py
@@ -1,17 +1,23 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 import sys
 import inspect
 import json
 import re
 import uuid
+from datetime import date
 from datetime import datetime
+from datetime import time
 from datetime import timedelta
+from decimal import Decimal
 from enum import Enum
 from importlib import import_module as imodule
 from importlib import util
 from pathlib import Path
+from types import AsyncGeneratorType
+from types import CoroutineType
 from types import GeneratorType
 from typing import Any
 from collections.abc import Callable
@@ -57,6 +63,99 @@ def is_hashable(obj) -> bool:
         return True
     except TypeError:
         return False
+
+
+def make_deterministic(item):
+    """Reduce *item* to a canonical, JSON-serialisable form for cross-process
+    identity hashing. Unlike make_hashable (which leans on per-process-randomized
+    hash()), dict/set ordering is normalised and objects are reduced to their
+    fields; opaque objects raise TypeError instead of degrading to an
+    address-dependent repr.
+    """
+    if item is None or isinstance(item, (bool, int, float, str)):
+        return item
+    if isinstance(item, complex):
+        return {"__complex__": [item.real, item.imag]}
+    if isinstance(item, (bytes, bytearray)):
+        return {"__bytes__": bytes(item).hex()}
+    if isinstance(item, Enum):
+        return make_deterministic(item.value)
+    if isinstance(item, dict):
+        pairs = [[make_deterministic(k), make_deterministic(v)] for k, v in item.items()]
+        pairs.sort(key=lambda kv: json.dumps(kv[0], sort_keys=True))
+        return {"__dict__": pairs}
+    if isinstance(item, (list, tuple)):
+        return [make_deterministic(i) for i in item]
+    if isinstance(item, (set, frozenset)):
+        elems = [make_deterministic(i) for i in item]
+        elems.sort(key=lambda e: json.dumps(e, sort_keys=True))
+        return {"__set__": elems}
+    if isinstance(item, (datetime, date, time)):
+        return item.isoformat()
+    if isinstance(item, timedelta):
+        return item.total_seconds()
+    if isinstance(item, Decimal):
+        return str(item)
+    if isinstance(item, uuid.UUID):
+        return str(item)
+    if isinstance(item, Path):
+        return str(item)
+
+    # Coroutines/generators (passed to parallel()/pipeline()): key by the
+    # function's qualified name plus its not-yet-started bound arguments.
+    frame, code = None, None
+    if isinstance(item, CoroutineType):
+        frame, code = item.cr_frame, item.cr_code
+    elif isinstance(item, GeneratorType):
+        frame, code = item.gi_frame, item.gi_code
+    elif isinstance(item, AsyncGeneratorType):
+        frame, code = item.ag_frame, item.ag_code
+    if code is not None:
+        fn_qualname = getattr(code, "co_qualname", code.co_name)
+        if frame is not None:
+            try:
+                argcount = code.co_argcount + code.co_kwonlyargcount
+                names = code.co_varnames[:argcount]
+                bound = {n: frame.f_locals[n] for n in names if n in frame.f_locals}
+                return {"__call__": fn_qualname, "args": make_deterministic(bound)}
+            except Exception:
+                pass
+        return {"__call__": fn_qualname}
+
+    qualname = f"{type(item).__module__}.{type(item).__qualname__}"
+
+    model_dump = getattr(item, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return {"__model__": qualname, "fields": make_deterministic(model_dump(mode="python"))}
+        except Exception:
+            pass
+
+    if dataclasses.is_dataclass(item) and not isinstance(item, type):
+        return {"__dataclass__": qualname, "fields": make_deterministic(dataclasses.asdict(item))}
+
+    if type(item).__name__ in ("DataFrame", "Series") and hasattr(item, "to_csv"):
+        return {"__pandas__": qualname, "csv": item.to_csv()}
+
+    if callable(item):
+        name = getattr(item, "__qualname__", None) or getattr(item, "__name__", None)
+        if name:
+            return {"__callable__": f"{getattr(item, '__module__', '')}.{name}"}
+
+    obj_dict = getattr(item, "__dict__", None)
+    if isinstance(obj_dict, dict):
+        return {"__object__": qualname, "fields": make_deterministic(obj_dict)}
+
+    slot_names = [s for cls in type(item).__mro__ for s in getattr(cls, "__slots__", ())]
+    if slot_names:
+        slots = {s: getattr(item, s) for s in slot_names if hasattr(item, s)}
+        return {"__object__": qualname, "fields": make_deterministic(slots)}
+
+    raise TypeError(
+        f"Cannot compute a deterministic task id for argument of type {qualname!r}. "
+        "Pass a value-based type (primitive, dict, list, set, dataclass, Pydantic "
+        "model, or an object with __dict__/__slots__) instead of an opaque object.",
+    )
 
 
 def to_json(obj):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.36.0"
+version = "0.36.1"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/e2e/fixtures/handoff_workflow.py
+++ b/tests/e2e/fixtures/handoff_workflow.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from flux import ExecutionContext, task, workflow
+from flux.tasks import pause
+
+
+@task
+async def record(path: str, tag: str):
+    with open(path, "a") as f:
+        f.write(tag + "\n")
+    return tag
+
+
+@workflow.with_options(affinity={"role": "handoff"})
+async def handoff_workflow(ctx: ExecutionContext):
+    path = ctx.input
+    await record(path, "a")
+    await record(path, "b")
+    await pause("gate")
+    await record(path, "c")
+    return "done"

--- a/tests/e2e/test_task_id_worker_handoff.py
+++ b/tests/e2e/test_task_id_worker_handoff.py
@@ -1,0 +1,88 @@
+"""Distributed cross-process replay guard.
+
+A workflow runs on a worker, pauses, then the worker is restarted as a new
+process with a different PYTHONHASHSEED (modelling a redeploy/crash-restart
+while the execution is paused) and resumes the execution. Pre-pause tasks must
+replay, not re-execute. Exercises the full server+worker path (SSE claim, HTTP
+checkpoint round-trip, sticky resume routing) on top of the deterministic
+task_id fix: under the old per-process hash() task ids, the restarted worker
+recomputed different ids, missed the replay short-circuit, and re-ran every
+pre-pause task.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+FIXTURES = Path(__file__).parent / "fixtures"
+WORKER = "handoff-worker"
+
+
+def _lines(p: Path) -> list[str]:
+    return [ln for ln in p.read_text().splitlines() if ln]
+
+
+def _is_online(cli) -> bool:
+    return any(w.get("name") == WORKER and w.get("status") == "online" for w in cli.worker_list())
+
+
+def _wait(cli, online: bool, timeout: int = 60):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _is_online(cli) is online:
+            return
+        time.sleep(1)
+    raise TimeoutError(f"worker {WORKER} did not become {'online' if online else 'offline'}")
+
+
+def test_completed_tasks_replay_on_worker_restart(cli):
+    counter = Path(tempfile.mkdtemp(prefix="flux-handoff-")) / "exec.log"
+    counter.write_text("")
+    cli.register(str(FIXTURES / "handoff_workflow.py"))
+
+    orig_seed = cli._env.get("PYTHONHASHSEED")
+    worker = None
+    try:
+        # Run on the worker (seed 0): records a + b, then pauses.
+        cli._env["PYTHONHASHSEED"] = "0"
+        worker = cli.start_worker(WORKER, labels={"role": "handoff"})
+        _wait(cli, online=True)
+
+        r = cli.run("handoff_workflow", json.dumps(str(counter)), mode="async", timeout=30)
+        exec_id = r["execution_id"]
+        s = cli.wait_for_state("handoff_workflow", exec_id, "PAUSED", timeout=60)
+        assert s.get("current_worker") == WORKER
+        assert _lines(counter) == ["a", "b"]
+
+        # Restart the same worker name in a new process with a different hash
+        # seed; sequence the disconnect before the reconnect to avoid a
+        # same-name registration race.
+        cli.stop_worker(worker)
+        worker = None
+        _wait(cli, online=False, timeout=30)
+        cli._env["PYTHONHASHSEED"] = "1"
+        worker = cli.start_worker(WORKER, labels={"role": "handoff"})
+        _wait(cli, online=True)
+
+        cli.resume("handoff_workflow", exec_id)
+        final = cli.wait_for_state("handoff_workflow", exec_id, "COMPLETED", timeout=60)
+        assert final.get("current_worker") == WORKER
+
+        # a + b ran once before the restart; only c ran after — no re-execution.
+        assert _lines(counter) == ["a", "b", "c"], (
+            f"expected no re-execution across worker restart, got {_lines(counter)}"
+        )
+    finally:
+        if worker is not None:
+            cli.stop_worker(worker)
+        if orig_seed is None:
+            cli._env.pop("PYTHONHASHSEED", None)
+        else:
+            cli._env["PYTHONHASHSEED"] = orig_seed

--- a/tests/flux/test_task_id_cross_process_replay.py
+++ b/tests/flux/test_task_id_cross_process_replay.py
@@ -1,0 +1,121 @@
+"""End-to-end cross-process replay guard.
+
+Reproduces the P0: a workflow runs and pauses in one process, then resumes in a
+*different* process (different ``PYTHONHASHSEED``). Tasks completed before the
+pause must NOT re-execute. Before ``task_id`` was made deterministic, the
+resuming process recomputed different ids, the replay short-circuit at
+``flux/task.py`` missed, and every pre-pause task ran a second time.
+
+The two phases run as separate subprocesses sharing one SQLite database and one
+side-effect counter file, with explicitly different hash seeds so the guard
+catches the regression deterministically rather than relying on the parent and
+child happening to differ.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+_MODULE = """
+from __future__ import annotations
+
+import os
+import sys
+
+from flux import ExecutionContext, task, workflow
+from flux.tasks import pause
+
+
+def _bump():
+    with open(os.environ["COUNTER_FILE"], "a") as f:
+        f.write("x")
+
+
+@task
+async def step_a(x):
+    _bump()
+    return x
+
+
+@task
+async def step_b(x):
+    _bump()
+    return x
+
+
+@task
+async def step_c(x):
+    _bump()
+    return x
+
+
+@workflow
+async def wf(ctx: ExecutionContext):
+    await step_a(1)
+    await step_b(2)
+    await pause("gate")
+    await step_c(3)
+    return "done"
+
+
+if __name__ == "__main__":
+    if sys.argv[1] == "run":
+        ctx = wf.run()
+        assert ctx.is_paused, f"expected paused, got {ctx.state}"
+        print(ctx.execution_id)
+    else:
+        ctx = wf.run(execution_id=sys.argv[2])
+        assert ctx.has_succeeded, f"expected succeeded, got {ctx.state}"
+        print("OK")
+"""
+
+
+def _env(db, counter, seed):
+    return {
+        **os.environ,
+        "PYTHONHASHSEED": str(seed),
+        "FLUX_DATABASE_URL": f"sqlite:///{db}",
+        "COUNTER_FILE": str(counter),
+        "FLUX_SECURITY__AUTH__ENABLED": "false",
+        "FLUX_WORKERS__BOOTSTRAP_TOKEN": "test-bootstrap-token",
+        "FLUX_SECURITY__ENCRYPTION__ENCRYPTION_KEY": "test-encryption-key-0123456789ab",
+    }
+
+
+def test_completed_tasks_not_reexecuted_on_cross_process_resume(tmp_path):
+    mod = tmp_path / "xproc_wf.py"
+    mod.write_text(_MODULE)
+    db = tmp_path / "flux.db"
+    counter = tmp_path / "counter.txt"
+    counter.write_text("")
+
+    # Phase A (seed 0): run until pause. step_a + step_b execute once each.
+    a = subprocess.run(
+        [sys.executable, str(mod), "run"],
+        env=_env(db, counter, 0),
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+    assert a.returncode == 0, f"run phase failed:\n{a.stderr}"
+    exec_id = a.stdout.strip().splitlines()[-1]
+    assert counter.read_text() == "xx", "pre-pause tasks should have run exactly once"
+
+    # Phase B (seed 1, a different hash seed): resume in a fresh process.
+    # step_a + step_b must replay (no new side effect); only step_c runs.
+    b = subprocess.run(
+        [sys.executable, str(mod), "resume", exec_id],
+        env=_env(db, counter, 1),
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+    assert b.returncode == 0, f"resume phase failed:\n{b.stderr}"
+
+    side_effects = counter.read_text()
+    assert side_effects == "xxx", (
+        f"expected 3 side effects (step_a, step_b once + step_c), got {len(side_effects)}: "
+        "completed tasks re-executed on cross-process resume"
+    )

--- a/tests/flux/test_task_id_determinism.py
+++ b/tests/flux/test_task_id_determinism.py
@@ -118,6 +118,33 @@ def test_make_deterministic_handles_coroutines_by_value():
             c.close()
 
 
+def test_make_deterministic_handles_string_slots():
+    """__slots__ may be a bare string; it must not be iterated character-by-character."""
+
+    class Slotted:
+        __slots__ = "value"
+
+        def __init__(self, v):
+            self.value = v
+
+    assert make_deterministic(Slotted(1)) == make_deterministic(Slotted(1))
+    assert make_deterministic(Slotted(1)) != make_deterministic(Slotted(2))
+
+
+def test_make_deterministic_coroutine_key_includes_module():
+    """Coroutine keys are module-qualified so same-named functions in different
+    modules do not collide."""
+
+    async def greet(name):
+        return name
+
+    c = greet("x")
+    try:
+        assert __name__ in make_deterministic(c)["__call__"]
+    finally:
+        c.close()
+
+
 def test_make_deterministic_guard_raises_on_opaque_object():
     """Objects with no value-based representation fail loudly instead of
     silently producing an address-dependent id."""

--- a/tests/flux/test_task_id_determinism.py
+++ b/tests/flux/test_task_id_determinism.py
@@ -1,0 +1,127 @@
+"""Cross-process determinism guard for task IDs.
+
+Mirrors ``tests/flux/domain/test_event_id_determinism.py``. ``task_id`` is the
+``source_id`` the replay short-circuit matches on (``flux/task.py``) and the
+``call_id`` the approval gate locks on. Built on Python's per-process-randomized
+``hash()`` it diverged across worker processes, so completed tasks re-executed
+and approvals re-paused on resume. It is now SHA256-derived over a canonical
+argument form, so the IDs below hold across any fresh interpreter run.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from flux.task import task
+from flux.utils import get_func_args, make_deterministic
+
+
+async def _sample(a, b):
+    return a + b
+
+
+def _compute(args, kwargs):
+    return task._compute_task_id("sample", get_func_args(_sample, args), args, kwargs)
+
+
+_SUBPROC = (
+    "from flux.task import task\n"
+    "from flux.utils import get_func_args\n"
+    "async def _sample(a, b):\n"
+    "    return a + b\n"
+    "args = (1, 2)\n"
+    "kwargs = {'opts': {'nested': [1, 2, 3], 'flag': True}}\n"
+    "print(task._compute_task_id('sample', get_func_args(_sample, args), args, kwargs))\n"
+)
+
+
+def _run(seed: int) -> str:
+    env = {**os.environ, "PYTHONHASHSEED": str(seed)}
+    return subprocess.check_output([sys.executable, "-c", _SUBPROC], text=True, env=env).strip()
+
+
+def test_task_id_is_stable_across_processes():
+    """The same call computes the same task_id under any PYTHONHASHSEED."""
+    ids = {_run(0), _run(1), _run(42), _run(12345)}
+    assert len(ids) == 1, f"task_id diverged across processes: {ids}"
+
+
+def test_task_id_matches_in_process_and_subprocess():
+    args = (1, 2)
+    kwargs = {"opts": {"nested": [1, 2, 3], "flag": True}}
+    assert _compute(args, kwargs) == _run(0)
+
+
+def test_task_id_stable_across_calls():
+    assert _compute((1, 2), {}) == _compute((1, 2), {})
+
+
+def test_task_id_differs_for_different_args():
+    assert _compute((1, 2), {}) != _compute((1, 3), {})
+    assert _compute((1, 2), {}) != _compute((2, 1), {})
+
+
+def test_task_id_has_name_prefix():
+    assert _compute((1, 2), {}).startswith("sample_")
+
+
+def test_task_id_is_value_based_for_distinct_equal_objects():
+    """Two distinct-but-equal object args yield the same task_id (not address-based)."""
+
+    class Cfg:
+        def __init__(self, v):
+            self.v = v
+
+    id1 = task._compute_task_id("t", {"c": Cfg(1)}, (Cfg(1),), {})
+    id2 = task._compute_task_id("t", {"c": Cfg(1)}, (Cfg(1),), {})
+    assert id1 == id2
+
+    id3 = task._compute_task_id("t", {"c": Cfg(2)}, (Cfg(2),), {})
+    assert id1 != id3
+
+
+def test_make_deterministic_is_value_based_for_objects_with_dict():
+    class Point:
+        def __init__(self, x, y):
+            self.x = x
+            self.y = y
+
+    assert make_deterministic(Point(1, 2)) == make_deterministic(Point(1, 2))
+    assert make_deterministic(Point(1, 2)) != make_deterministic(Point(1, 3))
+
+
+def test_make_deterministic_orders_sets_and_dicts_stably():
+    assert make_deterministic({1, 2, 3}) == make_deterministic({3, 2, 1})
+    assert make_deterministic({"a": 1, "b": 2}) == make_deterministic({"b": 2, "a": 1})
+
+
+def test_make_deterministic_handles_coroutines_by_value():
+    """parallel()/pipeline() pass coroutines as task args; they must canonicalise
+    deterministically (same call -> same form) instead of hashing by address."""
+
+    async def greet(name):
+        return name
+
+    coros = [greet("x"), greet("x"), greet("y")]
+    try:
+        same_a = make_deterministic(coros[0])
+        same_b = make_deterministic(coros[1])
+        diff = make_deterministic(coros[2])
+        assert same_a == same_b
+        assert same_a != diff
+    finally:
+        for c in coros:
+            c.close()
+
+
+def test_make_deterministic_guard_raises_on_opaque_object():
+    """Objects with no value-based representation fail loudly instead of
+    silently producing an address-dependent id."""
+    import threading
+
+    with pytest.raises(TypeError):
+        make_deterministic(threading.Lock())


### PR DESCRIPTION
## Problem

`task_id` was built from Python's builtin `hash()` (`flux/task.py:144`), which is **per-process randomized** under `PYTHONHASHSEED` (the default). But `task_id` is:

- the `source_id` the **replay short-circuit** matches on (`task.py:211-220`), and
- the `call_id` the **approval gate** locks on (`task.py:254`, `approvals.py`).

So when an execution resumed in a **different process** than it started in — worker handoff, worker restart/redeploy, or inline `flux execution resume` in a fresh CLI — the recomputed `task_id` no longer matched the persisted `source_id`. Consequences:

- **Every pre-pause task re-executed**, duplicating side effects (payments, emails, external writes) — silently violating the exactly-once/durable-replay guarantee the event log exists to provide.
- **Approval-gated workflows re-paused indefinitely**: the gate looked up the approval row by the recomputed (different) `task_id`, found none, and created a *new* pending row — the operator's approval was never consumed.

`event_id` was already migrated off `hash()` to SHA256 for this exact reason (see the comment in `flux/domain/events.py`); `task_id` was left behind.

Proof (flux's real formula): `task_id` differs under every `PYTHONHASHSEED` (`my_task_4624…` / `5880…` / `1684…`), while `event_id` (SHA256) is identical across all seeds.

## Fix

- **`make_deterministic()`** (`flux/utils.py`): canonical, order-stable, value-based serialization of task arguments. Dict/set ordering is normalised; objects are reduced to their fields; coroutines/generators (passed to `parallel()`/`pipeline()`) are keyed by qualified name + not-yet-started bound arguments. Genuinely opaque objects raise `TypeError` rather than degrading to an address-dependent `repr` (the arg-canonicalization guard).
- **`task._compute_task_id()`** (`flux/task.py`): SHA256 over the canonical call form, mirroring `ExecutionEvent` ids. Replaces the `hash()` formula.

## Tests

- `tests/flux/test_task_id_determinism.py` — `task_id` identical across 4 `PYTHONHASHSEED` values (subprocesses); value-based identity; coroutine handling; opaque-arg guard.
- `tests/flux/test_task_id_cross_process_replay.py` — runs the engine in **two processes with different seeds** sharing one event log; pause in A, resume in B; asserts pre-pause tasks do not re-execute. Reproduces the P0 on the old code (5 side effects vs 3).
- `tests/e2e/test_task_id_worker_handoff.py` — distributed: a worker runs+pauses, is **restarted as a new process with a different seed**, and resumes; asserts no re-execution across the restart (full SSE/HTTP/sticky-resume path).

## Verification

- Unit suite: **2252 passed**.
- E2E suite (`-m "not ollama"`): **102 passed**.
- Version bumped `0.36.0 → 0.36.1`.

> Note: surfaced an adjacent durability gap (out of scope here) — a *cleanly disconnected* worker is removed from the reaper's heartbeat map, so its PAUSED executions are never released by eviction. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)