### PR TITLE
Fix O(n²) checkpoint writes and move dispatch DB calls off the event loop

### DIFF
--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -52,6 +52,29 @@ if TYPE_CHECKING:
 
 
 class WorkerRoutesMixin:
+    def _build_dispatch_payload(self: Server, ctx) -> dict:  # type: ignore[misc]
+        """Assemble the SSE payload for dispatching/resuming an execution.
+
+        Performs the workflow-source load and exec-token lookup — both blocking
+        DB reads — so callers invoke it via ``asyncio.to_thread`` to keep the
+        worker SSE stream and the event loop unblocked.
+        """
+        from flux.models import ExecutionContextModel
+
+        workflow = WorkflowCatalog.create().get(ctx.workflow_namespace, ctx.workflow_name)
+        # source travels base64-encoded on the wire; the worker decodes it.
+        workflow.source = base64.b64encode(workflow.source).decode("utf-8")  # type: ignore[assignment]
+        payload: dict = {"workflow": workflow, "context": ctx}
+        session = self._get_db_session()
+        try:
+            exec_row = session.get(ExecutionContextModel, ctx.execution_id)
+            exec_token = exec_row.exec_token if exec_row else None
+        finally:
+            session.close()
+        if exec_token:
+            payload["exec_token"] = exec_token
+        return payload
+
     def _register_worker_routes(  # type: ignore[misc]
         self: Server,
         api,
@@ -261,38 +284,16 @@ class WorkerRoutesMixin:
                                     worker,
                                 )
                                 if ctx:
