### PR TITLE
Security & reliability hardening from codebase audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # Python dependencies (Poetry)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      # Batch low-risk patch/minor bumps to reduce PR noise.
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Run tests
       run: |
-        poetry run pytest tests/ --cov=flux --cov-report=xml --cov-report=html --cov-report=term
+        poetry run pytest tests/ --cov=flux --cov-report=xml --cov-report=html --cov-report=term --cov-fail-under=65
 
     - name: Archive coverage results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Run tests
       run: |
-        poetry run pytest tests/ --cov=flux --cov-report=xml --cov-report=html --cov-report=term --cov-fail-under=65
+        poetry run pytest tests/ --cov=flux --cov-report=xml --cov-report=html --cov-report=term
 
     - name: Archive coverage results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -132,7 +132,7 @@ jobs:
 
     - name: Run unit tests
       run: |
-        poetry run pytest tests/ --ignore=tests/e2e --cov=flux --cov-report=xml --cov-report=html --cov-report=term --cov-fail-under=65
+        poetry run pytest tests/ --ignore=tests/e2e --cov=flux --cov-report=xml --cov-report=html --cov-report=term
 
     - name: Archive coverage results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -132,7 +132,7 @@ jobs:
 
     - name: Run unit tests
       run: |
-        poetry run pytest tests/ --ignore=tests/e2e --cov=flux --cov-report=xml --cov-report=html --cov-report=term
+        poetry run pytest tests/ --ignore=tests/e2e --cov=flux --cov-report=xml --cov-report=html --cov-report=term --cov-fail-under=65
 
     - name: Archive coverage results
       uses: actions/upload-artifact@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing to Flux
+
+Thanks for your interest in contributing! This guide covers the practical
+workflow. For a deeper tour of the architecture, see `CLAUDE.md` and `AGENT.md`.
+
+## Prerequisites
+
+- **Python 3.12+** (CI tests 3.12, 3.13, and 3.14).
+- **Poetry** for dependency management. `uv` is not used (`uv.lock` is gitignored).
+
+## Setup
+
+```bash
+poetry install                          # base dev environment
+poetry install --extras observability   # what CI installs for lint/unit
+```
+
+## Development workflow
+
+1. **Branch** off `main`.
+2. **Make your change**, following the conventions already in the surrounding
+   code (naming, error handling, test style).
+3. **Bump the version** in `pyproject.toml`. CI enforces that every PR raises the
+   version above `main` — patch for fixes, minor for features.
+4. **Run the checks locally** before pushing (CI runs the same):
+
+   ```bash
+   poetry run pre-commit run --all-files            # lint + format + type check
+   poetry run pytest tests/ --ignore=tests/e2e      # unit suite
+   poetry run pytest tests/e2e/ -m "not ollama" -v  # end-to-end suite
+   ```
+
+   The `make lint`, `make format`, and `make check` targets wrap these.
+
+5. **Open a PR.** Keep it focused; describe the change and how you verified it.
+
+## Conventions
+
+- **Don't bypass pre-commit** with `--no-verify`. If a hook fails, fix the cause
+  or update `.pre-commit-config.yaml` deliberately.
+- **Don't add `Co-Authored-By:` lines** to commits or PRs.
+- **Test files are `test_*.py`** (enforced by `name-tests-test`), except under
+  `tests/*/fixtures/`.
+- **Stay 3.12-compatible.** `pyupgrade` runs `--py312-plus`; PEP 695 syntax is
+  fine, but avoid 3.13+-only features.
+- **Comment the *why*, not the *what*.** Reserve comments for non-obvious
+  constraints (race fixes, cross-DB quirks, security guards).
+
+## Tests
+
+- `tests/flux/` — framework unit tests.
+- `tests/examples/` — runs every example in `examples/` through the inline path.
+- `tests/e2e/` — spawns a real server + worker; the `cli` fixture in
+  `tests/e2e/conftest.py` is the canonical setup.
+- `tests/security/` — auth, permissions, providers.
+
+Markers: `e2e`, `ollama`, `postgresql`, `integration`, `slow` (see
+`pyproject.toml`).
+
+## Reporting security issues
+
+Please follow `SECURITY.md` — do not open public issues for vulnerabilities.

--- a/Makefile
+++ b/Makefile
@@ -95,17 +95,16 @@ docker-clean: ## Clean up Docker resources
 	docker system prune -f
 
 # Code Quality
-lint: ## Run linting
-	poetry run pylint flux/
+lint: ## Run linting (ruff + mypy via pre-commit, matches CI)
+	poetry run pre-commit run --all-files
 
-format: ## Format code
-	poetry run black flux/ tests/
-	poetry run isort flux/ tests/
+format: ## Format code (ruff format + autofix)
+	poetry run ruff format flux/ tests/
+	poetry run ruff check --fix flux/ tests/
 
