### PR TITLE
feat(agent): dynamic code steps for the planner

### DIFF
--- a/flux/config.py
+++ b/flux/config.py
@@ -129,6 +129,7 @@ class AgentConfig(BaseConfig):
     )
     dynamic_code_step_timeout: int = Field(
         default=30,
+        gt=0,
         description="Timeout in seconds for dynamic code step execution",
     )
 

--- a/flux/config.py
+++ b/flux/config.py
@@ -116,6 +116,23 @@ class SchedulingConfig(BaseConfig):
     )
 
 
+class AgentConfig(BaseConfig):
+    """Configuration for AI agents."""
+
+    dynamic_code_steps_enabled: bool = Field(
+        default=False,
+        description="Enable dynamic code step execution in agent planning",
+    )
+    dynamic_code_steps_agent_tools_enabled: bool = Field(
+        default=False,
+        description="Enable agent tools in dynamic code step execution",
+    )
+    dynamic_code_step_timeout: int = Field(
+        default=30,
+        description="Timeout in seconds for dynamic code step execution",
+    )
+
+
 class FluxConfig(BaseSettings):
     """Main configuration class for Flux framework."""
 
@@ -179,6 +196,7 @@ class FluxConfig(BaseSettings):
     )  # type: ignore[name-defined]
     mcp: MCPConfig = Field(default_factory=MCPConfig)
     scheduling: SchedulingConfig = Field(default_factory=SchedulingConfig)
+    agent: AgentConfig = Field(default_factory=AgentConfig)
     observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
 
     @field_validator("database_url")

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -19,16 +19,35 @@ logger = logging.getLogger("flux.agent")
 
 def _build_code_bindings(agents: list, tools_enabled: bool) -> dict:
     from flux.tasks import (
-        Graph, call, choice, now, parallel, pipeline, progress,
-        randint, randrange, sleep, uuid4,
+        Graph,
+        call,
+        choice,
+        now,
+        parallel,
+        pipeline,
+        progress,
+        randint,
+        randrange,
+        sleep,
+        uuid4,
     )
+
     bindings = {
-        "now": now, "uuid4": uuid4, "choice": choice, "randint": randint,
-        "randrange": randrange, "parallel": parallel, "sleep": sleep,
-        "pipeline": pipeline, "call": call, "Graph": Graph, "progress": progress,
+        "now": now,
+        "uuid4": uuid4,
+        "choice": choice,
+        "randint": randint,
+        "randrange": randrange,
+        "parallel": parallel,
+        "sleep": sleep,
+        "pipeline": pipeline,
+        "call": call,
+        "Graph": Graph,
+        "progress": progress,
     }
     if tools_enabled:
         from flux.tasks.ai.delegation import build_delegate
