### PR TITLE
Make scheduler dispatch a cross-replica singleton

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -189,17 +189,18 @@ jobs:
     - name: Install dependencies
       run: poetry install --no-interaction --extras postgresql
 
-    # Validates the migration runner against real PostgreSQL: fresh-DB chain,
-    # the legacy (pre-Alembic) stamp-and-upgrade path with index backfill, and
-    # idempotent re-runs against a populated database.
-    - name: Run migration tests against PostgreSQL
+    # Validates PostgreSQL-only behaviors against a real server: the migration
+    # runner (fresh-DB chain, legacy stamp-and-upgrade with index backfill,
+    # idempotent re-runs) and the scheduler dispatch advisory lock (exclusive
+    # acquisition across connections).
+    - name: Run PostgreSQL-only tests
       env:
         FLUX_DATABASE_URL: postgresql://flux_test_user:flux_test_password@localhost:5432/flux_test
         FLUX_DATABASE_TYPE: postgresql
         FLUX_WORKERS__BOOTSTRAP_TOKEN: ci-token
         FLUX_SECURITY__ENCRYPTION__ENCRYPTION_KEY: ci-encryption-key-0000000000000000
       run: |
-        poetry run pytest tests/flux/test_migrations_postgresql.py -m postgresql -v
+        poetry run pytest tests/flux/ -m postgresql -v
 
   e2e:
     needs: [version-check]

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -200,7 +200,10 @@ jobs:
         FLUX_WORKERS__BOOTSTRAP_TOKEN: ci-token
         FLUX_SECURITY__ENCRYPTION__ENCRYPTION_KEY: ci-encryption-key-0000000000000000
       run: |
-        poetry run pytest tests/flux/ -m postgresql -v
+        poetry run pytest \
+          tests/flux/test_migrations_postgresql.py \
+          tests/flux/test_scheduler_dispatch_lock.py \
+          -m postgresql -v
 
   e2e:
     needs: [version-check]

--- a/flux/schedule_manager.py
+++ b/flux/schedule_manager.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
 from datetime import datetime, timezone
 from typing import Any
 
@@ -18,6 +20,11 @@ from flux.errors import ExecutionError
 from flux.utils import get_logger
 
 logger = get_logger(__name__)
+
+# Session-scoped PostgreSQL advisory-lock key for the scheduler dispatch
+# singleton. Distinct from the migration lock (0x464C5558, "FLUX"); this adds a
+# trailing "S" ("FLUXS") so the two never collide.
+_SCHEDULER_LOCK_KEY = 0x464C555853
 
 
 class ScheduleManagerError(ExecutionError):
@@ -101,6 +108,15 @@ class ScheduleManager(ABC):
     ) -> list[ScheduleModel]:
         """Get schedules that are due to run"""
         pass
+
+    @abstractmethod
+    def dispatch_lock(self) -> AbstractContextManager[bool]:
+        """Cross-replica lock guarding one scheduler dispatch cycle.
+
+        A context manager yielding True if this replica may dispatch due
+        schedules this cycle, False if another replica already holds the lock.
+        """
+        raise NotImplementedError()
 
     @abstractmethod
     def record_run(self, schedule_id: str, run_time: datetime) -> None:
@@ -366,6 +382,50 @@ class DatabaseScheduleManager(ScheduleManager):
 
         except Exception as e:
             raise ScheduleManagerError(f"Failed to get due schedules: {str(e)}", e)
