### PR TITLE
Persist scheduler run state: schedules no longer re-fire every poll

### DIFF
--- a/flux/schedule_manager.py
+++ b/flux/schedule_manager.py
@@ -15,6 +15,9 @@ from flux.models import (
     ExecutionEventModel,
 )
 from flux.errors import ExecutionError
+from flux.utils import get_logger
+
+logger = get_logger(__name__)
 
 
 class ScheduleManagerError(ExecutionError):
@@ -97,6 +100,16 @@ class ScheduleManager(ABC):
         limit: int | None = None,
     ) -> list[ScheduleModel]:
         """Get schedules that are due to run"""
+        pass
+
+    @abstractmethod
+    def record_run(self, schedule_id: str, run_time: datetime) -> None:
+        """Persist a successful trigger: advance next_run_at and run stats."""
+        pass
+
+    @abstractmethod
+    def record_failure(self, schedule_id: str) -> None:
+        """Persist a failed trigger: increment the failure count."""
         pass
 
     @abstractmethod
@@ -353,6 +366,55 @@ class DatabaseScheduleManager(ScheduleManager):
 
         except Exception as e:
             raise ScheduleManagerError(f"Failed to get due schedules: {str(e)}", e)
+
+    def record_run(self, schedule_id: str, run_time: datetime) -> None:
+        """Persist a successful trigger against the stored schedule row.
+
+        ``get_due_schedules`` returns detached objects, so mutating those never
+        reaches the database; this loads the row in a fresh session and applies
+        ``mark_run`` (last_run_at, run_count, next_run_at) there. Without the
+        persisted ``next_run_at`` advance, a due schedule would re-fire on every
+        scheduler poll.
+
+        Never raises: stats/next-run recording must not break the dispatch loop;
+        failures are logged instead.
+        """
+        try:
+            with self._repository.session() as session:
+                model = session.query(ScheduleModel).filter(ScheduleModel.id == schedule_id).first()
+                if model is None:
+                    logger.warning(
+                        f"Schedule '{schedule_id}' disappeared before its run could be recorded",
+                    )
+                    return
+                model.mark_run(run_time)
+                session.commit()
+        except Exception:
+            logger.error(
+                f"Failed to record run for schedule '{schedule_id}'",
+                exc_info=True,
+            )
+
+    def record_failure(self, schedule_id: str) -> None:
+        """Persist a failed trigger (failure_count) for the stored schedule row.
+
+        Never raises — see ``record_run``.
+        """
+        try:
+            with self._repository.session() as session:
+                model = session.query(ScheduleModel).filter(ScheduleModel.id == schedule_id).first()
+                if model is None:
+                    logger.warning(
+                        f"Schedule '{schedule_id}' disappeared before its failure could be recorded",
+                    )
+                    return
+                model.mark_failure()
+                session.commit()
+        except Exception:
+            logger.error(
+                f"Failed to record failure for schedule '{schedule_id}'",
+                exc_info=True,
+            )
 
     def health_check(self) -> bool:
         """Check database connectivity"""