+
         bindings["delegate"] = build_delegate(agents or [])
     return bindings
 

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -148,8 +148,13 @@ async def agent(
 
         agent_cfg = Configuration.get().settings.agent
 
+        code_bindings = _build_code_bindings(
+            agents=agents or [],
+            tools_enabled=agent_cfg.dynamic_code_steps_agent_tools_enabled,
+        )
         system_prompt = system_prompt + build_plan_preamble(
             code_steps_enabled=agent_cfg.dynamic_code_steps_enabled,
+            code_bindings=list(code_bindings),
         )
         plan_tools, plan_summary_fn = await build_plan_tools(
             strict_dependencies=strict_dependencies,
@@ -160,10 +165,7 @@ async def agent(
                 "enabled": agent_cfg.dynamic_code_steps_enabled,
                 "timeout": agent_cfg.dynamic_code_step_timeout,
             },
-            code_bindings=_build_code_bindings(
-                agents=agents or [],
-                tools_enabled=agent_cfg.dynamic_code_steps_agent_tools_enabled,
-            ),
+            code_bindings=code_bindings,
         )
         tools = (tools or []) + plan_tools
 

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -142,6 +142,7 @@ async def agent(
         tools = (tools or []) + [build_delegate(agents)]
 
     plan_summary_fn = None
+    plan_advance_fn = None
     if planning:
         from flux.config import Configuration
         from flux.tasks.ai.agent_plan import build_plan_preamble, build_plan_tools
@@ -156,7 +157,7 @@ async def agent(
             code_steps_enabled=agent_cfg.dynamic_code_steps_enabled,
             code_bindings=list(code_bindings),
         )
-        plan_tools, plan_summary_fn = await build_plan_tools(
+        plan_tools, plan_summary_fn, plan_advance_fn = await build_plan_tools(
             strict_dependencies=strict_dependencies,
             max_plan_steps=max_plan_steps,
             approve_plan=approve_plan,
@@ -236,6 +237,7 @@ async def agent(
                 max_concurrent_tools=max_concurrent_tools,
                 stream=effective_stream,
                 plan_summary_fn=plan_summary_fn,
+                plan_advance_fn=plan_advance_fn,
                 approval_mode=approval_mode,
                 on_complete=on_complete,
                 on_pause=on_pause,
@@ -276,6 +278,7 @@ async def agent(
                 max_concurrent_tools=max_concurrent_tools,
                 stream=effective_stream,
                 plan_summary_fn=plan_summary_fn,
+                plan_advance_fn=plan_advance_fn,
                 approval_mode=approval_mode,
                 on_complete=on_complete,
                 on_pause=on_pause,
@@ -316,6 +319,7 @@ async def agent(
                 max_concurrent_tools=max_concurrent_tools,
                 stream=effective_stream,
                 plan_summary_fn=plan_summary_fn,
+                plan_advance_fn=plan_advance_fn,
                 approval_mode=approval_mode,
                 on_complete=on_complete,
                 on_pause=on_pause,
@@ -356,6 +360,7 @@ async def agent(
                 max_concurrent_tools=max_concurrent_tools,
                 stream=effective_stream,
                 plan_summary_fn=plan_summary_fn,
+                plan_advance_fn=plan_advance_fn,
                 approval_mode=approval_mode,
                 on_complete=on_complete,
                 on_pause=on_pause,

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -19,7 +19,6 @@ logger = logging.getLogger("flux.agent")
 
 def _build_code_bindings(agents: list, tools_enabled: bool) -> dict:
     from flux.tasks import (
-        Graph,
         call,
         choice,
         now,
@@ -42,7 +41,6 @@ def _build_code_bindings(agents: list, tools_enabled: bool) -> dict:
         "sleep": sleep,
         "pipeline": pipeline,
         "call": call,
-        "Graph": Graph,
         "progress": progress,
     }
     if tools_enabled and agents:

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -45,10 +45,10 @@ def _build_code_bindings(agents: list, tools_enabled: bool) -> dict:
         "Graph": Graph,
         "progress": progress,
     }
-    if tools_enabled:
+    if tools_enabled and agents:
         from flux.tasks.ai.delegation import build_delegate
 
-        bindings["delegate"] = build_delegate(agents or [])
+        bindings["delegate"] = build_delegate(agents)
     return bindings
 
 

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -17,6 +17,22 @@ if TYPE_CHECKING:
 logger = logging.getLogger("flux.agent")
 
 
+def _build_code_bindings(agents: list, tools_enabled: bool) -> dict:
+    from flux.tasks import (
+        Graph, call, choice, now, parallel, pipeline, progress,
+        randint, randrange, sleep, uuid4,
+    )
+    bindings = {
+        "now": now, "uuid4": uuid4, "choice": choice, "randint": randint,
+        "randrange": randrange, "parallel": parallel, "sleep": sleep,
+        "pipeline": pipeline, "call": call, "Graph": Graph, "progress": progress,
+    }
+    if tools_enabled:
+        from flux.tasks.ai.delegation import build_delegate
+        bindings["delegate"] = build_delegate(agents or [])
+    return bindings
+
+
 async def agent(
     system_prompt: str,
     *,
@@ -108,14 +124,27 @@ async def agent(
 
     plan_summary_fn = None
     if planning:
+        from flux.config import Configuration
         from flux.tasks.ai.agent_plan import build_plan_preamble, build_plan_tools
 
-        system_prompt = system_prompt + build_plan_preamble()
+        agent_cfg = Configuration.get().settings.agent
+
+        system_prompt = system_prompt + build_plan_preamble(
+            code_steps_enabled=agent_cfg.dynamic_code_steps_enabled,
+        )
         plan_tools, plan_summary_fn = await build_plan_tools(
             strict_dependencies=strict_dependencies,
             max_plan_steps=max_plan_steps,
             approve_plan=approve_plan,
             long_term_memory=long_term_memory,
+            code_config={
+                "enabled": agent_cfg.dynamic_code_steps_enabled,
+                "timeout": agent_cfg.dynamic_code_step_timeout,
+            },
+            code_bindings=_build_code_bindings(
+                agents=agents or [],
+                tools_enabled=agent_cfg.dynamic_code_steps_agent_tools_enabled,
+            ),
         )
         tools = (tools or []) + plan_tools
 

--- a/flux/tasks/ai/agent_loop.py
+++ b/flux/tasks/ai/agent_loop.py
@@ -124,6 +124,7 @@ async def run_agent_loop(
     max_concurrent_tools: int | None = None,
     stream: bool = False,
     plan_summary_fn: Any | None = None,
+    plan_advance_fn: Any | None = None,
     approval_mode: str = "default",
     on_complete: list[Any] | None = None,
     on_pause: list[Any] | None = None,

--- a/flux/tasks/ai/agent_loop.py
+++ b/flux/tasks/ai/agent_loop.py
@@ -256,16 +256,16 @@ async def run_agent_loop(
 
         tool_result_messages = formatter.format_tool_results(response.tool_calls, results)
 
-        if plan_summary_fn:
-            summary = plan_summary_fn()
-            if summary and tool_result_messages:
-                last = tool_result_messages[-1]
-                if isinstance(last, dict) and isinstance(last.get("content"), str):
-                    last["content"] += f"\n\n{summary}"
-                else:
-                    tool_result_messages.append(
-                        formatter.format_user_message(summary),
-                    )
+        advance_summary = await plan_advance_fn() if plan_advance_fn is not None else None
+        summary = advance_summary or (plan_summary_fn() if plan_summary_fn else None)
+        if summary and tool_result_messages:
+            last = tool_result_messages[-1]
+            if isinstance(last, dict) and isinstance(last.get("content"), str):
+                last["content"] += f"\n\n{summary}"
+            else:
+                tool_result_messages.append(
+                    formatter.format_user_message(summary),
+                )
 
         messages.extend(tool_result_messages)
 
@@ -280,28 +280,24 @@ async def run_agent_loop(
         )
         call_counter += 1
 
-        if (
-            not response.tool_calls
-            and not response.text
-            and plan_summary_fn
-            and plan_summary_fn()
-            and tool_call_count < max_tool_calls
-        ):
-            summary = plan_summary_fn()
-            messages.append(formatter.format_assistant_message(response))
-            messages.append(
-                formatter.format_user_message(f"Continue working on your plan. {summary}"),
-            )
-            response = await _call_llm(
-                llm_task,
-                formatter,
-                messages,
-                call_kwargs,
-                working_memory,
-                stream,
-                call_counter,
-            )
-            call_counter += 1
+        if not response.tool_calls and not response.text and tool_call_count < max_tool_calls:
+            advance_summary = await plan_advance_fn() if plan_advance_fn is not None else None
+            summary = advance_summary or (plan_summary_fn() if plan_summary_fn else None)
+            if summary:
+                messages.append(formatter.format_assistant_message(response))
+                messages.append(
+                    formatter.format_user_message(f"Continue working on your plan. {summary}"),
+                )
+                response = await _call_llm(
+                    llm_task,
+                    formatter,
+                    messages,
+                    call_kwargs,
+                    working_memory,
+                    stream,
+                    call_counter,
+                )
+                call_counter += 1
 
     if response.tool_calls and tool_call_count >= max_tool_calls:
         messages.append(formatter.format_assistant_message(response))

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -219,6 +219,8 @@ async def build_plan_tools(
     max_plan_steps: int = 20,
     approve_plan: bool = False,
     long_term_memory: LongTermMemory | None = None,
+    code_config: dict | None = None,
+    code_bindings: dict | None = None,
 ) -> tuple[list[task], Callable[[], str | None]]:
     """Build planning tools and a summary function.
 
@@ -236,6 +238,9 @@ async def build_plan_tools(
     async def _persist() -> None:
         if long_term_memory and ctx.plan:
             await long_term_memory.memorize("_active_plan", ctx.plan.to_dict())
+
+    code_cfg = code_config or {"enabled": False, "timeout": 30}
+    base_bindings = dict(code_bindings or {})
 
     @task
     async def create_plan(steps: str) -> dict:
@@ -262,14 +267,29 @@ async def build_plan_tools(
             raise PlanValidationError(
                 f"Plan has {len(parsed)} steps (max {max_plan_steps}). Use fewer, coarser steps.",
             )
+        from flux.tasks.ai.code_sandbox import CodeValidationError, validate_code
+
         new_steps = []
         for s in parsed:
             _validate_step_name(s["name"])
+            step_type = s.get("type", "reasoning")
+            step_code = s.get("code")
+            if step_type == "code":
+                if not code_cfg["enabled"]:
+                    return {"error": "Code steps are disabled (dynamic_code_steps_enabled=false)."}
+                if not step_code:
+                    return {"error": f"Step '{s['name']}' is type=code but has no code."}
+                try:
+                    validate_code(step_code, set(base_bindings) | {"deps"})
+                except CodeValidationError as ex:
+                    return {"error": f"Invalid code in step '{s['name']}': {ex}"}
             new_steps.append(
                 AgentStep(
                     name=s["name"],
                     description=s.get("description", ""),
                     depends_on=s.get("depends_on", []),
+                    type=step_type,
+                    code=step_code,
                 ),
             )
 
@@ -288,11 +308,24 @@ async def build_plan_tools(
                 new_steps = []
                 for s in resume_input["steps"]:
                     _validate_step_name(s["name"])
+                    step_type = s.get("type", "reasoning")
+                    step_code = s.get("code")
+                    if step_type == "code":
+                        if not code_cfg["enabled"]:
+                            return {"error": "Code steps are disabled (dynamic_code_steps_enabled=false)."}
+                        if not step_code:
+                            return {"error": f"Step '{s['name']}' is type=code but has no code."}
+                        try:
+                            validate_code(step_code, set(base_bindings) | {"deps"})
+                        except CodeValidationError as ex:
+                            return {"error": f"Invalid code in step '{s['name']}': {ex}"}
                     new_steps.append(
                         AgentStep(
                             name=s["name"],
                             description=s.get("description", ""),
                             depends_on=s.get("depends_on", []),
+                            type=step_type,
+                            code=step_code,
                         ),
                     )
                 new_plan = AgentPlan(steps=new_steps)
@@ -479,6 +512,48 @@ async def build_plan_tools(
 
         return {"ready_steps": result}
 
+    @task
+    async def run_step(step_name: str) -> dict:
+        """Execute a code-type step's lambda in the sandbox and record its result.
+
+        Use this for steps with type "code". For reasoning steps, use
+        start_step / complete_step instead.
+        """
+        if ctx.plan is None:
+            return {"error": "No plan exists. Call create_plan first."}
+        step = ctx.plan.get_step(step_name)
+        if step is None:
+            available = ", ".join(s.name for s in ctx.plan.steps)
+            return {"error": f"Step '{step_name}' not found. Available: {available}"}
+        if step.type != "code" or not step.code:
+            return {"error": f"Step '{step_name}' is not a code step."}
+        if step.status == "completed":
+            return step.to_dict()
+        if not ctx.plan.dependencies_satisfied(step):
+            return {"error": f"Step '{step_name}' has unmet dependencies."}
+
+        from flux.tasks.ai.code_sandbox import code_hash, run_code_step
+
+        bindings = dict(base_bindings)
+        bindings["deps"] = ctx.plan.dependency_results(step)
+        runner = task.with_options(name=f"plan_step_{step.name}")(run_code_step)
+        try:
+            step.status = "in_progress"
+            result = await runner(
+                step.code, bindings,
+                timeout=code_cfg["timeout"],
+                expected_hash=code_hash(step.code),
+            )
+        except Exception as ex:  # noqa: BLE001 — surface failure to the agent
+            step.status = "failed"
+            step.error = str(ex)
+            await _persist()
+            return {"error": f"Code step '{step_name}' failed: {ex}"}
+        step.status = "completed"
+        step.result = result
+        await _persist()
+        return step.to_dict()
+
     return [
         create_plan,
         start_step,
@@ -486,6 +561,7 @@ async def build_plan_tools(
         mark_step_failed,
         get_plan,
         get_ready_steps,
+        run_step,
     ], ctx.summary
 
 

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -578,7 +578,10 @@ async def build_plan_tools(
                 runner = compile_code_step(step.code, base_bindings, step_name=step.name)
                 try:
                     step.status = "in_progress"
-                    step.result = await runner(deps, safe_input)
+                    step.result = await asyncio.wait_for(
+                        runner(deps, safe_input),
+                        timeout=code_cfg["timeout"],
+                    )
                     step.status = "completed"
                     ran.append(f'"{step.name}" ok')
                 except asyncio.CancelledError:

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -33,6 +33,8 @@ class AgentStep:
     status: Literal["pending", "in_progress", "completed", "failed"] = "pending"
     result: Any | None = None
     error: str | None = None
+    type: Literal["reasoning", "code"] = "reasoning"
+    code: str | None = None
 
     def to_dict(self) -> dict:
         d = asdict(self)
@@ -42,6 +44,10 @@ class AgentStep:
             del d["result"]
         if d["error"] is None:
             del d["error"]
+        if d["type"] == "reasoning":
+            del d["type"]
+        if d["code"] is None:
+            del d["code"]
         return d
 
 
@@ -138,6 +144,8 @@ class AgentPlan:
                     status=s.get("status", "pending"),
                     result=s.get("result"),
                     error=s.get("error"),
+                    type=s.get("type", "reasoning"),
+                    code=s.get("code"),
                 ),
             )
         return cls(steps=steps)

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -90,7 +91,7 @@ class AgentPlan:
         results = {}
         for dep_name in step.depends_on:
             dep = self.get_step(dep_name)
-            if dep and dep.result is not None:
+            if dep and dep.status == "completed":
                 results[dep_name] = dep.result
         return results
 
@@ -537,24 +538,42 @@ async def build_plan_tools(
         if step.status == "completed":
             return step.to_dict()
         if step.status == "in_progress":
-            return step.to_dict()
+            return {"error": f"Step '{step_name}' is already running."}
         if step.status == "failed":
             return {"error": f"Step '{step_name}' already failed: {step.error}. Replan to retry."}
+        active = ctx.plan.active_step()
+        if active and active.name != step_name:
+            return {
+                "error": f'Step "{active.name}" is already in progress. '
+                f"Complete or fail it before running a code step.",
+            }
         if not ctx.plan.dependencies_satisfied(step):
             return {"error": f"Step '{step_name}' has unmet dependencies."}
 
-        from flux.tasks.ai.code_sandbox import run_code_step
+        from flux.tasks.ai.code_sandbox import CodeValidationError, run_code_step, sanitize_deps
 
-        bindings = dict(base_bindings)
-        bindings["deps"] = ctx.plan.dependency_results(step)
-        runner = task.with_options(name=f"plan_step_{step.name}")(run_code_step)
+        try:
+            deps = sanitize_deps(ctx.plan.dependency_results(step))
+        except CodeValidationError as ex:
+            step.status = "failed"
+            step.error = str(ex)
+            await _persist()
+            return {"error": f"Code step '{step_name}' has a non-value dependency result: {ex}"}
+
+        timeout = code_cfg["timeout"]
+
+        async def _host(code: str, deps: dict) -> object:
+            sandbox = dict(base_bindings)
+            sandbox["deps"] = deps
+            return await run_code_step(code, sandbox, timeout=timeout)
+
+        runner = task.with_options(name=f"plan_step_{step.name}")(_host)
         try:
             step.status = "in_progress"
-            result = await runner(
-                step.code,
-                bindings,
-                timeout=code_cfg["timeout"],
-            )
+            result = await runner(step.code, deps)
+        except asyncio.CancelledError:
+            step.status = "pending"
+            raise
         except Exception as ex:  # noqa: BLE001 — surface failure to the agent
             step.status = "failed"
             step.error = str(ex)

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -565,9 +565,9 @@ async def build_plan_tools(
     ], ctx.summary
 
 
-def build_plan_preamble() -> str:
+def build_plan_preamble(code_steps_enabled: bool = False) -> str:
     """Build system prompt section for agent planning."""
-    return """
+    preamble = """
 
 You have planning capabilities. Use them when a task requires multiple
 coordinated steps that benefit from thinking ahead.
@@ -615,3 +615,11 @@ Replanning:
 - You do not need to complete every step. If the plan is no longer relevant,
   stop calling plan tools and respond directly.
 """
+
+    if code_steps_enabled:
+        preamble += """
+
+Each step has a type: 'reasoning' (default) or 'code'. For a 'code' step, set "type":"code" and "code" to a single Python lambda that DISPATCHES flux tasks — e.g. `lambda: pipeline(step_one, step_two, input=deps['fetch'])`. The lambda runs in a sandbox: it may call the exposed flux built-in tasks, `delegate(...)`, and read `deps['<dep_name>']`; it must RETURN a value or a flux task. No imports, loops, comprehensions, arithmetic, or attribute access. Execute code steps with run_step(name), not start_step/complete_step.
+"""
+
+    return preamble

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -269,12 +270,12 @@ async def build_plan_tools(
     long_term_memory: LongTermMemory | None = None,
     code_config: dict | None = None,
     code_bindings: dict | None = None,
-) -> tuple[list[task], Callable[[], str | None]]:
+) -> tuple[list[task], Callable[[], str | None], Callable[[], Any]]:
     """Build planning tools and a summary function.
 
     Returns:
-        A tuple of (tools, summary_fn). The tools and summary_fn share
-        the same PlanContext via closure.
+        A tuple of (tools, summary_fn, advance_fn). The tools, summary_fn, and
+        advance_fn share the same PlanContext via closure.
     """
     ctx = PlanContext()
 
@@ -534,7 +535,65 @@ async def build_plan_tools(
         get_plan,
         get_ready_steps,
     ]
-    return tools, ctx.summary
+
+    async def advance() -> str | None:
+        """Drive ready code steps to a fixpoint. Returns a summary or None."""
+        if ctx.plan is None or not code_cfg["enabled"]:
+            return None
+        from flux import ExecutionContext
+        from flux.tasks.ai.code_sandbox import (
+            CodeValidationError,
+            compile_code_step,
+            sanitize_deps,
+        )
+
+        execution_input = None
+        try:
+            exec_ctx = await ExecutionContext.get()
+            execution_input = exec_ctx.input
+        except Exception:  # noqa: BLE001 — input is best-effort context
+            execution_input = None
+
+        ran: list[str] = []
+        while True:
+            ready = [
+                s
+                for s in ctx.plan.steps
+                if s.type == "code"
+                and s.code
+                and s.status == "pending"
+                and ctx.plan.dependencies_satisfied(s)
+            ]
+            if not ready:
+                break
+            for step in ready:
+                try:
+                    deps = sanitize_deps(ctx.plan.dependency_results(step))
+                    safe_input = sanitize_deps(execution_input)
+                except CodeValidationError as ex:
+                    step.status = "failed"
+                    step.error = f"non-value dependency/input: {ex}"
+                    ran.append(f'"{step.name}" failed')
+                    continue
+                runner = compile_code_step(step.code, base_bindings, step_name=step.name)
+                try:
+                    step.status = "in_progress"
+                    step.result = await runner(deps, safe_input)
+                    step.status = "completed"
+                    ran.append(f'"{step.name}" ok')
+                except asyncio.CancelledError:
+                    step.status = "pending"
+                    raise
+                except Exception as ex:  # noqa: BLE001 — surface failure to the agent
+                    step.status = "failed"
+                    step.error = str(ex)
+                    ran.append(f'"{step.name}" failed: {ex}')
+            await _persist()
+        if not ran:
+            return None
+        return "Ran code steps: " + ", ".join(ran) + ". " + (ctx.summary() or "")
+
+    return tools, ctx.summary, advance
 
 
 def build_plan_preamble(

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -213,6 +213,47 @@ class PlanContext:
         return self.plan.summary()
 
 
+def _build_steps_from_payload(
+    payload: list,
+    *,
+    code_cfg: dict,
+    base_bindings: dict,
+) -> tuple[list[AgentStep] | None, dict | None]:
+    """Build AgentSteps from a create_plan payload, validating code steps.
+
+    Returns (steps, None) on success or (None, error) when a code step is
+    rejected. PlanValidationError from step-name validation propagates.
+    """
+    from flux.tasks.ai.code_sandbox import CodeValidationError, validate_code
+
+    new_steps = []
+    for s in payload:
+        _validate_step_name(s["name"])
+        step_type = s.get("type", "reasoning")
+        step_code = s.get("code")
+        if step_type == "code":
+            if not code_cfg["enabled"]:
+                return None, {
+                    "error": "Code steps are disabled (dynamic_code_steps_enabled=false).",
+                }
+            if not step_code:
+                return None, {"error": f"Step '{s['name']}' is type=code but has no code."}
+            try:
+                validate_code(step_code, set(base_bindings) | {"deps"})
+            except CodeValidationError as ex:
+                return None, {"error": f"Invalid code in step '{s['name']}': {ex}"}
+        new_steps.append(
+            AgentStep(
+                name=s["name"],
+                description=s.get("description", ""),
+                depends_on=s.get("depends_on", []),
+                type=step_type,
+                code=step_code,
+            ),
+        )
+    return new_steps, None
+
+
 async def build_plan_tools(
     *,
     strict_dependencies: bool = False,
@@ -267,31 +308,13 @@ async def build_plan_tools(
             raise PlanValidationError(
                 f"Plan has {len(parsed)} steps (max {max_plan_steps}). Use fewer, coarser steps.",
             )
-        from flux.tasks.ai.code_sandbox import CodeValidationError, validate_code
-
-        new_steps = []
-        for s in parsed:
-            _validate_step_name(s["name"])
-            step_type = s.get("type", "reasoning")
-            step_code = s.get("code")
-            if step_type == "code":
-                if not code_cfg["enabled"]:
-                    return {"error": "Code steps are disabled (dynamic_code_steps_enabled=false)."}
-                if not step_code:
-                    return {"error": f"Step '{s['name']}' is type=code but has no code."}
-                try:
-                    validate_code(step_code, set(base_bindings) | {"deps"})
-                except CodeValidationError as ex:
-                    return {"error": f"Invalid code in step '{s['name']}': {ex}"}
-            new_steps.append(
-                AgentStep(
-                    name=s["name"],
-                    description=s.get("description", ""),
-                    depends_on=s.get("depends_on", []),
-                    type=step_type,
-                    code=step_code,
-                ),
-            )
+        new_steps, code_error = _build_steps_from_payload(
+            parsed,
+            code_cfg=code_cfg,
+            base_bindings=base_bindings,
+        )
+        if code_error:
+            return code_error
 
         new_plan = AgentPlan(steps=new_steps)
         _validate_dependencies(new_plan)
@@ -305,31 +328,13 @@ async def build_plan_tools(
                 return {"error": "Plan was rejected during review."}
 
             if isinstance(resume_input, dict) and "steps" in resume_input:
-                new_steps = []
-                for s in resume_input["steps"]:
-                    _validate_step_name(s["name"])
-                    step_type = s.get("type", "reasoning")
-                    step_code = s.get("code")
-                    if step_type == "code":
-                        if not code_cfg["enabled"]:
-                            return {
-                                "error": "Code steps are disabled (dynamic_code_steps_enabled=false).",
-                            }
-                        if not step_code:
-                            return {"error": f"Step '{s['name']}' is type=code but has no code."}
-                        try:
-                            validate_code(step_code, set(base_bindings) | {"deps"})
-                        except CodeValidationError as ex:
-                            return {"error": f"Invalid code in step '{s['name']}': {ex}"}
-                    new_steps.append(
-                        AgentStep(
-                            name=s["name"],
-                            description=s.get("description", ""),
-                            depends_on=s.get("depends_on", []),
-                            type=step_type,
-                            code=step_code,
-                        ),
-                    )
+                new_steps, code_error = _build_steps_from_payload(
+                    resume_input["steps"],
+                    code_cfg=code_cfg,
+                    base_bindings=base_bindings,
+                )
+                if code_error:
+                    return code_error
                 new_plan = AgentPlan(steps=new_steps)
                 _validate_dependencies(new_plan)
                 if len(new_plan.steps) < 2:
@@ -519,7 +524,7 @@ async def build_plan_tools(
         """Execute a code-type step's lambda in the sandbox and record its result.
 
         Use this for steps with type "code". For reasoning steps, use
-        start_step / complete_step instead.
+        start_step / mark_step_done instead.
         """
         if ctx.plan is None:
             return {"error": "No plan exists. Call create_plan first."}
@@ -538,7 +543,7 @@ async def build_plan_tools(
         if not ctx.plan.dependencies_satisfied(step):
             return {"error": f"Step '{step_name}' has unmet dependencies."}
 
-        from flux.tasks.ai.code_sandbox import code_hash, run_code_step
+        from flux.tasks.ai.code_sandbox import run_code_step
 
         bindings = dict(base_bindings)
         bindings["deps"] = ctx.plan.dependency_results(step)
@@ -549,7 +554,6 @@ async def build_plan_tools(
                 step.code,
                 bindings,
                 timeout=code_cfg["timeout"],
-                expected_hash=code_hash(step.code),
             )
         except Exception as ex:  # noqa: BLE001 — surface failure to the agent
             step.status = "failed"
@@ -574,7 +578,10 @@ async def build_plan_tools(
     return tools, ctx.summary
 
 
-def build_plan_preamble(code_steps_enabled: bool = False) -> str:
+def build_plan_preamble(
+    code_steps_enabled: bool = False,
+    code_bindings: list[str] | None = None,
+) -> str:
     """Build system prompt section for agent planning."""
     preamble = """
 
@@ -626,9 +633,12 @@ Replanning:
 """
 
     if code_steps_enabled:
-        preamble += """
+        names = (
+            ", ".join(sorted(code_bindings)) if code_bindings else "the exposed flux built-in tasks"
+        )
+        preamble += f"""
 
-Each step has a type: 'reasoning' (default) or 'code'. For a 'code' step, set "type":"code" and "code" to a single Python lambda that DISPATCHES flux tasks — e.g. `lambda: pipeline(step_one, step_two, input=deps['fetch'])`. The lambda runs in a sandbox: it may call the exposed flux built-in tasks, `delegate(...)`, and read `deps['<dep_name>']`; it must RETURN a value or a flux task. No imports, loops, comprehensions, arithmetic, or attribute access. Execute code steps with run_step(name), not start_step/complete_step.
+Each step has a type: 'reasoning' (default) or 'code'. For a 'code' step, set "type":"code" and "code" to a single Python lambda that DISPATCHES flux tasks and RETURNS a value or a flux task — e.g. `lambda: parallel(now(), now())`, or read a dependency with `lambda: deps['fetch']`. Available names: {names}; plus `deps['<dep_name>']` for a dependency's result. Only calls, subscripts like deps['x'], literals, and ternaries are allowed — no imports, statements, loops, comprehensions, f-strings, arithmetic, or attribute access (the `.` operator). Execute code steps with run_step(name), not start_step/mark_step_done.
 """
 
     return preamble

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import re
@@ -225,7 +224,11 @@ def _build_steps_from_payload(
     Returns (steps, None) on success or (None, error) when a code step is
     rejected. PlanValidationError from step-name validation propagates.
     """
-    from flux.tasks.ai.code_sandbox import CodeValidationError, validate_code
+    from flux.tasks.ai.code_sandbox import (
+        _SAFE_BUILTIN_NAMES,
+        CodeValidationError,
+        validate_code,
+    )
 
     new_steps = []
     for s in payload:
@@ -240,7 +243,10 @@ def _build_steps_from_payload(
             if not step_code:
                 return None, {"error": f"Step '{s['name']}' is type=code but has no code."}
             try:
-                validate_code(step_code, set(base_bindings) | {"deps"})
+                validate_code(
+                    step_code,
+                    set(base_bindings) | {"deps", "input"} | set(_SAFE_BUILTIN_NAMES),
+                )
             except CodeValidationError as ex:
                 return None, {"error": f"Invalid code in step '{s['name']}': {ex}"}
         new_steps.append(
@@ -520,70 +526,6 @@ async def build_plan_tools(
 
         return {"ready_steps": result}
 
-    @task
-    async def run_step(step_name: str) -> dict:
-        """Execute a code-type step's lambda in the sandbox and record its result.
-
-        Use this for steps with type "code". For reasoning steps, use
-        start_step / mark_step_done instead.
-        """
-        if ctx.plan is None:
-            return {"error": "No plan exists. Call create_plan first."}
-        step = ctx.plan.get_step(step_name)
-        if step is None:
-            available = ", ".join(s.name for s in ctx.plan.steps)
-            return {"error": f"Step '{step_name}' not found. Available: {available}"}
-        if step.type != "code" or not step.code:
-            return {"error": f"Step '{step_name}' is not a code step."}
-        if step.status == "completed":
-            return step.to_dict()
-        if step.status == "in_progress":
-            return {"error": f"Step '{step_name}' is already running."}
-        if step.status == "failed":
-            return {"error": f"Step '{step_name}' already failed: {step.error}. Replan to retry."}
-        active = ctx.plan.active_step()
-        if active and active.name != step_name:
-            return {
-                "error": f'Step "{active.name}" is already in progress. '
-                f"Complete or fail it before running a code step.",
-            }
-        if not ctx.plan.dependencies_satisfied(step):
-            return {"error": f"Step '{step_name}' has unmet dependencies."}
-
-        from flux.tasks.ai.code_sandbox import CodeValidationError, run_code_step, sanitize_deps
-
-        try:
-            deps = sanitize_deps(ctx.plan.dependency_results(step))
-        except CodeValidationError as ex:
-            step.status = "failed"
-            step.error = str(ex)
-            await _persist()
-            return {"error": f"Code step '{step_name}' has a non-value dependency result: {ex}"}
-
-        timeout = code_cfg["timeout"]
-
-        async def _host(code: str, deps: dict) -> object:
-            sandbox = dict(base_bindings)
-            sandbox["deps"] = deps
-            return await run_code_step(code, sandbox, timeout=timeout)
-
-        runner = task.with_options(name=f"plan_step_{step.name}")(_host)
-        try:
-            step.status = "in_progress"
-            result = await runner(step.code, deps)
-        except asyncio.CancelledError:
-            step.status = "pending"
-            raise
-        except Exception as ex:  # noqa: BLE001 — surface failure to the agent
-            step.status = "failed"
-            step.error = str(ex)
-            await _persist()
-            return {"error": f"Code step '{step_name}' failed: {ex}"}
-        step.status = "completed"
-        step.result = result
-        await _persist()
-        return step.to_dict()
-
     tools = [
         create_plan,
         start_step,
@@ -592,8 +534,6 @@ async def build_plan_tools(
         get_plan,
         get_ready_steps,
     ]
-    if code_cfg["enabled"]:
-        tools.append(run_step)
     return tools, ctx.summary
 
 
@@ -652,12 +592,28 @@ Replanning:
 """
 
     if code_steps_enabled:
-        names = (
-            ", ".join(sorted(code_bindings)) if code_bindings else "the exposed flux built-in tasks"
-        )
+        names = ", ".join(sorted(code_bindings)) if code_bindings else "the exposed flux tasks"
         preamble += f"""
 
-Each step has a type: 'reasoning' (default) or 'code'. For a 'code' step, set "type":"code" and "code" to a single Python lambda that DISPATCHES flux tasks and RETURNS a value or a flux task — e.g. `lambda: parallel(now(), now())`, or read a dependency with `lambda: deps['fetch']`. Available names: {names}; plus `deps['<dep_name>']` for a dependency's result. Only calls, subscripts like deps['x'], literals, and ternaries are allowed — no imports, statements, loops, comprehensions, f-strings, arithmetic, or attribute access (the `.` operator). Execute code steps with run_step(name), not start_step/mark_step_done.
+Some steps can be 'code' steps that run automatically. Set "type":"code" and
+"code" to a single async function exactly of the form:
+
+    async def step(deps, input):
+        ...
+        return <result>
+
+The function runs in a sandbox as soon as its dependencies are satisfied — you
+do NOT call a tool to run it. `deps` is a dict of this step's dependency results
+(deps['<dep_name>']); `input` is the original task input. You may use loops,
+conditionals, comprehensions, arithmetic, local variables, and `await` the
+available async tasks: {names}, plus delegate(...) when enabled.
+
+Hard rules: no imports; no attribute access (the '.' operator is forbidden — use
+subscripts like deps['x'] and comprehensions, not methods like list.append); the
+only callables are the listed tasks and these builtins: len, range, enumerate,
+sum, min, max, sorted, abs, zip, any, all, round, dict, list, set, tuple, str,
+int, float, bool. Return a value (it becomes the step's result). There is no CPU
+or memory limit, so avoid unbounded loops.
 """
 
     return preamble

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -531,6 +531,10 @@ async def build_plan_tools(
             return {"error": f"Step '{step_name}' is not a code step."}
         if step.status == "completed":
             return step.to_dict()
+        if step.status == "in_progress":
+            return step.to_dict()
+        if step.status == "failed":
+            return {"error": f"Step '{step_name}' already failed: {step.error}. Replan to retry."}
         if not ctx.plan.dependencies_satisfied(step):
             return {"error": f"Step '{step_name}' has unmet dependencies."}
 
@@ -557,15 +561,17 @@ async def build_plan_tools(
         await _persist()
         return step.to_dict()
 
-    return [
+    tools = [
         create_plan,
         start_step,
         mark_step_done,
         mark_step_failed,
         get_plan,
         get_ready_steps,
-        run_step,
-    ], ctx.summary
+    ]
+    if code_cfg["enabled"]:
+        tools.append(run_step)
+    return tools, ctx.summary
 
 
 def build_plan_preamble(code_steps_enabled: bool = False) -> str:

--- a/flux/tasks/ai/agent_plan.py
+++ b/flux/tasks/ai/agent_plan.py
@@ -312,7 +312,9 @@ async def build_plan_tools(
                     step_code = s.get("code")
                     if step_type == "code":
                         if not code_cfg["enabled"]:
-                            return {"error": "Code steps are disabled (dynamic_code_steps_enabled=false)."}
+                            return {
+                                "error": "Code steps are disabled (dynamic_code_steps_enabled=false).",
+                            }
                         if not step_code:
                             return {"error": f"Step '{s['name']}' is type=code but has no code."}
                         try:
@@ -540,7 +542,8 @@ async def build_plan_tools(
         try:
             step.status = "in_progress"
             result = await runner(
-                step.code, bindings,
+                step.code,
+                bindings,
                 timeout=code_cfg["timeout"],
                 expected_hash=code_hash(step.code),
             )

--- a/flux/tasks/ai/code_sandbox.py
+++ b/flux/tasks/ai/code_sandbox.py
@@ -72,33 +72,6 @@ def validate_code(code: str, allowed_names: set[str]) -> ast.Lambda:
     return lam
 
 
-_SAFE_BUILTINS = {
-    n: __builtins__[n] if isinstance(__builtins__, dict) else getattr(__builtins__, n)
-    for n in (
-        "len",
-        "range",
-        "enumerate",
-        "sum",
-        "min",
-        "max",
-        "sorted",
-        "dict",
-        "list",
-        "set",
-        "tuple",
-        "str",
-        "int",
-        "float",
-        "bool",
-        "abs",
-        "zip",
-        "any",
-        "all",
-        "round",
-    )
-}
-
-
 class _CallProxy:
     """Call-only wrapper: exposes __call__ and nothing else."""
 
@@ -119,13 +92,18 @@ class _CallProxy:
 
 def build_sandbox_globals(bindings: dict) -> dict:
     """Build eval globals: top-level callable bindings proxied, non-callables
-    passed by value, __builtins__ locked to the safe subset.
+    passed by value, __builtins__ emptied so no builtin is reachable.
+
+    The dispatch-only grammar rejects any bare name not in `bindings`, so no
+    builtin is callable from a code step regardless; __builtins__ is locked to
+    {} to make that explicit instead of shipping a subset the validator never
+    admits.
 
     Note: callables nested inside non-callable bindings (e.g. one stored in a
     deps dict) are NOT proxied. The caller controls `bindings` and is trusted;
     sanitize deps values before enabling tools that can produce live objects.
     """
-    g: dict = {"__builtins__": dict(_SAFE_BUILTINS)}
+    g: dict = {"__builtins__": {}}
     for name, value in bindings.items():
         g[name] = _CallProxy(value) if callable(value) else value
     return g

--- a/flux/tasks/ai/code_sandbox.py
+++ b/flux/tasks/ai/code_sandbox.py
@@ -86,52 +86,6 @@ _ALLOWED_NODES = (
 )
 
 
-_SAFE_BUILTINS: frozenset[str] = frozenset(
-    {
-        "abs",
-        "all",
-        "any",
-        "bool",
-        "bytes",
-        "dict",
-        "divmod",
-        "enumerate",
-        "filter",
-        "float",
-        "frozenset",
-        "hash",
-        "int",
-        "isinstance",
-        "issubclass",
-        "iter",
-        "len",
-        "list",
-        "map",
-        "max",
-        "min",
-        "next",
-        "print",
-        "range",
-        "repr",
-        "reversed",
-        "round",
-        "set",
-        "slice",
-        "sorted",
-        "str",
-        "sum",
-        "tuple",
-        "type",
-        "zip",
-        "None",
-        "True",
-        "False",
-        "NotImplemented",
-        "Ellipsis",
-    },
-)
-
-
 def _collect_bound_names(tree: ast.AST) -> set[str]:
     """Names bound inside the function: params + every Store target."""
     bound: set[str] = set()
@@ -167,7 +121,7 @@ def validate_code(code: str, allowed_names: set[str]) -> ast.AsyncFunctionDef:
         raise CodeValidationError("step must take exactly (deps, input)")
 
     bound = _collect_bound_names(fn)
-    allowed = set(allowed_names) | bound | _SAFE_BUILTINS
+    allowed = set(allowed_names) | bound
 
     for node in ast.walk(fn):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node is not fn:

--- a/flux/tasks/ai/code_sandbox.py
+++ b/flux/tasks/ai/code_sandbox.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import ast
+
+
+class CodeValidationError(ValueError):
+    """Raised when a code-step lambda fails sandbox validation."""
+
+
+# Node types permitted anywhere in a code-step expression. Dispatch-only:
+# no arithmetic (BinOp/UnaryOp), no iteration/comprehension, no FunctionDef.
+_ALLOWED_NODES = (
+    ast.Expression, ast.Lambda, ast.arguments, ast.arg,
+    ast.Call, ast.keyword, ast.Name, ast.Load, ast.Attribute,
+    ast.Subscript, ast.Constant, ast.List, ast.Tuple, ast.Dict, ast.Set,
+    ast.IfExp, ast.Compare, ast.BoolOp, ast.And, ast.Or,
+    ast.Eq, ast.NotEq, ast.Lt, ast.LtE, ast.Gt, ast.GtE, ast.In, ast.NotIn,
+    ast.Slice,
+)
+
+
+def validate_code(code: str, allowed_names: set[str]) -> ast.Lambda:
+    """Parse and validate a code-step lambda. Returns the Lambda node.
+
+    Raises CodeValidationError on any disallowed construct or free name.
+    """
+    try:
+        tree = ast.parse(code, mode="eval")
+    except SyntaxError as ex:
+        raise CodeValidationError(f"syntax error: {ex}") from ex
+
+    if not isinstance(tree.body, ast.Lambda):
+        raise CodeValidationError("code must be a single lambda expression")
+
+    lam = tree.body
+    bound = {a.arg for a in lam.args.args}  # lambda params (usually none)
+    if lam.args.defaults or lam.args.kw_defaults:
+        raise CodeValidationError("lambda default arguments are not allowed")
+
+    for node in ast.walk(tree):
+        if not isinstance(node, _ALLOWED_NODES):
+            raise CodeValidationError(f"disallowed syntax: {type(node).__name__}")
+        if isinstance(node, ast.Attribute):
+            if node.attr.startswith("_"):
+                raise CodeValidationError(f"disallowed attribute: {node.attr}")
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+            if node.id not in allowed_names and node.id not in bound:
+                raise CodeValidationError(f"unknown name: {node.id}")
+    return lam

--- a/flux/tasks/ai/code_sandbox.py
+++ b/flux/tasks/ai/code_sandbox.py
@@ -86,6 +86,29 @@ _ALLOWED_NODES = (
 )
 
 
+_DENIED_NAMES = frozenset(
+    {
+        "eval",
+        "exec",
+        "compile",
+        "open",
+        "globals",
+        "locals",
+        "vars",
+        "getattr",
+        "setattr",
+        "delattr",
+        "breakpoint",
+        "memoryview",
+        "__import__",
+    },
+)
+
+
+def _is_denied_name(name: str) -> bool:
+    return name in _DENIED_NAMES or (name.startswith("__") and name.endswith("__"))
+
+
 def _collect_bound_names(tree: ast.AST) -> set[str]:
     """Names bound inside the function: params + every Store target."""
     bound: set[str] = set()
@@ -119,6 +142,10 @@ def validate_code(code: str, allowed_names: set[str]) -> ast.AsyncFunctionDef:
     params = [a.arg for a in fn.args.args]
     if params != ["deps", "input"] or fn.args.vararg or fn.args.kwarg or fn.args.kwonlyargs:
         raise CodeValidationError("step must take exactly (deps, input)")
+    if fn.decorator_list:
+        raise CodeValidationError("decorators are not allowed on a code step")
+    if fn.args.defaults or fn.args.kw_defaults or fn.args.posonlyargs:
+        raise CodeValidationError("default or positional-only arguments are not allowed")
 
     bound = _collect_bound_names(fn)
     allowed = set(allowed_names) | bound
@@ -128,6 +155,10 @@ def validate_code(code: str, allowed_names: set[str]) -> ast.AsyncFunctionDef:
             raise CodeValidationError("nested function definitions are not allowed")
         if not isinstance(node, _ALLOWED_NODES):
             raise CodeValidationError(f"disallowed syntax: {type(node).__name__}")
+        if isinstance(node, ast.Name) and _is_denied_name(node.id):
+            raise CodeValidationError(f"disallowed name: {node.id}")
+        if isinstance(node, ast.arg) and _is_denied_name(node.arg):
+            raise CodeValidationError(f"disallowed name: {node.arg}")
         if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
             if node.id not in allowed:
                 raise CodeValidationError(f"unknown name: {node.id}")

--- a/flux/tasks/ai/code_sandbox.py
+++ b/flux/tasks/ai/code_sandbox.py
@@ -44,3 +44,40 @@ def validate_code(code: str, allowed_names: set[str]) -> ast.Lambda:
             if node.id not in allowed_names and node.id not in bound:
                 raise CodeValidationError(f"unknown name: {node.id}")
     return lam
+
+
+_SAFE_BUILTINS = {
+    n: __builtins__[n] if isinstance(__builtins__, dict) else getattr(__builtins__, n)
+    for n in (
+        "len", "range", "enumerate", "sum", "min", "max", "sorted",
+        "dict", "list", "set", "tuple", "str", "int", "float", "bool",
+        "abs", "zip", "any", "all", "round",
+    )
+}
+
+
+class _CallProxy:
+    """Call-only wrapper: exposes __call__ and nothing else."""
+
+    __slots__ = ("_fn",)
+
+    def __init__(self, fn):
+        object.__setattr__(self, "_fn", fn)
+
+    def __call__(self, *args, **kwargs):
+        return object.__getattribute__(self, "_fn")(*args, **kwargs)
+
+    def __getattr__(self, name):
+        raise AttributeError(name)
+
+    def __setattr__(self, name, value):
+        raise AttributeError(name)
+
+
+def build_sandbox_globals(bindings: dict) -> dict:
+    """Build eval globals: callables proxied, non-callables passed by value,
+    __builtins__ locked to the safe subset."""
+    g: dict = {"__builtins__": dict(_SAFE_BUILTINS)}
+    for name, value in bindings.items():
+        g[name] = _CallProxy(value) if callable(value) else value
+    return g

--- a/flux/tasks/ai/code_sandbox.py
+++ b/flux/tasks/ai/code_sandbox.py
@@ -11,7 +11,7 @@ class CodeValidationError(ValueError):
 # no arithmetic (BinOp/UnaryOp), no iteration/comprehension, no FunctionDef.
 _ALLOWED_NODES = (
     ast.Expression, ast.Lambda, ast.arguments, ast.arg,
-    ast.Call, ast.keyword, ast.Name, ast.Load, ast.Attribute,
+    ast.Call, ast.keyword, ast.Name, ast.Load,
     ast.Subscript, ast.Constant, ast.List, ast.Tuple, ast.Dict, ast.Set,
     ast.IfExp, ast.Compare, ast.BoolOp, ast.And, ast.Or,
     ast.Eq, ast.NotEq, ast.Lt, ast.LtE, ast.Gt, ast.GtE, ast.In, ast.NotIn,
@@ -40,9 +40,6 @@ def validate_code(code: str, allowed_names: set[str]) -> ast.Lambda:
     for node in ast.walk(tree):
         if not isinstance(node, _ALLOWED_NODES):
             raise CodeValidationError(f"disallowed syntax: {type(node).__name__}")
-        if isinstance(node, ast.Attribute):
-            if node.attr.startswith("_"):
-                raise CodeValidationError(f"disallowed attribute: {node.attr}")
         if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
             if node.id not in allowed_names and node.id not in bound:
                 raise CodeValidationError(f"unknown name: {node.id}")

--- a/flux/tasks/ai/code_sandbox.py
+++ b/flux/tasks/ai/code_sandbox.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 import ast
+import asyncio
+import hashlib
+
+from flux.utils import maybe_awaitable
 
 
 class CodeValidationError(ValueError):
@@ -81,3 +85,28 @@ def build_sandbox_globals(bindings: dict) -> dict:
     for name, value in bindings.items():
         g[name] = _CallProxy(value) if callable(value) else value
     return g
+
+
+def code_hash(code: str) -> str:
+    return hashlib.sha256(code.encode("utf-8")).hexdigest()[:16]
+
+
+async def run_code_step(
+    code: str,
+    bindings: dict,
+    *,
+    timeout: int,
+    expected_hash: str | None = None,
+) -> object:
+    """Validate, then evaluate a code-step lambda and run its result.
+
+    The lambda is re-validated here (defense in depth, identical to plan time).
+    `expected_hash` (when given) must match the code's hash before eval.
+    """
+    if expected_hash is not None and code_hash(code) != expected_hash:
+        raise CodeValidationError("code hash mismatch — refusing to execute")
+    allowed = set(bindings.keys())
+    validate_code(code, allowed)
+    g = build_sandbox_globals(bindings)
+    fn = eval(code, g)  # noqa: S307 — validated, locked builtins, proxied globals
+    return await asyncio.wait_for(maybe_awaitable(fn()), timeout=timeout)

--- a/flux/tasks/ai/code_sandbox.py
+++ b/flux/tasks/ai/code_sandbox.py
@@ -5,6 +5,8 @@ import builtins
 import dataclasses
 import hashlib
 
+from flux.task import task
+
 
 _MAX_DEPS_DEPTH = 6
 
@@ -223,3 +225,21 @@ def sanitize_deps(value: object, _depth: int = 0) -> object:
 
 def code_hash(code: str) -> str:
     return hashlib.sha256(code.encode("utf-8")).hexdigest()[:16]
+
+
+def compile_code_step(code: str, bindings: dict, *, step_name: str) -> task:
+    """Validate and compile an `async def step(deps, input)` into a flux task.
+
+    `bindings` are the exposed flux primitives (callables) made available as
+    module globals to the function; `deps`/`input` are supplied at call time.
+    The code hash is folded into the task name so re-authoring the body yields a
+    distinct task identity (no stale replay).
+    """
+    allowed = set(bindings) | {"deps", "input"} | set(_SAFE_BUILTIN_NAMES)
+    validate_code(code, allowed)
+
+    g: dict = {"__builtins__": dict(_SAFE_BUILTINS)}
+    g.update(bindings)
+    exec(compile(code, "<code-step>", "exec"), g)  # noqa: S102 — validated, locked builtins
+    fn = g["step"]
+    return task(fn, name=f"plan_step_{step_name}_{code_hash(code)}")

--- a/flux/tasks/ai/code_sandbox.py
+++ b/flux/tasks/ai/code_sandbox.py
@@ -14,11 +14,33 @@ class CodeValidationError(ValueError):
 # Node types permitted anywhere in a code-step expression. Dispatch-only:
 # no arithmetic (BinOp/UnaryOp), no iteration/comprehension, no FunctionDef.
 _ALLOWED_NODES = (
-    ast.Expression, ast.Lambda, ast.arguments, ast.arg,
-    ast.Call, ast.keyword, ast.Name, ast.Load,
-    ast.Subscript, ast.Constant, ast.List, ast.Tuple, ast.Dict, ast.Set,
-    ast.IfExp, ast.Compare, ast.BoolOp, ast.And, ast.Or,
-    ast.Eq, ast.NotEq, ast.Lt, ast.LtE, ast.Gt, ast.GtE, ast.In, ast.NotIn,
+    ast.Expression,
+    ast.Lambda,
+    ast.arguments,
+    ast.arg,
+    ast.Call,
+    ast.keyword,
+    ast.Name,
+    ast.Load,
+    ast.Subscript,
+    ast.Constant,
+    ast.List,
+    ast.Tuple,
+    ast.Dict,
+    ast.Set,
+    ast.IfExp,
+    ast.Compare,
+    ast.BoolOp,
+    ast.And,
+    ast.Or,
+    ast.Eq,
+    ast.NotEq,
+    ast.Lt,
+    ast.LtE,
+    ast.Gt,
+    ast.GtE,
+    ast.In,
+    ast.NotIn,
     ast.Slice,
 )
 
@@ -53,9 +75,26 @@ def validate_code(code: str, allowed_names: set[str]) -> ast.Lambda:
 _SAFE_BUILTINS = {
     n: __builtins__[n] if isinstance(__builtins__, dict) else getattr(__builtins__, n)
     for n in (
-        "len", "range", "enumerate", "sum", "min", "max", "sorted",
-        "dict", "list", "set", "tuple", "str", "int", "float", "bool",
-        "abs", "zip", "any", "all", "round",
+        "len",
+        "range",
+        "enumerate",
+        "sum",
+        "min",
+        "max",
+        "sorted",
+        "dict",
+        "list",
+        "set",
+        "tuple",
+        "str",
+        "int",
+        "float",
+        "bool",
+        "abs",
+        "zip",
+        "any",
+        "all",
+        "round",
     )
 }
 

--- a/flux/tasks/ai/code_sandbox.py
+++ b/flux/tasks/ai/code_sandbox.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import dataclasses
 import hashlib
 
 from flux.utils import maybe_awaitable
+
+_MAX_DEPS_DEPTH = 6
 
 
 class CodeValidationError(ValueError):
@@ -100,13 +103,45 @@ def build_sandbox_globals(bindings: dict) -> dict:
     admits.
 
     Note: callables nested inside non-callable bindings (e.g. one stored in a
-    deps dict) are NOT proxied. The caller controls `bindings` and is trusted;
-    sanitize deps values before enabling tools that can produce live objects.
+    deps dict) are NOT proxied. Callers must run deps through sanitize_deps so
+    no live callable reaches the sandbox via deps['a']['b'](...).
     """
     g: dict = {"__builtins__": {}}
     for name, value in bindings.items():
         g[name] = _CallProxy(value) if callable(value) else value
     return g
+
+
+def sanitize_deps(value: object, _depth: int = 0) -> object:
+    """Return a value-only deep copy of a dependency result for the sandbox.
+
+    Primitives pass through; list/tuple/set become lists and dict keeps its
+    keys, with every element sanitized recursively; objects exposing
+    model_dump() (Pydantic) or dataclass fields are dumped first. Anything else
+    — a callable, or an opaque object — raises CodeValidationError.
+
+    Value-only output serves two guarantees at once: generated code can never
+    reach a live callable smuggled in via deps (the dispatch grammar permits
+    deps['a']['b'](...)), and the result is deterministically serializable so
+    the host task_id stays stable across replay.
+    """
+    if _depth > _MAX_DEPS_DEPTH:
+        raise CodeValidationError("dependency value nested too deeply to sanitize")
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (list, tuple, set)):
+        return [sanitize_deps(v, _depth + 1) for v in value]
+    if isinstance(value, dict):
+        return {k: sanitize_deps(v, _depth + 1) for k, v in value.items()}
+    dump = getattr(value, "model_dump", None)
+    if callable(dump):
+        return sanitize_deps(dump(), _depth + 1)
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return sanitize_deps(dataclasses.asdict(value), _depth + 1)
+    raise CodeValidationError(
+        f"dependency value of type {type(value).__name__} is not value-only; "
+        "code steps only receive primitive/JSON-like dependency results",
+    )
 
 
 def code_hash(code: str) -> str:

--- a/flux/tasks/ai/code_sandbox.py
+++ b/flux/tasks/ai/code_sandbox.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import ast
 import builtins
 import dataclasses
+import datetime
 import hashlib
+import uuid
+from decimal import Decimal
 
 from flux.task import task
 
@@ -208,6 +211,12 @@ def sanitize_deps(value: object, _depth: int = 0) -> object:
         raise CodeValidationError("dependency value nested too deeply to sanitize")
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
+    if isinstance(value, (datetime.datetime, datetime.date, datetime.time)):
+        return value.isoformat()
+    if isinstance(value, uuid.UUID):
+        return str(value)
+    if isinstance(value, Decimal):
+        return str(value)
     if isinstance(value, (list, tuple, set)):
         return [sanitize_deps(v, _depth + 1) for v in value]
     if isinstance(value, dict):

--- a/flux/tasks/ai/code_sandbox.py
+++ b/flux/tasks/ai/code_sandbox.py
@@ -79,8 +79,13 @@ class _CallProxy:
 
 
 def build_sandbox_globals(bindings: dict) -> dict:
-    """Build eval globals: callables proxied, non-callables passed by value,
-    __builtins__ locked to the safe subset."""
+    """Build eval globals: top-level callable bindings proxied, non-callables
+    passed by value, __builtins__ locked to the safe subset.
+
+    Note: callables nested inside non-callable bindings (e.g. one stored in a
+    deps dict) are NOT proxied. The caller controls `bindings` and is trusted;
+    sanitize deps values before enabling tools that can produce live objects.
+    """
     g: dict = {"__builtins__": dict(_SAFE_BUILTINS)}
     for name, value in bindings.items():
         g[name] = _CallProxy(value) if callable(value) else value

--- a/flux/tasks/ai/code_sandbox.py
+++ b/flux/tasks/ai/code_sandbox.py
@@ -14,26 +14,63 @@ class CodeValidationError(ValueError):
     """Raised when a code-step lambda fails sandbox validation."""
 
 
-# Node types permitted anywhere in a code-step expression. Dispatch-only:
-# no arithmetic (BinOp/UnaryOp), no iteration/comprehension, no FunctionDef.
 _ALLOWED_NODES = (
-    ast.Expression,
-    ast.Lambda,
+    ast.Module,
+    ast.AsyncFunctionDef,
     ast.arguments,
     ast.arg,
+    ast.Assign,
+    ast.AugAssign,
+    ast.AnnAssign,
+    ast.Return,
+    ast.Expr,
+    ast.Pass,
+    ast.Break,
+    ast.Continue,
+    ast.For,
+    ast.While,
+    ast.If,
+    ast.IfExp,
+    ast.ListComp,
+    ast.SetComp,
+    ast.DictComp,
+    ast.GeneratorExp,
+    ast.comprehension,
+    ast.BinOp,
+    ast.UnaryOp,
+    ast.BoolOp,
+    ast.Compare,
+    ast.Await,
     ast.Call,
     ast.keyword,
+    ast.Starred,
+    ast.Subscript,
+    ast.Slice,
     ast.Name,
     ast.Load,
-    ast.Subscript,
+    ast.Store,
     ast.Constant,
     ast.List,
     ast.Tuple,
     ast.Dict,
     ast.Set,
-    ast.IfExp,
-    ast.Compare,
-    ast.BoolOp,
+    ast.Add,
+    ast.Sub,
+    ast.Mult,
+    ast.Div,
+    ast.FloorDiv,
+    ast.Mod,
+    ast.Pow,
+    ast.LShift,
+    ast.RShift,
+    ast.BitOr,
+    ast.BitAnd,
+    ast.BitXor,
+    ast.MatMult,
+    ast.UAdd,
+    ast.USub,
+    ast.Not,
+    ast.Invert,
     ast.And,
     ast.Or,
     ast.Eq,
@@ -42,37 +79,105 @@ _ALLOWED_NODES = (
     ast.LtE,
     ast.Gt,
     ast.GtE,
+    ast.Is,
+    ast.IsNot,
     ast.In,
     ast.NotIn,
-    ast.Slice,
 )
 
 
-def validate_code(code: str, allowed_names: set[str]) -> ast.Lambda:
-    """Parse and validate a code-step lambda. Returns the Lambda node.
+_SAFE_BUILTINS: frozenset[str] = frozenset(
+    {
+        "abs",
+        "all",
+        "any",
+        "bool",
+        "bytes",
+        "dict",
+        "divmod",
+        "enumerate",
+        "filter",
+        "float",
+        "frozenset",
+        "hash",
+        "int",
+        "isinstance",
+        "issubclass",
+        "iter",
+        "len",
+        "list",
+        "map",
+        "max",
+        "min",
+        "next",
+        "print",
+        "range",
+        "repr",
+        "reversed",
+        "round",
+        "set",
+        "slice",
+        "sorted",
+        "str",
+        "sum",
+        "tuple",
+        "type",
+        "zip",
+        "None",
+        "True",
+        "False",
+        "NotImplemented",
+        "Ellipsis",
+    },
+)
 
-    Raises CodeValidationError on any disallowed construct or free name.
+
+def _collect_bound_names(tree: ast.AST) -> set[str]:
+    """Names bound inside the function: params + every Store target."""
+    bound: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.arg):
+            bound.add(node.arg)
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+            bound.add(node.id)
+    return bound
+
+
+def validate_code(code: str, allowed_names: set[str]) -> ast.AsyncFunctionDef:
+    """Parse and validate a code step. Returns the `step` function node.
+
+    The source must be exactly one `async def step(deps, input)`. Raises
+    CodeValidationError on any disallowed construct or unknown free name.
     """
     try:
-        tree = ast.parse(code, mode="eval")
+        tree = ast.parse(code, mode="exec")
     except SyntaxError as ex:
         raise CodeValidationError(f"syntax error: {ex}") from ex
 
-    if not isinstance(tree.body, ast.Lambda):
-        raise CodeValidationError("code must be a single lambda expression")
+    body = tree.body
+    if len(body) != 1 or not isinstance(body[0], ast.AsyncFunctionDef):
+        raise CodeValidationError(
+            "code must be exactly one 'async def step(deps, input)' function",
+        )
+    fn = body[0]
+    if fn.name != "step":
+        raise CodeValidationError(f"function must be named 'step', got '{fn.name}'")
+    params = [a.arg for a in fn.args.args]
+    if params != ["deps", "input"] or fn.args.vararg or fn.args.kwarg or fn.args.kwonlyargs:
+        raise CodeValidationError("step must take exactly (deps, input)")
 
-    lam = tree.body
-    bound = {a.arg for a in lam.args.args}  # lambda params (usually none)
-    if lam.args.defaults or lam.args.kw_defaults:
-        raise CodeValidationError("lambda default arguments are not allowed")
+    bound = _collect_bound_names(fn)
+    allowed = set(allowed_names) | bound | _SAFE_BUILTINS
 
-    for node in ast.walk(tree):
+    for node in ast.walk(fn):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node is not fn:
+            raise CodeValidationError("nested function definitions are not allowed")
         if not isinstance(node, _ALLOWED_NODES):
             raise CodeValidationError(f"disallowed syntax: {type(node).__name__}")
         if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
-            if node.id not in allowed_names and node.id not in bound:
+            if node.id not in allowed:
                 raise CodeValidationError(f"unknown name: {node.id}")
-    return lam
+    return fn
 
 
 class _CallProxy:

--- a/flux/tasks/ai/code_sandbox.py
+++ b/flux/tasks/ai/code_sandbox.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import ast
-import asyncio
+import builtins
 import dataclasses
 import hashlib
 
-from flux.utils import maybe_awaitable
 
 _MAX_DEPS_DEPTH = 6
 
@@ -109,6 +108,31 @@ def _is_denied_name(name: str) -> bool:
     return name in _DENIED_NAMES or (name.startswith("__") and name.endswith("__"))
 
 
+_SAFE_BUILTIN_NAMES = (
+    "len",
+    "range",
+    "enumerate",
+    "sum",
+    "min",
+    "max",
+    "sorted",
+    "abs",
+    "zip",
+    "any",
+    "all",
+    "round",
+    "dict",
+    "list",
+    "set",
+    "tuple",
+    "str",
+    "int",
+    "float",
+    "bool",
+)
+_SAFE_BUILTINS = {n: getattr(builtins, n) for n in _SAFE_BUILTIN_NAMES}
+
+
 def _collect_bound_names(tree: ast.AST) -> set[str]:
     """Names bound inside the function: params + every Store target."""
     bound: set[str] = set()
@@ -165,43 +189,6 @@ def validate_code(code: str, allowed_names: set[str]) -> ast.AsyncFunctionDef:
     return fn
 
 
-class _CallProxy:
-    """Call-only wrapper: exposes __call__ and nothing else."""
-
-    __slots__ = ("_fn",)
-
-    def __init__(self, fn):
-        object.__setattr__(self, "_fn", fn)
-
-    def __call__(self, *args, **kwargs):
-        return object.__getattribute__(self, "_fn")(*args, **kwargs)
-
-    def __getattr__(self, name):
-        raise AttributeError(name)
-
-    def __setattr__(self, name, value):
-        raise AttributeError(name)
-
-
-def build_sandbox_globals(bindings: dict) -> dict:
-    """Build eval globals: top-level callable bindings proxied, non-callables
-    passed by value, __builtins__ emptied so no builtin is reachable.
-
-    The dispatch-only grammar rejects any bare name not in `bindings`, so no
-    builtin is callable from a code step regardless; __builtins__ is locked to
-    {} to make that explicit instead of shipping a subset the validator never
-    admits.
-
-    Note: callables nested inside non-callable bindings (e.g. one stored in a
-    deps dict) are NOT proxied. Callers must run deps through sanitize_deps so
-    no live callable reaches the sandbox via deps['a']['b'](...).
-    """
-    g: dict = {"__builtins__": {}}
-    for name, value in bindings.items():
-        g[name] = _CallProxy(value) if callable(value) else value
-    return g
-
-
 def sanitize_deps(value: object, _depth: int = 0) -> object:
     """Return a value-only deep copy of a dependency result for the sandbox.
 
@@ -236,24 +223,3 @@ def sanitize_deps(value: object, _depth: int = 0) -> object:
 
 def code_hash(code: str) -> str:
     return hashlib.sha256(code.encode("utf-8")).hexdigest()[:16]
-
-
-async def run_code_step(
-    code: str,
-    bindings: dict,
-    *,
-    timeout: int,
-    expected_hash: str | None = None,
-) -> object:
-    """Validate, then evaluate a code-step lambda and run its result.
-
-    The lambda is re-validated here (defense in depth, identical to plan time).
-    `expected_hash` (when given) must match the code's hash before eval.
-    """
-    if expected_hash is not None and code_hash(code) != expected_hash:
-        raise CodeValidationError("code hash mismatch — refusing to execute")
-    allowed = set(bindings.keys())
-    validate_code(code, allowed)
-    g = build_sandbox_globals(bindings)
-    fn = eval(code, g)  # noqa: S307 — validated, locked builtins, proxied globals
-    return await asyncio.wait_for(maybe_awaitable(fn()), timeout=timeout)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.36.1"
+version = "0.36.2"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.37.0"
+version = "0.38.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.36.2"
+version = "0.37.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/tasks/ai/test_agent_loop.py
+++ b/tests/flux/tasks/ai/test_agent_loop.py
@@ -370,3 +370,59 @@ def test_multiple_tool_iterations():
     ctx = test_wf.run()
     assert ctx.has_succeeded, ctx.output
     assert "42" in ctx.output
+
+
+def test_loop_awaits_plan_advance_fn():
+    from flux.tasks.ai.agent_loop import run_agent_loop
+
+    calls = {"n": 0}
+    captured_messages: dict[str, Any] = {}
+
+    async def advance() -> str:
+        calls["n"] += 1
+        return 'Ran code steps: "a" ok.'
+
+    call_index = {"i": 0}
+
+    @task
+    async def capturing_llm(messages: list[dict], **kwargs: Any) -> LLMResponse:
+        idx = call_index["i"]
+        call_index["i"] += 1
+        captured_messages[f"call_{idx}"] = list(messages)
+        responses = [
+            LLMResponse(
+                text="",
+                tool_calls=[
+                    ToolCall(id="call_1", name="search_web", arguments={"query": "flux"}),
+                ],
+            ),
+            LLMResponse(text="Done."),
+        ]
+        if idx < len(responses):
+            return responses[idx]
+        return LLMResponse(text="fallback")
+
+    formatter = MockFormatter()
+
+    @workflow
+    async def test_wf(ctx: ExecutionContext):
+        return await run_agent_loop(
+            llm_task=capturing_llm,
+            formatter=formatter,
+            system_prompt="You are helpful.",
+            instruction="Do something with tools",
+            tools=[search_web],
+            tool_schemas=[{"name": "search_web", "parameters": {}}],
+            max_tool_calls=10,
+            plan_advance_fn=advance,
+        )
+
+    ctx = test_wf.run()
+    assert ctx.has_succeeded, ctx.output
+    assert calls["n"] >= 1
+
+    second_call_messages = captured_messages.get("call_1", [])
+    all_content = " ".join(
+        msg.get("content", "") or "" for msg in second_call_messages if isinstance(msg, dict)
+    )
+    assert "Ran code steps" in all_content

--- a/tests/flux/tasks/ai/test_agent_plan.py
+++ b/tests/flux/tasks/ai/test_agent_plan.py
@@ -499,7 +499,7 @@ def test_build_plan_tools_returns_tools_and_summary():
 
     ctx = test_wf.run()
     assert ctx.has_succeeded
-    assert ctx.output["count"] == 6
+    assert ctx.output["count"] == 7
     assert ctx.output["summary"] is None
 
 
@@ -520,6 +520,7 @@ def test_build_plan_tools_tool_names():
         "mark_step_failed",
         "get_plan",
         "get_ready_steps",
+        "run_step",
     }
 
 

--- a/tests/flux/tasks/ai/test_agent_plan.py
+++ b/tests/flux/tasks/ai/test_agent_plan.py
@@ -494,7 +494,7 @@ def test_build_plan_tools_returns_tools_and_summary():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, summary_fn = await build_plan_tools()
+        tools, summary_fn, _ = await build_plan_tools()
         return {"count": len(tools), "summary": summary_fn()}
 
     ctx = test_wf.run()
@@ -508,7 +508,7 @@ def test_build_plan_tools_tool_names():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         return {t.func.__name__ for t in tools}
 
     ctx = test_wf.run()
@@ -530,7 +530,7 @@ def test_create_plan():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, summary_fn = await build_plan_tools()
+        tools, summary_fn, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         result = await create_plan_tool(
             steps=json.dumps(
@@ -560,7 +560,7 @@ def test_create_plan_invalid_name():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         return await create_plan_tool(
             steps=json.dumps([{"name": "Bad-Name", "description": "Invalid."}]),
@@ -577,7 +577,7 @@ def test_create_plan_circular_dependency():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         return await create_plan_tool(
             steps=json.dumps(
@@ -599,7 +599,7 @@ def test_create_plan_preserves_completed_on_replan():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         await create_plan_tool(
@@ -642,7 +642,7 @@ def test_mark_step_done():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, summary_fn = await build_plan_tools()
+        tools, summary_fn, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         await create_plan_tool(
@@ -665,7 +665,7 @@ def test_mark_step_done_no_plan():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         return await mark_step_done_tool(step_name="a", result="Done.")
 
@@ -681,7 +681,7 @@ def test_mark_step_done_not_found():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         await create_plan_tool(
@@ -704,7 +704,7 @@ def test_mark_step_done_already_completed():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         await create_plan_tool(
@@ -730,7 +730,7 @@ def test_get_plan():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         get_plan_tool = next(t for t in tools if t.func.__name__ == "get_plan")
         await create_plan_tool(
@@ -750,7 +750,7 @@ def test_get_plan_no_plan():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         get_plan_tool = next(t for t in tools if t.func.__name__ == "get_plan")
         return await get_plan_tool()
 
@@ -768,7 +768,7 @@ def test_start_step():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, summary_fn = await build_plan_tools()
+        tools, summary_fn, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
         await create_plan_tool(
@@ -793,7 +793,7 @@ def test_start_step_no_plan():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
         return await start_step_tool(step_name="a")
 
@@ -808,7 +808,7 @@ def test_start_step_not_found():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
         await create_plan_tool(
@@ -832,7 +832,7 @@ def test_start_step_already_in_progress():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
         await create_plan_tool(
@@ -858,7 +858,7 @@ def test_start_step_deps_not_satisfied_warns():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
         await create_plan_tool(
@@ -883,7 +883,7 @@ def test_start_step_strict_deps_blocks():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools(strict_dependencies=True)
+        tools, _, _ = await build_plan_tools(strict_dependencies=True)
         create_plan_tool = tools[0]
         start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
         await create_plan_tool(
@@ -930,7 +930,7 @@ def test_mark_step_failed():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, summary_fn = await build_plan_tools()
+        tools, summary_fn, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
         mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
@@ -958,7 +958,7 @@ def test_mark_step_failed_no_plan():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
         return await mark_step_failed_tool(step_name="a", reason="Error.")
 
@@ -973,7 +973,7 @@ def test_mark_step_failed_allows_from_pending():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
         await create_plan_tool(
@@ -997,7 +997,7 @@ def test_mark_step_failed_already_completed():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
@@ -1023,7 +1023,7 @@ def test_mark_step_done_from_in_progress():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
         mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
@@ -1049,7 +1049,7 @@ def test_mark_step_done_from_pending_grace():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         await create_plan_tool(
@@ -1073,7 +1073,7 @@ def test_mark_step_done_rejects_failed():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         mark_step_failed_tool = next(t for t in tools if t.func.__name__ == "mark_step_failed")
         mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
@@ -1102,7 +1102,7 @@ def test_create_plan_rejects_single_step():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         return await create_plan_tool(
             steps=json.dumps([{"name": "a", "description": "Do A."}]),
@@ -1118,7 +1118,7 @@ def test_create_plan_rejects_too_many_steps():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools(max_plan_steps=5)
+        tools, _, _ = await build_plan_tools(max_plan_steps=5)
         create_plan_tool = tools[0]
         steps = [{"name": f"s{i}", "description": f"Step {i}."} for i in range(6)]
         return await create_plan_tool(steps=json.dumps(steps))
@@ -1133,7 +1133,7 @@ def test_create_plan_accepts_at_limit():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools(max_plan_steps=5)
+        tools, _, _ = await build_plan_tools(max_plan_steps=5)
         create_plan_tool = tools[0]
         steps = [{"name": f"s{i}", "description": f"Step {i}."} for i in range(5)]
         return await create_plan_tool(steps=json.dumps(steps))
@@ -1148,7 +1148,7 @@ def test_create_plan_default_max_is_20():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         steps = [{"name": f"s{i}", "description": f"Step {i}."} for i in range(21)]
         return await create_plan_tool(steps=json.dumps(steps))
@@ -1166,7 +1166,7 @@ def test_get_ready_steps():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         get_ready_steps_tool = next(t for t in tools if t.func.__name__ == "get_ready_steps")
@@ -1197,7 +1197,7 @@ def test_get_ready_steps_no_plan():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         get_ready_steps_tool = next(t for t in tools if t.func.__name__ == "get_ready_steps")
         return await get_ready_steps_tool()
 
@@ -1212,7 +1212,7 @@ def test_get_ready_steps_none_ready():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         start_step_tool = next(t for t in tools if t.func.__name__ == "start_step")
         get_ready_steps_tool = next(t for t in tools if t.func.__name__ == "get_ready_steps")
@@ -1238,7 +1238,7 @@ def test_replan_warns_about_dropped_completed_steps():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         await create_plan_tool(
@@ -1271,7 +1271,7 @@ def test_replan_no_warning_when_steps_preserved():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
         await create_plan_tool(
@@ -1307,7 +1307,7 @@ def test_create_plan_pauses_for_approval():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools(approve_plan=True)
+        tools, _, _ = await build_plan_tools(approve_plan=True)
         create_plan_tool = tools[0]
         return await create_plan_tool(
             steps=json.dumps(
@@ -1333,7 +1333,7 @@ def test_create_plan_resumes_with_approved_plan():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, summary_fn = await build_plan_tools(approve_plan=True)
+        tools, summary_fn, _ = await build_plan_tools(approve_plan=True)
         create_plan_tool = tools[0]
         result = await create_plan_tool(
             steps=json.dumps(
@@ -1363,7 +1363,7 @@ def test_create_plan_resumes_with_modified_plan():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools(approve_plan=True)
+        tools, _, _ = await build_plan_tools(approve_plan=True)
         create_plan_tool = tools[0]
         return await create_plan_tool(
             steps=json.dumps(
@@ -1395,7 +1395,7 @@ def test_create_plan_resumes_with_rejection():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, summary_fn = await build_plan_tools(approve_plan=True)
+        tools, summary_fn, _ = await build_plan_tools(approve_plan=True)
         create_plan_tool = tools[0]
         result = await create_plan_tool(
             steps=json.dumps(
@@ -1422,7 +1422,7 @@ def test_create_plan_no_pause_when_approval_disabled():
 
     @workflow
     async def test_wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools(approve_plan=False)
+        tools, _, _ = await build_plan_tools(approve_plan=False)
         create_plan_tool = tools[0]
         return await create_plan_tool(
             steps=json.dumps(
@@ -1453,7 +1453,7 @@ def test_build_plan_tools_restores_from_ltm():
         ltm = LongTermMemory(provider=provider, agent="plan_wf", scope="_plan")
         phase = ctx.input or "setup"
         if phase == "setup":
-            tools, _ = await build_plan_tools(long_term_memory=ltm)
+            tools, _, _ = await build_plan_tools(long_term_memory=ltm)
             create_plan_tool = tools[0]
             mark_step_done_tool = next(t for t in tools if t.func.__name__ == "mark_step_done")
             await create_plan_tool(
@@ -1467,7 +1467,7 @@ def test_build_plan_tools_restores_from_ltm():
             await mark_step_done_tool(step_name="a", result="Done A.")
             return "setup done"
         else:
-            tools, summary_fn = await build_plan_tools(long_term_memory=ltm)
+            tools, summary_fn, _ = await build_plan_tools(long_term_memory=ltm)
             get_plan_tool = next(t for t in tools if t.func.__name__ == "get_plan")
             plan = await get_plan_tool()
             return {"plan": plan, "summary": summary_fn()}
@@ -1489,7 +1489,7 @@ def test_build_plan_tools_works_without_ltm():
 
     @workflow
     async def test_wf2(ctx: ExecutionContext):
-        tools, summary_fn = await build_plan_tools()
+        tools, summary_fn, _ = await build_plan_tools()
         create_plan_tool = tools[0]
         await create_plan_tool(
             steps=json.dumps(

--- a/tests/flux/tasks/ai/test_agent_plan.py
+++ b/tests/flux/tasks/ai/test_agent_plan.py
@@ -499,7 +499,7 @@ def test_build_plan_tools_returns_tools_and_summary():
 
     ctx = test_wf.run()
     assert ctx.has_succeeded
-    assert ctx.output["count"] == 7
+    assert ctx.output["count"] == 6
     assert ctx.output["summary"] is None
 
 
@@ -520,7 +520,6 @@ def test_build_plan_tools_tool_names():
         "mark_step_failed",
         "get_plan",
         "get_ready_steps",
-        "run_step",
     }
 
 

--- a/tests/flux/tasks/ai/test_agent_plan_code_steps.py
+++ b/tests/flux/tasks/ai/test_agent_plan_code_steps.py
@@ -1,3 +1,26 @@
+from __future__ import annotations
+
+from flux.tasks.ai.agent_plan import AgentStep, AgentPlan
+
+
+def test_step_defaults_to_reasoning():
+    s = AgentStep(name="a", description="d")
+    assert s.type == "reasoning"
+    assert s.code is None
+    assert "type" not in s.to_dict()
+    assert "code" not in s.to_dict()
+
+
+def test_code_step_roundtrips_through_dict():
+    s = AgentStep(name="a", description="d", type="code", code="lambda: now()")
+    d = s.to_dict()
+    assert d["type"] == "code"
+    assert d["code"] == "lambda: now()"
+    restored = AgentPlan.from_dict({"steps": [d]}).steps[0]
+    assert restored.type == "code"
+    assert restored.code == "lambda: now()"
+
+
 def test_agent_config_defaults_off():
     from flux.config import Configuration
     cfg = Configuration.get().settings.agent

--- a/tests/flux/tasks/ai/test_agent_plan_code_steps.py
+++ b/tests/flux/tasks/ai/test_agent_plan_code_steps.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from flux.tasks.ai.agent_plan import AgentStep, AgentPlan
+from flux.tasks.ai.agent_plan import AgentPlan, AgentStep, build_plan_tools
 
 
 def test_step_defaults_to_reasoning():
@@ -23,14 +23,11 @@ def test_code_step_roundtrips_through_dict():
 
 def test_agent_config_defaults_off():
     from flux.config import Configuration
+
     cfg = Configuration.get().settings.agent
     assert cfg.dynamic_code_steps_enabled is False
     assert cfg.dynamic_code_steps_agent_tools_enabled is False
     assert cfg.dynamic_code_step_timeout == 30
-
-
-import asyncio as _asyncio
-from flux.tasks.ai.agent_plan import build_plan_tools
 
 
 def _tool(tools, name):
@@ -67,7 +64,9 @@ def test_run_step_executes_code_and_records_result():
         )
         create = _tool(tools, "create_plan")
         run_step = _tool(tools, "run_step")
-        await create('[{"name":"a","description":"compute","type":"code","code":"lambda: answer()"},{"name":"b","description":"d"}]')
+        await create(
+            '[{"name":"a","description":"compute","type":"code","code":"lambda: answer()"},{"name":"b","description":"d"}]',
+        )
         return await run_step("a")
 
     ctx = wf.run()
@@ -79,6 +78,7 @@ def test_run_step_executes_code_and_records_result():
 
 def test_preamble_describes_code_steps_when_enabled():
     from flux.tasks.ai.agent_plan import build_plan_preamble
+
     text = build_plan_preamble(code_steps_enabled=True)
     assert "code" in text.lower()
     assert "lambda" in text.lower()
@@ -87,14 +87,27 @@ def test_preamble_describes_code_steps_when_enabled():
 
 def test_default_code_bindings_includes_builtins():
     from flux.tasks.ai.agent import _build_code_bindings
+
     b = _build_code_bindings(agents=[], tools_enabled=False)
-    for name in ("now", "uuid4", "parallel", "pipeline", "call", "Graph", "progress",
-                 "choice", "randint", "randrange", "sleep"):
+    for name in (
+        "now",
+        "uuid4",
+        "parallel",
+        "pipeline",
+        "call",
+        "Graph",
+        "progress",
+        "choice",
+        "randint",
+        "randrange",
+        "sleep",
+    ):
         assert name in b
     assert "delegate" not in b
 
 
 def test_code_bindings_includes_delegate_when_tools_enabled():
     from flux.tasks.ai.agent import _build_code_bindings
+
     b = _build_code_bindings(agents=[], tools_enabled=True)
     assert "delegate" in b

--- a/tests/flux/tasks/ai/test_agent_plan_code_steps.py
+++ b/tests/flux/tasks/ai/test_agent_plan_code_steps.py
@@ -5,6 +5,14 @@ import json as _json
 from flux.tasks.ai.agent_plan import AgentPlan, AgentStep, build_plan_tools
 
 
+async def _answer():
+    return 42
+
+
+async def _raise():
+    raise RuntimeError("boom")
+
+
 def test_step_defaults_to_reasoning():
     s = AgentStep(name="a", description="d")
     assert s.type == "reasoning"
@@ -81,7 +89,7 @@ def test_approve_plan_resume_rejects_invalid_code():
 
     @workflow
     async def wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools(
+        tools, _, _ = await build_plan_tools(
             approve_plan=True,
             code_config={"enabled": True, "timeout": 5},
             code_bindings={"now": lambda: 1},
@@ -125,7 +133,7 @@ def test_create_plan_accepts_v2_code_step():
 
     @workflow
     async def wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools(
+        tools, _, _ = await build_plan_tools(
             code_config={"enabled": True, "timeout": 5},
             code_bindings={"answer": lambda: 42},
         )
@@ -148,7 +156,7 @@ def test_create_plan_rejects_invalid_v2_code():
 
     @workflow
     async def wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools(
+        tools, _, _ = await build_plan_tools(
             code_config={"enabled": True, "timeout": 5},
             code_bindings={"answer": lambda: 42},
         )
@@ -172,7 +180,7 @@ def test_run_step_tool_removed():
 
     @workflow
     async def wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools(
+        tools, _, _ = await build_plan_tools(
             code_config={"enabled": True, "timeout": 5},
             code_bindings={"answer": lambda: 42},
         )
@@ -191,3 +199,95 @@ def test_preamble_describes_v2_contract_when_enabled():
     assert "attribute access" in text.lower()
     assert "now" in text and "parallel" in text
     assert "async def step" not in build_plan_preamble(code_steps_enabled=False)
+
+
+def test_advance_runs_ready_code_steps_to_fixpoint():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        tools, _, advance = await build_plan_tools(
+            code_config={"enabled": True, "timeout": 5},
+            code_bindings={"answer": _answer},
+        )
+        create = _tool(tools, "create_plan")
+        get_plan = _tool(tools, "get_plan")
+        a = "async def step(deps, input):\n    return await answer()\n"
+        b = "async def step(deps, input):\n    return deps['a'] + 1\n"
+        steps = _json.dumps(
+            [
+                {"name": "a", "description": "x", "type": "code", "code": a},
+                {"name": "b", "description": "y", "type": "code", "code": b, "depends_on": ["a"]},
+            ],
+        )
+        await create(steps)
+        summary = await advance()
+        return {"summary": summary, "plan": await get_plan()}
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    steps = {s["name"]: s for s in ctx.output["plan"]["steps"]}
+    assert steps["a"]["status"] == "completed" and steps["a"]["result"] == 42
+    assert steps["b"]["status"] == "completed" and steps["b"]["result"] == 43
+
+
+def test_advance_waits_on_reasoning_dependency():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        tools, _, advance = await build_plan_tools(
+            code_config={"enabled": True, "timeout": 5},
+            code_bindings={"answer": _answer},
+        )
+        create = _tool(tools, "create_plan")
+        get_plan = _tool(tools, "get_plan")
+        c = "async def step(deps, input):\n    return deps['think']\n"
+        steps = _json.dumps(
+            [
+                {"name": "think", "description": "reason"},
+                {
+                    "name": "use",
+                    "description": "u",
+                    "type": "code",
+                    "code": c,
+                    "depends_on": ["think"],
+                },
+            ],
+        )
+        await create(steps)
+        await advance()
+        return await get_plan()
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    steps = {s["name"]: s for s in ctx.output["steps"]}
+    assert steps["use"]["status"] == "pending"
+
+
+def test_advance_records_failure():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        tools, _, advance = await build_plan_tools(
+            code_config={"enabled": True, "timeout": 5},
+            code_bindings={"boom": _raise},
+        )
+        create = _tool(tools, "create_plan")
+        get_plan = _tool(tools, "get_plan")
+        a = "async def step(deps, input):\n    return await boom()\n"
+        steps = _json.dumps(
+            [
+                {"name": "a", "description": "x", "type": "code", "code": a},
+                {"name": "b", "description": "y"},
+            ],
+        )
+        await create(steps)
+        summary = await advance()
+        return {"summary": summary, "plan": await get_plan()}
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    steps = {s["name"]: s for s in ctx.output["plan"]["steps"]}
+    assert steps["a"]["status"] == "failed"

--- a/tests/flux/tasks/ai/test_agent_plan_code_steps.py
+++ b/tests/flux/tasks/ai/test_agent_plan_code_steps.py
@@ -145,3 +145,167 @@ def test_run_step_already_failed_returns_error_message():
     assert "error" in result
     assert "already failed" in result["error"]
     assert "Replan to retry" in result["error"]
+
+
+def test_run_step_error_branches():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools(
+            code_config={"enabled": True, "timeout": 5},
+            code_bindings={"answer": lambda: 42},
+        )
+        create = _tool(tools, "create_plan")
+        run_step = _tool(tools, "run_step")
+        # distinct arg: run_step memoizes by (name, args), so reusing "calc"
+        # here would replay this no-plan result on the later real call.
+        out = {"no_plan": await run_step("ghost")}
+        await create(
+            '[{"name":"calc","description":"c","type":"code","code":"lambda: answer()"},'
+            '{"name":"think","description":"d"}]',
+        )
+        out["not_found"] = await run_step("missing")
+        out["non_code"] = await run_step("think")
+        out["ok"] = await run_step("calc")
+        out["completed_rerun"] = await run_step("calc")
+        return out
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    o = ctx.output
+    assert "No plan exists" in o["no_plan"]["error"]
+    assert "not found" in o["not_found"]["error"]
+    assert "not a code step" in o["non_code"]["error"]
+    assert o["ok"]["status"] == "completed" and o["ok"]["result"] == 42
+    assert o["completed_rerun"]["status"] == "completed"
+
+
+def test_run_step_unmet_dependencies():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools(
+            code_config={"enabled": True, "timeout": 5},
+            code_bindings={"answer": lambda: 42},
+        )
+        create = _tool(tools, "create_plan")
+        run_step = _tool(tools, "run_step")
+        await create(
+            '[{"name":"src","description":"d"},'
+            '{"name":"calc","description":"c","type":"code","code":"lambda: answer()","depends_on":["src"]}]',
+        )
+        return await run_step("calc")
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    assert "unmet dependencies" in ctx.output["error"]
+
+
+def test_run_step_blocked_by_active_reasoning_step():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools(
+            code_config={"enabled": True, "timeout": 5},
+            code_bindings={"answer": lambda: 42},
+        )
+        create = _tool(tools, "create_plan")
+        start = _tool(tools, "start_step")
+        run_step = _tool(tools, "run_step")
+        await create(
+            '[{"name":"think","description":"d"},'
+            '{"name":"calc","description":"c","type":"code","code":"lambda: answer()"}]',
+        )
+        await start("think")
+        return await run_step("calc")
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    assert "already in progress" in ctx.output["error"]
+
+
+def test_code_step_dependency_with_none_result_is_available():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools(
+            code_config={"enabled": True, "timeout": 5},
+            code_bindings={"nothing": lambda: None},
+        )
+        create = _tool(tools, "create_plan")
+        run_step = _tool(tools, "run_step")
+        await create(
+            '[{"name":"src","description":"s","type":"code","code":"lambda: nothing()"},'
+            '{"name":"use","description":"u","type":"code","code":"lambda: deps[\'src\']","depends_on":["src"]}]',
+        )
+        await run_step("src")
+        return await run_step("use")
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    o = ctx.output
+    assert o["status"] == "completed"
+    assert o.get("result") is None
+
+
+def test_code_step_rejects_live_callable_dependency():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools(
+            code_config={"enabled": True, "timeout": 5},
+            code_bindings={"getopen": lambda: open},
+        )
+        create = _tool(tools, "create_plan")
+        run_step = _tool(tools, "run_step")
+        await create(
+            '[{"name":"src","description":"s","type":"code","code":"lambda: getopen()"},'
+            '{"name":"use","description":"u","type":"code","code":"lambda: deps[\'src\']","depends_on":["src"]}]',
+        )
+        await run_step("src")
+        return await run_step("use")
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    assert "non-value dependency" in ctx.output["error"]
+
+
+def test_approve_plan_resume_rejects_invalid_code():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools(
+            approve_plan=True,
+            code_config={"enabled": True, "timeout": 5},
+            code_bindings={"now": lambda: 1},
+        )
+        create = _tool(tools, "create_plan")
+        return await create('[{"name":"a","description":"d"},{"name":"b","description":"d"}]')
+
+    ctx = wf.run()
+    assert ctx.is_paused
+    modified = {
+        "steps": [
+            {"name": "a", "description": "d", "type": "code", "code": "lambda: __import__('os')"},
+            {"name": "b", "description": "d"},
+        ],
+    }
+    ctx = wf.resume(ctx.execution_id, modified)
+    assert ctx.has_succeeded
+    assert "error" in ctx.output and "code" in ctx.output["error"].lower()
+
+
+def test_agent_config_rejects_nonpositive_timeout():
+    import pytest
+    from pydantic import ValidationError
+
+    from flux.config import AgentConfig
+
+    with pytest.raises(ValidationError):
+        AgentConfig(dynamic_code_step_timeout=0)

--- a/tests/flux/tasks/ai/test_agent_plan_code_steps.py
+++ b/tests/flux/tasks/ai/test_agent_plan_code_steps.py
@@ -49,7 +49,7 @@ def _tool(tools, name):
     return next((t for t in tools if t.name == name), None)
 
 
-def test_default_code_bindings_includes_builtins():
+def test_default_code_bindings_excludes_graph():
     from flux.tasks.ai.agent import _build_code_bindings
 
     b = _build_code_bindings(agents=[], tools_enabled=False)
@@ -59,7 +59,6 @@ def test_default_code_bindings_includes_builtins():
         "parallel",
         "pipeline",
         "call",
-        "Graph",
         "progress",
         "choice",
         "randint",
@@ -67,6 +66,7 @@ def test_default_code_bindings_includes_builtins():
         "sleep",
     ):
         assert name in b
+    assert "Graph" not in b  # unusable: fluent builder needs attribute access
     assert "delegate" not in b
 
 

--- a/tests/flux/tasks/ai/test_agent_plan_code_steps.py
+++ b/tests/flux/tasks/ai/test_agent_plan_code_steps.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json as _json
+
 from flux.tasks.ai.agent_plan import AgentPlan, AgentStep, build_plan_tools
 
 
@@ -12,13 +14,18 @@ def test_step_defaults_to_reasoning():
 
 
 def test_code_step_roundtrips_through_dict():
-    s = AgentStep(name="a", description="d", type="code", code="lambda: now()")
+    s = AgentStep(
+        name="a",
+        description="d",
+        type="code",
+        code="async def step(deps, input):\n    return await now()\n",
+    )
     d = s.to_dict()
     assert d["type"] == "code"
-    assert d["code"] == "lambda: now()"
+    assert d["code"] == "async def step(deps, input):\n    return await now()\n"
     restored = AgentPlan.from_dict({"steps": [d]}).steps[0]
     assert restored.type == "code"
-    assert restored.code == "lambda: now()"
+    assert restored.code == "async def step(deps, input):\n    return await now()\n"
 
 
 def test_agent_config_defaults_off():
@@ -31,58 +38,7 @@ def test_agent_config_defaults_off():
 
 
 def _tool(tools, name):
-    return next(t for t in tools if t.name == name)
-
-
-def test_create_plan_rejects_invalid_code():
-    from flux import ExecutionContext, workflow
-
-    @workflow
-    async def wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools(
-            code_config={"enabled": True, "timeout": 5},
-            code_bindings={"now": lambda: 1},
-        )
-        create = _tool(tools, "create_plan")
-        steps = '[{"name":"a","description":"d","type":"code","code":"lambda: __import__(\'os\')"},{"name":"b","description":"d"}]'
-        return await create(steps)
-
-    ctx = wf.run()
-    assert ctx.has_succeeded
-    result = ctx.output
-    assert "error" in result and "code" in result["error"].lower()
-
-
-def test_run_step_executes_code_and_records_result():
-    from flux import ExecutionContext, workflow
-
-    @workflow
-    async def wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools(
-            code_config={"enabled": True, "timeout": 5},
-            code_bindings={"answer": lambda: 42},
-        )
-        create = _tool(tools, "create_plan")
-        run_step = _tool(tools, "run_step")
-        await create(
-            '[{"name":"a","description":"compute","type":"code","code":"lambda: answer()"},{"name":"b","description":"d"}]',
-        )
-        return await run_step("a")
-
-    ctx = wf.run()
-    assert ctx.has_succeeded
-    result = ctx.output
-    assert result["status"] == "completed"
-    assert result["result"] == 42
-
-
-def test_preamble_describes_code_steps_when_enabled():
-    from flux.tasks.ai.agent_plan import build_plan_preamble
-
-    text = build_plan_preamble(code_steps_enabled=True)
-    assert "code" in text.lower()
-    assert "lambda" in text.lower()
-    assert "lambda" not in build_plan_preamble(code_steps_enabled=False).lower()
+    return next((t for t in tools if t.name == name), None)
 
 
 def test_default_code_bindings_includes_builtins():
@@ -120,161 +76,6 @@ def test_code_bindings_delegate_requires_agents():
     assert "delegate" in _build_code_bindings(agents=[_StubAgent()], tools_enabled=True)
 
 
-def test_run_step_already_failed_returns_error_message():
-    from flux import ExecutionContext, workflow
-
-    @workflow
-    async def wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools(
-            code_config={"enabled": True, "timeout": 5},
-            code_bindings={"answer": lambda: 42},
-        )
-        create = _tool(tools, "create_plan")
-        run_step = _tool(tools, "run_step")
-        mark_step_failed = _tool(tools, "mark_step_failed")
-        await create(
-            '[{"name":"a","description":"compute","type":"code","code":"lambda: answer()"},{"name":"b","description":"d"}]',
-        )
-        await mark_step_failed(step_name="a", reason="previous run failed")
-        result = await run_step("a")
-        return result
-
-    ctx = wf.run()
-    assert ctx.has_succeeded
-    result = ctx.output
-    assert "error" in result
-    assert "already failed" in result["error"]
-    assert "Replan to retry" in result["error"]
-
-
-def test_run_step_error_branches():
-    from flux import ExecutionContext, workflow
-
-    @workflow
-    async def wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools(
-            code_config={"enabled": True, "timeout": 5},
-            code_bindings={"answer": lambda: 42},
-        )
-        create = _tool(tools, "create_plan")
-        run_step = _tool(tools, "run_step")
-        # distinct arg: run_step memoizes by (name, args), so reusing "calc"
-        # here would replay this no-plan result on the later real call.
-        out = {"no_plan": await run_step("ghost")}
-        await create(
-            '[{"name":"calc","description":"c","type":"code","code":"lambda: answer()"},'
-            '{"name":"think","description":"d"}]',
-        )
-        out["not_found"] = await run_step("missing")
-        out["non_code"] = await run_step("think")
-        out["ok"] = await run_step("calc")
-        out["completed_rerun"] = await run_step("calc")
-        return out
-
-    ctx = wf.run()
-    assert ctx.has_succeeded
-    o = ctx.output
-    assert "No plan exists" in o["no_plan"]["error"]
-    assert "not found" in o["not_found"]["error"]
-    assert "not a code step" in o["non_code"]["error"]
-    assert o["ok"]["status"] == "completed" and o["ok"]["result"] == 42
-    assert o["completed_rerun"]["status"] == "completed"
-
-
-def test_run_step_unmet_dependencies():
-    from flux import ExecutionContext, workflow
-
-    @workflow
-    async def wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools(
-            code_config={"enabled": True, "timeout": 5},
-            code_bindings={"answer": lambda: 42},
-        )
-        create = _tool(tools, "create_plan")
-        run_step = _tool(tools, "run_step")
-        await create(
-            '[{"name":"src","description":"d"},'
-            '{"name":"calc","description":"c","type":"code","code":"lambda: answer()","depends_on":["src"]}]',
-        )
-        return await run_step("calc")
-
-    ctx = wf.run()
-    assert ctx.has_succeeded
-    assert "unmet dependencies" in ctx.output["error"]
-
-
-def test_run_step_blocked_by_active_reasoning_step():
-    from flux import ExecutionContext, workflow
-
-    @workflow
-    async def wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools(
-            code_config={"enabled": True, "timeout": 5},
-            code_bindings={"answer": lambda: 42},
-        )
-        create = _tool(tools, "create_plan")
-        start = _tool(tools, "start_step")
-        run_step = _tool(tools, "run_step")
-        await create(
-            '[{"name":"think","description":"d"},'
-            '{"name":"calc","description":"c","type":"code","code":"lambda: answer()"}]',
-        )
-        await start("think")
-        return await run_step("calc")
-
-    ctx = wf.run()
-    assert ctx.has_succeeded
-    assert "already in progress" in ctx.output["error"]
-
-
-def test_code_step_dependency_with_none_result_is_available():
-    from flux import ExecutionContext, workflow
-
-    @workflow
-    async def wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools(
-            code_config={"enabled": True, "timeout": 5},
-            code_bindings={"nothing": lambda: None},
-        )
-        create = _tool(tools, "create_plan")
-        run_step = _tool(tools, "run_step")
-        await create(
-            '[{"name":"src","description":"s","type":"code","code":"lambda: nothing()"},'
-            '{"name":"use","description":"u","type":"code","code":"lambda: deps[\'src\']","depends_on":["src"]}]',
-        )
-        await run_step("src")
-        return await run_step("use")
-
-    ctx = wf.run()
-    assert ctx.has_succeeded
-    o = ctx.output
-    assert o["status"] == "completed"
-    assert o.get("result") is None
-
-
-def test_code_step_rejects_live_callable_dependency():
-    from flux import ExecutionContext, workflow
-
-    @workflow
-    async def wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools(
-            code_config={"enabled": True, "timeout": 5},
-            code_bindings={"getopen": lambda: open},
-        )
-        create = _tool(tools, "create_plan")
-        run_step = _tool(tools, "run_step")
-        await create(
-            '[{"name":"src","description":"s","type":"code","code":"lambda: getopen()"},'
-            '{"name":"use","description":"u","type":"code","code":"lambda: deps[\'src\']","depends_on":["src"]}]',
-        )
-        await run_step("src")
-        return await run_step("use")
-
-    ctx = wf.run()
-    assert ctx.has_succeeded
-    assert "non-value dependency" in ctx.output["error"]
-
-
 def test_approve_plan_resume_rejects_invalid_code():
     from flux import ExecutionContext, workflow
 
@@ -292,7 +93,12 @@ def test_approve_plan_resume_rejects_invalid_code():
     assert ctx.is_paused
     modified = {
         "steps": [
-            {"name": "a", "description": "d", "type": "code", "code": "lambda: __import__('os')"},
+            {
+                "name": "a",
+                "description": "d",
+                "type": "code",
+                "code": "async def step(deps, input):\n    import os\n    return os\n",
+            },
             {"name": "b", "description": "d"},
         ],
     }
@@ -309,3 +115,79 @@ def test_agent_config_rejects_nonpositive_timeout():
 
     with pytest.raises(ValidationError):
         AgentConfig(dynamic_code_step_timeout=0)
+
+
+GOOD_STEP = "async def step(deps, input):\n    return await answer()\n"
+
+
+def test_create_plan_accepts_v2_code_step():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools(
+            code_config={"enabled": True, "timeout": 5},
+            code_bindings={"answer": lambda: 42},
+        )
+        create = _tool(tools, "create_plan")
+        steps = _json.dumps(
+            [
+                {"name": "calc", "description": "c", "type": "code", "code": GOOD_STEP},
+                {"name": "think", "description": "d"},
+            ],
+        )
+        return await create(steps)
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    assert "error" not in ctx.output
+
+
+def test_create_plan_rejects_invalid_v2_code():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools(
+            code_config={"enabled": True, "timeout": 5},
+            code_bindings={"answer": lambda: 42},
+        )
+        create = _tool(tools, "create_plan")
+        bad = "async def step(deps, input):\n    import os\n    return os\n"
+        steps = _json.dumps(
+            [
+                {"name": "calc", "description": "c", "type": "code", "code": bad},
+                {"name": "think", "description": "d"},
+            ],
+        )
+        return await create(steps)
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    assert "error" in ctx.output and "code" in ctx.output["error"].lower()
+
+
+def test_run_step_tool_removed():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools(
+            code_config={"enabled": True, "timeout": 5},
+            code_bindings={"answer": lambda: 42},
+        )
+        return [t.name for t in tools]
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    assert "run_step" not in ctx.output
+
+
+def test_preamble_describes_v2_contract_when_enabled():
+    from flux.tasks.ai.agent_plan import build_plan_preamble
+
+    text = build_plan_preamble(code_steps_enabled=True, code_bindings=["now", "parallel"])
+    assert "async def step(deps, input)" in text
+    assert "attribute access" in text.lower()
+    assert "now" in text and "parallel" in text
+    assert "async def step" not in build_plan_preamble(code_steps_enabled=False)

--- a/tests/flux/tasks/ai/test_agent_plan_code_steps.py
+++ b/tests/flux/tasks/ai/test_agent_plan_code_steps.py
@@ -75,3 +75,11 @@ def test_run_step_executes_code_and_records_result():
     result = ctx.output
     assert result["status"] == "completed"
     assert result["result"] == 42
+
+
+def test_preamble_describes_code_steps_when_enabled():
+    from flux.tasks.ai.agent_plan import build_plan_preamble
+    text = build_plan_preamble(code_steps_enabled=True)
+    assert "code" in text.lower()
+    assert "lambda" in text.lower()
+    assert "lambda" not in build_plan_preamble(code_steps_enabled=False).lower()

--- a/tests/flux/tasks/ai/test_agent_plan_code_steps.py
+++ b/tests/flux/tasks/ai/test_agent_plan_code_steps.py
@@ -106,8 +106,42 @@ def test_default_code_bindings_includes_builtins():
     assert "delegate" not in b
 
 
-def test_code_bindings_includes_delegate_when_tools_enabled():
+def test_code_bindings_delegate_requires_agents():
     from flux.tasks.ai.agent import _build_code_bindings
 
-    b = _build_code_bindings(agents=[], tools_enabled=True)
-    assert "delegate" in b
+    class _StubAgent:
+        name = "helper"
+        description = "a helper sub-agent"
+
+        def __call__(self, *a, **k):
+            return None
+
+    assert "delegate" not in _build_code_bindings(agents=[], tools_enabled=True)
+    assert "delegate" in _build_code_bindings(agents=[_StubAgent()], tools_enabled=True)
+
+
+def test_run_step_already_failed_returns_error_message():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools(
+            code_config={"enabled": True, "timeout": 5},
+            code_bindings={"answer": lambda: 42},
+        )
+        create = _tool(tools, "create_plan")
+        run_step = _tool(tools, "run_step")
+        mark_step_failed = _tool(tools, "mark_step_failed")
+        await create(
+            '[{"name":"a","description":"compute","type":"code","code":"lambda: answer()"},{"name":"b","description":"d"}]',
+        )
+        await mark_step_failed(step_name="a", reason="previous run failed")
+        result = await run_step("a")
+        return result
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    result = ctx.output
+    assert "error" in result
+    assert "already failed" in result["error"]
+    assert "Replan to retry" in result["error"]

--- a/tests/flux/tasks/ai/test_agent_plan_code_steps.py
+++ b/tests/flux/tasks/ai/test_agent_plan_code_steps.py
@@ -27,3 +27,51 @@ def test_agent_config_defaults_off():
     assert cfg.dynamic_code_steps_enabled is False
     assert cfg.dynamic_code_steps_agent_tools_enabled is False
     assert cfg.dynamic_code_step_timeout == 30
+
+
+import asyncio as _asyncio
+from flux.tasks.ai.agent_plan import build_plan_tools
+
+
+def _tool(tools, name):
+    return next(t for t in tools if t.name == name)
+
+
+def test_create_plan_rejects_invalid_code():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools(
+            code_config={"enabled": True, "timeout": 5},
+            code_bindings={"now": lambda: 1},
+        )
+        create = _tool(tools, "create_plan")
+        steps = '[{"name":"a","description":"d","type":"code","code":"lambda: __import__(\'os\')"},{"name":"b","description":"d"}]'
+        return await create(steps)
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    result = ctx.output
+    assert "error" in result and "code" in result["error"].lower()
+
+
+def test_run_step_executes_code_and_records_result():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        tools, _ = await build_plan_tools(
+            code_config={"enabled": True, "timeout": 5},
+            code_bindings={"answer": lambda: 42},
+        )
+        create = _tool(tools, "create_plan")
+        run_step = _tool(tools, "run_step")
+        await create('[{"name":"a","description":"compute","type":"code","code":"lambda: answer()"},{"name":"b","description":"d"}]')
+        return await run_step("a")
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    result = ctx.output
+    assert result["status"] == "completed"
+    assert result["result"] == 42

--- a/tests/flux/tasks/ai/test_agent_plan_code_steps.py
+++ b/tests/flux/tasks/ai/test_agent_plan_code_steps.py
@@ -83,3 +83,18 @@ def test_preamble_describes_code_steps_when_enabled():
     assert "code" in text.lower()
     assert "lambda" in text.lower()
     assert "lambda" not in build_plan_preamble(code_steps_enabled=False).lower()
+
+
+def test_default_code_bindings_includes_builtins():
+    from flux.tasks.ai.agent import _build_code_bindings
+    b = _build_code_bindings(agents=[], tools_enabled=False)
+    for name in ("now", "uuid4", "parallel", "pipeline", "call", "Graph", "progress",
+                 "choice", "randint", "randrange", "sleep"):
+        assert name in b
+    assert "delegate" not in b
+
+
+def test_code_bindings_includes_delegate_when_tools_enabled():
+    from flux.tasks.ai.agent import _build_code_bindings
+    b = _build_code_bindings(agents=[], tools_enabled=True)
+    assert "delegate" in b

--- a/tests/flux/tasks/ai/test_agent_plan_code_steps.py
+++ b/tests/flux/tasks/ai/test_agent_plan_code_steps.py
@@ -1,0 +1,6 @@
+def test_agent_config_defaults_off():
+    from flux.config import Configuration
+    cfg = Configuration.get().settings.agent
+    assert cfg.dynamic_code_steps_enabled is False
+    assert cfg.dynamic_code_steps_agent_tools_enabled is False
+    assert cfg.dynamic_code_step_timeout == 30

--- a/tests/flux/tasks/ai/test_agent_plan_code_steps.py
+++ b/tests/flux/tasks/ai/test_agent_plan_code_steps.py
@@ -13,6 +13,13 @@ async def _raise():
     raise RuntimeError("boom")
 
 
+async def _slow():
+    import asyncio
+
+    await asyncio.sleep(3)
+    return 1
+
+
 def test_step_defaults_to_reasoning():
     s = AgentStep(name="a", description="d")
     assert s.type == "reasoning"
@@ -290,4 +297,32 @@ def test_advance_records_failure():
     ctx = wf.run()
     assert ctx.has_succeeded
     steps = {s["name"]: s for s in ctx.output["plan"]["steps"]}
+    assert steps["a"]["status"] == "failed"
+
+
+def test_advance_times_out_slow_code_step():
+    from flux import ExecutionContext, workflow
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        tools, _, advance = await build_plan_tools(
+            code_config={"enabled": True, "timeout": 1},
+            code_bindings={"slow": _slow},
+        )
+        create = _tool(tools, "create_plan")
+        get_plan = _tool(tools, "get_plan")
+        a = "async def step(deps, input):\n    return await slow()\n"
+        steps = _json.dumps(
+            [
+                {"name": "a", "description": "x", "type": "code", "code": a},
+                {"name": "b", "description": "y"},
+            ],
+        )
+        await create(steps)
+        await advance()
+        return await get_plan()
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    steps = {s["name"]: s for s in ctx.output["steps"]}
     assert steps["a"]["status"] == "failed"

--- a/tests/flux/tasks/ai/test_agent_plan_e2e.py
+++ b/tests/flux/tasks/ai/test_agent_plan_e2e.py
@@ -27,7 +27,7 @@ def test_integration_create_plan_via_execute_tools():
 
     @workflow
     async def wf(ctx: ExecutionContext):
-        tools, summary_fn = await build_plan_tools()
+        tools, summary_fn, _ = await build_plan_tools()
         result = await execute_tools(
             [
                 {
@@ -68,7 +68,7 @@ def test_integration_full_plan_lifecycle():
 
     @workflow
     async def wf(ctx: ExecutionContext):
-        tools, summary_fn = await build_plan_tools()
+        tools, summary_fn, _ = await build_plan_tools()
 
         r1 = await execute_tools(
             [
@@ -165,7 +165,7 @@ def test_integration_mark_step_failed():
 
     @workflow
     async def wf(ctx: ExecutionContext):
-        tools, summary_fn = await build_plan_tools()
+        tools, summary_fn, _ = await build_plan_tools()
 
         await execute_tools(
             [
@@ -235,7 +235,7 @@ def test_integration_get_ready_steps():
 
     @workflow
     async def wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
 
         await execute_tools(
             [
@@ -319,7 +319,7 @@ def test_integration_replan_preserves_completed():
 
     @workflow
     async def wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
 
         await execute_tools(
             [
@@ -389,7 +389,7 @@ def test_integration_mark_step_done_errors():
 
     @workflow
     async def wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
 
         r1 = await execute_tools(
             [
@@ -446,7 +446,7 @@ def test_integration_validation_errors():
 
     @workflow
     async def wf(ctx: ExecutionContext):
-        tools, _ = await build_plan_tools()
+        tools, _, _ = await build_plan_tools()
 
         r1 = await execute_tools(
             [
@@ -501,7 +501,7 @@ def test_integration_plan_summary_injection():
 
     @workflow
     async def wf(ctx: ExecutionContext):
-        tools, summary_fn = await build_plan_tools()
+        tools, summary_fn, _ = await build_plan_tools()
 
         assert summary_fn() is None
 

--- a/tests/flux/tasks/ai/test_code_sandbox.py
+++ b/tests/flux/tasks/ai/test_code_sandbox.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+from flux.tasks.ai.code_sandbox import validate_code, CodeValidationError
+
+ALLOWED = {"now", "parallel", "deps", "delegate"}
+
+
+def test_accepts_dispatch_lambda():
+    validate_code("lambda: now()", ALLOWED)
+    validate_code('lambda: parallel(now(), now())', ALLOWED)
+    validate_code('lambda: deps["fetch"]', ALLOWED)
+    validate_code('lambda: now() if deps["x"] else now()', ALLOWED)
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "lambda: __import__('os')",
+        "lambda: open('/etc/passwd')",
+        "lambda: (1).__class__",
+        "lambda: sum(range(10**18))",
+        "lambda: [0] * 10**9",
+        "lambda: [x for x in deps]",
+        "lambda: now.__globals__",
+        "now()",
+        "lambda: missing()",
+    ],
+)
+def test_rejects_unsafe(code):
+    with pytest.raises(CodeValidationError):
+        validate_code(code, ALLOWED)

--- a/tests/flux/tasks/ai/test_code_sandbox.py
+++ b/tests/flux/tasks/ai/test_code_sandbox.py
@@ -51,8 +51,7 @@ def test_build_sandbox_globals_locks_builtins():
     from flux.tasks.ai.code_sandbox import build_sandbox_globals, _CallProxy
 
     g = build_sandbox_globals({"now": lambda: 1})
-    assert "open" not in g["__builtins__"]
-    assert "len" in g["__builtins__"]
+    assert g["__builtins__"] == {}
     assert isinstance(g["now"], _CallProxy)
 
 

--- a/tests/flux/tasks/ai/test_code_sandbox.py
+++ b/tests/flux/tasks/ai/test_code_sandbox.py
@@ -75,6 +75,11 @@ def test_run_code_step_awaits_coroutine():
     assert out == 42
 
 
+def test_validate_code_rejects_builtin_not_in_bindings():
+    with pytest.raises(CodeValidationError):
+        validate_code("lambda: sum(range(9))", {"now"})
+
+
 def test_run_code_step_rejects_tampered_hash():
     import asyncio
     from flux.tasks.ai.code_sandbox import run_code_step, code_hash

--- a/tests/flux/tasks/ai/test_code_sandbox.py
+++ b/tests/flux/tasks/ai/test_code_sandbox.py
@@ -10,7 +10,7 @@ GOOD = """
 async def step(deps, input):
     picked = [d for d in deps['fetch'] if d['score'] > 0.5]
     out = [await summarize(d) for d in picked]
-    return {'n': len(out), 'first': input}
+    return {'items': out, 'first': input}
 """
 
 

--- a/tests/flux/tasks/ai/test_code_sandbox.py
+++ b/tests/flux/tasks/ai/test_code_sandbox.py
@@ -26,6 +26,8 @@ def test_accepts_dispatch_lambda():
         "lambda: now.__globals__",
         "now()",
         "lambda: missing()",
+        'lambda: deps["x"].format(now())',   # str.format MRO-walk via attribute
+        "lambda: now().something",            # attribute access on call result
     ],
 )
 def test_rejects_unsafe(code):

--- a/tests/flux/tasks/ai/test_code_sandbox.py
+++ b/tests/flux/tasks/ai/test_code_sandbox.py
@@ -54,3 +54,31 @@ def test_build_sandbox_globals_locks_builtins():
     assert "open" not in g["__builtins__"]
     assert "len" in g["__builtins__"]
     assert isinstance(g["now"], _CallProxy)
+
+
+def test_run_code_step_returns_value():
+    import asyncio
+    from flux.tasks.ai.code_sandbox import run_code_step
+    out = asyncio.run(run_code_step("lambda: deps['x']", {"deps": {"x": 42}}, timeout=5))
+    assert out == 42
+
+
+def test_run_code_step_awaits_coroutine():
+    import asyncio
+    from flux.tasks.ai.code_sandbox import run_code_step
+
+    async def double(n):
+        return n * 2
+
+    out = asyncio.run(run_code_step("lambda: double(21)", {"double": double}, timeout=5))
+    assert out == 42
+
+
+def test_run_code_step_rejects_tampered_hash():
+    import asyncio
+    from flux.tasks.ai.code_sandbox import run_code_step, code_hash
+    good = "lambda: deps['x']"
+    with pytest.raises(Exception):
+        asyncio.run(run_code_step(good, {"deps": {"x": 1}}, timeout=5, expected_hash="deadbeef"))
+    out = asyncio.run(run_code_step(good, {"deps": {"x": 1}}, timeout=5, expected_hash=code_hash(good)))
+    assert out == 1

--- a/tests/flux/tasks/ai/test_code_sandbox.py
+++ b/tests/flux/tasks/ai/test_code_sandbox.py
@@ -9,7 +9,7 @@ ALLOWED = {"now", "parallel", "deps", "delegate"}
 
 def test_accepts_dispatch_lambda():
     validate_code("lambda: now()", ALLOWED)
-    validate_code('lambda: parallel(now(), now())', ALLOWED)
+    validate_code("lambda: parallel(now(), now())", ALLOWED)
     validate_code('lambda: deps["fetch"]', ALLOWED)
     validate_code('lambda: now() if deps["x"] else now()', ALLOWED)
 
@@ -26,8 +26,8 @@ def test_accepts_dispatch_lambda():
         "lambda: now.__globals__",
         "now()",
         "lambda: missing()",
-        'lambda: deps["x"].format(now())',   # str.format MRO-walk via attribute
-        "lambda: now().something",            # attribute access on call result
+        'lambda: deps["x"].format(now())',  # str.format MRO-walk via attribute
+        "lambda: now().something",  # attribute access on call result
     ],
 )
 def test_rejects_unsafe(code):
@@ -59,6 +59,7 @@ def test_build_sandbox_globals_locks_builtins():
 def test_run_code_step_returns_value():
     import asyncio
     from flux.tasks.ai.code_sandbox import run_code_step
+
     out = asyncio.run(run_code_step("lambda: deps['x']", {"deps": {"x": 42}}, timeout=5))
     assert out == 42
 
@@ -77,8 +78,11 @@ def test_run_code_step_awaits_coroutine():
 def test_run_code_step_rejects_tampered_hash():
     import asyncio
     from flux.tasks.ai.code_sandbox import run_code_step, code_hash
+
     good = "lambda: deps['x']"
     with pytest.raises(Exception):
         asyncio.run(run_code_step(good, {"deps": {"x": 1}}, timeout=5, expected_hash="deadbeef"))
-    out = asyncio.run(run_code_step(good, {"deps": {"x": 1}}, timeout=5, expected_hash=code_hash(good)))
+    out = asyncio.run(
+        run_code_step(good, {"deps": {"x": 1}}, timeout=5, expected_hash=code_hash(good)),
+    )
     assert out == 1

--- a/tests/flux/tasks/ai/test_code_sandbox.py
+++ b/tests/flux/tasks/ai/test_code_sandbox.py
@@ -90,3 +90,64 @@ def test_run_code_step_rejects_tampered_hash():
         run_code_step(good, {"deps": {"x": 1}}, timeout=5, expected_hash=code_hash(good)),
     )
     assert out == 1
+
+
+def test_run_code_step_times_out():
+    import asyncio
+    from flux.tasks.ai.code_sandbox import run_code_step
+
+    async def slow():
+        await asyncio.sleep(3)
+        return 1
+
+    with pytest.raises(asyncio.TimeoutError):
+        asyncio.run(run_code_step("lambda: slow()", {"slow": slow}, timeout=1))
+
+
+def test_deps_attribute_walk_rejected_by_grammar():
+    with pytest.raises(CodeValidationError):
+        validate_code('lambda: deps["x"].secret', {"deps"})
+
+
+def test_sanitize_deps_passes_value_only_structures():
+    from flux.tasks.ai.code_sandbox import sanitize_deps
+
+    src = {"a": 1, "b": [1, "x", True, None], "c": {"d": 2.5}}
+    assert sanitize_deps(src) == src
+    assert sanitize_deps((1, 2)) == [1, 2]
+    assert sorted(sanitize_deps({1, 2, 3})) == [1, 2, 3]
+
+
+def test_sanitize_deps_dumps_pydantic_and_dataclass():
+    from dataclasses import dataclass
+    from pydantic import BaseModel
+    from flux.tasks.ai.code_sandbox import sanitize_deps
+
+    class M(BaseModel):
+        x: int
+        y: str
+
+    @dataclass
+    class D:
+        a: int
+        b: list
+
+    assert sanitize_deps(M(x=1, y="z")) == {"x": 1, "y": "z"}
+    assert sanitize_deps(D(a=1, b=[2, 3])) == {"a": 1, "b": [2, 3]}
+
+
+def test_sanitize_deps_rejects_nested_callable():
+    from flux.tasks.ai.code_sandbox import sanitize_deps
+
+    with pytest.raises(CodeValidationError):
+        sanitize_deps({"t": {"reader": open}})
+
+
+def test_sanitize_deps_rejects_opaque_object():
+    from flux.tasks.ai.code_sandbox import sanitize_deps
+
+    class Opaque:
+        pass
+
+    with pytest.raises(CodeValidationError):
+        sanitize_deps(Opaque())

--- a/tests/flux/tasks/ai/test_code_sandbox.py
+++ b/tests/flux/tasks/ai/test_code_sandbox.py
@@ -133,6 +133,19 @@ def test_sanitize_deps_rejects_opaque_object():
         sanitize_deps(Opaque())
 
 
+def test_sanitize_deps_allows_datetime_uuid_decimal():
+    import datetime
+    import uuid
+    from decimal import Decimal
+    from flux.tasks.ai.code_sandbox import sanitize_deps
+
+    assert sanitize_deps(datetime.datetime(2026, 1, 1)) == "2026-01-01T00:00:00"
+    u = uuid.uuid4()
+    assert sanitize_deps(u) == str(u)
+    assert sanitize_deps(Decimal("1.5")) == "1.5"
+    assert sanitize_deps({"t": datetime.date(2026, 1, 1)}) == {"t": "2026-01-01"}
+
+
 def test_safe_builtins_subset():
     from flux.tasks.ai.code_sandbox import _SAFE_BUILTINS
 

--- a/tests/flux/tasks/ai/test_code_sandbox.py
+++ b/tests/flux/tasks/ai/test_code_sandbox.py
@@ -89,80 +89,6 @@ def test_locals_and_loop_targets_resolve():
     )
 
 
-def test_callproxy_blocks_attribute_access():
-    from flux.tasks.ai.code_sandbox import _CallProxy
-
-    def f(x):
-        return x + 1
-
-    p = _CallProxy(f)
-    assert p(1) == 2
-    with pytest.raises(AttributeError):
-        _ = p.__globals__
-
-
-def test_build_sandbox_globals_locks_builtins():
-    from flux.tasks.ai.code_sandbox import build_sandbox_globals, _CallProxy
-
-    g = build_sandbox_globals({"now": lambda: 1})
-    assert g["__builtins__"] == {}
-    assert isinstance(g["now"], _CallProxy)
-
-
-def test_run_code_step_returns_value():
-    import asyncio
-    from flux.tasks.ai.code_sandbox import run_code_step
-
-    out = asyncio.run(run_code_step("lambda: deps['x']", {"deps": {"x": 42}}, timeout=5))
-    assert out == 42
-
-
-def test_run_code_step_awaits_coroutine():
-    import asyncio
-    from flux.tasks.ai.code_sandbox import run_code_step
-
-    async def double(n):
-        return n * 2
-
-    out = asyncio.run(run_code_step("lambda: double(21)", {"double": double}, timeout=5))
-    assert out == 42
-
-
-def test_validate_code_rejects_builtin_not_in_bindings():
-    with pytest.raises(CodeValidationError):
-        validate_code("lambda: sum(range(9))", {"now"})
-
-
-def test_run_code_step_rejects_tampered_hash():
-    import asyncio
-    from flux.tasks.ai.code_sandbox import run_code_step, code_hash
-
-    good = "lambda: deps['x']"
-    with pytest.raises(Exception):
-        asyncio.run(run_code_step(good, {"deps": {"x": 1}}, timeout=5, expected_hash="deadbeef"))
-    out = asyncio.run(
-        run_code_step(good, {"deps": {"x": 1}}, timeout=5, expected_hash=code_hash(good)),
-    )
-    assert out == 1
-
-
-def test_run_code_step_times_out():
-    import asyncio
-    from flux.tasks.ai.code_sandbox import run_code_step
-
-    async def slow():
-        await asyncio.sleep(3)
-        return 1
-
-    with pytest.raises(asyncio.TimeoutError):
-        asyncio.run(run_code_step("lambda: slow()", {"slow": slow}, timeout=1))
-
-
-def test_deps_attribute_walk_rejected_by_grammar():
-    with pytest.raises(CodeValidationError):
-        validate_code('lambda: deps["x"].secret', {"deps"})
-
-
 def test_sanitize_deps_passes_value_only_structures():
     from flux.tasks.ai.code_sandbox import sanitize_deps
 
@@ -205,3 +131,12 @@ def test_sanitize_deps_rejects_opaque_object():
 
     with pytest.raises(CodeValidationError):
         sanitize_deps(Opaque())
+
+
+def test_safe_builtins_subset():
+    from flux.tasks.ai.code_sandbox import _SAFE_BUILTINS
+
+    assert "len" in _SAFE_BUILTINS
+    assert "range" in _SAFE_BUILTINS
+    for banned in ("open", "__import__", "eval", "exec", "getattr", "type", "compile"):
+        assert banned not in _SAFE_BUILTINS

--- a/tests/flux/tasks/ai/test_code_sandbox.py
+++ b/tests/flux/tasks/ai/test_code_sandbox.py
@@ -44,11 +44,38 @@ def test_accepts_control_flow_and_arithmetic():
         "async def step(deps):\n    return 1\n",
         "async def other(deps, input):\n    return 1\n",
         "async def step(deps, input):\n    try:\n        return 1\n    except Exception:\n        return 2\n",
+        # name-binding escape: Store target smuggles a forbidden name
+        "async def step(deps, input):\n    [__import__ for __import__ in []]\n    return __import__\n",
+        # __builtins__ reachable by name + subscript (no attribute access)
+        "async def step(deps, input):\n    return __builtins__['__import__']('os')\n",
+        # binding a denied non-dunder name via comprehension target
+        "async def step(deps, input):\n    [open for open in []]\n    return open\n",
+        # getattr would defeat the no-attribute-access model
+        "async def step(deps, input):\n    return getattr(deps, 'x')\n",
+        # decorator invokes a callable at definition time
+        "@parallel\nasync def step(deps, input):\n    return 1\n",
+        # default-arg expression
+        "async def step(deps, input=1):\n    return 1\n",
+        # positional-only args
+        "async def step(deps, input, /):\n    return 1\n",
+        # dunder name read
+        "async def step(deps, input):\n    return deps['x'].__class__\n",
     ],
 )
 def test_rejects(code):
     with pytest.raises(CodeValidationError):
         validate_code(code, ALLOWED)
+
+
+def test_denylist_does_not_block_normal_locals():
+    validate_code(
+        "async def step(deps, input):\n"
+        "    open_count = 0\n"
+        "    for x in deps['xs']:\n"
+        "        open_count = open_count + 1\n"
+        "    return open_count\n",
+        ALLOWED,
+    )
 
 
 def test_locals_and_loop_targets_resolve():

--- a/tests/flux/tasks/ai/test_code_sandbox.py
+++ b/tests/flux/tasks/ai/test_code_sandbox.py
@@ -33,3 +33,24 @@ def test_accepts_dispatch_lambda():
 def test_rejects_unsafe(code):
     with pytest.raises(CodeValidationError):
         validate_code(code, ALLOWED)
+
+
+def test_callproxy_blocks_attribute_access():
+    from flux.tasks.ai.code_sandbox import _CallProxy
+
+    def f(x):
+        return x + 1
+
+    p = _CallProxy(f)
+    assert p(1) == 2
+    with pytest.raises(AttributeError):
+        _ = p.__globals__
+
+
+def test_build_sandbox_globals_locks_builtins():
+    from flux.tasks.ai.code_sandbox import build_sandbox_globals, _CallProxy
+
+    g = build_sandbox_globals({"now": lambda: 1})
+    assert "open" not in g["__builtins__"]
+    assert "len" in g["__builtins__"]
+    assert isinstance(g["now"], _CallProxy)

--- a/tests/flux/tasks/ai/test_code_sandbox.py
+++ b/tests/flux/tasks/ai/test_code_sandbox.py
@@ -140,3 +140,46 @@ def test_safe_builtins_subset():
     assert "range" in _SAFE_BUILTINS
     for banned in ("open", "__import__", "eval", "exec", "getattr", "type", "compile"):
         assert banned not in _SAFE_BUILTINS
+
+
+def test_compile_runs_and_returns_value():
+    from flux import ExecutionContext, workflow
+    from flux.tasks.ai.code_sandbox import compile_code_step
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        async def double(n):
+            return n * 2
+
+        code = "async def step(deps, input):\n    return await double(deps['x']) + input\n"
+        runner = compile_code_step(code, {"double": double}, step_name="calc")
+        return await runner({"x": 21}, 0)
+
+    ctx = wf.run()
+    assert ctx.has_succeeded
+    assert ctx.output == 42
+
+
+def test_compile_uses_safe_builtins_and_blocks_others():
+    from flux.tasks.ai.code_sandbox import compile_code_step, CodeValidationError
+
+    compile_code_step(
+        "async def step(deps, input):\n    return len(deps['xs'])\n",
+        {},
+        step_name="ok",
+    )
+    with pytest.raises(CodeValidationError):
+        compile_code_step(
+            "async def step(deps, input):\n    return open('/x')\n",
+            {},
+            step_name="bad",
+        )
+
+
+def test_compile_task_name_includes_code_hash():
+    from flux.tasks.ai.code_sandbox import compile_code_step, code_hash
+
+    code = "async def step(deps, input):\n    return 1\n"
+    runner = compile_code_step(code, {}, step_name="s")
+    assert code_hash(code) in runner.name
+    assert runner.name.startswith("plan_step_s_")

--- a/tests/flux/tasks/ai/test_code_sandbox.py
+++ b/tests/flux/tasks/ai/test_code_sandbox.py
@@ -4,35 +4,62 @@ import pytest
 
 from flux.tasks.ai.code_sandbox import validate_code, CodeValidationError
 
-ALLOWED = {"now", "parallel", "deps", "delegate"}
+ALLOWED = {"now", "parallel", "summarize", "delegate"}
+
+GOOD = """
+async def step(deps, input):
+    picked = [d for d in deps['fetch'] if d['score'] > 0.5]
+    out = [await summarize(d) for d in picked]
+    return {'n': len(out), 'first': input}
+"""
 
 
-def test_accepts_dispatch_lambda():
-    validate_code("lambda: now()", ALLOWED)
-    validate_code("lambda: parallel(now(), now())", ALLOWED)
-    validate_code('lambda: deps["fetch"]', ALLOWED)
-    validate_code('lambda: now() if deps["x"] else now()', ALLOWED)
+def test_accepts_full_async_step():
+    validate_code(GOOD, ALLOWED)
+
+
+def test_accepts_control_flow_and_arithmetic():
+    validate_code(
+        "async def step(deps, input):\n"
+        "    total = 0\n"
+        "    for x in deps['nums']:\n"
+        "        if x > 0:\n"
+        "            total = total + x * 2\n"
+        "    return total\n",
+        ALLOWED,
+    )
 
 
 @pytest.mark.parametrize(
     "code",
     [
-        "lambda: __import__('os')",
-        "lambda: open('/etc/passwd')",
-        "lambda: (1).__class__",
-        "lambda: sum(range(10**18))",
-        "lambda: [0] * 10**9",
-        "lambda: [x for x in deps]",
-        "lambda: now.__globals__",
-        "now()",
-        "lambda: missing()",
-        'lambda: deps["x"].format(now())',  # str.format MRO-walk via attribute
-        "lambda: now().something",  # attribute access on call result
+        "async def step(deps, input):\n    return deps['x'].secret\n",
+        "async def step(deps, input):\n    return ('{0.__class__}').format(deps)\n",
+        "async def step(deps, input):\n    import os\n    return os\n",
+        "def helper():\n    return 1\nasync def step(deps, input):\n    return helper()\n",
+        "async def step(deps, input):\n    f = lambda: 1\n    return f()\n",
+        "async def step(deps, input):\n    return missing()\n",
+        "async def step(deps, input):\n    global x\n    return 1\n",
+        "x = 1\n",
+        "async def step(deps):\n    return 1\n",
+        "async def other(deps, input):\n    return 1\n",
+        "async def step(deps, input):\n    try:\n        return 1\n    except Exception:\n        return 2\n",
     ],
 )
-def test_rejects_unsafe(code):
+def test_rejects(code):
     with pytest.raises(CodeValidationError):
         validate_code(code, ALLOWED)
+
+
+def test_locals_and_loop_targets_resolve():
+    validate_code(
+        "async def step(deps, input):\n"
+        "    acc = [y for y in deps['xs']]\n"
+        "    for z in acc:\n"
+        "        acc = acc + [z]\n"
+        "    return acc\n",
+        ALLOWED,
+    )
 
 
 def test_callproxy_blocks_attribute_access():

--- a/tests/flux/test_code_step_cross_process_replay.py
+++ b/tests/flux/test_code_step_cross_process_replay.py
@@ -1,0 +1,29 @@
+"""Cross-process determinism guard for code-step hashing.
+
+A code step is persisted as its source string; on replay (possibly in a
+different worker process) the same source must produce the same hash so the
+step's host task_id is stable. code_hash uses SHA-256, so it must be identical
+across processes with different PYTHONHASHSEED values.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def test_code_hash_stable_across_processes():
+    code = "lambda: side_effect()"
+    runner = (
+        "from flux.tasks.ai.code_sandbox import code_hash\n"
+        f"print(code_hash({code!r}))\n"
+    )
+    outs = set()
+    for seed in ("0", "1", "42"):
+        env = {**os.environ, "PYTHONHASHSEED": seed}
+        out = subprocess.check_output(
+            [sys.executable, "-c", runner], env=env, text=True
+        ).strip()
+        outs.add(out)
+    assert len(outs) == 1, f"code_hash diverged across processes: {outs}"

--- a/tests/flux/test_code_step_cross_process_replay.py
+++ b/tests/flux/test_code_step_cross_process_replay.py
@@ -1,9 +1,11 @@
 """Cross-process determinism guard for code-step hashing.
 
-A code step is persisted as its source string; on replay (possibly in a
-different worker process) the same source must produce the same hash so the
-step's host task_id is stable. code_hash uses SHA-256, so it must be identical
-across processes with different PYTHONHASHSEED values.
+A code step is persisted as its source string; the hash is folded into the host
+task name (``plan_step_<name>_<code_hash>``), so on replay — possibly in a
+different worker process — the same source must produce the same hash for the
+task identity to be stable (and re-authored code to get a distinct identity).
+code_hash uses SHA-256, so it must be identical across processes with different
+PYTHONHASHSEED values.
 """
 
 from __future__ import annotations
@@ -14,7 +16,7 @@ import sys
 
 
 def test_code_hash_stable_across_processes():
-    code = "lambda: side_effect()"
+    code = "async def step(deps, input):\n    return await side_effect()\n"
     runner = f"from flux.tasks.ai.code_sandbox import code_hash\nprint(code_hash({code!r}))\n"
     outs = set()
     for seed in ("0", "1", "42"):

--- a/tests/flux/test_code_step_cross_process_replay.py
+++ b/tests/flux/test_code_step_cross_process_replay.py
@@ -15,15 +15,10 @@ import sys
 
 def test_code_hash_stable_across_processes():
     code = "lambda: side_effect()"
-    runner = (
-        "from flux.tasks.ai.code_sandbox import code_hash\n"
-        f"print(code_hash({code!r}))\n"
-    )
+    runner = f"from flux.tasks.ai.code_sandbox import code_hash\nprint(code_hash({code!r}))\n"
     outs = set()
     for seed in ("0", "1", "42"):
         env = {**os.environ, "PYTHONHASHSEED": seed}
-        out = subprocess.check_output(
-            [sys.executable, "-c", runner], env=env, text=True
-        ).strip()
+        out = subprocess.check_output([sys.executable, "-c", runner], env=env, text=True).strip()
         outs.add(out)
     assert len(outs) == 1, f"code_hash diverged across processes: {outs}"


### PR DESCRIPTION
## Summary

Adds **dynamic code steps** to the agent planner — the planner can author Python that *orchestrates* flux tasks with real control flow, which the runtime executes deterministically and auto-runs as the plan advances. Inspired by Claude Code "dynamic workflows" / Anthropic programmatic tool calling. **Opt-in, default-off.**

Implements `.claude/docs/2026-06-03-dynamic-code-steps-v2-design.md`.

## Model

A plan step may be `type:"code"` carrying a single async function:

```python
async def step(deps, input):
    picked = [d for d in deps['fetch'] if d['score'] > 0.5]
    summaries = await parallel([summarize(d) for d in picked])
    return {'count': len(summaries), 'items': summaries}
```

- The runtime **compiles** it and wraps it as a checkpointed flux task — `task(fn, name="plan_step_<name>_<code_hash>")` — then `await`s it. The code hash in the name keeps replay correct when a step is re-authored.
- The agent loop **auto-runs** ready code steps to a fixpoint (`advance_fn`) at each advancement point — **no `run_step` tool**; the model authors at plan time, the runtime executes.
- `deps` = sanitized dependency results; `input` = sanitized execution input. Intermediate results stay out of the LLM context; only the final result returns.

## Safety (in-process, no isolation)

The body is full Python but the escape surface is closed by AST validation:
- **No attribute access** (`.` banned) → no `__class__`/`__globals__` walk, no `"{0.__class__}".format(x)`.
- **No imports**, no nested defs/lambdas, no decorators/default-args.
- **Denylist** of dunders + dangerous builtins (`eval`/`exec`/`getattr`/`__import__`/…) on every name, regardless of binding.
- **Restricted namespace**: only the exposed flux tasks + `deps`/`input`/locals + 20 value-only safe builtins; `__builtins__` pinned to that subset.
- `deps`/`input` deep-**sanitized** to value-only (primitives, containers, datetime/UUID/Decimal, Pydantic/dataclass dumps) — no live callables reach the sandbox.
- Per-step **timeout** backstop (`dynamic_code_step_timeout`).

**Security-reviewed twice.** The first pass found a real escape — comprehension `Store`-target name laundering (`[__import__ for __import__ in []]`) reaching `__builtins__['__import__']` with no `.` — now closed by the denylist. The final end-to-end pass (~45 bypass attempts) found **no escape**. Accepted residual risk (per design): a synchronous `while True:` / huge allocation can still exhaust the worker — the timeout bounds async runaways, not sync CPU; subprocess isolation is the documented future option.

## Config (all default-off)

- `agent.dynamic_code_steps_enabled` (bool, default `false`)
- `agent.dynamic_code_steps_agent_tools_enabled` (bool, default `false`) — exposes `delegate(...)` in code steps
- `agent.dynamic_code_step_timeout` (int seconds, default `30`, `gt=0`)

## Examples

Valid (dispatch + control flow; **no attribute access** — subscripts & comprehensions):

```python
async def step(deps, input):
    return await parallel([summarize(d) for d in deps['docs']])

async def step(deps, input):
    total = 0
    for x in deps['nums']:
        if x > 0:
            total = total + x * 2
    return total
```

Rejected at plan time (`create_plan` returns an error):

```python
async def step(deps, input):
    import os                       # imports banned
    return deps['x'].secret         # attribute access banned
    return getattr(deps, 'x')       # denied name
    return __builtins__['__import__']('os')   # denied name
```

## Testing

- ~45 code-step unit tests (validator escapes, compile→task→await, sanitize, `advance_fn` fixpoint/ordering/failure/timeout, loop wiring, preamble).
- Full unit suite **2302 passed**; AI+config **741 passed**.
- E2E cross-process replay (`test_task_id_worker_handoff`) passes.

## Notes

- Built subagent-per-task (TDD); the security-critical validator and the executor wiring got dedicated adversarial review.
- This replaces the earlier v1 dispatch-only lambda model (same PR, unreleased). `run_step` and the lambda path are removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