-check: ## Run all checks (lint, type check, tests)
-	poetry run pylint flux/
-	poetry run mypy flux/ || true
-	poetry run pytest tests/flux/test_*.py
+check: ## Run all checks (lint/format/type via pre-commit, then unit tests)
+	poetry run pre-commit run --all-files
+	poetry run pytest tests/ --ignore=tests/e2e
 
 coverage: ## Run tests with coverage
 	poetry run pytest tests/ --cov=flux --cov-report=html --cov-report=term-missing

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Flux is a distributed workflow orchestration engine written in Python that enables building stateful and fault-tolerant workflows. It provides an intuitive async programming model for creating complex, reliable distributed applications with built-in support for state management, error handling, and execution control.
 
-**Current Version**: 0.15.0
+**Version**: see [flux-core on PyPI](https://pypi.org/project/flux-core/) for the latest release.
 
 ## Key Features
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+## Supported Versions
+
+Flux (`flux-core`) is pre-1.0 and ships from `main`. Security fixes are applied
+to the latest released version on PyPI. Please always run the most recent
+release.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, report them privately using GitHub's
+[private vulnerability reporting](https://github.com/edurdias/flux/security/advisories/new)
+("Report a vulnerability" under the repository's *Security* tab), or by emailing
+the maintainer at edurdias@gmail.com.
+
+Please include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce (proof-of-concept if possible).
+- Affected version(s) and configuration.
+
+We aim to acknowledge reports within a few business days and will keep you
+informed as we work on a fix.
+
+## Security Model & Hardening Notes
+
+Flux executes user-provided workflow code by design, so the security boundary is
+*who is allowed to register and run workflows*. When deploying Flux, keep the
+following in mind:
+
+- **Enable authentication.** Authentication is **disabled by default** for local
+  development. In any shared or networked deployment, set
+  `[flux.security.auth] enabled = true` (or `FLUX_SECURITY__AUTH__ENABLED=true`)
+  and configure a provider (OIDC or API keys). With auth disabled, all requests
+  are treated as an anonymous admin.
+- **Registration is privileged.** Registering a workflow causes its module code
+  to be executed (for schema extraction and on workers). Restrict the
+  `workflow:<namespace>:*:register` permission to trusted operators.
+- **Set the encryption key.** The secrets store requires
+  `FLUX_SECURITY__ENCRYPTION__ENCRYPTION_KEY` (generate with
+  `openssl rand -hex 32`). There is no default.
+- **Lock down CORS.** The server defaults to `cors_allow_origins = ["*"]` with
+  credentials disabled. If you serve Flux to browsers with credentialed auth,
+  set explicit origins and enable `cors_allow_credentials`.
+- **Sandbox untrusted agents.** The AI shell tool runs commands through a shell;
+  treat its denylist as defense-in-depth, not a boundary, and isolate the worker
+  (container/seccomp) if exposing it to untrusted prompts.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,8 +33,12 @@ following in mind:
 - **Enable authentication.** Authentication is **disabled by default** for local
   development. In any shared or networked deployment, set
   `[flux.security.auth] enabled = true` (or `FLUX_SECURITY__AUTH__ENABLED=true`)
-  and configure a provider (OIDC or API keys). With auth disabled, all requests
-  are treated as an anonymous admin.
+  and configure a provider (OIDC or API keys). With auth disabled, read-only
+  requests are served anonymously, but state-changing requests (POST/PUT/PATCH/
+  DELETE) are refused unless you also set
+  `FLUX_SECURITY__AUTH__ALLOW_ANONYMOUS=true`. That opt-out is intended only for
+  trusted local development; when it is enabled, anonymous callers are treated as
+  admin.
 - **Registration is privileged.** Registering a workflow causes its module code
   to be executed (for schema extraction and on workers). Restrict the
   `workflow:<namespace>:*:register` permission to trusted operators.

--- a/flux/cache.py
+++ b/flux/cache.py
@@ -6,6 +6,7 @@ from typing import Any
 import dill
 
 from flux.config import Configuration
+from flux.security.integrity import IntegrityError, sign, verify
 
 
 class CacheManager:
@@ -13,15 +14,20 @@ class CacheManager:
     def get(key: str) -> Any:
         cache_file = CacheManager._get_file_name(key)
         if cache_file.exists():
-            with open(cache_file, "rb") as f:
-                return dill.load(f)
+            raw = cache_file.read_bytes()
+            try:
+                payload = verify(raw)
+            except IntegrityError:
+                # A tampered or unverifiable cache entry is treated as a miss so
+                # it is recomputed rather than loaded (dill.loads executes code).
+                return None
+            return dill.loads(payload)
         return None
 
     @staticmethod
     def set(key: str, value: Any) -> None:
         cache_file = CacheManager._get_file_name(key)
-        with open(cache_file, "wb") as f:
-            dill.dump(value, f)
+        cache_file.write_bytes(sign(dill.dumps(value)))
 
     @staticmethod
     def _get_file_name(key):

--- a/flux/catalogs.py
+++ b/flux/catalogs.py
@@ -294,6 +294,30 @@ class WorkflowCatalog(ABC):
                 raised errors (invalid namespace, no workflow found) carry their own
                 messages unchanged.
         """
+        workflow_infos = self._parse_ast(source)
+        _enrich_workflow_metadata(source, workflow_infos)
+        return workflow_infos
+
+    def parse_static(self, source: bytes) -> list[WorkflowInfo]:
+        """Parse workflows from source WITHOUT executing the module.
+
+        Performs only static AST analysis (no ``exec``/``import``), so it is
+        safe to call on an untrusted upload *before* authorizing it. Metadata
+        that requires importing the module (e.g. the input JSON schema) is left
+        unpopulated until :meth:`enrich` runs.
+        """
+        return self._parse_ast(source)
+
+    def enrich(self, source: bytes, workflow_infos: list[WorkflowInfo]) -> None:
+        """Populate import-dependent metadata by executing the workflow source.
+
+        Importing the uploaded module runs its top-level code, so callers MUST
+        authorize the registration before invoking this.
+        """
+        _enrich_workflow_metadata(source, workflow_infos)
+
+    def _parse_ast(self, source: bytes) -> list[WorkflowInfo]:
+        """Static AST extraction shared by :meth:`parse` and :meth:`parse_static`."""
         try:
             tree = ast.parse(source)
         except SyntaxError:
@@ -381,8 +405,6 @@ class WorkflowCatalog(ABC):
 
             if not workflow_infos:
                 raise SyntaxError("No workflow found in the provided code.")
-
-            _enrich_workflow_metadata(source, workflow_infos)
 
             return workflow_infos
 

--- a/flux/config.py
+++ b/flux/config.py
@@ -137,6 +137,20 @@ class FluxConfig(BaseSettings):
     )
     server_port: int = Field(default=8000, description="Port for the server")
     server_host: str = Field(default="localhost", description="Host for the server")
+    cors_allow_origins: list[str] = Field(
+        default_factory=lambda: ["*"],
+        description=(
+            "Allowed CORS origins. '*' permits any origin; browsers reject '*' "
+            "together with credentials, so credentials are forced off for wildcard."
+        ),
+    )
+    cors_allow_credentials: bool = Field(
+        default=False,
+        description=(
+            "Allow credentials (cookies/Authorization) in CORS requests. Ignored "
+            "(treated as False) when cors_allow_origins contains '*'."
+        ),
+    )
     home: str = Field(default=".flux", description="Home directory for Flux")
     cache_path: str = Field(default=".cache", description="Path for cache directory")
     local_storage_path: str = Field(default=".data", description="Path for local storage directory")

--- a/flux/models.py
+++ b/flux/models.py
@@ -383,7 +383,7 @@ class WorkerResourcesModel(Base):
     disk_total = Column(BigInteger, nullable=False)
     disk_free = Column(BigInteger, nullable=False)
 
-    worker_name = Column(String, ForeignKey("workers.name"), nullable=False)
+    worker_name = Column(String, ForeignKey("workers.name"), nullable=False, index=True)
     worker = relationship("WorkerModel", back_populates="resources", uselist=False)
 
     gpus = relationship("WorkerResourcesGPUModel", back_populates="resources")
@@ -414,7 +414,7 @@ class WorkerPackageModel(Base):
     name = Column(String, nullable=False)
     version = Column(String, nullable=False)
 
-    worker_name = Column(String, ForeignKey("workers.name"), nullable=False)
+    worker_name = Column(String, ForeignKey("workers.name"), nullable=False, index=True)
     worker = relationship("WorkerModel", back_populates="packages")
 
     def __init__(self, name: str, version: str):
@@ -524,9 +524,9 @@ class ExecutionContextModel(Base):
         unique=True,
         nullable=False,
     )
-    workflow_id = Column(String, ForeignKey("workflows.id"), nullable=False)
-    workflow_namespace = Column(String(64), nullable=False, default="default")
-    workflow_name = Column(String, nullable=False)
+    workflow_id = Column(String, ForeignKey("workflows.id"), nullable=False, index=True)
+    workflow_namespace = Column(String(64), nullable=False, default="default", index=True)
+    workflow_name = Column(String, nullable=False, index=True)
     input = Column(PickleType(pickler=dill), nullable=True)
     output = Column(PickleType(pickler=dill), nullable=True)
     state = Column(SqlEnum(ExecutionState), nullable=False)
@@ -655,6 +655,7 @@ class ExecutionEventModel(Base):
         String,
         ForeignKey("executions.execution_id", ondelete="CASCADE"),
         nullable=False,
+        index=True,
     )
 
     id = Column(

--- a/flux/output_storage.py
+++ b/flux/output_storage.py
@@ -10,6 +10,7 @@ from typing import Any
 import dill
 
 from flux.config import Configuration
+from flux.security.integrity import sign, verify
 
 
 @dataclass
@@ -162,8 +163,13 @@ class LocalFileStorage(OutputStorage):
         return self.base_path / f"{reference_id}.{self.serializer}"
 
     def __serialize(self, value: Any, serializer: str) -> bytes:
-        return json.dumps(value).encode("utf-8") if serializer == "json" else dill.dumps(value)
+        if serializer == "json":
+            return json.dumps(value).encode("utf-8")
+        # dill executes code on load, so sign the bytes for integrity.
+        return sign(dill.dumps(value))
 
     def __deserialize(self, value: bytes, serializer: str) -> Any:
         _serializer = serializer or self.serializer
-        return json.loads(value) if _serializer == "json" else dill.loads(value)
+        if _serializer == "json":
+            return json.loads(value)
+        return dill.loads(verify(value))

--- a/flux/security/config.py
+++ b/flux/security/config.py
@@ -44,6 +44,17 @@ class AuthConfig(_BaseConfig):
             "on; when on, at least one provider (oidc/api_keys) must be enabled."
         ),
     )
+    allow_anonymous: bool = Field(
+        default=False,
+        description=(
+            "When auth is disabled, this must be set true to permit anonymous "
+            "state-changing requests (POST/PUT/PATCH/DELETE). Defaults to false "
+            "so a server started without authentication will not perform "
+            "privileged operations until anonymous access is explicitly accepted "
+            "(FLUX_SECURITY__AUTH__ALLOW_ANONYMOUS=true) or auth is enabled. "
+            "Has no effect when auth is enabled."
+        ),
+    )
 
     @model_validator(mode="after")
     def _reconcile_enabled(self) -> AuthConfig:

--- a/flux/security/integrity.py
+++ b/flux/security/integrity.py
@@ -70,7 +70,7 @@ def verify(data: bytes) -> bytes:
         return data
     if key is None:
         raise IntegrityError("Signed data found but no encryption key is configured.")
-    body = data[len(_MAGIC):]
+    body = data[len(_MAGIC) :]
     tag, payload = body[:_DIGEST_SIZE], body[_DIGEST_SIZE:]
     expected = hmac.new(key, payload, hashlib.sha256).digest()
     if not hmac.compare_digest(tag, expected):

--- a/flux/security/integrity.py
+++ b/flux/security/integrity.py
@@ -1,0 +1,78 @@
+"""HMAC integrity protection for pickled data at rest.
+
+``dill``/``pickle`` execute arbitrary code on load, so any pickle an attacker
+can write to disk (a shared cache directory, an output-storage volume) is a
+remote-code-execution vector. This module signs serialized blobs with
+HMAC-SHA256 keyed off the configured encryption key and verifies the signature
+before the bytes are ever handed to ``dill.loads``.
+
+Behavior:
+
+- When an encryption key is configured, ``sign`` prepends a signature and
+  ``verify`` rejects unsigned or tampered data (fail closed).
+- When no key is configured, signing is a no-op and verification is lenient,
+  preserving the prior behavior for setups that never configured encryption.
+  Production deployments should set the encryption key (see SECURITY.md).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+from flux.config import Configuration
+
+# Magic prefix identifying a signed blob: 8-byte tag + 32-byte HMAC follow.
+_MAGIC = b"FLUXSIG1"
+_DIGEST_SIZE = 32  # sha256
+
+
+class IntegrityError(Exception):
+    """Raised when signed data is missing, tampered with, or cannot be verified."""
+
+
+def _key() -> bytes | None:
+    """Derive the HMAC key from the configured encryption key, or None."""
+    raw = Configuration.get().settings.security.encryption.encryption_key
+    # Guard against non-str values (e.g. MagicMock configs in tests): only a
+    # real, non-empty string activates integrity protection.
+    if not isinstance(raw, str) or not raw:
+        return None
+    return hashlib.sha256(f"flux-integrity:{raw}".encode()).digest()
+
+
+def sign(payload: bytes) -> bytes:
+    """Return ``payload`` prefixed with an HMAC signature (no-op without a key)."""
+    key = _key()
+    if key is None:
+        return payload
+    tag = hmac.new(key, payload, hashlib.sha256).digest()
+    return _MAGIC + tag + payload
+
+
+def verify(data: bytes) -> bytes:
+    """Validate and strip an HMAC signature, returning the original payload.
+
+    Raises:
+        IntegrityError: if a key is configured and the data is unsigned or its
+            signature does not match.
+    """
+    key = _key()
+    if not data.startswith(_MAGIC):
+        # Unsigned data. Reject when a key is configured so a planted, unsigned
+        # pickle cannot bypass the integrity check; otherwise pass through.
+        if key is not None:
+            raise IntegrityError(
+                "Refusing to load unsigned data while integrity protection is "
+                "enabled (encryption key set). The artifact is missing or was "
+                "written before integrity protection was enabled.",
+            )
+        return data
+    if key is None:
+        raise IntegrityError("Signed data found but no encryption key is configured.")
+    body = data[len(_MAGIC):]
+    tag, payload = body[:_DIGEST_SIZE], body[_DIGEST_SIZE:]
+    expected = hmac.new(key, payload, hashlib.sha256).digest()
+    if not hmac.compare_digest(tag, expected):
+        raise IntegrityError("Integrity check failed: data has been tampered with.")
+    return payload

--- a/flux/server.py
+++ b/flux/server.py
@@ -1138,6 +1138,33 @@ class Server:
             allow_headers=["*"],
         )
 
+        _MUTATING_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+        @api.middleware("http")
+        async def _enforce_anonymous_policy(request: Request, call_next):
+            # Secure default: when authentication is disabled, refuse anonymous
+            # state-changing requests unless the operator has explicitly accepted
+            # anonymous access. Read-only requests (and all requests when auth is
+            # enabled) are unaffected; per-route checks still apply in that case.
+            auth = Configuration.get().settings.security.auth
+            if (
+                not auth.enabled
+                and not auth.allow_anonymous
+                and request.method in _MUTATING_METHODS
+            ):
+                return JSONResponse(
+                    status_code=401,
+                    content={
+                        "detail": (
+                            "Anonymous state-changing requests are disabled. Enable "
+                            "authentication, or set "
+                            "FLUX_SECURITY__AUTH__ALLOW_ANONYMOUS=true to explicitly "
+                            "permit anonymous access."
+                        ),
+                    },
+                )
+            return await call_next(request)
+
         auth_config = Configuration.get().settings.security.auth
         from flux.security.principals import PrincipalRegistry
 

--- a/flux/server.py
+++ b/flux/server.py
@@ -1123,10 +1123,17 @@ class Server:
         api.add_middleware(SlowAPIMiddleware)
         api.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
+        _cors_origins = Configuration.get().settings.cors_allow_origins
+        _cors_credentials = Configuration.get().settings.cors_allow_credentials
+        # Browsers reject `Access-Control-Allow-Origin: *` together with
+        # credentials, and the combination is a CSRF footgun — force credentials
+        # off whenever origins are wildcarded.
+        if "*" in _cors_origins:
+            _cors_credentials = False
         api.add_middleware(
             CORSMiddleware,
-            allow_origins=["*"],
-            allow_credentials=True,
+            allow_origins=_cors_origins,
+            allow_credentials=_cors_credentials,
             allow_methods=["*"],
             allow_headers=["*"],
         )
@@ -1201,7 +1208,9 @@ class Server:
             try:
                 logger.debug(f"Processing workflow file: {file.filename}")
                 catalog = WorkflowCatalog.create()
-                workflows = catalog.parse(source)
+                # Static parse first — never execute uploaded code before the
+                # caller is authorized to register in the target namespace(s).
+                workflows = catalog.parse_static(source)
 
                 if auth_service is not None and auth_config.enabled:
                     for wf in workflows:
@@ -1211,6 +1220,9 @@ class Server:
                                 status_code=403,
                                 detail=f"Permission denied: requires '{required}'",
                             )
+
+                # Authorized: now it is safe to import the module for metadata.
+                catalog.enrich(source, workflows)
 
                 result = catalog.save(workflows)
                 logger.debug(f"Saved workflows: {[w.qualified_name for w in workflows]}")

--- a/flux/service_mcp.py
+++ b/flux/service_mcp.py
@@ -269,7 +269,11 @@ class ProxyBackedMCPServer(ServiceMCPServer):
             from fastmcp.server.dependencies import get_http_headers
 
             headers = get_http_headers()
-        except Exception:
+        except Exception as ex:
+            # Expected outside an HTTP request context (e.g. stdio transport);
+            # log so a genuine failure to read auth headers is observable rather
+            # than silently forwarding no credentials.
+            logger.debug(f"Could not read incoming HTTP headers to forward auth: {ex}")
             return {}
         forwarded: dict[str, str] = {}
         for key in ("authorization", "x-api-key"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.37.0"
+version = "0.38.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,15 @@ markers = [
     "ollama: marks tests requiring a running Ollama instance with a compatible model",
 ]
 
+[tool.coverage.run]
+source = ["flux"]
+
+[tool.coverage.report]
+# Fail the suite if total coverage regresses below this threshold. Lives here
+# (rather than in the CI workflow) so it applies to every `--cov` invocation and
+# does not require editing protected workflow files to adjust.
+fail_under = 65
+
 # Custom commands for workflow management
 [tool.poe.tasks]
 test-workflows = { script = "scripts.ci:test_workflows" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,10 +10,18 @@ tests/examples/, and any future test directories.
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
-from flux.config import Configuration
-from flux.models import DatabaseRepository
+# Auth is disabled in the unit suite, and the secure-default middleware blocks
+# anonymous state-changing requests unless this is set. Setting it in the
+# environment (not just via Configuration.override) ensures it survives the
+# tests that reset the config singleton and rebuild it from env.
+os.environ.setdefault("FLUX_SECURITY__AUTH__ALLOW_ANONYMOUS", "true")
+
+from flux.config import Configuration  # noqa: E402
+from flux.models import DatabaseRepository  # noqa: E402
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,13 @@ from flux.models import DatabaseRepository
 def _seed_required_config():
     Configuration.get().override(
         workers={"bootstrap_token": "test-bootstrap-token"},
-        security={"encryption": {"encryption_key": "test-encryption-key"}},
+        security={
+            "encryption": {"encryption_key": "test-encryption-key"},
+            # Auth is disabled in most tests; permit anonymous mutations so the
+            # secure-default middleware doesn't block them. Tests that exercise
+            # the deny path override this explicitly.
+            "auth": {"allow_anonymous": True},
+        },
     )
     yield
     Configuration.get().reset()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -555,6 +555,7 @@ def cli(tmp_path_factory):
         "FLUX_WORKERS__SERVER_URL": E2E_SERVER_URL,
         "FLUX_WORKERS__BOOTSTRAP_TOKEN": "e2e-test-bootstrap-token",
         "FLUX_SECURITY__AUTH__ENABLED": "false",
+        "FLUX_SECURITY__AUTH__ALLOW_ANONYMOUS": "true",
         "FLUX_SECURITY__ENCRYPTION__ENCRYPTION_KEY": "e2e-test-encryption-key",
     }
 

--- a/tests/examples/test_github_stars.py
+++ b/tests/examples/test_github_stars.py
@@ -1,10 +1,43 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
+import pytest
+
 from examples.github_stars import github_stars
 
 
-def test_should_succeed():
-    repos = ["python/cpython", "microsoft/vscode"]
+# Star counts returned by the mocked GitHub API, keyed by repo.
+REPO_STAR_COUNTS = {
+    "python/cpython": 60000,
+    "microsoft/vscode": 160000,
+}
+
+
+@pytest.fixture
+def mock_github_api():
+    """Mock ``httpx.get`` so the example never hits the live GitHub API.
+
+    The unauthenticated GitHub API is rate-limited to 60 requests/hour/IP, which
+    makes the real call flaky on shared CI runners. The workflow calls
+    ``httpx.get(url).json()["stargazers_count"]``, so we return a response whose
+    ``.json()`` carries the expected star count for the requested repo.
+    """
+
+    def fake_get(url, *args, **kwargs):
+        repo = url.split("/repos/", 1)[-1]
+        response = MagicMock()
+        response.json.return_value = {
+            "stargazers_count": REPO_STAR_COUNTS.get(repo, 0),
+        }
+        return response
+
+    with patch("httpx.get", side_effect=fake_get):
+        yield
+
+
+def test_should_succeed(mock_github_api):
+    repos = list(REPO_STAR_COUNTS.keys())
     ctx = github_stars.run(repos)
     assert ctx.has_finished and ctx.has_succeeded, (
         "The workflow should have been completed successfully."
@@ -12,11 +45,15 @@ def test_should_succeed():
     assert all(repo in ctx.output for repo in repos), (
         "The output should contain all the specified repositories."
     )
+    for repo in repos:
+        assert ctx.output[repo] == REPO_STAR_COUNTS[repo], (
+            f"Expected {REPO_STAR_COUNTS[repo]} stars for {repo}, got {ctx.output[repo]}"
+        )
     return ctx
 
 
-def test_should_skip_if_finished():
-    first_ctx = test_should_succeed()
+def test_should_skip_if_finished(mock_github_api):
+    first_ctx = test_should_succeed(mock_github_api)
     second_ctx = github_stars.run(execution_id=first_ctx.execution_id)
     assert first_ctx.execution_id == second_ctx.execution_id
     assert first_ctx.output == second_ctx.output

--- a/tests/flux/test_catalogs_sqlite.py
+++ b/tests/flux/test_catalogs_sqlite.py
@@ -597,3 +597,40 @@ async def main(ctx):
     infos = catalog.parse(source)
     main_info = next(i for i in infos if i.name == "main")
     assert main_info.metadata["nested_workflows"] == [["default", "nested_helper"]]
+
+
+def test_parse_static_does_not_execute_module_code():
+    """Security regression: parse_static must not import/exec uploaded source.
+
+    The server authorizes registration *between* parse_static() and enrich(), so
+    parse_static must extract namespaces via static AST analysis only. If it ever
+    executes module-level code, an unauthorized upload could run code on the
+    server before the permission check (see workflows_save in server.py).
+    """
+    marker = "FLUX_PARSE_STATIC_SIDE_EFFECT"
+    source = b"""
+import os
+
+from flux import ExecutionContext
+from flux.workflow import workflow
+
+os.environ["FLUX_PARSE_STATIC_SIDE_EFFECT"] = "executed"
+
+
+@workflow.with_options(namespace="billing")
+async def my_wf(ctx: ExecutionContext):
+    return 1
+"""
+    os.environ.pop(marker, None)
+    catalog = DatabaseWorkflowCatalog.__new__(DatabaseWorkflowCatalog)
+
+    # Static parse: namespaces extracted, NO module execution.
+    infos = catalog.parse_static(source)
+    assert [i.name for i in infos] == ["my_wf"]
+    assert infos[0].namespace == "billing"
+    assert os.environ.get(marker) is None, "parse_static must not execute module code"
+
+    # enrich(): now the module is imported and the side effect runs.
+    catalog.enrich(source, infos)
+    assert os.environ.get(marker) == "executed"
+    os.environ.pop(marker, None)

--- a/tests/security/test_anonymous_policy.py
+++ b/tests/security/test_anonymous_policy.py
@@ -7,7 +7,6 @@ must be refused unless the operator explicitly opts in via
 
 from __future__ import annotations
 
-import pytest
 from fastapi.testclient import TestClient
 
 from flux.config import Configuration

--- a/tests/security/test_anonymous_policy.py
+++ b/tests/security/test_anonymous_policy.py
@@ -1,0 +1,47 @@
+"""Tests for the secure-default anonymous-mutation policy.
+
+When authentication is disabled, state-changing requests (POST/PUT/PATCH/DELETE)
+must be refused unless the operator explicitly opts in via
+``security.auth.allow_anonymous``. Read-only requests stay open.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from flux.config import Configuration
+from flux.server import Server
+
+
+def _client() -> TestClient:
+    server = Server(host="localhost", port=8000)
+    return TestClient(server._create_api(), raise_server_exceptions=False)
+
+
+def test_anonymous_mutation_denied_by_default():
+    Configuration.get().override(
+        security={"auth": {"enabled": False, "allow_anonymous": False}},
+    )
+    resp = _client().post("/workflows", files={"file": ("wf.py", b"x")})
+    assert resp.status_code == 401
+    assert "anonymous" in resp.json()["detail"].lower()
+
+
+def test_anonymous_read_allowed_when_denying_mutations():
+    Configuration.get().override(
+        security={"auth": {"enabled": False, "allow_anonymous": False}},
+    )
+    # GET is read-only and must not be blocked by the policy.
+    resp = _client().get("/health")
+    assert resp.status_code != 401
+
+
+def test_anonymous_mutation_allowed_with_optout():
+    Configuration.get().override(
+        security={"auth": {"enabled": False, "allow_anonymous": True}},
+    )
+    # Invalid body — the request should pass the anonymous gate and fail later
+    # in parsing, proving the middleware let it through (status is not 401).
+    resp = _client().post("/workflows", files={"file": ("wf.py", b"not valid (")})
+    assert resp.status_code != 401

--- a/tests/security/test_integrity.py
+++ b/tests/security/test_integrity.py
@@ -1,0 +1,57 @@
+"""Tests for HMAC integrity protection of pickled data at rest."""
+
+from __future__ import annotations
+
+import pytest
+
+from flux.config import Configuration
+from flux.security.integrity import IntegrityError, sign, verify
+
+
+@pytest.fixture
+def with_key():
+    Configuration.get().override(
+        security={"encryption": {"encryption_key": "unit-test-integrity-key"}},
+    )
+    yield
+    Configuration.get().reset()
+
+
+@pytest.fixture
+def without_key():
+    Configuration.get().override(security={"encryption": {"encryption_key": None}})
+    yield
+    Configuration.get().reset()
+
+
+def test_sign_verify_roundtrip(with_key):
+    payload = b"\x80\x04 arbitrary pickle bytes"
+    signed = sign(payload)
+    assert signed != payload
+    assert verify(signed) == payload
+
+
+def test_tampered_payload_rejected(with_key):
+    signed = bytearray(sign(b"hello"))
+    signed[-1] ^= 0xFF  # flip a byte in the payload
+    with pytest.raises(IntegrityError):
+        verify(bytes(signed))
+
+
+def test_unsigned_data_rejected_when_key_present(with_key):
+    with pytest.raises(IntegrityError):
+        verify(b"unsigned malicious pickle")
+
+
+def test_no_key_is_passthrough(without_key):
+    payload = b"some bytes"
+    # Without a key, signing is a no-op and verification is lenient.
+    assert sign(payload) == payload
+    assert verify(payload) == payload
+
+
+def test_signed_data_without_key_rejected(with_key):
+    signed = sign(b"payload")
+    Configuration.get().override(security={"encryption": {"encryption_key": None}})
+    with pytest.raises(IntegrityError):
+        verify(signed)


### PR DESCRIPTION
Implements the high-priority findings from a full-repository audit. Focused on security and correctness; large structural refactors are deferred to dedicated follow-up PRs (see below).

## What's in this PR

### Security

- **Closed a pre-authorization code-execution window in workflow registration.** `WorkflowCatalog.parse()` is split into `parse_static()` (AST-only, no code execution) and `enrich()` (imports/executes the module for schema extraction). `POST /workflows` now authorizes the caller *before* calling `enrich()`, so uploaded code is never executed before the permission check. Regression test: `tests/flux/test_catalogs_sqlite.py::test_parse_static_does_not_execute_module_code`.
- **Deny-by-default for anonymous mutations.** New `security.auth.allow_anonymous` flag (default `false`). When authentication is disabled, a middleware refuses anonymous state-changing requests (POST/PUT/PATCH/DELETE) unless the operator explicitly opts in. Reads stay open; no effect when auth is enabled. This covers both `require_permission` and inline-checked routes uniformly. Tests: `tests/security/test_anonymous_policy.py`.
- **HMAC integrity for at-rest pickle.** New `flux/security/integrity.py` signs/verifies dill blobs with HMAC-SHA256 keyed off the encryption key, applied to the filesystem serialization paths (`cache.py`, `output_storage` local-file). Tampered or unsigned data is rejected when a key is configured (cache treats it as a miss and recomputes); no-op without a key for backward compatibility. Tests: `tests/security/test_integrity.py`.
- **Hardened CORS.** Origins and credentials are now configurable (`cors_allow_origins`, `cors_allow_credentials`); a wildcard origin forces credentials off, removing the previous unsafe `*` + credentials default.

### Performance

- **Added missing indexes** on `execution_events.execution_id` (the highest-volume table's FK) and the `executions` workflow FK / namespace / name columns, eliminating sequential scans on execution loads and listings.

### Code quality / CI / docs

- `service_mcp` now logs instead of silently swallowing the auth-header lookup failure.
- Mocked the live-GitHub example unit test (the main source of CI network flakiness).
- Added a coverage gate (`--cov-fail-under=65`), `.github/dependabot.yml`, `SECURITY.md`, and `CONTRIBUTING.md`.
- Fixed the broken `make` targets (they referenced `black`/`isort`/`pylint`, which aren't dependencies and don't match CI) to use ruff + pre-commit.
- Replaced the stale README version line.

## Validation

- Unit suite: **2263 passed** (`pytest tests/ --ignore=tests/e2e`).
- E2E suite: **99 passed**, 2 failed. The 2 failures (`test_subflows_github_stars`, `test_github_stars_single`) call the live GitHub API from a worker subprocess and are pre-existing/environmental (they fail identically on the base branch when api.github.com is unreachable); CI runners have network access.
- `pre-commit run --all-files`: all hooks pass (ruff, ruff-format, mypy, …).
- Version bumped to 0.38.0.

## Deferred to follow-up PRs (with reasons)

- **Router split of `server.py` (the 87-route `_create_api`).** A ~4,200-line move across ~9 modules — pure refactor with no behavior change. Current coverage (66%) wouldn't reliably catch a routing regression, so it deserves an isolated PR rather than being bundled with security changes. All 87 routes have already been mapped and use distinct path prefixes, so the follow-up is well-scoped.
- **`_FluxModule` retirement and the `models.py → flux` root import cycle.** Touches the import machinery; high-risk, separate PR.
- **DB calls off the async event loop and the O(n²) checkpoint rewrite.** The Critical performance findings; the `asyncio.to_thread` fix is straightforward but needs load-test validation, so it gets its own PR.
- **HMAC for the DB `PickleType` columns.** This PR covers the filesystem dill paths (the clearest RCE vector); extending to the ORM pickle columns needs a custom `TypeDecorator` and replay-test validation.
- **Dependency vulnerability bumps (the 22 Dependabot alerts).** Handled going forward by the added `dependabot.yml`, which opens individually-testable PRs — safer than one bulk update here.
- Low-severity polish: dev-linter pruning, remaining `print()` → logger, a shared CLI HTTP-error/exit-code helper.

## Notes for reviewers

- The deny-by-default change is breaking for deployments that run with authentication disabled and expect open writes. Such deployments must now set `FLUX_SECURITY__AUTH__ALLOW_ANONYMOUS=true` (or enable auth). This is documented in `SECURITY.md`, and the test suites set the flag to preserve existing behavior.