+
+    @contextmanager
+    def dispatch_lock(self) -> Iterator[bool]:
+        """Hold a cross-replica dispatch lock for one scheduler cycle.
+
+        Yields True if this replica may dispatch due schedules this cycle, or
+        False if another replica already holds the lock (so the caller skips
+        the cycle). Wrapping a whole cycle — ``get_due_schedules`` through the
+        ``record_run`` that advances ``next_run_at`` — in this lock guarantees
+        no two replicas can both see the same schedule as due and dispatch it.
+
+        On PostgreSQL this is a session-scoped ``pg_try_advisory_lock`` held on
+        a dedicated connection for the duration of the ``with`` block and
+        released on exit; if the holding replica dies mid-cycle, its connection
+        drops and PostgreSQL releases the lock automatically. SQLite is
+        single-node, so there is only ever one dispatcher and it yields True.
+        """
+        engine = self._repository._engine
+        if engine.dialect.name != "postgresql":
+            yield True
+            return
+
+        connection = engine.connect()
+        try:
+            acquired = bool(
+                connection.exec_driver_sql(
+                    "SELECT pg_try_advisory_lock(%(key)s)",
+                    {"key": _SCHEDULER_LOCK_KEY},
+                ).scalar(),
+            )
+            # End the transaction exec_driver_sql autobegan; the advisory lock
+            # is session-scoped and survives the commit (see PR #108 review).
+            connection.commit()
+            try:
+                yield acquired
+            finally:
+                if acquired:
+                    connection.exec_driver_sql(
+                        "SELECT pg_advisory_unlock(%(key)s)",
+                        {"key": _SCHEDULER_LOCK_KEY},
+                    )
+                    connection.commit()
+        finally:
+            connection.close()
 
     def record_run(self, schedule_id: str, run_time: datetime) -> None:
         """Persist a successful trigger against the stored schedule row.

--- a/flux/server.py
+++ b/flux/server.py
@@ -735,24 +735,38 @@ class Server(
                 try:
                     await asyncio.sleep(self.poll_interval)
 
-                    # Get due schedules
-                    current_time = datetime.now(timezone.utc)
-                    due_schedules = schedule_manager.get_due_schedules(current_time=current_time)
-
-                    if due_schedules:
-                        logger.info(f"Found {len(due_schedules)} due schedule(s)")
-
-                    # Trigger each due schedule
-                    for schedule in due_schedules:
-                        try:
-                            await self._trigger_scheduled_workflow(schedule, current_time)
-                        except Exception as e:
-                            # The trigger path already recorded the failure before
-                            # re-raising; recording here would double-count it.
-                            logger.error(
-                                f"Failed to trigger schedule '{schedule.name}': {str(e)}",
-                                exc_info=True,
+                    # Only one replica dispatches per cycle. The lock spans the
+                    # whole cycle — reading due schedules through the record_run
+                    # that advances next_run_at — so replicas can't double-fire
+                    # the same schedule. Skipped cycles cost a single try-lock.
+                    with schedule_manager.dispatch_lock() as is_dispatcher:
+                        if not is_dispatcher:
+                            logger.debug(
+                                "Another replica holds the scheduler dispatch lock; "
+                                "skipping this cycle",
                             )
+                            continue
+
+                        # Get due schedules
+                        current_time = datetime.now(timezone.utc)
+                        due_schedules = schedule_manager.get_due_schedules(
+                            current_time=current_time,
+                        )
+
+                        if due_schedules:
+                            logger.info(f"Found {len(due_schedules)} due schedule(s)")
+
+                        # Trigger each due schedule
+                        for schedule in due_schedules:
+                            try:
+                                await self._trigger_scheduled_workflow(schedule, current_time)
+                            except Exception as e:
+                                # The trigger path already recorded the failure before
+                                # re-raising; recording here would double-count it.
+                                logger.error(
+                                    f"Failed to trigger schedule '{schedule.name}': {str(e)}",
+                                    exc_info=True,
+                                )
 
                 except Exception as e:
                     logger.error(f"Error in scheduler cycle: {str(e)}", exc_info=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.50.2"
+version = "0.50.3"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_scheduler_dispatch_lock.py
+++ b/tests/flux/test_scheduler_dispatch_lock.py
@@ -1,0 +1,125 @@
+"""Tests for the scheduler dispatch singleton (cross-replica advisory lock).
+
+The lock ensures that with multiple server replicas only one dispatches due
+schedules per cycle, so the same schedule cannot fire on every replica.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from flux.config import Configuration
+from flux.schedule_manager import create_schedule_manager
+
+_DB_URL = os.environ.get("FLUX_DATABASE_URL", "")
+
+
+@pytest.fixture
+def manager(tmp_path):
+    Configuration.get().override(database_url=f"sqlite:///{tmp_path / 'sched.db'}")
+    from flux.models import DatabaseRepository
+
+    DatabaseRepository._engines.clear()
+    yield create_schedule_manager()
+    DatabaseRepository._engines.clear()
+
+
+def test_dispatch_lock_yields_true_on_sqlite(manager):
+    # SQLite is single-node: the lone server is always the dispatcher.
+    with manager.dispatch_lock() as is_dispatcher:
+        assert is_dispatcher is True
+
+
+def test_dispatch_lock_reentrant_on_sqlite(manager):
+    # No real lock on SQLite, so nested acquisition is allowed (single node).
+    with manager.dispatch_lock() as outer:
+        assert outer is True
+        with manager.dispatch_lock() as inner:
+            assert inner is True
+
+
+def _cm(value):
+    @contextmanager
+    def _factory():
+        yield value
+
+    return _factory
+
+
+async def _run_one_scheduler_cycle(server, mock_manager):
+    """Drive Server._scheduler_loop through exactly one iteration."""
+    server.scheduler_running = True
+    server.poll_interval = 0
+
+    call_count = 0
+
+    async def sleep_then_cancel(delay):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return
+        raise asyncio.CancelledError()
+
+    with (
+        patch("flux.server.create_schedule_manager", return_value=mock_manager),
+        patch("asyncio.sleep", side_effect=sleep_then_cancel),
+    ):
+        await server._scheduler_loop()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_loop_skips_dispatch_when_not_lock_holder():
+    from flux.server import Server
+
+    server = Server("127.0.0.1", 0)
+    mock_manager = MagicMock()
+    mock_manager.dispatch_lock = _cm(False)
+
+    await _run_one_scheduler_cycle(server, mock_manager)
+
+    # Lock not held → this replica must not read or trigger schedules.
+    mock_manager.get_due_schedules.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_loop_dispatches_when_lock_holder():
+    from flux.server import Server
+
+    server = Server("127.0.0.1", 0)
+    mock_manager = MagicMock()
+    mock_manager.dispatch_lock = _cm(True)
+    mock_manager.get_due_schedules.return_value = []
+
+    await _run_one_scheduler_cycle(server, mock_manager)
+
+    # Lock held → this replica reads due schedules (none here, so no triggers).
+    mock_manager.get_due_schedules.assert_called_once()
+
+
+@pytest.mark.postgresql
+@pytest.mark.skipif(
+    not _DB_URL.startswith("postgresql://"),
+    reason="requires a PostgreSQL FLUX_DATABASE_URL",
+)
+def test_dispatch_lock_is_exclusive_on_postgres():
+    """A second concurrent acquirer is denied while the first holds the lock."""
+    from flux.models import DatabaseRepository
+
+    DatabaseRepository._engines.clear()
+    try:
+        manager = create_schedule_manager()
+        with manager.dispatch_lock() as first:
+            assert first is True
+            # A distinct connection cannot take the session-scoped lock.
+            with manager.dispatch_lock() as second:
+                assert second is False
+        # Once released, the lock is grantable again.
+        with manager.dispatch_lock() as again:
+            assert again is True
+    finally:
+        DatabaseRepository._engines.clear()


