### PR TITLE
Persist worker heartbeats for cross-replica liveness

### DIFF
--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -214,8 +214,7 @@ class WorkerRoutesMixin:
             """Receive heartbeat pong from a worker."""
             try:
                 self._verify_worker_identity(identity, name)
-                self._worker_last_pong[name] = time.monotonic()
-                self._worker_stale_since.pop(name, None)
+                await self._record_heartbeat(name)
                 logger.debug(f"Pong received from worker {name}")
                 return {"status": "ok"}
             except HTTPException:
@@ -241,9 +240,8 @@ class WorkerRoutesMixin:
                 self._worker_evicted[name] = eviction_event
                 if name not in self._worker_names:
                     self._worker_names.append(name)
-                self._worker_last_pong[name] = time.monotonic()
-                self._worker_stale_since.pop(name, None)
                 self._worker_offline_since.pop(name, None)
+                await self._record_heartbeat(name)
                 gen = self._worker_connection_gen.get(name, 0) + 1
                 self._worker_connection_gen[name] = gen
                 if name in self._worker_cache:

--- a/flux/migrations/versions/0003_worker_last_seen.py
+++ b/flux/migrations/versions/0003_worker_last_seen.py
@@ -1,0 +1,44 @@
+"""Add workers.last_seen_at for cross-replica heartbeat tracking.
+
+Persists each worker's last heartbeat as a wall-clock timestamp so that any
+server replica's reaper has a global view of worker liveness. Before this,
+liveness lived only in the per-process ``_worker_last_pong`` map, so a worker
+attached to one replica was invisible to the others and its executions could
+not be reclaimed if that replica died.
+
+Additive and nullable, so it is safe on both fresh and legacy databases and
+needs no backfill (existing rows simply start NULL until the next heartbeat).
+
+Revision ID: 0003_worker_last_seen
+Revises: 0002_backfill_indexes
+Create Date: 2026-06-13
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0003_worker_last_seen"
+down_revision: str | None = "0002_backfill_indexes"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "workers"
+_COLUMN = "last_seen_at"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    if _COLUMN not in existing:
+        op.add_column(_TABLE, sa.Column(_COLUMN, sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    if _COLUMN in existing:
+        op.drop_column(_TABLE, _COLUMN)

--- a/flux/models.py
+++ b/flux/models.py
@@ -477,6 +477,11 @@ class WorkerModel(Base):
     )
     session_token = Column(String, nullable=False, default=lambda: uuid4().hex)
     labels = Column(Base64Type(), nullable=True)
+    # Wall-clock UTC timestamp of the worker's last heartbeat. Persisted (rather
+    # than tracked in per-process memory) so that any server replica's reaper
+    # sees a global view of worker liveness and can reclaim orphaned executions
+    # when the replica a worker was attached to dies.
+    last_seen_at = Column(DateTime, nullable=True)
 
     runtime = relationship("WorkerRuntimeModel", back_populates="worker", uselist=False)
     packages = relationship("WorkerPackageModel", back_populates="worker")

--- a/flux/server.py
+++ b/flux/server.py
@@ -665,7 +665,11 @@ class Server(
             if name in locally_connected:
                 continue
             try:
-                await asyncio.to_thread(self._unclaim_worker_executions, name)
+                # Called directly on the event loop (not via to_thread) because
+                # it sets asyncio.Events (_execution_events, _work_available),
+                # which are not thread-safe. This mirrors the local eviction
+                # path, which also invokes it synchronously.
+                self._unclaim_worker_executions(name)
             except Exception as e:
                 logger.warning(f"Failed to reclaim executions for orphaned worker {name}: {e}")
 

--- a/flux/server.py
+++ b/flux/server.py
@@ -38,7 +38,7 @@ from flux.api.schedule_routes import ScheduleRoutesMixin
 from flux.api.execution_routes import ExecutionRoutesMixin
 from flux.api.service_routes import ServiceRoutesMixin
 from flux.api.rbac_routes import RbacRoutesMixin
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 # Re-exported for backward compatibility (these were defined here before the
 # route modules were extracted). flux.api.schemas is the source of truth.
@@ -521,6 +521,27 @@ class Server(
                 pass
             logger.info("Heartbeat reaper stopped")
 
+    def _persist_worker_heartbeat(self, name: str) -> None:
+        from flux.worker_registry import WorkerRegistry
+
+        WorkerRegistry.create().record_heartbeat(name)
+
+    async def _record_heartbeat(self, name: str) -> None:
+        """Record a worker heartbeat: in-memory fast-path + persisted timestamp.
+
+        The in-memory ``_worker_last_pong`` drives this replica's round-robin
+        and local stale tracking; the persisted ``last_seen_at`` gives every
+        replica's reaper a global view of liveness so orphaned executions can
+        be reclaimed when the replica a worker was attached to dies. Persisting
+        runs off the event loop and never fails the request.
+        """
+        self._worker_last_pong[name] = time.monotonic()
+        self._worker_stale_since.pop(name, None)
+        try:
+            await asyncio.to_thread(self._persist_worker_heartbeat, name)
+        except Exception as e:
+            logger.debug(f"Failed to persist heartbeat for worker {name}: {e}")
+
     def _disconnect_worker(self, name: str, reason: str = "disconnect") -> None:
         """Remove a worker from the connected set and mark it offline in cache."""
         self._worker_events.pop(name, None)
@@ -614,6 +635,40 @@ class Server(
 
         self._work_available.set()
 
+    async def _reclaim_orphaned_executions(self) -> None:
+        """Reclaim executions stranded by a dead replica (cross-replica sweep).
+
+        The local stale/evict path above only sees workers attached to *this*
+        replica. If the replica a worker was attached to dies, no local reaper
+        knows the worker is gone. This sweep reads the persisted ``last_seen_at``
+        so any surviving replica can detect a globally-stale worker — one no
+        replica has heard from for the full stale-plus-grace window — and
+        reclaim its executions.
+
+        Workers connected to this replica are skipped (the local path owns them).
+        ``unclaim`` converges idempotently, so it is safe if several replicas
+        run this sweep concurrently for the same orphan.
+        """
+        deadline_seconds = self.heartbeat_timeout + self.eviction_grace_period
+        threshold = datetime.now(timezone.utc) - timedelta(seconds=deadline_seconds)
+        try:
+            from flux.worker_registry import WorkerRegistry
+
+            registry = WorkerRegistry.create()
+            stale = await asyncio.to_thread(registry.find_stale, threshold)
+        except Exception as e:
+            logger.debug(f"Orphan reclaim sweep failed to query stale workers: {e}")
+            return
+
+        locally_connected = set(self._worker_names)
+        for name in stale:
+            if name in locally_connected:
+                continue
+            try:
+                await asyncio.to_thread(self._unclaim_worker_executions, name)
+            except Exception as e:
+                logger.warning(f"Failed to reclaim executions for orphaned worker {name}: {e}")
+
     async def _run_heartbeat_reaper(self):
         """Background task: two-phase eviction (stale → grace → evict) and offline cache pruning."""
         try:
@@ -652,6 +707,8 @@ class Server(
                     )
                     self._disconnect_worker(name, reason="evicted")
                     self._unclaim_worker_executions(name)
+
+                await self._reclaim_orphaned_executions()
 
                 expired = [
                     name

--- a/flux/worker_registry.py
+++ b/flux/worker_registry.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from abc import ABC
 from abc import abstractmethod
+from collections.abc import Sequence
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
@@ -94,6 +96,21 @@ class WorkerRegistry(ABC):
     def list(self) -> list[WorkerInfo]:  # pragma: no cover
         raise NotImplementedError()
 
+    @abstractmethod
+    def record_heartbeat(self, name: str) -> None:  # pragma: no cover
+        """Persist ``name``'s heartbeat as the current wall-clock UTC time."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def find_stale(self, threshold: datetime) -> Sequence[str]:  # pragma: no cover
+        """Names of workers whose last heartbeat predates ``threshold``.
+
+        Workers that have never reported a heartbeat (NULL ``last_seen_at``)
+        are excluded, so freshly-registered workers are not swept before they
+        first connect.
+        """
+        raise NotImplementedError()
+
     @staticmethod
     def create() -> WorkerRegistry:
         return DatabaseWorkerRegistry()
