### PR TITLE
fix(approvals): don't strand a PENDING approval on a cancelling execution

### DIFF
--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -69,6 +69,22 @@ class ContextManager(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def save_checked(
+        self,
+        ctx: ExecutionContext,
+        *,
+        uow: UnitOfWork | None = None,
+    ) -> bool:  # pragma: no cover
+        """Like ``save`` but report whether the state write was applied.
+
+        Returns ``False`` when ``_accept_state_write`` rejected the write
+        because a concurrent terminal/cancelling transition already won the
+        row. Callers chaining dependent writes (e.g. the approval gate
+        creating a row) use this to abort instead of stranding orphans.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def get(self, execution_id: str | None) -> ExecutionContext:  # pragma: no cover
         raise NotImplementedError()
 
@@ -178,6 +194,15 @@ class DatabaseContextManager(ContextManager):
         *,
         uow: UnitOfWork | None = None,
     ) -> ExecutionContext:
+        self.save_checked(ctx, uow=uow)
+        return ctx
+
+    def save_checked(
+        self,
+        ctx: ExecutionContext,
+        *,
+        uow: UnitOfWork | None = None,
+    ) -> bool:
         if uow is not None:
             return self._save_with_session(ctx, uow.session, manage_transaction=False)
         with self.session() as session:
@@ -189,19 +214,21 @@ class DatabaseContextManager(ContextManager):
         session: Session,
         *,
         manage_transaction: bool,
-    ) -> ExecutionContext:
+    ) -> bool:
         try:
             model = self._lock_for_write(session, ctx.execution_id)
             if model:
-                if _accept_state_write(ctx.state, model.state):
+                accepted = _accept_state_write(ctx.state, model.state)
+                if accepted:
                     model.state = ctx.state
                     model.output = ctx.output
                     session.add_all(self._get_additional_events(ctx, session))
             else:
+                accepted = True
                 session.add(ExecutionContextModel.from_plain(ctx))
             if manage_transaction:
                 session.commit()
-            return ctx
+            return accepted
         except IntegrityError:  # pragma: no cover
             if manage_transaction:
                 session.rollback()

--- a/flux/task.py
+++ b/flux/task.py
@@ -521,24 +521,31 @@ class task:
                 from flux.unit_of_work import UnitOfWork
 
                 cm = ContextManager.create()
+                awaiting_event = ExecutionEvent(
+                    type=ExecutionEventType.TASK_AWAITING_APPROVAL,
+                    source_id=call_id,
+                    name=full_name,
+                    value={
+                        "task_call_id": call_id,
+                        "workflow_namespace": ctx.workflow_namespace,
+                        "workflow_name": ctx.workflow_name,
+                        "task_name": self.name,
+                    },
+                )
                 with UnitOfWork() as uow:
-                    ctx.events.append(
-                        ExecutionEvent(
-                            type=ExecutionEventType.TASK_AWAITING_APPROVAL,
-                            source_id=call_id,
-                            name=full_name,
-                            value={
-                                "task_call_id": call_id,
-                                "workflow_namespace": ctx.workflow_namespace,
-                                "workflow_name": ctx.workflow_name,
-                                "task_name": self.name,
-                            },
-                        ),
-                    )
+                    ctx.events.append(awaiting_event)
                     # Persist the execution context *before* the approval row
                     # is flushed so the approval_requests.execution_id foreign
-                    # key has its target row (enforced on PostgreSQL).
-                    cm.save(ctx, uow=uow)
+                    # key has its target row (enforced on PostgreSQL). If a
+                    # concurrent cancel already moved the execution to
+                    # CANCELLING (or a terminal state), the state write is
+                    # rejected — drop the in-memory awaiting event (so the
+                    # cancellation checkpoint doesn't persist it), skip creating
+                    # a PENDING approval on a no-longer-pausable execution, and
+                    # unwind the task so the cancellation flow proceeds.
+                    if not cm.save_checked(ctx, uow=uow):
+                        ctx.events.remove(awaiting_event)
+                        raise asyncio.CancelledError()
                     mgr.create(
                         execution_id=ctx.execution_id,
                         task_call_id=call_id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.50.3"
+version = "0.50.4"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_state_precedence.py
+++ b/tests/flux/test_state_precedence.py
@@ -211,3 +211,31 @@ def test_update_does_not_demote_cancelling_to_paused(isolated_db):
 
     fetched = cm.get(ctx.execution_id)
     assert fetched.state == ExecutionState.CANCELLING
+
+
+# --- save_checked signals rejected writes ---------------------------------
+
+
+def test_save_checked_returns_true_on_accepted_write(isolated_db):
+    ctx = _make_ctx(ExecutionState.RUNNING)
+    cm = ContextManager.create()
+    assert cm.save_checked(ctx) is True
+
+
+def test_save_checked_returns_false_when_demote_to_paused_rejected(isolated_db):
+    ctx = _make_ctx(ExecutionState.RUNNING)
+    cm = ContextManager.create()
+    cm.save(ctx)
+    _set_db_state(ctx.execution_id, ExecutionState.CANCELLING)
+
+    ctx.pause("wf", "stale", output=None)
+    assert cm.save_checked(ctx) is False
+
+
+def test_save_checked_returns_false_over_cancelling(isolated_db):
+    ctx = _make_ctx(ExecutionState.RUNNING)
+    cm = ContextManager.create()
+    cm.save(ctx)
+    _set_db_state(ctx.execution_id, ExecutionState.CANCELLING)
+
+    assert cm.save_checked(ctx) is False

--- a/tests/flux/test_task_approval.py
+++ b/tests/flux/test_task_approval.py
@@ -549,3 +549,44 @@ def test_retry_attempt_is_independently_re_gated(isolated_db):
     pending = mgr.list(execution_id=ctx.execution_id, status=ApprovalStatus.PENDING)
     assert len(pending) == 1
     assert pending[0].task_call_id.endswith("~retry1")
+
+
+def test_gate_skips_create_when_execution_already_cancelling(isolated_db):
+    """#73: a concurrent cancel that moved the execution to CANCELLING must not
+    leave the gate stranding a brand-new PENDING approval row.
+
+    The worker's in-memory ctx still reads RUNNING, but the persisted row is
+    already CANCELLING (the cancel handler won the FOR UPDATE race). The gate's
+    state write is rejected, so it must abort instead of creating an approval.
+    """
+    import asyncio
+
+    from flux.context_managers import ContextManager
+    from flux.domain import ExecutionState
+    from flux.models import ExecutionContextModel
+
+    @task_decorator.with_options(requires_approval=True)
+    async def gated() -> str:
+        return "done"
+
+    ctx = _build_test_ctx()
+    ctx._state = ExecutionState.RUNNING
+    ContextManager.create().save(ctx)
+
+    cm = ContextManager.create()
+    with cm.session() as session:
+        row = session.get(ExecutionContextModel, ctx.execution_id)
+        assert row is not None
+        row.state = ExecutionState.CANCELLING
+        session.commit()
+
+    call_id = "call-cancelling-1"
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(gated._approval_gate(ctx, call_id, "default.test.gated", (), {}))
+
+    assert ApprovalManager().get_by_call(ctx.execution_id, call_id) is None
+    # The in-memory awaiting event is dropped so a later cancellation
+    # checkpoint reusing this ctx does not persist a misleading event.
+    from flux.domain.events import ExecutionEventType
+
+    assert not any(e.type == ExecutionEventType.TASK_AWAITING_APPROVAL for e in ctx.events)


### PR DESCRIPTION
## Problem (#73)

When a task reaches its approval gate (`flux/task.py` `_approval_gate`), the gate persists the execution context and inserts a PENDING approval row inside a single `UnitOfWork`:

```python
cm.save(ctx, uow=uow)
mgr.create(...)
uow.commit()
```

If a concurrent cancellation had already moved the execution to `CANCELLING` (or a terminal state) and won the `FOR UPDATE` row lock, `_accept_state_write` rejects the gate's state write — but `ContextManager.save()` returned normally with **no signal**, so the gate went on to commit a brand-new PENDING approval. The cancellation handler had, by then, already cancelled the execution's pre-existing approvals, so this new row dangles as PENDING forever.

The execution itself still cancels correctly (the worker's later PAUSED write is also rejected); the bug is an **orphan PENDING approval row**.

## Fix

- Add `ContextManager.save_checked()` (and make `_save_with_session` return the `accepted` bool). `save()` keeps its existing signature/return for all current callers.
- The approval gate now uses `save_checked()`. When the write is rejected it:
  - removes the in-memory `TASK_AWAITING_APPROVAL` event so the subsequent cancellation checkpoint (which reuses the same in-memory `ctx`) doesn't persist a misleading event, and
  - raises `asyncio.CancelledError()` so the in-flight task unwinds and the cancellation flow proceeds — mirroring the existing `verdict.cancelled` path — instead of creating the orphan approval.

## Tests

- `test_task_approval.py::test_gate_skips_create_when_execution_already_cancelling` — reproduces the race: persists an execution as CANCELLING, runs the gate, asserts `CancelledError` is raised, **no** approval row is created, and no stale awaiting event lingers on the ctx.
- `test_state_precedence.py` — three `save_checked` contract tests (returns `True` on accepted write, `False` when a demote-to-PAUSED or write-over-CANCELLING is rejected).

## Verification

- Targeted: approval + state-precedence suites (39) pass; full `tests/flux`, `tests/flux/tasks`, `tests/flux/agents`, `tests/security`, `tests/examples`, and top-level suites pass (~2,300 tests, 0 failures).
- E2E: `tests/e2e/test_approvals.py` — 4 passed.
- pre-commit clean (ruff, format, mypy).

## Related

Part of the PR #66 approval follow-ups. Sibling issues #70 (decide/cancel-before-PAUSED) and #71 (non-deterministic `task_call_id`) were verified already fixed on `main` and closed. #72 (retry-attempt replay) is a separate design problem tracked for a dedicated change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)