--- a/flux/server.py
+++ b/flux/server.py
@@ -686,11 +686,12 @@ class Server(
                         try:
                             await self._trigger_scheduled_workflow(schedule, current_time)
                         except Exception as e:
+                            # The trigger path already recorded the failure before
+                            # re-raising; recording here would double-count it.
                             logger.error(
                                 f"Failed to trigger schedule '{schedule.name}': {str(e)}",
                                 exc_info=True,
                             )
-                            schedule.mark_failure()
 
                 except Exception as e:
                     logger.error(f"Error in scheduler cycle: {str(e)}", exc_info=True)
@@ -707,6 +708,7 @@ class Server(
             f"Triggering scheduled workflow '{schedule.workflow_name}' (schedule: {schedule.name})",
         )
 
+        schedule_manager = create_schedule_manager()
         try:
             from flux.security.auth_service import AuthService
 
@@ -720,7 +722,7 @@ class Server(
                     logger.error(
                         f"Schedule '{schedule.name}': no service account configured, skipping",
                     )
-                    schedule.mark_failure()
+                    schedule_manager.record_failure(schedule.id)
                     return
 
                 from flux.security.principals import PrincipalRegistry
@@ -736,7 +738,7 @@ class Server(
                     logger.error(
                         f"Schedule '{schedule.name}': SA principal '{sa_name}' not found or disabled, skipping",
                     )
-                    schedule.mark_failure()
+                    schedule_manager.record_failure(schedule.id)
                     return
 
                 from flux.security.identity import FluxIdentity
@@ -762,7 +764,7 @@ class Server(
                     logger.error(
                         f"Schedule '{schedule.name}': workflow '{schedule.workflow_name}' not found: {e}",
                     )
-                    schedule.mark_failure()
+                    schedule_manager.record_failure(schedule.id)
                     return
 
                 auth_result = await db_auth_service.authorize(
@@ -776,7 +778,7 @@ class Server(
                         f"Schedule '{schedule.name}': SA '{sa_principal.subject}' lacks permissions: "
                         f"{auth_result.missing_permissions}",
                     )
-                    schedule.mark_failure()
+                    schedule_manager.record_failure(schedule.id)
                     return
 
             _sched_ns = schedule.workflow_namespace
@@ -816,8 +818,9 @@ class Server(
             finally:
                 sched_link_session.close()
 
-            # Update schedule tracking
-            schedule.mark_run(scheduled_time)
+            # Persist the run: advances next_run_at and run stats in the DB so the
+            # schedule is no longer due (mutating the detached object alone is lost).
+            schedule_manager.record_run(schedule.id, scheduled_time)
 
             logger.info(
                 f"Triggered execution '{ctx.execution_id}' for '{schedule.workflow_name}'",
@@ -830,7 +833,7 @@ class Server(
                 m.record_schedule_trigger(schedule.name, "success")
 
         except Exception as e:
-            schedule.mark_failure()
+            schedule_manager.record_failure(schedule.id)
             logger.error(f"Failed to trigger scheduled workflow: {str(e)}", exc_info=True)
 
             from flux.observability import get_metrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.42.0"
+version = "0.43.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_schedule_run_persistence.py
+++ b/tests/flux/test_schedule_run_persistence.py
@@ -1,0 +1,92 @@
+"""Regression tests: scheduler trigger run-state must be persisted.
+
+``get_due_schedules`` returns detached ORM rows; the scheduler loop used to
+call ``mark_run``/``mark_failure`` on those, so ``next_run_at`` never advanced
+in the database and a due schedule re-fired on every poll while
+``run_count``/``failure_count`` stayed at zero forever.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from flux.config import Configuration
+from flux.domain.schedule import interval
+from flux.schedule_manager import create_schedule_manager
+
+
+@pytest.fixture
+def manager(tmp_path):
+    Configuration.get().override(database_url=f"sqlite:///{tmp_path / 'sched.db'}")
+    from flux.models import DatabaseRepository
+
+    DatabaseRepository._engines.clear()
+    yield create_schedule_manager()
+    DatabaseRepository._engines.clear()
+
+
+def _create(manager, name="s1"):
+    return manager.create_schedule(
+        workflow_id="wid",
+        workflow_name="wf",
+        workflow_namespace="default",
+        name=name,
+        schedule=interval(minutes=5),
+    )
+
+
+def _future():
+    return datetime.now(timezone.utc) + timedelta(days=1)
+
+
+def test_record_run_persists_and_schedule_stops_being_due(manager):
+    sch = _create(manager)
+    due = manager.get_due_schedules(current_time=_future())
+    assert [d.id for d in due] == [sch.id]
+
+    manager.record_run(sch.id, datetime.now(timezone.utc))
+
+    fresh = manager.get_schedule(sch.id)
+    assert fresh.run_count == 1
+    assert fresh.last_run_at is not None
+    assert fresh.next_run_at != sch.next_run_at, "next_run_at must advance in the DB"
+    # The schedule must no longer be due for the same window it just ran in.
+    assert manager.get_due_schedules(current_time=datetime.now(timezone.utc)) == []
+
+
+def test_record_failure_persists(manager):
+    sch = _create(manager)
+    manager.record_failure(sch.id)
+    manager.record_failure(sch.id)
+    assert manager.get_schedule(sch.id).failure_count == 2
+
+
+def test_record_on_deleted_schedule_does_not_raise(manager):
+    sch = _create(manager)
+    manager.delete_schedule(sch.id)
+    manager.record_run(sch.id, datetime.now(timezone.utc))
+    manager.record_failure(sch.id)
+
+
+async def test_trigger_scheduled_workflow_persists_run(manager):
+    """End-to-end through Server._trigger_scheduled_workflow (auth disabled)."""
+    from flux.server import Server
+
+    sch = _create(manager, name="trigger-test")
+    due = manager.get_due_schedules(current_time=_future())
+    assert len(due) == 1
+
+    server = Server("127.0.0.1", 0)
+    mock_ctx = MagicMock()
+    mock_ctx.execution_id = "exec-sched-1"
+    with patch.object(Server, "_create_execution", return_value=mock_ctx):
+        await server._trigger_scheduled_workflow(due[0], datetime.now(timezone.utc))
+
+    fresh = manager.get_schedule(sch.id)
+    assert fresh.run_count == 1, "the trigger path must persist the run"
+    assert manager.get_due_schedules(current_time=datetime.now(timezone.utc)) == [], (
+        "a triggered schedule must not still be due (it would re-fire every poll)"
+    )

--- a/tests/security/test_server_auth_routes.py
+++ b/tests/security/test_server_auth_routes.py
@@ -463,15 +463,19 @@ class TestSchedulerAuthIntegration:
         mock_registry_instance.find.return_value = None
         mock_registry_cls = MagicMock(return_value=mock_registry_instance)
 
+        mock_manager = MagicMock()
         with (
             patch("flux.security.principals.PrincipalRegistry", mock_registry_cls),
+            patch("flux.server.create_schedule_manager", return_value=mock_manager),
             patch("flux.server.Configuration") as mock_cfg,
         ):
             mock_auth = mock_cfg.get.return_value.settings.security.auth
             mock_auth.enabled = True
 
             await server._trigger_scheduled_workflow(schedule, None)
-            schedule.mark_failure.assert_called_once()
+            # Failures are persisted through the manager (detached-object
+            # mutations are lost), so the skip must record via record_failure.
+            mock_manager.record_failure.assert_called_once_with(schedule.id)
 
     @pytest.mark.asyncio
     async def test_trigger_skips_when_principal_disabled(self):
@@ -494,15 +498,19 @@ class TestSchedulerAuthIntegration:
         mock_registry_instance.find.return_value = disabled_principal
         mock_registry_cls = MagicMock(return_value=mock_registry_instance)
 
+        mock_manager = MagicMock()
         with (
             patch("flux.security.principals.PrincipalRegistry", mock_registry_cls),
+            patch("flux.server.create_schedule_manager", return_value=mock_manager),
             patch("flux.server.Configuration") as mock_cfg,
         ):
             mock_auth = mock_cfg.get.return_value.settings.security.auth
             mock_auth.enabled = True
 
             await server._trigger_scheduled_workflow(schedule, None)
-            schedule.mark_failure.assert_called_once()
+            # Failures are persisted through the manager (detached-object
+            # mutations are lost), so the skip must record via record_failure.
+            mock_manager.record_failure.assert_called_once_with(schedule.id)
 
 
 class TestOldAuthIsAuthorizedTestUpdated:


### PR DESCRIPTION
First fix from the production-readiness review (P0-1): a verified live correctness bug in the scheduler.

## Problem

`get_due_schedules` returns ORM rows from a closed session — detached objects (`flux/schedule_manager.py`). The scheduler trigger path then called `schedule.mark_run(...)` / `schedule.mark_failure()` on those detached objects with no merge/commit, so **the writes never reached the database**.

Verified consequences (reproduced empirically against a fresh DB):
- `next_run_at` never advances → every due schedule **re-fires on every scheduler poll** (~every 30s) instead of on its cadence.
- `run_count`, `last_run_at`, and `failure_count` stay at zero/NULL forever — schedule statistics were never recorded.

## Changes

- `ScheduleManager` gains `record_run(schedule_id, run_time)` and `record_failure(schedule_id)`: load the row in a fresh session, apply `mark_run`/`mark_failure` on the **attached** object, commit. They deliberately never raise — stats recording must not break the dispatch loop (failures are logged).
- All six trigger-path call sites in `server.py` now persist through the manager.
- Fixed a latent **double-count**: a failed trigger recorded the failure in `_trigger_scheduled_workflow`'s `except` block and then again in the scheduler loop's `catch` after the re-raise. The loop no longer records (the trigger path already did).
- Updated the two scheduler-auth integration tests that asserted the old detached-mutation behavior.

## Validation

- New regression tests (`tests/flux/test_schedule_run_persistence.py`), including end-to-end through the real `Server._trigger_scheduled_workflow`: a triggered schedule persists its run state and **is no longer due** (the re-fire scenario).
- Full unit suite: 2276 passed (2274 + the 2 updated auth tests).
- Existing scheduling suites (`tests/test_scheduling*.py`, 18 tests) pass unchanged.
- `pre-commit` (ruff, mypy) green. Version bumped to 0.43.0.

## Context

This is a prerequisite for the upcoming leader-elected scheduler work: electing a single leader is pointless while that leader re-fires every schedule on every poll.