### PR DESCRIPTION
Phase 2 (HA), step 2: stop duplicate schedule firing across server replicas.

## Problem

Every server replica runs its own scheduler loop. With more than one replica, each independently polls `get_due_schedules`, sees the same schedule as due (its `next_run_at` hasn't been advanced yet), and triggers it — so **one schedule fires once per replica**. #99 fixed single-scheduler re-firing by persisting the `next_run_at` advance, but it did nothing for the multi-replica case.

## Change

Guard each dispatch cycle with a session-scoped PostgreSQL advisory lock (`pg_try_advisory_lock`, non-blocking):

- Only the replica that acquires the lock reads due schedules and triggers them; the others skip the cycle at the cost of a single try-lock call.
- The lock spans the **whole cycle** — from `get_due_schedules` through the `record_run` that advances `next_run_at` — so two replicas can never both see a schedule as due and dispatch it.
- If the holder dies mid-cycle, its connection drops and PostgreSQL releases the lock automatically, so another replica picks up the next cycle. No leader heartbeat or handoff to manage — which deliberately keeps this simpler than sticky leader election.
- **SQLite** is single-node, so the lock is a no-op (always the sole dispatcher).

Implementation notes:
- New `ScheduleManager.dispatch_lock()` context manager (`flux/schedule_manager.py`); `Server._scheduler_loop` wraps its cycle in it.
- Lock key `0x464C555853` ("FLUXS") is distinct from the migration lock `0x464C5558` ("FLUX") so they never collide.
- The acquire commits immediately to end the autobegun transaction (the session-scoped lock survives the commit), matching the lesson from the migration runner's #108 review.

## Tests

- `test_scheduler_dispatch_lock.py` — SQLite yields True (and is reentrant); `Server._scheduler_loop` skips `get_due_schedules` when the lock isn't held and calls it when it is; a PostgreSQL-tagged test asserts a second concurrent acquirer is denied while the first holds the lock, then grantable again after release.
- The PostgreSQL CI lane now runs **all** `postgresql`-marked tests in `tests/flux/` (migration tests + the new exclusivity test), not just the migrations file.
- Full unit suite: 2296 passed, 4 skipped. pre-commit clean.

## Scope

Scheduler dispatch only. The remaining Phase 2 follow-up is multi-replica SSE reclaim-on-disconnect (faster orphan recovery than waiting out the heartbeat-timeout window added in #109).