@@ -155,6 +172,33 @@ class DatabaseWorkerRegistry(WorkerRegistry):
         with self.session() as session:
             workers = session.query(WorkerModel).all()
             return [self._to_info(worker) for worker in workers]
+
+    def record_heartbeat(self, name: str) -> None:
+        from flux.models import WorkerModel
+
+        now = datetime.now(timezone.utc)
+        with self.session() as session:
+            # Targeted UPDATE — cheap enough to run on every pong, and avoids
+            # loading the worker's runtime/packages/resources relationships.
+            session.query(WorkerModel).filter(WorkerModel.name == name).update(
+                {WorkerModel.last_seen_at: now},
+                synchronize_session=False,
+            )
+            session.commit()
+
+    def find_stale(self, threshold: datetime) -> Sequence[str]:
+        from flux.models import WorkerModel
+
+        with self.session() as session:
+            rows = (
+                session.query(WorkerModel.name)
+                .filter(
+                    WorkerModel.last_seen_at.isnot(None),
+                    WorkerModel.last_seen_at < threshold,
+                )
+                .all()
+            )
+            return [row[0] for row in rows]
 
     def _from_info(self, name, runtime, packages, resources, labels=None):
         # Import here to avoid circular imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.50.1"
+version = "0.50.2"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_heartbeat.py
+++ b/tests/flux/test_heartbeat.py
@@ -250,6 +250,89 @@ class TestServerHeartbeatReaper:
         assert mock_manager.unclaim.call_count == 2
 
 