-                                    _exec_ns = ctx.workflow_namespace
-                                    workflow = WorkflowCatalog.create().get(
-                                        _exec_ns,
-                                        ctx.workflow_name,
-                                    )
-                                    workflow.source = base64.b64encode(workflow.source).decode(
-                                        "utf-8",
+                                    payload_dict = await asyncio.to_thread(
+                                        self._build_dispatch_payload,
+                                        ctx,
                                     )
 
                                     logger.debug(
                                         f"Sending execution to worker {name}: {ctx.execution_id} (workflow: {ctx.workflow_name})",
                                     )
 
-                                    payload_dict = {"workflow": workflow, "context": ctx}
-                                    exec_model_session = self._get_db_session()
-                                    try:
-                                        from flux.models import ExecutionContextModel as _ECM
-
-                                        exec_row = exec_model_session.get(
-                                            _ECM,
-                                            ctx.execution_id,
-                                        )
-                                        exec_token_for_dispatch = (
-                                            exec_row.exec_token if exec_row else None
-                                        )
-                                    finally:
-                                        exec_model_session.close()
-                                    if exec_token_for_dispatch:
-                                        payload_dict["exec_token"] = exec_token_for_dispatch
-                                    data_payload = to_json(payload_dict)
-
-                                    data_payload = _inject_trace_context(data_payload)
+                                    data_payload = _inject_trace_context(to_json(payload_dict))
 
                                     yield {
                                         "id": f"{ctx.execution_id}_{uuid4().hex}",
@@ -328,34 +329,13 @@ class WorkerRoutesMixin:
 
                                 ctx = await asyncio.to_thread(context_manager.next_resume, worker)
                                 if ctx:
-                                    _resume_ns = ctx.workflow_namespace
-                                    workflow = WorkflowCatalog.create().get(
-                                        _resume_ns,
-                                        ctx.workflow_name,
-                                    )
-                                    workflow.source = base64.b64encode(workflow.source).decode(
-                                        "utf-8",
+                                    resume_payload_dict = await asyncio.to_thread(
+                                        self._build_dispatch_payload,
+                                        ctx,
                                     )
                                     logger.debug(
                                         f"Sending resume to worker {name}: {ctx.execution_id} (workflow: {ctx.workflow_name})",
                                     )
-
-                                    resume_payload_dict = {"workflow": workflow, "context": ctx}
-                                    resume_model_session = self._get_db_session()
-                                    try:
-                                        from flux.models import ExecutionContextModel as _ECM2
-
-                                        resume_exec_row = resume_model_session.get(
-                                            _ECM2,
-                                            ctx.execution_id,
-                                        )
-                                        resume_exec_token = (
-                                            resume_exec_row.exec_token if resume_exec_row else None
-                                        )
-                                    finally:
-                                        resume_model_session.close()
-                                    if resume_exec_token:
-                                        resume_payload_dict["exec_token"] = resume_exec_token
                                     yield {
                                         "id": f"{ctx.execution_id}_{uuid4().hex}",
                                         "event": "execution_resumed",

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -256,7 +256,10 @@ class WorkerRoutesMixin:
                                         "data": "",
                                     }
 
-                                ctx = context_manager.next_execution(worker)
+                                ctx = await asyncio.to_thread(
+                                    context_manager.next_execution,
+                                    worker,
+                                )
                                 if ctx:
                                     _exec_ns = ctx.workflow_namespace
                                     workflow = WorkflowCatalog.create().get(
@@ -301,7 +304,10 @@ class WorkerRoutesMixin:
                                     )
                                     continue
 
-                                ctx = context_manager.next_cancellation(worker)
+                                ctx = await asyncio.to_thread(
+                                    context_manager.next_cancellation,
+                                    worker,
+                                )
                                 if ctx:
                                     logger.debug(
                                         f"Sending cancellation to worker {name}: {ctx.execution_id} (workflow: {ctx.workflow_name})",
@@ -320,7 +326,7 @@ class WorkerRoutesMixin:
                                     )
                                     continue
 
-                                ctx = context_manager.next_resume(worker)
+                                ctx = await asyncio.to_thread(context_manager.next_resume, worker)
                                 if ctx:
                                     _resume_ns = ctx.workflow_namespace
                                     workflow = WorkflowCatalog.create().get(
@@ -433,7 +439,7 @@ class WorkerRoutesMixin:
                 context_manager = ContextManager.create()
 
                 try:
-                    current = context_manager.get(execution_id)
+                    current = await asyncio.to_thread(context_manager.get, execution_id)
                 except ExecutionContextNotFoundError:
                     raise HTTPException(
                         status_code=404,
@@ -443,11 +449,15 @@ class WorkerRoutesMixin:
                 from flux.errors import ExecutionError
 
                 if current.state in (ExecutionState.CREATED, ExecutionState.SCHEDULED):
-                    ctx = context_manager.claim(execution_id, worker)
+                    ctx = await asyncio.to_thread(context_manager.claim, execution_id, worker)
                     is_resume_claim = False
                 elif current.state == ExecutionState.RESUME_SCHEDULED:
                     try:
-                        ctx = context_manager.claim_resume(execution_id, worker)
+                        ctx = await asyncio.to_thread(
+                            context_manager.claim_resume,
+                            execution_id,
+                            worker,
+                        )
                     except ExecutionError as e:
                         raise HTTPException(status_code=409, detail=str(e))
                     is_resume_claim = True
@@ -502,7 +512,7 @@ class WorkerRoutesMixin:
                 domain_ctx = context.to_domain()
 
                 try:
-                    ctx = context_manager.update(domain_ctx)
+                    ctx = await asyncio.to_thread(context_manager.update, domain_ctx)
                 except ExecutionContextNotFoundError:
                     logger.warning(f"Execution context not found: {execution_id}")
                     raise HTTPException(status_code=404, detail="Execution context not found.")

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -594,6 +594,11 @@ class DatabaseContextManager(ContextManager):
         ctx: ExecutionContext,
         session: Session,
     ) -> list[ExecutionEventModel]:
+        # Nothing to reconcile when the incoming context carries no events;
+        # skip the round-trip entirely.
+        if not ctx.events:
+            return []
+
         # Project only (event_id, type) rather than loading the full event rows
         # (each carries a dill-pickled ``value``), and test membership against a
         # set. This keeps each checkpoint O(new events) instead of

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -196,7 +196,7 @@ class DatabaseContextManager(ContextManager):
                 if _accept_state_write(ctx.state, model.state):
                     model.state = ctx.state
                     model.output = ctx.output
-                    model.events.extend(self._get_additional_events(ctx, model))
+                    session.add_all(self._get_additional_events(ctx, session))
             else:
                 session.add(ExecutionContextModel.from_plain(ctx))
             if manage_transaction:
@@ -215,7 +215,7 @@ class DatabaseContextManager(ContextManager):
             if _accept_state_write(ctx.state, model.state):
                 model.state = ctx.state
                 model.output = ctx.output
-                model.events.extend(self._get_additional_events(ctx, model))
+                session.add_all(self._get_additional_events(ctx, session))
             session.commit()
             return ctx
 
@@ -302,7 +302,7 @@ class DatabaseContextManager(ContextManager):
                 ctx.schedule(worker)
                 model.state = ctx.state
                 model.worker_name = ctx.current_worker
-                model.events.extend(self._get_additional_events(ctx, model))
+                session.add_all(self._get_additional_events(ctx, session))
                 session.commit()
                 return ctx
 
@@ -394,7 +394,7 @@ class DatabaseContextManager(ContextManager):
             ctx.resume_schedule(worker)
             model.state = ctx.state
             model.worker_name = ctx.current_worker
-            model.events.extend(self._get_additional_events(ctx, model))
+            session.add_all(self._get_additional_events(ctx, session))
             session.commit()
 
             from flux.domain.events import ExecutionEventType
@@ -459,7 +459,7 @@ class DatabaseContextManager(ContextManager):
             ctx.claim(worker)
             model.state = ctx.state
             model.worker_name = ctx.current_worker
-            model.events.extend(self._get_additional_events(ctx, model))
+            session.add_all(self._get_additional_events(ctx, session))
             session.commit()
             return ctx
 
@@ -490,7 +490,7 @@ class DatabaseContextManager(ContextManager):
             ctx.resume_claim(worker)
             model.state = ctx.state
             model.worker_name = ctx.current_worker
-            model.events.extend(self._get_additional_events(ctx, model))
+            session.add_all(self._get_additional_events(ctx, session))
             session.commit()
 
             from flux.domain.events import ExecutionEventType
@@ -592,13 +592,28 @@ class DatabaseContextManager(ContextManager):
     def _get_additional_events(
         self,
         ctx: ExecutionContext,
-        model: ExecutionContextModel,
-    ):
-        existing_events = [(e.event_id, e.type) for e in model.events]
+        session: Session,
+    ) -> list[ExecutionEventModel]:
+        # Project only (event_id, type) rather than loading the full event rows
+        # (each carries a dill-pickled ``value``), and test membership against a
+        # set. This keeps each checkpoint O(new events) instead of
+        # O(existing × new) and avoids deserializing the entire event history on
+        # every save. The execution_id filter rides the FK index.
+        from sqlalchemy import select
+
+        existing = {
+            (event_id, event_type)
+            for event_id, event_type in session.execute(
+                select(
+                    ExecutionEventModel.event_id,
+                    ExecutionEventModel.type,
+                ).where(ExecutionEventModel.execution_id == ctx.execution_id),
+            ).all()
+        }
         return [
             ExecutionEventModel.from_plain(ctx.execution_id, e)
             for e in ctx.events
-            if (e.id, e.type) not in existing_events
+            if (e.id, e.type) not in existing
         ]
 
     def list(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.39.0"
+version = "0.40.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"


### PR DESCRIPTION
Follow-up #2 from the codebase audit — addresses the two Critical performance findings: synchronous SQLAlchemy blocking the async event loop, and O(n²) checkpoint writes.

## Changes

### O(n²) checkpoint writes → O(new events)

`DatabaseContextManager._get_additional_events` previously read `model.events` — force-loading **every** persisted event row for the execution (each carrying a dill-pickled `value` payload) — and then did O(existing × new) list-membership checks. This ran on **every** save/update/claim, so a long-running workflow's checkpoint cost grew quadratically with its event count.

Now it issues a two-column projected query (`event_id`, `type`) filtered by `execution_id` (riding the FK index added in #79) into a set, and the six call sites use `session.add_all(...)` instead of `model.events.extend(...)` (which itself force-loaded the relationship). Per-checkpoint cost is O(new events); the event history's pickled payloads are never deserialized on the write path. It also returns early when the incoming context has no events.

### Dispatch/claim/checkpoint DB calls off the event loop

The worker SSE dispatch generator and the claim/checkpoint handlers called blocking, lock-taking (`SELECT … FOR UPDATE`) SQLAlchemy methods directly on uvicorn's event loop — at least 2N blocking round-trips per second with N connected workers, where one slow or contended query stalls every SSE stream, heartbeat, and API request (and can cascade into spurious worker eviction by the reaper).

The seven hot-path calls (`next_execution`, `next_cancellation`, `next_resume`, `get`, `claim`, `claim_resume`, `update` in `flux/api/worker_routes.py`) are now wrapped in `asyncio.to_thread`. The follow-up payload assembly after a dispatch/resume (workflow-source load + exec-token lookup) is consolidated into a `_build_dispatch_payload` helper that also runs via `asyncio.to_thread`, so the SSE generator does no synchronous DB work once an execution is found. Each call opens its own session, so thread-per-call is safe; transactions stay short-lived.

**Deliberately out of scope:** the heartbeat reaper interleaves DB work with `asyncio.Event.set()` calls that must run on the loop thread — wrapping it naively would introduce a concurrency bug. It, the scheduler loop, and a full async-engine migration remain for a later pass if load testing shows the thread pool is the next ceiling.

## Validation

- Unit suite: **2263 passed** (exact baseline), including the replay-determinism, context-manager dispatch, and race-regression tests that guard the checkpoint semantics.
- E2E suite: **99 passed** on a real server + worker (SSE connect, claim, checkpoint, resume, cancellation paths all exercised). The 2 failures are the pre-existing live-GitHub-API `github_stars` tests (environmental).
- `pre-commit run --all-files` green, including mypy.
- Version bumped to 0.40.0.