### PR TITLE
Run full CI on Dependabot PRs and auto-bump minor version on unbumped merges

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -5,6 +5,15 @@ on:
     branches: [ main ]
   workflow_dispatch:  # Allow manual triggering
 
+# The build job may push an automatic version-bump commit to main.
+permissions:
+  contents: write
+
+# Serialize main builds so two merges can't race on the auto-bump.
+concurrency:
+  group: build-publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -60,6 +69,35 @@ jobs:
         path: htmlcov/
         retention-days: 14
 
+    - name: Check whether this version is already on PyPI
+      id: version-exists
+      run: |
+        VERSION=$(poetry version -s)
+        if curl -fsSL "https://pypi.org/pypi/flux-core/${VERSION}/json" -o /dev/null; then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+          echo "flux-core ${VERSION} already on PyPI - an unbumped merge (e.g. Dependabot); will auto-bump."
+        else
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+          echo "flux-core ${VERSION} not yet on PyPI."
+        fi
+
+    # Unbumped merges (Dependabot's grouped updates don't touch the version)
+    # get an automatic minor bump committed back to main, after tests passed
+    # and before the wheel is built. Pushes made with GITHUB_TOKEN do not
+    # retrigger workflows, so this cannot loop; the concurrency group above
+    # prevents two merges racing on the bump.
+    - name: Auto-bump minor version for unbumped merge
+      if: github.ref == 'refs/heads/main' && steps.version-exists.outputs.exists == 'true'
+      run: |
+        poetry version minor
+        NEW_VERSION=$(poetry version -s)
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add pyproject.toml
+        git commit -m "Bump version to ${NEW_VERSION}"
+        git push origin HEAD:main
+        echo "Auto-bumped to ${NEW_VERSION}"
+
     - name: Build package
       run: poetry build
 
@@ -69,20 +107,8 @@ jobs:
         name: dist
         path: dist/
 
-    - name: Check whether this version is already on PyPI
-      id: version-exists
-      run: |
-        VERSION=$(grep -m 1 'version = ' pyproject.toml | sed 's/version = //g' | sed 's/"//g' | tr -d ' ')
-        if curl -fsSL "https://pypi.org/pypi/flux-core/${VERSION}/json" -o /dev/null; then
-          echo "exists=true" >> "$GITHUB_OUTPUT"
-          echo "flux-core ${VERSION} already on PyPI - skipping publish (expected for merges that don't bump, e.g. Dependabot)."
-        else
-          echo "exists=false" >> "$GITHUB_OUTPUT"
-          echo "flux-core ${VERSION} not yet on PyPI - will publish."
-        fi
-
     - name: Publish to PyPI
-      if: github.ref == 'refs/heads/main' && steps.version-exists.outputs.exists == 'false'
+      if: github.ref == 'refs/heads/main'
       run: |
         poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
         poetry publish --no-interaction

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -69,8 +69,20 @@ jobs:
         name: dist
         path: dist/
 
+    - name: Check whether this version is already on PyPI
+      id: version-exists
+      run: |
+        VERSION=$(grep -m 1 'version = ' pyproject.toml | sed 's/version = //g' | sed 's/"//g' | tr -d ' ')
+        if curl -fsSL "https://pypi.org/pypi/flux-core/${VERSION}/json" -o /dev/null; then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+          echo "flux-core ${VERSION} already on PyPI - skipping publish (expected for merges that don't bump, e.g. Dependabot)."
+        else
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+          echo "flux-core ${VERSION} not yet on PyPI - will publish."
+        fi
+
     - name: Publish to PyPI
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main' && steps.version-exists.outputs.exists == 'false'
       run: |
         poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
         poetry publish --no-interaction

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,9 +9,9 @@ jobs:
   version-check:
     runs-on: ubuntu-latest
     # Dependabot PRs never bump the project version; exempt them so their