+class TestServerOrphanReclaim:
+    """Tests for the cross-replica orphan reclamation sweep."""
+
+    @pytest.fixture
+    def server(self):
+        with patch("flux.server.Configuration") as mock_conf:
+            settings = MagicMock()
+            settings.scheduling.poll_interval = 30.0
+            settings.workers.heartbeat_interval = 2
+            settings.workers.heartbeat_timeout = 5
+            settings.workers.offline_ttl = 10
+            settings.workers.eviction_grace_period = 10
+            settings.observability.enabled = False
+            mock_conf.get.return_value.settings = settings
+            s = Server(host="localhost", port=8000)
+        return s
+
+    @pytest.mark.asyncio
+    async def test_reclaims_executions_for_globally_stale_worker(self, server):
+        """A worker stale in the persisted store but not connected here is reclaimed."""
+        mock_registry = MagicMock()
+        mock_registry.find_stale.return_value = ["dead-worker"]
+
+        mock_manager = MagicMock()
+        ctx = MagicMock()
+        ctx.execution_id = "exec-1"
+        mock_manager.find_by_worker.return_value = [ctx]
+
+        with (
+            patch("flux.worker_registry.WorkerRegistry.create", return_value=mock_registry),
+            patch("flux.server.ContextManager") as mock_cm,
+        ):
+            mock_cm.create.return_value = mock_manager
+            await server._reclaim_orphaned_executions()
+
+        mock_manager.find_by_worker.assert_called_once_with("dead-worker")
+        mock_manager.unclaim.assert_called_once_with("exec-1")
+
+    @pytest.mark.asyncio
+    async def test_skips_workers_connected_to_this_replica(self, server):
+        """A stale-persisted worker still connected to this replica is left alone."""
+        server._worker_names.append("local-worker")
+        mock_registry = MagicMock()
+        mock_registry.find_stale.return_value = ["local-worker"]
+
+        mock_manager = MagicMock()
+
+        with (
+            patch("flux.worker_registry.WorkerRegistry.create", return_value=mock_registry),
+            patch("flux.server.ContextManager") as mock_cm,
+        ):
+            mock_cm.create.return_value = mock_manager
+            await server._reclaim_orphaned_executions()
+
+        mock_manager.find_by_worker.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_stale_workers_is_noop(self, server):
+        mock_registry = MagicMock()
+        mock_registry.find_stale.return_value = []
+
+        mock_manager = MagicMock()
+
+        with (
+            patch("flux.worker_registry.WorkerRegistry.create", return_value=mock_registry),
+            patch("flux.server.ContextManager") as mock_cm,
+        ):
+            mock_cm.create.return_value = mock_manager
+            await server._reclaim_orphaned_executions()
+
+        mock_manager.find_by_worker.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_query_failure_is_swallowed(self, server):
+        """A failure querying stale workers must not crash the reaper loop."""
+        mock_registry = MagicMock()
+        mock_registry.find_stale.side_effect = RuntimeError("db down")
+
+        with patch("flux.worker_registry.WorkerRegistry.create", return_value=mock_registry):
+            # Should not raise.
+            await server._reclaim_orphaned_executions()
+
+
 class TestWorkerCache:
     """Tests for the in-memory worker cache."""
 

--- a/tests/flux/test_migrations.py
+++ b/tests/flux/test_migrations.py
@@ -13,7 +13,7 @@ import flux.security.models  # noqa: F401
 from flux.migrations.runner import current_revision, run_migrations
 from flux.models import Base
 
-HEAD = "0002_backfill_indexes"
+HEAD = "0003_worker_last_seen"
 BASELINE = "0001_baseline"
 
 # A representative index added after the original create_all schema, used to
@@ -84,6 +84,23 @@ def test_baseline_creates_same_tables_as_metadata(tmp_path):
         migrated_cols = {c["name"] for c in insp.get_columns(table)}
         model_cols = {c.name for c in Base.metadata.tables[table].columns}
         assert migrated_cols == model_cols, f"column mismatch in {table}"
+
+
+def test_legacy_database_gains_worker_last_seen_at(tmp_path):
+    """A pre-0003 database missing workers.last_seen_at gains it on upgrade."""
+    engine = _engine(tmp_path, "no_last_seen.db")
+    Base.metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.exec_driver_sql("ALTER TABLE workers DROP COLUMN last_seen_at")
+
+    cols = {c["name"] for c in inspect(engine).get_columns("workers")}
+    assert "last_seen_at" not in cols
+
+    run_migrations(engine)
+
+    cols = {c["name"] for c in inspect(engine).get_columns("workers")}
+    assert "last_seen_at" in cols
+    assert current_revision(engine) == HEAD
 
 
 @pytest.mark.parametrize("missing", ["idx_execution_state", "idx_schedule_status_next_run"])

--- a/tests/flux/test_migrations_postgresql.py
+++ b/tests/flux/test_migrations_postgresql.py
@@ -27,7 +27,7 @@ pytestmark = [
     ),
 ]
 
-HEAD = "0002_backfill_indexes"
+HEAD = "0003_worker_last_seen"
 _BACKFILL_INDEX = "ix_executions_workflow_id"
 
 