-    # dependency updates still run lint/unit/e2e. The publish job on main
-    # independently skips versions that already exist on PyPI, so merging an
-    # unbumped PR cannot break the build.
+    # dependency updates still run lint/unit/e2e. When an unbumped PR merges,
+    # the publish workflow on main detects the already-released version and
+    # auto-bumps a minor before building and publishing.
     if: github.actor != 'dependabot[bot]'
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   version-check:
     runs-on: ubuntu-latest
+    # Dependabot PRs never bump the project version; exempt them so their
+    # dependency updates still run lint/unit/e2e. The publish job on main
+    # independently skips versions that already exist on PyPI, so merging an
+    # unbumped PR cannot break the build.
+    if: github.actor != 'dependabot[bot]'
     steps:
     - uses: actions/checkout@v6
       with:
@@ -56,6 +61,8 @@ jobs:
 
   lint:
     needs: [version-check]
+    # Run when version-check succeeded OR was skipped (Dependabot exemption).
+    if: ${{ !cancelled() && (needs.version-check.result == 'success' || needs.version-check.result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -94,6 +101,8 @@ jobs:
 
   unit:
     needs: [version-check]
+    # Run when version-check succeeded OR was skipped (Dependabot exemption).
+    if: ${{ !cancelled() && (needs.version-check.result == 'success' || needs.version-check.result == 'skipped') }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -143,6 +152,8 @@ jobs:
 
   e2e:
     needs: [version-check]
+    # Run when version-check succeeded OR was skipped (Dependabot exemption).
+    if: ${{ !cancelled() && (needs.version-check.result == 'success' || needs.version-check.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.46.0"
+version = "0.47.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"


### PR DESCRIPTION
Fixes the failures on Dependabot PRs #104 and #105 — and on every future grouped Dependabot PR — by exempting Dependabot from the version gate and making releases of unbumped merges automatic.

## Problem

The `version-check` gate fails any PR that doesn't bump `pyproject.toml`'s version, and Dependabot never bumps it. Result on #104/#105: `version-check` **failure**, with lint/unit/e2e all **skipped** — the dependency updates were never even tested. With the grouped-monthly Dependabot config, every monthly update would dead-end the same way.

## Changes

### 1. Dependabot exemption from the version gate (`pull-request.yml`)
- `version-check` is skipped when the PR actor is `dependabot[bot]`.
- `lint` / `unit` / `e2e` now run when the gate **succeeded or was skipped** (`!cancelled() && (result == 'success' || result == 'skipped')`), so Dependabot PRs get full CI.
- Human PRs are unaffected — the version gate applies to them exactly as before.

### 2. Automatic minor bump + release for unbumped merges (`build-publish.yml`)
When the publish workflow on `main` detects that the current version already exists on PyPI (i.e. an unbumped merge such as Dependabot's), it:
1. runs lint + the full test suite first, as always;
2. **auto-bumps a minor** (`poetry version minor`) and commits `Bump version to X.Y.0` back to `main` as `github-actions[bot]`;
3. builds the wheel **after** the bump, so the artifact carries the new version;
4. publishes it in the same run.

So merging a Dependabot PR produces a normal, versioned release with no manual step.

### Why this can't loop or race
- Pushes made with `GITHUB_TOKEN` don't trigger workflows, so the bump commit cannot re-run the publish workflow.
- A `concurrency` group serializes builds per ref — two quick merges can't both detect "exists" and double-bump.

### Caveat
The auto-bump pushes directly to `main` as `github-actions[bot]`. If branch protection is ever enabled on `main`, that push needs an allowance (or the bump step must move to a PR-based flow).

## Validation
- YAML validated; pre-commit green.
- Skipped-`needs` semantics follow GitHub's documented behavior (hence the explicit `!cancelled()` conditions).
- Version 0.47.0.

## After merging
Re-run checks on #104/#105 → full CI runs on both → merging each auto-bumps a minor and releases. (#105's content has already been validated and fixed on its branch: fastmcp capped at `<3`, pandas-3 example fix, lock regenerated on current main — 2276 unit / 99 e2e green locally.)