--- a/tests/flux/test_worker_heartbeat_persistence.py
+++ b/tests/flux/test_worker_heartbeat_persistence.py
@@ -1,0 +1,103 @@
+"""Tests for persisted worker heartbeats (cross-replica liveness)."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from flux.models import WorkerModel
+from flux.worker_registry import (
+    DatabaseWorkerRegistry,
+    WorkerResourcesInfo,
+    WorkerRuntimeInfo,
+)
+
+
+@pytest.fixture
+def registry():
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as f:
+        db_path = f.name
+    db_url = f"sqlite:///{db_path}"
+    with patch("flux.config.Configuration.get") as mock_config:
+        mock_config.return_value.settings.database_url = db_url
+        mock_config.return_value.settings.database_type = "sqlite"
+        mock_config.return_value.settings.security.auth.enabled = False
+        yield DatabaseWorkerRegistry()
+    if os.path.exists(db_path):
+        os.unlink(db_path)
+
+
+def _runtime():
+    return WorkerRuntimeInfo(os_name="Linux", os_version="6.0", python_version="3.12.0")
+
+
+def _resources():
+    return WorkerResourcesInfo(
+        cpu_total=4,
+        cpu_available=4,
+        memory_total=8_000_000_000,
+        memory_available=8_000_000_000,
+        disk_total=100_000_000_000,
+        disk_free=100_000_000_000,
+        gpus=[],
+    )
+
+
+def _register(registry, name):
+    registry.register(name=name, runtime=_runtime(), packages=[], resources=_resources())
+
+
+def _last_seen_at(registry, name):
+    with registry.session() as session:
+        return session.query(WorkerModel.last_seen_at).filter(WorkerModel.name == name).scalar()
+
+
+def _set_last_seen_at(registry, name, value):
+    with registry.session() as session:
+        session.query(WorkerModel).filter(WorkerModel.name == name).update(
+            {WorkerModel.last_seen_at: value},
+            synchronize_session=False,
+        )
+        session.commit()
+
+
+def test_fresh_worker_has_null_last_seen_at(registry):
+    _register(registry, "w1")
+    assert _last_seen_at(registry, "w1") is None
+
+
+def test_record_heartbeat_persists_timestamp(registry):
+    _register(registry, "w1")
+    before = datetime.now(timezone.utc).replace(tzinfo=None)
+    registry.record_heartbeat("w1")
+    seen = _last_seen_at(registry, "w1")
+    assert seen is not None
+    # SQLite stores naive datetimes; allow a small clock window.
+    assert seen >= before - timedelta(seconds=1)
+
+
+def test_record_heartbeat_unknown_worker_is_noop(registry):
+    # No row matches; the UPDATE simply affects zero rows and does not raise.
+    registry.record_heartbeat("does-not-exist")
+
+
+def test_find_stale_returns_workers_past_threshold(registry):
+    _register(registry, "old")
+    _register(registry, "fresh")
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    _set_last_seen_at(registry, "old", now - timedelta(seconds=120))
+    _set_last_seen_at(registry, "fresh", now)
+
+    stale = registry.find_stale(now - timedelta(seconds=60))
+    assert stale == ["old"]
+
+
+def test_find_stale_excludes_never_seen_workers(registry):
+    # A registered-but-never-connected worker (NULL last_seen_at) is not stale.
+    _register(registry, "never")
+    stale = registry.find_stale(datetime.now(timezone.utc).replace(tzinfo=None))
+    assert "never" not in stale


### PR DESCRIPTION
Phase 2 (HA), step 1: make worker liveness visible across server replicas so orphaned executions can be reclaimed when a replica dies.

## Problem

Worker liveness lived only in each server process's in-memory `_worker_last_pong` map, keyed on a **monotonic** clock (per-process, not comparable across machines). A worker attached over SSE to one replica was invisible to the others. Two consequences under multi-replica deployment:

- If the replica a worker is attached to dies, no surviving reaper knows the worker is gone, and its in-flight (claimed/running) executions are **orphaned indefinitely**.
- Each replica's reaper can only reason about workers it personally holds an SSE stream for — there is no global view of the fleet.

## Change

- **New column `workers.last_seen_at`** (wall-clock UTC), added by **migration `0003_worker_last_seen`** — the first additive migration on the Alembic system landed in #107/#108, so it also exercises that path end-to-end. Additive + nullable, idempotent guard, safe on fresh and legacy databases with no backfill.
- **Persist the heartbeat** on every `/pong` and `/connect` via a new `WorkerRegistry.record_heartbeat(name)` (targeted single-row `UPDATE`, run off the event loop). A busy worker keeps `last_seen_at` fresh because pongs are answered concurrently with workflow execution.
- **Cross-replica reaper sweep** (`_reclaim_orphaned_executions`): reads persisted timestamps via `WorkerRegistry.find_stale(threshold)`, finds workers no replica has heard from for the full stale-plus-grace window, skips any still connected to *this* replica, and reclaims their executions. `unclaim` converges idempotently, so concurrent sweeps across replicas are safe **without leader election** (that's the deferred scheduler-singleton piece).

The existing in-memory path is unchanged and still drives this replica's round-robin and local stale/evict handling; the persisted timestamp only adds the global view the in-memory map can't provide.

## Tests

- `test_worker_heartbeat_persistence.py` — `record_heartbeat` persists a timestamp, unknown-worker update is a no-op, `find_stale` returns past-threshold workers and excludes never-seen (NULL) ones.
- `test_heartbeat.py::TestServerOrphanReclaim` — reclaims a globally-stale worker's executions, skips locally-connected workers, no-ops on empty, and swallows query failures.
- `test_migrations.py` — legacy DB missing `last_seen_at` gains it on upgrade; HEAD bumped to `0003`.
- Full unit suite: 2292 passed, 3 skipped. pre-commit clean.

## Scope

This is the persisted-heartbeat/reaper piece only. The scheduler-singleton (advisory-lock leader election) and multi-replica SSE reclaim-on-disconnect remain separate Phase 2 follow-ups.