### PR TITLE
Production readiness: event-driven dispatch, durable checkpointing, and transient workflows for AI mesh

### DIFF
--- a/docs/advanced-features/ai-memory.md
+++ b/docs/advanced-features/ai-memory.md
@@ -162,7 +162,7 @@ from flux.tasks.ai.memory import postgresql
 provider = postgresql("postgresql://user:password@localhost/mydb")
 ```
 
-Requires the `psycopg2` package:
+Requires the `psycopg` (v3) package:
 
 ```bash
 pip install flux-core[postgresql]

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -1,0 +1,128 @@
+# Production Deployment Guide
+
+How to run Flux in production: the hardening checklist, multi-replica
+topology, worker-fleet operations, and the configuration that matters at
+scale. Defaults are development-friendly; production requires the explicit
+choices below.
+
+## The checklist
+
+Every item here maps to a failure mode observed in the production-readiness
+review (`docs/production-readiness-review.md`).
+
+1. **PostgreSQL, not SQLite.** SQLite is single-node only: `SELECT … FOR
+   UPDATE SKIP LOCKED` (claim safety) and FK cascades are silently
+   unenforced there. Set `FLUX_DATABASE_URL=postgresql://…`. PostgreSQL 14+
+   is expected; the driver is psycopg v3 (`pip install 'flux-core[postgresql]'`).
+2. **Enable authentication and set the secrets.** With auth off, every
+   caller is the anonymous admin. The server refuses to start when auth is
+   enabled without these two values (they otherwise fail mid-traffic):
+   ```
+   FLUX_SECURITY__AUTH__ENABLED=true
+   FLUX_SECURITY__EXECUTION_TOKEN_SECRET=<random 32+ bytes>
+   FLUX_SECURITY__ENCRYPTION__ENCRYPTION_KEY=<random 32+ bytes>
+   ```
+3. **Terminate TLS in front of every replica.** Flux serves plain HTTP.
+   Bearer tokens, worker session keys, pickled payloads, and decrypted
+   secrets (`/workers/{name}/secrets/batch`) all travel over this channel —
+   an ingress/load-balancer with TLS is a hard requirement, not an option.
+4. **Event dispatch mode.** `FLUX_DISPATCH__MODE=event` runs one dispatcher
+   per replica with LISTEN/NOTIFY wakeups and batch `SKIP LOCKED` claims.
+   The default `poll` mode is the legacy per-worker query loop and degrades
+   superlinearly with fleet size (measured: at 500 workers it saturates the
+   DB executor and takes minutes to accept submissions — see the review's
+   stress-test table). Poll mode remains for one release as a fallback.
+5. **Enable retention.** Execution history grows without bound otherwise
+   (every task is a persisted event row):
+   ```
+   FLUX_RETENTION__ENABLED=true
+   FLUX_RETENTION__RETENTION_DAYS=30
+   ```
+6. **Size the database pool and executor together.** Defaults are
+   `database_pool_size=20`, `database_max_overflow=20`,
+   `database_executor_threads=16` per replica. Keep executor ≤ pool so DB
+   threads never block waiting for a connection, and give PostgreSQL
+   `max_connections ≥ replicas × (pool_size + max_overflow) + workers' LISTEN
+   connections + headroom`.
+7. **Registration rate limit.** `/workers/register` validates the shared
+   bootstrap token and is limited to `30/minute` per client IP by default.
+   Large fleets restarting behind one NAT need it raised
+   (`FLUX_WORKERS__REGISTER_RATE_LIMIT=300/minute`) — or run the server
+   behind a proxy that forwards real client IPs (uvicorn `--proxy-headers`).
+8. **Probes.** Point liveness at `GET /health` and readiness at
+   `GET /ready`. `/ready` performs a database round-trip and returns 503
+   when the DB is unreachable — wire it to load-balancer membership, not
+   restarts, so a DB blip drains traffic instead of bouncing pods.
+9. **Bootstrap token custody.** The worker bootstrap token is a fleet-wide
+   join secret: anyone holding it can register a worker (and workers receive
+   workflow source and secrets). Set it explicitly
+   (`FLUX_WORKERS__BOOTSTRAP_TOKEN`), store it in your secret manager, and
+   rotate it deliberately — rotation invalidates the whole fleet's ability
+   to re-register until workers get the new value.
+
+## Multi-replica topology
+
+Multiple server replicas coordinate through PostgreSQL; there is no leader
+election to configure. What each mechanism relies on:
+
+- **Dispatch**: every replica's dispatcher batch-claims with
+  `FOR UPDATE SKIP LOCKED`; replicas never double-assign. New-work wakeups
+  travel via `NOTIFY flux_work`; a missed notification is covered by the
+  dispatcher's fallback tick (`dispatch.fallback_interval`, default 15s).
+- **Scheduler and retention**: fleet-wide singletons per cycle via
+  PostgreSQL advisory locks; a dead holder's lock auto-releases.
+- **Worker liveness**: heartbeats persist to `workers.last_seen_at`
+  (batched, one UPDATE per interval per replica), so any replica's reaper
+  can reclaim executions from a dead replica's workers.
+- **Sync/stream callers**: a caller held open on replica A is woken by a
+  checkpoint landing on replica B via `NOTIFY flux_exec`; the 30s poll
+  fallback remains as the safety net.
+- **`GET /workers`** reads the workers table — every replica returns the
+  same fleet view, with liveness derived from persisted heartbeats.
+
+**Sticky routing requirement.** A worker's SSE stream, its dispatch queue,
+and its in-flight execution signals live on the replica it connected to.
+Configure the load balancer with connection affinity (source-IP or cookie
+stickiness) for `/workers/{name}/connect`, and let workers reconnect through
+the same path. Plain HTTP round-robin works for everything else.
+
+## Worker fleet operations
+
+- **Capacity**: workers advertise `FLUX_WORKERS__MAX_CONCURRENT_EXECUTIONS`
+  (default 16, `0` = unlimited) at registration; the server never assigns
+  beyond a worker's free slots on any dispatch path. Size it to what one
+  worker process can genuinely run concurrently — workflow code shares the
+  worker's event loop.
+- **Deploys**: send SIGTERM and let the worker drain — it stops accepting
+  work, finishes running executions (up to `FLUX_WORKERS__DRAIN_TIMEOUT`,
+  default 60s), flushes terminal checkpoints, then exits. A second signal
+  aborts the drain. Give the orchestrator a termination grace period of
+  `drain_timeout + 30s`.
+- **Credentials rotate themselves**: worker API keys are minted with a TTL
+  (`FLUX_SECURITY__AUTH__API_KEYS__WORKER_KEY_TTL`, default 7 days); on the
+  first 401 after expiry the worker re-registers and gets a fresh key.
+  Principals of workers offline past `offline_ttl` are disabled and their
+  keys revoked automatically; a returning worker re-enables on registration.
+- **Fencing**: if a partitioned worker is evicted and its executions
+  reassigned, its later checkpoints are rejected (stale claim generation)
+  and it aborts those local runs — expect `stale-claim` warnings in worker
+  logs after partitions heal; they are the mechanism working.
+
+## Registering workflows is code execution
+
+Workflow registration executes the uploaded Python on the server (metadata
+enrichment) and on every worker that runs it. Treat
+`workflow:<namespace>:*:register` as a deploy permission: grant it to CI
+identities, not humans-at-large, and never enable `allow_anonymous` on a
+network where untrusted parties can reach the server.
+
+## Observability
+
+- `GET /metrics` (Prometheus) requires `admin:metrics:read` — provision a
+  scrape credential. Worker/schedule names are deliberately not metric
+  labels (unbounded cardinality); dashboards aggregate by event/reason.
+- OpenTelemetry traces/metrics export via `[flux.observability]` with the
+  `observability` extra installed.
+- Capacity planning numbers (measured, single 4-core host): see the
+  stress-test table in `docs/production-readiness-review.md` §7.6 and
+  `scripts/stress_dispatch.py` to reproduce against your own hardware.

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -108,6 +108,24 @@ the same path. Plain HTTP round-robin works for everything else.
   and it aborts those local runs — expect `stale-claim` warnings in worker
   logs after partitions heal; they are the mechanism working.
 
+## Transient executions (AI mesh)
+
+Workflows registered with `durability="transient"` keep the normal outer
+lifecycle — execution row, dispatch, terminal state, visible in
+`flux execution list` — but persist **no task-level state**: the worker
+suppresses every intermediate checkpoint and the terminal checkpoint carries
+only `WORKFLOW_*` events. Use it for high-frequency agent/mesh workflows
+whose intermediate step payloads (LLM inputs/outputs per task) would
+otherwise dominate `execution_events` growth. Measured on an 8-task
+workflow: 4.0 persisted event rows per execution vs 19.9 durable, with
+unchanged latency. Limits:
+
+- Pause and approvals are hard errors (they need replayable task history);
+  schedules are rejected at decoration time.
+- A retried/requeued transient execution re-runs all tasks from scratch —
+  at-least-once for side effects, with no replay short-circuit.
+- Works in both dispatch modes and with sync/async/stream callers.
+
 ## Registering workflows is code execution
 
 Workflow registration executes the uploaded Python on the server (metadata

--- a/docs/production-readiness-review.md
+++ b/docs/production-readiness-review.md
@@ -1,0 +1,262 @@
+# Production Readiness Review — Scale to Thousands of Workers & Transient Workflows for AI Mesh
+
+**Date:** 2026-07-02 · **Scope:** dispatch/claim path, persistence, worker runtime, security/operations, and a design assessment for transient/stateless workflows supporting an AI-mesh use case.
+
+## Executive summary
+
+Flux has a well-factored core — event-sourced `ExecutionContext`, pessimistic `SELECT … FOR UPDATE SKIP LOCKED` claiming, Alembic migrations, HMAC-signed pickles, deny-by-default anonymous policy, cross-replica scheduler singleton — and a lot of recent hardening has landed. **It is production-credible today at the scale of tens of workers and modest execution rates. It is not yet ready for thousands of workers or for high-frequency agent-to-agent traffic**, for three structural reasons:
+
+1. **Dispatch is a per-worker server-side poll loop, not push.** Each connected worker costs the server ~10–12 DB queries/sec even when idle, against a 15-connection pool and a ~32-thread executor. The system saturates in the low hundreds of workers per replica.
+2. **Durability is per-task full-context checkpointing.** Every task completion re-ships the entire event history (O(K²) payload over a K-task workflow), checkpoints are fire-and-forget with no retry and no HTTP timeout, and there is no retention story for `execution_events`.
+3. **Every execution — including every agent LLM/tool step — pays full durable-workflow cost.** A trivial 1-task workflow costs ≥6 persisted events, 5 locking DB transactions, and ~5 HTTP hops. An agent loop multiplies that per iteration. There is no transient/ephemeral execution mode — but the seam for one already exists and is clean (see §6).
+
+The recommended sequencing: fix the P0 correctness/robustness items (§7), replace polling dispatch with event-driven dispatch, then add a `durability="transient"` execution mode that reuses the existing checkpoint-callable seam. Transient mode is the single highest-leverage change for the AI-mesh use case: it removes ~all DB work from the hot path and converts an agent hop from ~5 round-trips + 5 transactions to 1 relay round-trip.
+
+---
+
+## 1. What is already solid
+
+Credit where due — these are done correctly and should not be re-litigated:
+
+- **Double-claim prevention.** Dispatch and claim use `with_for_update(skip_locked=True)` with worker-name pinning and atomic state flips (`flux/context_managers.py:286,450-521`). No double-claim on PostgreSQL.
+- **Cross-replica scheduler singleton** via `pg_try_advisory_lock` per cycle (`flux/schedule_manager.py:386-428`), and idempotent cross-replica orphan reclaim from persisted heartbeats.
+- **Migrations.** Real Alembic chain with a frozen baseline, advisory-lock-guarded concurrent upgrade, and legacy `create_all` adoption (`flux/migrations/runner.py`).
+- **Deterministic replay identity.** Task IDs and event IDs are content-addressed SHA-256 (`flux/task.py:142-157`, `flux/domain/events.py:96-112`), which makes event dedup and replay short-circuiting stable across processes.
+- **Security fundamentals.** Constant-time bootstrap-token compare, static-parse-before-exec authorization ordering on registration, HMAC integrity signing of at-rest pickles (fail-closed when a key is set), worker identity binding on worker endpoints, secrets-batch allow-list enforcement.
+- **Terminal-state write guard.** `_accept_state_write` (`flux/context_managers.py:41-58`) prevents a stale worker from resurrecting a completed/cancelled execution.
+
+---
+
+## 2. Scalability to thousands of workers
+
+Findings ranked by severity. The first three interact: together they cap a replica at roughly 100–300 connected workers before pool exhaustion and executor queueing set in.
+
+### S1 (Critical) — Per-worker 0.5s server-side poll loop
+
+`GET /workers/{name}/connect` looks like SSE push, but the server-side generator (`flux/api/worker_routes.py:260-388`) is a poll loop per connected worker: each tick calls `next_execution` + `next_cancellation` + `next_resume` (5–6 queries), and even with the event-based wakeups the fallback timeout is hard-coded to **0.5s** (`worker_routes.py:261`). An idle worker costs ~10–12 queries/sec:
+
+| Connected workers | Idle dispatch queries/sec |
+|---:|---:|
+| 100 | ~1,000–1,200 |
+| 1,000 | ~10,000–12,000 |
+| 5,000 | ~50,000–60,000 |
+
+Worse, new-work wakeups broadcast on a single shared `_work_available` event (`worker_routes.py:352-356`) — a **thundering herd**: one enqueued execution wakes every connected worker's loop, each of which runs the full match query stack and all but one loses the `SKIP LOCKED` race.
+
+**Fix direction:** event-driven dispatch. Per-replica in-memory work queues fed by PostgreSQL `LISTEN/NOTIFY` (or a lightweight fan-out table poll by *one* dispatcher task per replica, not one loop per worker), with targeted per-worker wakeups instead of broadcast, and the 0.5s fallback raised to a slow safety-net interval (10–30s).
+
+### S2 (Critical) — 15-connection DB pool and 32-thread executor ceiling
+
+- PostgreSQL pool defaults: `pool_size=5`, `max_overflow=10` → **15 connections per replica** (`flux/config.py:166-173`, `flux/models.py:120-125`), `pool_timeout=30s`. The per-worker poll loops alone exceed this in the low hundreds of workers; requests then block 30s and error.
+- All sync-SQLAlchemy work is offloaded via `asyncio.to_thread`, which uses the default loop executor (~`min(32, cpu+4)` threads; never overridden anywhere). That is the global concurrency ceiling for *all* DB operations — dispatch, checkpoints, admin routes.
+
+**Fix direction:** make pool size and a dedicated, explicitly sized `ThreadPoolExecutor` configurable and sized together (executor ≤ pool); long-term, S1 removes most of the demand. Consider async SQLAlchemy for the hot paths eventually, but sizing + event-driven dispatch buys the most for the least risk.
+
+### S3 (High) — `_is_least_loaded_worker` full aggregate per dispatch attempt
+
+Every `next_execution` call first runs a `GROUP BY` aggregate over **all** active executions (`flux/context_managers.py:338-369`) with no per-worker filter. Cost is O(workers × active_executions) per 0.5s across the fleet, and every idle tick pays it just to bail out.
+
+**Fix direction:** maintain an `active_executions` counter on the `workers` row (incremented/decremented in the same transactions that flip execution state), or compute load in the single per-replica dispatcher (S1) instead of per worker per tick.
+
+### S4 (High) — Single-process server; per-replica in-memory state breaks multi-replica semantics
+
+- Uvicorn runs one process, one event loop, no `workers=` (`flux/server.py:196-202`). SSE loops, the reaper, orphan reclaim (which deliberately runs *on* the event loop to set asyncio Events), and the scheduler all share it. A large stale-worker sweep blocks everything.
+- Worker registry, SSE routing, round-robin index, execution-event signaling, and progress buffers are per-replica dicts (`flux/server.py:113-129`). Consequences with >1 replica: `GET /workers` shows only the local slice (`worker_routes.py:631-665`); a checkpoint arriving on replica B never wakes a sync/stream caller waiting on replica A (it falls back to a 30s timeout re-poll, `flux/server.py:449`); work enqueued on replica B doesn't wake workers connected to replica A (0.5s poll masks it — until S1 removes the poll).
+
+**Fix direction:** make the DB (or LISTEN/NOTIFY) the cross-replica signal plane: `GET /workers` reads the `workers` table; checkpoint completion NOTIFYs so any replica's sync waiters wake; document sticky routing for SSE as an interim requirement.
+
+### S5 (Medium) — Heartbeat/reaper costs
+
+- `workers.last_seen_at` is **unindexed** (`flux/models.py:484`); `find_stale` full-scans the workers table every 10s per replica (`flux/worker_registry.py:189-201`).
+- Heartbeat pongs are one targeted UPDATE-commit per worker per 10s — ~500 tiny write transactions/sec at 5,000 workers, competing for the same pool. Batch or lengthen the interval at scale.
+- Mass eviction of a busy worker unclaims its executions one-by-one, unpaginated, on the event loop (`flux/server.py:595-636`).
+
+### S6 (Medium) — No connection/backpressure limits on the worker plane
+
+Unbounded workers may open `/connect`; each permanently consumes an asyncio task and poll loop. Rate limiting (slowapi) exists but is not applied here, and is keyed by remote address only. Add a max-connected-workers guard and registration rate limits (see also SEC1).
+
+---
+
+## 3. Durability & correctness
+
+### D1 (Critical) — O(K²) checkpoint amplification
+
+Every checkpoint serializes the **entire** context including all accumulated events (`flux/domain/execution_context.py:518-522`; the worker sends `to_dict()` at `flux/worker.py:677-685`). Over a K-task workflow that is ~K²/2 event objects shipped, with every large task output dill-re-serialized on each subsequent checkpoint. Server-side, dedup re-reads the `(event_id, type)` set per checkpoint (`flux/context_managers.py:636-644`) — O(K²) read work — plus a `FOR UPDATE` lock on the execution row each time.
+
+**Fix direction:** delta checkpoints. The worker knows which events are new since the last acknowledged checkpoint; send only those (keep a full-resync path for recovery). This also fixes the payload-size problem (M5 below) and most of the dedup cost.
+
+### D2 (Critical) — Checkpoints are fire-and-forget, coalesced, unretried, and untimed
+
+- Intermediate checkpoints run as background tasks, and each new checkpoint **cancels any still-pending one** (`flux/worker.py:644-659`) — under rapid task completion, nothing is durably persisted until a lull or the terminal checkpoint.
+- No retry on failure (`flux/worker.py:661-666,701-704`); events live only in worker memory between successful checkpoints.
+- `default_timeout` defaults to `0` → `httpx.AsyncClient(timeout=None)` (`flux/worker.py:100`): claim/checkpoint/pong can hang forever on a black-holed connection. A workflow that completes during a server blip may never persist COMPLETED — the reaper eventually unclaims it and it **re-executes from scratch**.
+
+**Fix direction:** bounded retry with backoff for checkpoints (mandatory for terminal ones), an explicit default HTTP timeout, and an outbound event buffer that survives coalescing (coalesce *sends*, never *events*).
+
+### D3 (High) — At-least-once without fencing → split-brain on partition
+
+Eviction resets RUNNING executions to CREATED and re-dispatches (`flux/context_managers.py:544-575`). A network-partitioned-but-alive worker keeps executing the original; nothing fences its subsequent checkpoints from interleaving with the new owner's (`_accept_state_write` only guards terminal states). Two live workers can run the same execution concurrently.
+
+**Fix direction:** a claim-generation fencing token: bump a `claim_generation` column on every (re)claim, embed it in the execution token/checkpoint, and reject checkpoints bearing a stale generation.
+
+### D4 (High) — Unbounded growth: no retention for executions/events
+
+There is no pruning, TTL, archival, or partitioning for `executions`/`execution_events` anywhere. Events carry inline pickled BLOB values. At AI-mesh rates (each agent LLM/tool step = 2 events + a checkpoint) this is millions of rows per hour. **Fix direction:** a retention job (age- and state-based), and per-workflow retention overrides. Transient mode (§6) removes most of the volume at the source.
+
+### D5 (Medium) — Full-history load and unpickle on every read
+
+`ContextManager.get()` materializes and dill-unpickles every event row, every time (`flux/models.py:645`), and it is called on status polls, claims, sync-wait loop iterations, unclaims, and the secrets batch. Long executions make their own status checks progressively more expensive. **Fix direction:** state/summary reads that skip event hydration (a `summary()` exists on the context — the server should have a query-level equivalent), and lazy event loading.
+
+### D6 (Medium) — Replay determinism is assumed, not enforced or documented
+
+Resume re-executes the entire workflow body; only `@task` results short-circuit from the log (`flux/task.py:230-268`). Non-task I/O, `datetime.now()`, `random`, or wall-clock branching in a workflow body silently corrupts replay and can desync task IDs. This is a standard event-sourcing contract, but it appears nowhere in user-facing docs. Document it prominently; consider a debug-mode replay-divergence detector.
+
+### D7 (Medium) — SQLite/PostgreSQL behavioral drift
+
+On SQLite: `SKIP LOCKED` is a no-op (double-claim protection silently absent), FK cascades are unenforced (no `PRAGMA foreign_keys=ON`), and the single writer serializes checkpoints. SQLite must be positioned explicitly as dev/single-node only; consider emitting a startup warning when a worker fleet >1 registers against SQLite.
+
+---
+
+## 4. Worker runtime robustness
+
+### W1 (Critical) — No isolation, no per-workflow timeout, no concurrency cap
+
+Workflow source is `exec()`'d and run on the worker's single event loop (`flux/worker.py:594,614`). One CPU-bound or sync-blocking workflow freezes the SSE reader, heartbeat pongs, and checkpoints for every co-tenant execution — missed pongs then get the *whole worker* evicted and all its executions mass-orphaned. There is **no per-worker max-concurrency knob**: every dispatch unconditionally `create_task`s (`flux/worker.py:259`); server-side least-loaded gating is a balancing heuristic, not a cap. Per-task `timeout` uses `asyncio.wait_for` and cannot bound sync code.
+
+**Fix direction (ordered):** (1) `max_concurrent_executions` per worker, advertised at registration and respected by dispatch — also the backpressure primitive the AI mesh needs; (2) optional subprocess execution mode per workflow for untrusted/CPU-heavy code, with a real wall-clock kill; (3) worker self-health: detect event-loop starvation and stop claiming.
+
+### W2 (High) — No graceful draining
+
+Shutdown cancels the main task; nothing awaits `_running_workflows` or pending checkpoints (`flux/worker.py:123-134`). Rolling deploys abandon in-flight executions to the ~60s reaper and full re-execution. **Fix:** a drain phase — stop claiming, await running executions up to a configurable deadline, flush terminal checkpoints, deregister.
+
+### W3 (Medium) — Token lifecycle gaps
+
+Only the SSE connect path recovers from 401/403 by re-registering (`flux/worker.py:174-179`); checkpoint/claim/pong/authorize have no 401 recovery, so a mid-execution key revocation silently drops durability. Registration **revokes all prior keys** for the principal (`flux/api/worker_routes.py:128`), so two workers sharing a name thrash each other's tokens. **Fix:** 401→re-register→retry-once wrapper on all worker HTTP calls; reject duplicate live registrations for the same name instead of rotating keys.
+
+### W4 (Medium) — Module cache staleness and leaks
+
+Cache key is `namespace:name:version` with a 300s TTL (`flux/worker.py:540-597`): re-registering different source under the same version serves stale code for up to 5 minutes, and `sys.modules` entries for old versions are never freed (unbounded growth on version churn). **Fix:** include a source hash in the cache key; add an LRU size cap and evict `sys.modules` alongside.
+
+---
+
+## 5. Security & operations
+
+### SEC1 (Critical) — No rate limiting on authentication paths
+
+slowapi is wired up but only `/auth/test-token` is limited. `POST /workers/register` — gated by a single fleet-wide bootstrap secret — and every API-key/JWT authentication are brute-forceable at full request rate (`flux/api/worker_routes.py:87-101`, `flux/security/auth_service.py:85-102`). **Fix:** default limits on register/auth endpoints, keyed with `X-Forwarded-For` awareness.
+
+### SEC2 (Critical) — Plaintext transport; secrets shipped decrypted over HTTP
+
+The server binds plain HTTP with no TLS support in-app (`flux/server.py:196`), Docker/compose default to `http://`, and `/workers/{name}/secrets/batch` returns decrypted secret values (`flux/api/worker_routes.py:580`). Encryption-at-rest is good; in-transit is entirely delegated to an undocumented external layer. **Fix:** first-class TLS config (or at minimum a prominent, hard requirement in deployment docs), and consider envelope-encrypting secret payloads to a worker-held key.
+
+### SEC3 (High) — Bootstrap token is a fleet-wide master secret; worker keys are immortal
+
+One shared bootstrap token grants registration under **any** worker name (names are caller-controlled), yielding the `worker` role (read all configs/executions, claim work → receive secrets). Worker API keys are minted with no expiry and no `last_used_at`; principals are never garbage-collected on eviction, so the principals table grows unbounded with churn (`flux/api/worker_routes.py:112-133`). Execution tokens are 7-day HS256 JWTs with no revocation list (`flux/security/execution_token.py:66-143`). **Fix:** key expiry + refresh for workers, principal GC tied to worker pruning, shorter execution-token TTL (they're scoped to one execution — hours, not a week), and per-registration one-time join tokens as an upgrade path from the shared bootstrap secret.
+
+### SEC4 (High, accepted-by-design) — `exec()` of registered source is RCE by contract
+
+Registration → `exec` on server (schedule extraction, enrich) and on every worker. The permission gate ordering is correct and SECURITY.md documents the trust boundary, but the only control is "restrict `workflow:*:register`". With auth disabled + `allow_anonymous=true`, registration is anonymous RCE. This is an inherent property of the programming model; it needs to stay loudly documented, and W1's subprocess isolation is the mitigation path.
+
+### SEC5 (Medium) — Operational hygiene
+
+- **Metrics cardinality:** `worker_name` (caller-controlled) is a Prometheus label on four worker metrics (`flux/observability/metrics.py:258-278`) — unbounded cardinality and a DoS vector at thousands of churning workers. Drop or hash the label.
+- **Probes:** `/health` conflates liveness and readiness (a DB blip can flap pod restarts); `/metrics` requires an admin-scoped credential, which is friction for scrapers. Add `/ready`; consider a scrape-scoped role.
+- **Body limits:** workflow upload is capped, but checkpoint, run-input, and progress bodies are not — unbounded dill payloads into memory. Add a global body-size middleware.
+- **Late config failure:** missing `encryption_key` silently disables pickle signing and surfaces only at first secret use; missing `execution_token_secret` fails at first mint. Validate at startup.
+- **Defaults:** auth disabled and CORS `*` by default are acceptable for a dev-first tool but deserve a one-page "production checklist" doc (auth on, key set, TLS, PostgreSQL, pool sizing).
+- **Pagination:** `GET /workers`, principals, and roles listings are unpaginated.
+- **Dispatch payload rebuild:** compiled dispatch payloads are built per event; fine today, worth caching per workflow version at mesh rates.
+
+---
+
+## 6. Transient/stateless workflows for the AI mesh
+
+### Why the current model can't serve a mesh
+
+Measured minimum cost of one trivial distributed execution today:
+
+| Cost | Count | Where |
+|---|---|---|
+| Persisted events | 6 (SCHEDULED, CLAIMED, STARTED, TASK_STARTED, TASK_COMPLETED, COMPLETED) | `context_managers.py`, `workflow.py:132-149`, `task.py:280-393` |
+| Locking DB transactions | 5 (create, schedule, claim, 2× checkpoint) | each with `FOR UPDATE` + dedup SELECT |
+| HTTP round-trips | ~5 (run, SSE push, claim, 2× checkpoint) | +1 authorize POST per task with auth on |
+
+An agent invocation multiplies this: **each LLM call and each tool call is a nested `@task`** (`flux/tasks/ai/agent_loop.py:88-101`, `flux/tasks/ai/tool_executor.py:238-309`) — 2 events + 1 checkpoint each. A modest 3-iteration agent with 2 tools/iteration ≈ 10 tasks → ~20 events + ~10 checkpoints. And **every cross-workflow call is a full new durable execution**: `flux/tasks/call.py` POSTs `/workflows/{ns}/{name}/run/sync`, and `workflow_agent()` (`flux/tasks/ai/delegation.py:229-261`) does the same. Completion visibility for the caller is a held-open sync request that re-reads the full context from the DB on every wake (30s timeout loop), SSE, or polling — there are no webhooks. Chain three agents and the floor is dozens of transactions per user request.
+
+### The seam already exists
+
+This is the encouraging part — the architecture is unusually well-prepared for a transient mode:
+
+1. **`ExecutionContext._checkpoint` is an injected callable defaulting to a no-op** (`flux/domain/execution_context.py:50,426-429`). The context has zero DB knowledge; `task.py`/`workflow.py` call `ctx.checkpoint()` blindly. A transient execution is literally a context whose checkpoint stays the no-op — events still accumulate in memory, so within-run replay/retry semantics keep working. **Zero changes to the task/workflow engine needed.**
+2. **`ContextManager` is an ABC with a single hard-coded implementation** (`flux/context_managers.py:61,156-158`) — an `InMemoryContextManager` slots in cleanly for server-side lookups of transient executions.
+3. The context already nulls its checkpoint callable on pickle (`execution_context.py:499-513`) — it is designed to travel without its persistence hook.
+
+### Proposed design: `durability="transient"`
+
+**API surface.**
+
+```python
+@workflow.with_options(durability="transient")   # default: "durable"
+async def route_request(ctx: ExecutionContext[AgentRequest]): ...
+```
+
+Also accept a per-invocation override on the run endpoint (`POST /workflows/{ns}/{name}/run/sync?durability=transient`) so the same workflow can serve both modes; `call()` and `workflow_agent()` grow a matching `durability=` passthrough.
+
+**Execution path (server-relayed, phase 1).**
+
+1. `POST …/run/sync` with transient: **no `executions` row, no catalog FK write, no events**. The server assigns an ID, registers it in an in-memory transient registry (TTL-bounded), and pushes the dispatch frame down an eligible worker's existing SSE stream — same matching, no `next_execution` DB query (pick from the in-memory registry of connected workers; this rides on the S1 dispatch rework).
+2. The worker executes with the no-op checkpoint and POSTs a single **result** message (output or exception) to a new `/workers/{name}/result/{execution_id}` endpoint — no claim round-trip (the SSE push *is* the claim; transient work is never re-dispatched, so claim races don't exist).
+3. The held-open sync request is completed from memory. Net cost: **1 client round-trip + 1 SSE push + 1 result POST, 0 DB transactions.**
+4. Failure semantics are **at-most-once with error propagation**: worker death or TTL expiry fails the caller's request with a structured error; the *caller* retries. No reaper, no unclaim, no replay.
+
+**Hard constraints (fail loudly, don't degrade silently).**
+
+- `pause()`, `requires_approval`, and cross-worker resume are inherently durable — they require rows another process can act on (`flux/task.py:474-593` writes approval rows via its own manager, bypassing the checkpoint seam). A transient execution hitting any of these must raise a clear error at that point — and registration should reject `durability="transient"` combined with `schedule=` or approval-gated tasks where statically detectable.
+- Within-run retry/fallback/rollback keep working unchanged (they're in-memory event mechanics).
+- Transient executions are invisible to `flux execution list`/history by design; emit OTel metrics (count, latency, outcome) so the mesh is still observable in aggregate.
+
+**Phase 2 — mesh fast paths.**
+
+- `call(durability="transient")` becomes the cheap agent-to-agent hop; in-process delegation (`build_delegate`) already avoids the round-trip and stays the first choice when the target lives in the same worker.
+- Sticky same-worker scheduling: when a transient sub-call's target workflow is loadable on the calling worker, execute in-process (module cache already holds compiled workflows) and skip the server entirely — this is the true mesh path, with the server relay as fallback and service discovery.
+- Optional bounded result cache (in-memory, TTL) so `mode=async` + late `GET /executions/{id}` works for transient runs within the TTL.
+
+**Prerequisites from the rest of this review.** Transient mode shifts pressure from the DB to the worker fleet, so W1 (per-worker concurrency cap + advertised capacity → backpressure with a `429`-style "mesh busy" signal), D2 (HTTP timeouts), and S1 (event-driven dispatch) are prerequisites, not nice-to-haves. Multi-replica relay needs sticky routing or a cross-replica result channel (S4).
+
+### Sizing sanity check
+
+At 1,000 sustained agent requests/sec with 3 transient hops each: today's model would be ~15,000 locking DB transactions/sec plus O(K²) checkpoint traffic — not feasible. The transient model is ~4,000 in-memory HTTP/SSE messages/sec spread across replicas and workers, with the DB touched only by durable workflows. That is an achievable target for a FastAPI/uvicorn fleet once S1/S2 land.
+
+---
+
+## 7. Prioritized roadmap
+
+**P0 — correctness & safety (before any scale push)**
+
+1. Checkpoint retry + explicit HTTP timeouts + never-drop event buffering (D2) — silent event loss is the worst current behavior.
+2. Delta checkpoints (D1) — removes O(K²) payloads and most server-side dedup cost.
+3. Rate limits on `/workers/register` and auth paths (SEC1); startup validation of `encryption_key`/`execution_token_secret` (SEC5).
+4. Per-worker `max_concurrent_executions` (W1) and graceful drain (W2).
+5. Claim-generation fencing token (D3).
+6. TLS story — in-app or as a documented hard requirement — given secrets-in-transit (SEC2).
+
+**P1 — scale to thousands of workers**
+
+7. Event-driven dispatch: one dispatcher per replica + LISTEN/NOTIFY + targeted worker wakeups; kill the 0.5s per-worker poll and the broadcast herd (S1).
+8. Pool + executor sizing knobs, sized together (S2).
+9. Replace the least-loaded aggregate with maintained per-worker counters (S3).
+10. Index `workers.last_seen_at`; batch heartbeat writes (S5).
+11. Cross-replica signal plane: DB-backed `GET /workers`, NOTIFY-driven sync-waiter wakeups (S4).
+12. Retention/pruning job for executions/events (D4); summary reads without event hydration (D5).
+13. Worker key expiry + refresh, principal GC, shorter execution-token TTL (SEC3); bounded metrics label cardinality (SEC5).
+
+**P2 — transient mode & AI mesh**
+
+14. `durability="transient"`: no-op checkpoint + in-memory transient registry + server-relayed sync execution (§6, phase 1).
+15. `call()`/`workflow_agent()` transient passthrough; sticky same-worker in-process execution (§6, phase 2).
+16. Subprocess isolation mode for untrusted/CPU-bound workflows (W1); module-cache source-hash keys + LRU (W4).
+17. Production deployment guide: PostgreSQL-only for fleets, replica topology, probes (`/ready`), pool sizing, security checklist.
+
+---
+
+*Methodology: five parallel code-level reviews (dispatch/claim path, persistence, worker runtime, execution-overhead/transient seams, security/ops) over the repository at commit `305962c`, consolidated and de-duplicated. File/line references are to that commit.*

--- a/docs/production-readiness-review.md
+++ b/docs/production-readiness-review.md
@@ -322,8 +322,9 @@ max_overflow = 20
 executor_threads = 16          # dedicated DB thread pool (replaces default loop executor)
 
 [flux.retention]
-enabled = true
-retention_days = 30            # terminal executions + events
+enabled = true                 # shipped default is false: enabling deletion is
+                               # an explicit production choice, never an upgrade side effect
+retention_days = 30            # terminal executions + events (age since last event)
 sweep_interval = 3600
 
 [flux.transient]

--- a/docs/production-readiness-review.md
+++ b/docs/production-readiness-review.md
@@ -369,8 +369,12 @@ connection errors) and median dispatch reaches 2 minutes. Poll mode degrades
 superlinearly with fleet size (throughput 6.6 → 2.5/s, median 32 → 117 s
 from 200 → 500 workers); event mode holds (19.7 → 16.6/s, first dispatch
 sub-second at both sizes). Event mode's remaining idle load (~0.4
-transactions/worker/sec) is heartbeat pongs — the P1 "batch heartbeat
-writes" item.
+transactions/worker/sec) was heartbeat pongs — the P1 "batch heartbeat
+writes" item, since landed: with pongs buffered and flushed as one UPDATE
+per reaper tick, measured idle load dropped to **45 tx/s @ 200 workers and
+101 tx/s @ 500** (~half). The residual ~0.18 tx/worker/sec tracks the
+per-request auth/permission resolution on worker endpoints — a future
+candidate for role-resolution caching.
 
 ### 7.7 Rollout path
 

--- a/docs/production-readiness-review.md
+++ b/docs/production-readiness-review.md
@@ -223,6 +223,35 @@ Also accept a per-invocation override on the run endpoint (`POST /workflows/{ns}
 
 **Prerequisites from the rest of this review.** Transient mode shifts pressure from the DB to the worker fleet, so W1 (per-worker concurrency cap + advertised capacity → backpressure with a `429`-style "mesh busy" signal), D2 (HTTP timeouts), and S1 (event-driven dispatch) are prerequisites, not nice-to-haves. Multi-replica relay needs sticky routing or a cross-replica result channel (S4).
 
+### Implemented (phase 1, revised) — measured
+
+Implemented with one deliberate revision to the design above: instead of
+skipping persistence entirely, a transient execution **keeps the outer
+lifecycle** — execution row, dispatch/claim, `WORKFLOW_*` events, terminal
+state, visible in `flux execution list` like any run — and removes the
+task-level durability: the worker suppresses every intermediate checkpoint
+and the single terminal checkpoint carries no `TASK_*` events. This keeps
+auditability, cancellation, fencing, and reaper recovery intact, works in
+both dispatch modes, and reduces the feature to worker-side checkpoint
+suppression driven by a flag in the dispatch payload.
+
+Measured on real workers (same fleet, 8-task workflow, 150 sync calls):
+
+| | durable | transient |
+|---|---:|---:|
+| persisted event rows per execution | 19.9 | **4.0** |
+| p50 latency | 534 ms | 526 ms |
+| throughput | 18.2/s | 19.0/s |
+
+Latency is unchanged because intermediate checkpoints were already
+asynchronous and coalesced; the win is storage and payload traffic — an
+agent loop's per-step LLM/tool payloads never reach the database. Pause and
+approvals are hard errors on transient runs (they need replayable task
+history); schedules are rejected at decoration time. Replay-on-retry
+re-executes tasks from scratch (no task history), i.e. at-least-once for
+side effects. The same-worker in-process fast path remains the phase-2
+follow-up.
+
 ### Sizing sanity check
 
 At 1,000 sustained agent requests/sec with 3 transient hops each: today's model would be ~15,000 locking DB transactions/sec plus O(K²) checkpoint traffic — not feasible. The transient model is ~4,000 in-memory HTTP/SSE messages/sec spread across replicas and workers, with the DB touched only by durable workflows. That is an achievable target for a FastAPI/uvicorn fleet once S1/S2 land.

--- a/docs/production-readiness-review.md
+++ b/docs/production-readiness-review.md
@@ -380,4 +380,12 @@ Each step is independently shippable and backward-compatible: (1) driver swap ps
 
 ---
 
+## Decisions log
+
+- **2026-07-03 — PostgreSQL-only for multi-node.** Multi-node deployments require PostgreSQL; SQLite remains fully supported for dev and single-node inline use. The dispatcher, LISTEN/NOTIFY signal plane, and fencing all assume PG semantics. Add a startup warning when more than one worker registers against SQLite.
+- **2026-07-03 — Transient semantics: at-most-once at the workflow level.** Transient executions are never re-dispatched by the server; worker death or TTL expiry returns a structured error and the caller retries. Task-level retry/fallback/rollback inside a transient run is unchanged (in-memory event mechanics are kept, only persistence is skipped). Pause, approval gates, and schedules on transient workflows are hard errors.
+- **2026-07-03 — Dependency posture.** fastmcp floored at 2.14.2 (clears the fixable advisories); the 3.2.0-only advisories are accepted as unused-feature risk until the tracked fastmcp 3.x migration; diskcache advisory accepted (transitive, no fixed release).
+
+---
+
 *Methodology: five parallel code-level reviews (dispatch/claim path, persistence, worker runtime, execution-overhead/transient seams, security/ops) over the repository at commit `305962c`, consolidated and de-duplicated. File/line references are to that commit.*

--- a/docs/production-readiness-review.md
+++ b/docs/production-readiness-review.md
@@ -344,6 +344,34 @@ At 5,000 workers across 3 replicas (~1,700 SSE connections each — comfortable 
 
 The DB write load becomes proportional to durable execution throughput alone — which is exactly what a durable store should be paying for.
 
+#### Measured: dispatch-plane stress test (poll vs event)
+
+Measured after the dispatcher landed, using `scripts/stress_dispatch.py`:
+protocol-level simulated workers (register → SSE connect → ping/pong →
+claim → checkpoint COMPLETED over real HTTP; no workflow code executes)
+against a real server on PostgreSQL 16. Environment: one 4-core/16 GB
+machine hosting server, fleet, and PostgreSQL together — absolute numbers
+are conservative; the poll-vs-event comparison is the signal.
+
+| Metric | poll @ 200 | event @ 200 | poll @ 500 | event @ 500 |
+|---|---:|---:|---:|---:|
+| Idle DB transactions/sec (no work) | 641 | 76 | 613 † | 198 |
+| Accepting 400/600 run-submissions | 55.2 s | 8.9 s | 221.6 s | 15.3 s |
+| Drain throughput (completions/sec) | 6.6 | 19.7 | 2.5 | 16.6 |
+| First dispatch after enqueue | 4.7 s | 0.86 s | 11.5 s | 0.70 s |
+| Median dispatch latency | 31.7 s | 12.8 s | 117.4 s | 22.4 s |
+
+† Poll idle load is *executor-throttled*, not stable: nominal demand at 500
+workers is ~6,000 queries/sec but the DB thread pool can only push ~600, so
+poll loops queue up behind each other — which is why submissions crawl
+(600 POSTs took 3.7 minutes; an earlier identical run failed outright with
+connection errors) and median dispatch reaches 2 minutes. Poll mode degrades
+superlinearly with fleet size (throughput 6.6 → 2.5/s, median 32 → 117 s
+from 200 → 500 workers); event mode holds (19.7 → 16.6/s, first dispatch
+sub-second at both sizes). Event mode's remaining idle load (~0.4
+transactions/worker/sec) is heartbeat pongs — the P1 "batch heartbeat
+writes" item.
+
 ### 7.7 Rollout path
 
 Each step is independently shippable and backward-compatible: (1) driver swap psycopg2→psycopg3 and pool/executor knobs — no behavior change; (2) checkpoint v2 with protocol negotiation (workers advertise delta support at registration; server accepts both, full-snapshot remains the recovery path); (3) dispatcher behind a feature flag, per-worker poll kept as fallback for one release, then removed; (4) capacity slots + drain; (5) retention job; (6) transient mode (new surface, additive); (7) subprocess isolation (opt-in per workflow). Steps 1–2 are P0-aligned, 3–5 deliver the thousands-of-workers target, 6–7 deliver the mesh.

--- a/docs/production-readiness-review.md
+++ b/docs/production-readiness-review.md
@@ -10,7 +10,7 @@ Flux has a well-factored core — event-sourced `ExecutionContext`, pessimistic 
 2. **Durability is per-task full-context checkpointing.** Every task completion re-ships the entire event history (O(K²) payload over a K-task workflow), checkpoints are fire-and-forget with no retry and no HTTP timeout, and there is no retention story for `execution_events`.
 3. **Every execution — including every agent LLM/tool step — pays full durable-workflow cost.** A trivial 1-task workflow costs ≥6 persisted events, 5 locking DB transactions, and ~5 HTTP hops. An agent loop multiplies that per iteration. There is no transient/ephemeral execution mode — but the seam for one already exists and is clean (see §6).
 
-The recommended sequencing: fix the P0 correctness/robustness items (§7), replace polling dispatch with event-driven dispatch, then add a `durability="transient"` execution mode that reuses the existing checkpoint-callable seam. Transient mode is the single highest-leverage change for the AI-mesh use case: it removes ~all DB work from the hot path and converts an agent hop from ~5 round-trips + 5 transactions to 1 relay round-trip.
+The recommended sequencing: fix the P0 correctness/robustness items (§8), replace polling dispatch with event-driven dispatch (§7), then add a `durability="transient"` execution mode that reuses the existing checkpoint-callable seam. Transient mode is the single highest-leverage change for the AI-mesh use case: it removes ~all DB work from the hot path and converts an agent hop from ~5 round-trips + 5 transactions to 1 relay round-trip.
 
 ---
 
@@ -229,7 +229,128 @@ At 1,000 sustained agent requests/sec with 3 transient hops each: today's model 
 
 ---
 
-## 7. Prioritized roadmap
+## 7. Proposed solution — target architecture, stack, and dependencies
+
+This section turns the fix directions above into one coherent design. The guiding principle: **PostgreSQL stays the only required piece of infrastructure**, the FastAPI/uvicorn/SQLAlchemy stack is kept, and scale comes from changing *access patterns* (push instead of poll, deltas instead of full snapshots, memory instead of rows for transient work) rather than from new middleware.
+
+### 7.1 Target architecture
+
+```
+                       ┌───────────────────────── control plane ─────────────────────────┐
+   clients             │  server replica 1..R (FastAPI + uvicorn, sticky SSE routing)    │
+     │                 │                                                                 │
+     │ run/sync ──────▶│  ┌──────────────┐   assign    ┌────────────────────────────┐    │
+     │ run/async       │  │  Dispatcher  │────────────▶│ per-worker outbound queues │    │
+     │ (durable or     │  │ (1 task/rep.)│             │  (existing SSE streams)    │    │
+     │  transient)     │  └──────┬───────┘             └─────────────┬──────────────┘    │
+     │                 │         │ batch claim                       │ push frames       │
+     │                 │         ▼ (SKIP LOCKED)                     │                    │
+     │                 │  ┌─────────────────┐    LISTEN/NOTIFY  ┌────┴───────────────┐   │
+     │                 │  │   PostgreSQL    │◀═════════════════▶│ Transient registry │   │
+     │                 │  │ durable source  │  (wakeups only,   │ (in-memory, TTL,   │   │
+     │                 │  │ of truth + WAL  │   R listeners)    │  sync-wait futures)│   │
+     │                 │  └─────────────────┘                   └────────────────────┘   │
+     └────────────────▶│  retention job · reaper · scheduler (advisory-lock singletons)  │
+                       └──────────────────────────────┬──────────────────────────────────┘
+                                                      │ SSE (dispatch) / HTTP (results,
+                                                      │ delta checkpoints, heartbeats)
+                       ┌───────────────────────────── ▼ ── data plane ───────────────────┐
+                       │  worker 1..W (capacity slots, drain, delta-checkpoint buffer)   │
+                       │   ├─ in-process executor (async workflows, trusted)             │
+                       │   ├─ subprocess pool (isolation="process", wall-clock kill)     │
+                       │   └─ mesh fast path: transient sub-calls run in-process when    │
+                       │      the target workflow is locally loadable                    │
+                       └──────────────────────────────────────────────────────────────────┘
+```
+
+Key inversion vs today: **the per-worker server-side poll loops disappear.** Each replica runs exactly one dispatcher task; DB load scales with `replicas × work rate`, not `workers × 2/sec`. Workers' SSE handlers become passive consumers of an in-memory queue.
+
+### 7.2 Component designs
+
+**Dispatcher (replaces the per-worker poll, fixes S1/S3/S6).** One asyncio task per replica. It holds an in-memory view of locally connected workers — labels, resource capabilities, advertised `max_concurrent_executions`, current in-flight count (from dispatch/complete accounting, replacing the `GROUP BY` aggregate). Wakeup sources: a `LISTEN flux_work` notification (fired by a trigger or by the enqueue transaction), a local enqueue, a worker slot freeing up, or a 10–30s fallback tick. On wakeup it claims a **batch** of `CREATED`/`RESUME_SCHEDULED`/`CANCELLING` rows with one `FOR UPDATE SKIP LOCKED LIMIT n` query, matches them against local free slots in memory (label/resource matching moves out of SQL row iteration), flips them to `SCHEDULED` with `worker_name` and a bumped `claim_generation` in one transaction, and pushes dispatch frames onto the target workers' queues. Unmatched rows are released for other replicas. `SKIP LOCKED` makes concurrent dispatchers on other replicas coordination-free. NOTIFY delivery is best-effort by design — notifications are pure wakeups; the DB rows are the truth and the fallback tick covers missed signals. The worker's claim POST is kept as a cheap PK-targeted ack (`CLAIMED`), no scan.
+
+**Checkpoint pipeline v2 (fixes D1/D2/D3).** Add a per-execution monotonic `seq` to events and a `claim_generation` column to executions. The worker keeps a per-execution outbound buffer and high-water mark of the last *acknowledged* seq; each checkpoint POST carries only `events[acked+1:]`, the current state, and the claim generation. The server appends, acks the new high-water mark, and **rejects stale generations** (a fenced-out partitioned worker gets a 409 and aborts its copy). Coalescing applies to *sends*, never to buffered events. Retries use capped exponential backoff (tenacity); terminal checkpoints must succeed before the execution is considered delivered, within the drain deadline. On resync (worker restart, 409, unknown seq) the worker falls back to one full-context POST — today's behavior becomes the recovery path instead of the hot path. All worker HTTP calls get explicit timeouts and a 401 → re-register → retry-once wrapper.
+
+**Transient execution plane (§6, fixes the mesh cost).** A `TransientExecutionRegistry` per replica: `execution_id → {future, worker, deadline}` with a TTL sweeper. `POST /workflows/{ns}/{name}/run/sync` with `durability=transient` skips the `executions` insert entirely, registers the future, and hands the dispatch frame straight to the dispatcher's matching stage (same worker-selection code path, no DB). The worker runs it with the no-op checkpoint and POSTs one result message; the registry completes the future and the held-open request returns. Worker death, disconnect, or TTL expiry fails the future with a structured error — the caller retries (at-most-once). Because both the SSE stream and the sync waiter live on the same replica, no cross-replica channel is needed in phase 1 (sticky routing); phase 2 can add a NOTIFY-relayed result path or the optional Redis backend for replica-crossing calls. `call()` and `workflow_agent()` pass `durability` through; when the target workflow is loadable on the calling worker (module cache), the sub-call executes in-process and never leaves the worker — the true mesh path.
+
+**Worker runtime v2 (fixes W1–W4).** Registration advertises `max_concurrent_executions`; the dispatcher never exceeds a worker's free slots, giving real backpressure (mesh callers get a fast "no capacity" failure instead of a queue). Shutdown gains a drain phase: deregister-from-dispatch → await running executions up to `drain_timeout` → flush terminal checkpoints. The module cache key gains a source hash and an LRU cap with `sys.modules` eviction. A new per-workflow option `isolation="process"` routes execution to a small `concurrent.futures.ProcessPoolExecutor`: the child runs `asyncio.run(wfunc(ctx))`, streams events back over a pipe, and can be killed on a wall-clock deadline — the mitigation for untrusted/CPU-bound code and the `exec()` trust boundary (SEC4), with no new dependency.
+
+**Data layer.** Pool size, overflow, and a dedicated DB `ThreadPoolExecutor` (sized ≤ pool) become config knobs and replace the default 32-thread loop executor. Index `workers.last_seen_at`; batch heartbeat updates per replica (`UPDATE … WHERE name = ANY(…)` every interval). A retention job (advisory-lock singleton, like the scheduler) deletes terminal executions/events past `retention_days` in batches; `execution_events` optionally moves to native monthly partitioning via an Alembic migration for high-volume installs. Status reads get a summary query that skips event hydration.
+
+**Security hardening.** slowapi default limits on `/workers/register` and auth-bearing routes (with `X-Forwarded-For` key function); worker API keys minted with expiry + a refresh endpoint; principal GC tied to worker pruning; execution-token TTL down to hours; startup validation of `encryption_key`/`execution_token_secret`; optional in-app TLS via uvicorn's `ssl_certfile`/`ssl_keyfile` passthrough plus documented terminate-at-ingress guidance; global body-size middleware; `worker_name` dropped from metric labels; `/ready` endpoint separate from `/health`.
+
+### 7.3 Stack decisions
+
+| Layer | Decision | Rationale |
+|---|---|---|
+| Language/runtime | **Keep** Python 3.12 + asyncio; add optional `uvloop` | No rewrite; uvloop is a drop-in ~2× event-loop win for SSE-heavy replicas and workers on Linux |
+| HTTP/app server | **Keep** FastAPI + uvicorn (single process per replica, scale by replicas) | SSE + in-memory dispatcher state make process-per-replica the natural unit; `--limit-concurrency` guards the connection plane |
+| Durable store & queue | **Keep** PostgreSQL as the only required infra; `SKIP LOCKED` batch claims + `LISTEN/NOTIFY` wakeups | Postgres-as-queue at batch granularity is a proven pattern; avoids operating a broker; transactional with execution state |
+| DB driver | **Migrate `psycopg2` → `psycopg` v3** (`postgresql+psycopg` dialect) | One driver serves sync SQLAlchemy *and* the async `LISTEN` connection; psycopg2 has no async path |
+| ORM | **Keep** sync SQLAlchemy behind a right-sized executor; async SQLAlchemy only if profiling demands it later | Sizing + push dispatch removes the pressure that would justify an async migration's risk |
+| Signal plane | **LISTEN/NOTIFY first**; optional Redis backend behind a small `SignalPlane` interface | R listeners (replicas), not W (workers); payloads are wakeups only, so the 8 KB/non-durable limits don't bite |
+| Isolation | stdlib subprocess pool (`isolation="process"`) | No dependency; real kill semantics; container/K8s handles the outer boundary |
+| Message broker (Kafka/RabbitMQ/NATS) | **Explicit non-goal** | Dispatch needs transactional consistency with execution rows, not throughput a broker adds; a broker would double the ops burden for every Flux install |
+
+### 7.4 New dependencies
+
+| Dependency | Where | Required? | Purpose |
+|---|---|---|---|
+| `psycopg[binary,pool] >= 3.2` | `postgresql` extra (replaces `psycopg2`) | Yes, for multi-node | Async `LISTEN/NOTIFY` listener + unified sync/async driver |
+| `tenacity >= 9` | core | Yes | Checkpoint/claim/result retry policies with capped backoff and jitter |
+| `uvloop >= 0.21` | new `performance` extra | Optional | Event-loop throughput for server replicas and workers (Linux/macOS) |
+| `redis >= 5` | new `mesh-redis` extra | Optional | Alternative signal plane + cross-replica transient result relay beyond LISTEN/NOTIFY scale |
+
+Everything else in the design — subprocess isolation, delta checkpoints, capacity slots, retention, rate limiting (slowapi already present), body-size middleware — uses the stdlib or existing dependencies.
+
+### 7.5 Configuration surface added
+
+```toml
+[flux.dispatch]
+batch_size = 64            # rows claimed per dispatcher wakeup
+fallback_interval = 15     # safety-net tick (s); replaces the 0.5s per-worker poll
+max_connected_workers = 2000   # per replica; excess registrations get 503
+
+[flux.workers]
+max_concurrent_executions = 16 # advertised capacity; dispatcher never exceeds free slots
+drain_timeout = 60             # graceful-shutdown drain deadline (s)
+default_timeout = 30           # worker HTTP timeout — no longer 0/None
+
+[flux.database]
+pool_size = 20                 # sized with executor_threads; executor <= pool
+max_overflow = 20
+executor_threads = 16          # dedicated DB thread pool (replaces default loop executor)
+
+[flux.retention]
+enabled = true
+retention_days = 30            # terminal executions + events
+sweep_interval = 3600
+
+[flux.transient]
+result_ttl = 120               # seconds a transient result/future may wait
+```
+
+### 7.6 Capacity model after the changes
+
+At 5,000 workers across 3 replicas (~1,700 SSE connections each — comfortable for uvicorn with mostly-idle streams):
+
+| Load source | Today | Proposed |
+|---|---|---|
+| Idle dispatch queries | ~50–60k/s (5–6 per worker per 0.5s) | ~0.2/s (one fallback tick per replica per 15s) |
+| Dispatch under load | thundering herd × full match stack per worker | `work_rate / batch_size` batch claims, herd eliminated |
+| Heartbeat writes | ~500 single-row commits/s | ~0.3 batched statements/s |
+| K-task workflow checkpoint bytes | O(K²) | O(K) (deltas; full snapshot only on resync) |
+| Transient agent hop | 6 events, 5 locking txns, ~5 HTTP hops | 0 DB txns, 3 in-memory messages (0 when same-worker in-process) |
+
+The DB write load becomes proportional to durable execution throughput alone — which is exactly what a durable store should be paying for.
+
+### 7.7 Rollout path
+
+Each step is independently shippable and backward-compatible: (1) driver swap psycopg2→psycopg3 and pool/executor knobs — no behavior change; (2) checkpoint v2 with protocol negotiation (workers advertise delta support at registration; server accepts both, full-snapshot remains the recovery path); (3) dispatcher behind a feature flag, per-worker poll kept as fallback for one release, then removed; (4) capacity slots + drain; (5) retention job; (6) transient mode (new surface, additive); (7) subprocess isolation (opt-in per workflow). Steps 1–2 are P0-aligned, 3–5 deliver the thousands-of-workers target, 6–7 deliver the mesh.
+
+---
+
+## 8. Prioritized roadmap
 
 **P0 — correctness & safety (before any scale push)**
 

--- a/flux/api/schemas.py
+++ b/flux/api/schemas.py
@@ -55,6 +55,8 @@ class WorkerRegistration(BaseModel):
     packages: list[dict[str, str]]
     resources: WorkerResourcesModel
     labels: dict[str, str] = Field(default_factory=dict)
+    # Advertised capacity; None/0 means unlimited (legacy workers).
+    max_concurrent_executions: int | None = None
 
 
 class SecretRequest(BaseModel):

--- a/flux/api/system_routes.py
+++ b/flux/api/system_routes.py
@@ -73,7 +73,12 @@ class SystemRoutesMixin:
             the process" (liveness). Points a database round-trip.
             """
             try:
-                db_ready = await asyncio.to_thread(WorkflowCatalog.create().health_check)
+                # The catalog construction itself opens the engine on first
+                # use, so it must run inside the thread hop as well — not just
+                # the health check — or a slow DB blocks the event loop.
+                db_ready = await asyncio.to_thread(
+                    lambda: WorkflowCatalog.create().health_check(),
+                )
             except Exception:
                 db_ready = False
             if not db_ready:

--- a/flux/api/system_routes.py
+++ b/flux/api/system_routes.py
@@ -7,6 +7,8 @@ to ``self`` (the ``Server`` instance) and the shared per-app dependencies.
 
 from __future__ import annotations
 
+import asyncio
+
 from typing import TYPE_CHECKING
 
 
@@ -61,6 +63,23 @@ class SystemRoutesMixin:
         # ===========================================
         # Health & System Endpoints
         # ===========================================
+
+        @api.get("/ready")
+        async def ready(response: Response):
+            """Readiness probe: can this replica serve traffic right now?
+
+            Separate from /health so orchestrators can distinguish "remove
+            from the load balancer" (readiness, e.g. a DB blip) from "restart
+            the process" (liveness). Points a database round-trip.
+            """
+            try:
+                db_ready = await asyncio.to_thread(WorkflowCatalog.create().health_check)
+            except Exception:
+                db_ready = False
+            if not db_ready:
+                response.status_code = 503
+                return {"status": "not-ready", "database": False}
+            return {"status": "ready", "database": True}
 
         @api.get("/health", response_model=HealthResponse)
         async def health(response: Response):

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -21,7 +21,10 @@ from fastapi import Depends
 from fastapi import Header
 from fastapi import HTTPException
 from fastapi import Query
+from fastapi import Request
 from sse_starlette import EventSourceResponse
+
+from flux.config import Configuration
 
 from flux.catalogs import WorkflowCatalog
 from flux.context_managers import ContextManager
@@ -84,8 +87,17 @@ class WorkerRoutesMixin:
         principal_registry,
         limiter,
     ):
+        # The bootstrap token is a shared secret validated on every registration;
+        # without a rate limit it is online-brute-forceable at full request rate.
+        register_rate_limit = Configuration.get().settings.workers.register_rate_limit
+
+        def _register_limited(fn):
+            return limiter.limit(register_rate_limit)(fn) if register_rate_limit else fn
+
         @api.post("/workers/register")
+        @_register_limited
         async def workers_register(
+            request: Request,
             registration: WorkerRegistration = Body(...),
             authorization: str = Header(None),
         ):

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -140,9 +140,15 @@ class WorkerRoutesMixin:
                     if "worker" not in existing_roles:
                         principal_registry.assign_role(principal.id, "worker")
                     await auth_service.revoke_all_api_keys(principal.id)
+                    from datetime import timedelta
+
+                    key_ttl = auth_config.api_keys.worker_key_ttl
                     api_key = await auth_service.create_api_key(
                         principal.id,
                         key_name=f"worker-{registration.name}",
+                        # Expiring keys rotate themselves: workers re-register
+                        # on the first 401 after expiry and get a fresh key.
+                        expires=timedelta(seconds=key_ttl) if key_ttl else None,
                     )
                     result.session_token = api_key
 
@@ -600,10 +606,14 @@ class WorkerRoutesMixin:
                     # a full fleet gets assigned now.
                     self._notify_next_worker()
 
-                # Notify any waiting sync/stream endpoint
+                # Notify any waiting sync/stream endpoint — locally, and on
+                # other replicas via NOTIFY when the state is one a caller
+                # blocks on (the waiter re-reads the row either way).
                 event = self._execution_events.get(execution_id)
                 if event:
                     event.set()
+                if self._dispatcher is not None and (ctx.has_finished or ctx.is_paused):
+                    self._dispatcher.notify_execution_update(execution_id)
 
                 return ctx.summary()
             except HTTPException:
@@ -734,7 +744,13 @@ class WorkerRoutesMixin:
             status: Literal["online", "offline"] | None = Query(None),
             identity: FluxIdentity = Depends(get_identity),
         ):
-            """List workers from in-memory cache. Optional ?status=online|offline filter.
+            """List workers fleet-wide. Optional ?status=online|offline filter.
+
+            Reads the workers table rather than this replica's in-memory cache,
+            so every replica returns the same, complete fleet view; liveness is
+            derived from the persisted heartbeat (a worker is online while its
+            last_seen_at is within heartbeat_timeout + eviction grace, matching
+            the reaper's staleness window).
 
             Worker visibility is intentionally unpermissioned — any authenticated user
             may discover available workers. Sensitive details are not exposed.
@@ -742,18 +758,32 @@ class WorkerRoutesMixin:
             try:
                 logger.debug(f"Listing workers (filter={status})")
 
-                if status == "online":
-                    result = [
-                        self._worker_cache[n] for n in self._worker_names if n in self._worker_cache
-                    ]
-                elif status == "offline":
-                    result = [
-                        self._worker_cache[n]
-                        for n in self._worker_offline_since
-                        if n in self._worker_cache
-                    ]
-                else:
-                    result = list(self._worker_cache.values())
+                registry = WorkerRegistry.create()
+                infos = await asyncio.to_thread(registry.list)
+
+                from datetime import datetime, timedelta, timezone
+
+                threshold = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(
+                    seconds=self.heartbeat_timeout + self.eviction_grace_period,
+                )
+
+                def _status(info) -> str:
+                    last_seen = getattr(info, "last_seen_at", None)
+                    return (
+                        "online" if last_seen is not None and last_seen >= threshold else "offline"
+                    )
+
+                result = []
+                for info in infos:
+                    worker_status = _status(info)
+                    if status is not None and worker_status != status:
+                        continue
+                    cached = self._worker_cache.get(info.name)
+                    if cached is not None:
+                        cached.status = worker_status
+                        result.append(cached)
+                    else:
+                        result.append(WorkerResponse(name=info.name, status=worker_status))
 
                 logger.debug(f"Found {len(result)} workers")
                 return result

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -768,6 +768,15 @@ class WorkerRoutesMixin:
                 )
 
                 def _status(info) -> str:
+                    # This replica knows its own connections authoritatively —
+                    # and immediately (a locally-disconnected worker must not
+                    # read "online" for the rest of its heartbeat window). The
+                    # persisted-heartbeat fallback covers workers attached to
+                    # OTHER replicas, which this process cannot see directly.
+                    if info.name in self._worker_names:
+                        return "online"
+                    if info.name in self._worker_offline_since:
+                        return "offline"
                     last_seen = getattr(info, "last_seen_at", None)
                     return (
                         "online" if last_seen is not None and last_seen >= threshold else "offline"

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -69,6 +69,10 @@ class WorkerRoutesMixin:
         # source travels base64-encoded on the wire; the worker decodes it.
         workflow.source = base64.b64encode(workflow.source).decode("utf-8")  # type: ignore[assignment]
         payload: dict = {"workflow": workflow, "context": ctx}
+        if (workflow.metadata or {}).get("durability") == "transient":
+            # The worker suppresses intermediate (task-level) checkpoints for
+            # transient workflows; only the terminal workflow state persists.
+            payload["transient"] = True
         session = self._get_db_session()
         try:
             exec_row = session.get(ExecutionContextModel, ctx.execution_id)

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -269,6 +269,61 @@ class WorkerRoutesMixin:
                     f"Worker {name} registered for round-robin (total: {len(self._worker_names)})",
                 )
 
+                self._worker_info[name] = worker
+                dispatch_mode = Configuration.get().settings.dispatch.mode
+                if dispatch_mode == "event":
+                    # A reconnect supersedes any previous stream for this worker:
+                    # release frames the old queue never delivered, then install
+                    # the new queue the dispatcher will feed.
+                    self._drain_worker_queue(name)
+                    frame_queue: asyncio.Queue = asyncio.Queue()
+                    self._worker_queues[name] = frame_queue
+                    # New capacity — let the dispatcher assign any pending work.
+                    self._work_available.set()
+
+                    async def consume_dispatch_queue():
+                        last_ping_time = time.monotonic()
+                        try:
+                            while True:
+                                if eviction_event.is_set():
+                                    logger.info(f"Worker {name} evicted by reaper, closing SSE")
+                                    return
+
+                                now = time.monotonic()
+                                if (now - last_ping_time) >= self.heartbeat_interval:
+                                    last_ping_time = now
+                                    yield {"event": "ping", "data": ""}
+
+                                try:
+                                    item = await asyncio.wait_for(frame_queue.get(), timeout=1.0)
+                                except TimeoutError:
+                                    continue
+                                logger.debug(
+                                    f"Sending {item.kind} to worker {name}: {item.execution_id}",
+                                )
+                                yield item.frame
+                        finally:
+                            if self._worker_connection_gen.get(name) == gen:
+                                self._disconnect_worker(name)
+                                logger.info(
+                                    f"Worker {name} disconnected "
+                                    f"(remaining: {len(self._worker_names)})",
+                                )
+                            else:
+                                logger.debug(
+                                    f"Stale SSE for {name} closed (superseded by newer connection)",
+                                )
+
+                    return EventSourceResponse(
+                        consume_dispatch_queue(),
+                        media_type="text/event-stream",
+                        headers={
+                            "Content-Type": "text/event-stream",
+                            "Cache-Control": "no-cache",
+                            "Connection": "keep-alive",
+                        },
+                    )
+
                 async def check_for_new_executions():
                     fallback_interval = 0.5
                     last_ping_time = time.monotonic()

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -119,6 +119,7 @@ class WorkerRoutesMixin:
                     registration.packages,
                     registration.resources,
                     labels=registration.labels,
+                    max_concurrent_executions=registration.max_concurrent_executions,
                 )
 
                 if auth_service is not None and auth_config.api_keys.enabled:
@@ -565,6 +566,10 @@ class WorkerRoutesMixin:
 
                 if ctx.has_finished:
                     self._execution_queue_times.pop(execution_id, None)
+                    # A finished execution frees one of the worker's capacity
+                    # slots — wake dispatch so any work that was held back by
+                    # a full fleet gets assigned now.
+                    self._notify_next_worker()
 
                 # Notify any waiting sync/stream endpoint
                 event = self._execution_events.get(execution_id)

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -22,6 +22,7 @@ from fastapi import Header
 from fastapi import HTTPException
 from fastapi import Query
 from fastapi import Request
+from fastapi import Response
 from sse_starlette import EventSourceResponse
 
 from flux.config import Configuration
@@ -29,7 +30,7 @@ from flux.config import Configuration
 from flux.catalogs import WorkflowCatalog
 from flux.context_managers import ContextManager
 from flux.domain.events import ExecutionEvent, ExecutionEventType
-from flux.errors import ExecutionContextNotFoundError, WorkerNotFoundError
+from flux.errors import ExecutionContextNotFoundError, StaleClaimError, WorkerNotFoundError
 from flux.secret_managers import SecretManager
 from flux.security.dependencies import get_identity, require_permission
 from flux.security.identity import FluxIdentity
@@ -473,6 +474,7 @@ class WorkerRoutesMixin:
         async def workers_claim(
             name: str,
             execution_id: str,
+            response: Response,
             identity: FluxIdentity = Depends(require_permission("worker:*:*")),
         ):
             from flux.domain import ExecutionState
@@ -531,6 +533,15 @@ class WorkerRoutesMixin:
                 if event:
                     event.set()
 
+                # Fencing token: the worker echoes this on every checkpoint so
+                # a superseded claim (unclaimed after partition, reassigned)
+                # can be rejected instead of interleaving with the new owner.
+                generation = await asyncio.to_thread(
+                    context_manager.get_claim_generation,
+                    execution_id,
+                )
+                response.headers["X-Flux-Claim-Generation"] = str(generation)
+
                 return ctx.to_dict()
             except HTTPException:
                 raise
@@ -543,6 +554,7 @@ class WorkerRoutesMixin:
             name: str,
             execution_id: str,
             context: ExecutionContextDTO = Body(...),
+            claim_generation: str | None = Header(None, alias="X-Flux-Claim-Generation"),
             identity: FluxIdentity = Depends(require_permission("worker:*:*")),
         ):
             try:
@@ -557,8 +569,25 @@ class WorkerRoutesMixin:
                 context_manager = ContextManager.create()
                 domain_ctx = context.to_domain()
 
+                expected_generation = None
+                if claim_generation is not None:
+                    try:
+                        expected_generation = int(claim_generation)
+                    except ValueError:
+                        raise HTTPException(
+                            status_code=400,
+                            detail="Invalid X-Flux-Claim-Generation header.",
+                        )
+
                 try:
-                    ctx = await asyncio.to_thread(context_manager.update, domain_ctx)
+                    ctx = await asyncio.to_thread(
+                        context_manager.update,
+                        domain_ctx,
+                        expected_generation,
+                    )
+                except StaleClaimError as e:
+                    logger.warning(str(e))
+                    raise HTTPException(status_code=409, detail=f"stale-claim: {e}")
                 except ExecutionContextNotFoundError:
                     logger.warning(f"Execution context not found: {execution_id}")
                     raise HTTPException(status_code=404, detail="Execution context not found.")

--- a/flux/catalogs.py
+++ b/flux/catalogs.py
@@ -347,6 +347,7 @@ class WorkflowCatalog(ABC):
                     workflow_namespace = DEFAULT_NAMESPACE
                     workflow_requests = None
                     workflow_affinity = None
+                    workflow_durability = None
 
                     for decorator in node.decorator_list:
                         # Simple @workflow decorator
@@ -379,6 +380,11 @@ class WorkflowCatalog(ABC):
                                     workflow_requests = self._extract_workflow_requests(kw.value)
                                 elif kw.arg == "affinity":
                                     workflow_affinity = self._extract_affinity(kw.value)
+                                elif kw.arg == "durability" and isinstance(
+                                    kw.value,
+                                    ast.Constant,
+                                ):
+                                    workflow_durability = kw.value.value
 
                             if not workflow_name:
                                 workflow_name = node.name
@@ -390,6 +396,9 @@ class WorkflowCatalog(ABC):
                             node,
                             tree,
                         )
+                        if workflow_durability is not None:
+                            wf_metadata = dict(wf_metadata or {})
+                            wf_metadata["durability"] = workflow_durability
                         workflow_infos.append(
                             WorkflowInfo(
                                 id=f"{workflow_namespace}/{workflow_name}",

--- a/flux/config.py
+++ b/flux/config.py
@@ -78,6 +78,15 @@ class WorkersConfig(BaseConfig):
         default=300,
         description="Seconds to cache compiled workflow modules (0 to disable)",
     )
+    register_rate_limit: str = Field(
+        default="30/minute",
+        description=(
+            "Per-client-IP rate limit for POST /workers/register, guarding the "
+            "shared bootstrap token against online brute force. slowapi syntax "
+            "(e.g. '30/minute'); empty string disables. Raise it for large "
+            "fleets restarting behind a shared NAT."
+        ),
+    )
 
 
 class MCPConfig(BaseConfig):

--- a/flux/config.py
+++ b/flux/config.py
@@ -179,12 +179,21 @@ class FluxConfig(BaseSettings):
         description="Database backend type",
     )
     database_pool_size: int = Field(
-        default=5,
+        default=20,
         description="Database connection pool size (PostgreSQL only)",
     )
     database_max_overflow: int = Field(
-        default=10,
+        default=20,
         description="Maximum pool overflow (PostgreSQL only)",
+    )
+    database_executor_threads: int = Field(
+        default=16,
+        description=(
+            "Size of the server's thread pool for blocking database calls "
+            "(asyncio.to_thread). Size it at or below the connection pool so "
+            "threads never block waiting for a connection. 0 keeps the "
+            "asyncio default executor."
+        ),
     )
     database_pool_timeout: int = Field(
         default=30,

--- a/flux/config.py
+++ b/flux/config.py
@@ -39,6 +39,21 @@ class WorkersConfig(BaseConfig):
         description="Default server URL to connect to",
     )
     default_timeout: int = Field(default=0, description="Default task timeout in seconds")
+    http_timeout: int = Field(
+        default=30,
+        description="Timeout in seconds for worker HTTP calls to the server (0 disables)",
+    )
+    checkpoint_retry_max_delay: int = Field(
+        default=30,
+        description="Backoff cap in seconds between checkpoint send retries",
+    )
+    terminal_checkpoint_deadline: int = Field(
+        default=300,
+        description=(
+            "Max seconds to keep retrying a terminal (finished-state) checkpoint "
+            "before giving up and leaving the execution to the server reaper"
+        ),
+    )
     retry_attempts: int = Field(default=3, description="Default number of retry attempts")
     retry_delay: int = Field(default=1, description="Default delay between retries in seconds")
     retry_backoff: int = Field(default=2, description="Default backoff multiplier for retries")

--- a/flux/config.py
+++ b/flux/config.py
@@ -245,7 +245,7 @@ class FluxConfig(BaseSettings):
         """Auto-infer database type from URL if not explicitly set"""
         if v == "sqlite":  # Default case
             database_url = info.data.get("database_url", "")
-            if database_url.startswith("postgresql://"):
+            if database_url.startswith(("postgresql://", "postgresql+")):
                 return "postgresql"
         return v
 

--- a/flux/config.py
+++ b/flux/config.py
@@ -89,6 +89,31 @@ class WorkersConfig(BaseConfig):
     )
 
 
+class DispatchConfig(BaseConfig):
+    """Configuration for server-side execution dispatch."""
+
+    mode: Literal["poll", "event"] = Field(
+        default="poll",
+        description=(
+            "Dispatch strategy. 'poll' runs the legacy per-worker query loop "
+            "(~5 queries per worker per 0.5s). 'event' runs one dispatcher task "
+            "per replica that batch-claims work on wakeups (LISTEN/NOTIFY on "
+            "PostgreSQL) — the scalable mode for large worker fleets."
+        ),
+    )
+    batch_size: int = Field(
+        default=64,
+        description="Max executions claimed per dispatcher wakeup (event mode)",
+    )
+    fallback_interval: float = Field(
+        default=15.0,
+        description=(
+            "Dispatcher safety-net tick in seconds (event mode); covers missed "
+            "notifications, which are wakeups only and carry no data"
+        ),
+    )
+
+
 class MCPConfig(BaseConfig):
     """Configuration for MCP server."""
 
@@ -225,6 +250,7 @@ class FluxConfig(BaseSettings):
         ).SecurityConfig(),
     )  # type: ignore[name-defined]
     mcp: MCPConfig = Field(default_factory=MCPConfig)
+    dispatch: DispatchConfig = Field(default_factory=DispatchConfig)
     scheduling: SchedulingConfig = Field(default_factory=SchedulingConfig)
     observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
 

--- a/flux/config.py
+++ b/flux/config.py
@@ -78,6 +78,21 @@ class WorkersConfig(BaseConfig):
         default=300,
         description="Seconds to cache compiled workflow modules (0 to disable)",
     )
+    max_concurrent_executions: int = Field(
+        default=16,
+        description=(
+            "Capacity the worker advertises at registration: the server never "
+            "assigns more than this many concurrent executions to it "
+            "(0 = unlimited, the legacy behavior)"
+        ),
+    )
+    drain_timeout: int = Field(
+        default=60,
+        description=(
+            "Seconds a stopping worker waits for running executions to finish "
+            "before cancelling them (0 = cancel immediately)"
+        ),
+    )
     register_rate_limit: str = Field(
         default="30/minute",
         description=(

--- a/flux/config.py
+++ b/flux/config.py
@@ -104,6 +104,32 @@ class WorkersConfig(BaseConfig):
     )
 
 
+class RetentionConfig(BaseConfig):
+    """Configuration for execution-history retention."""
+
+    enabled: bool = Field(
+        default=False,
+        description=(
+            "Delete terminal executions (and their events/approvals/sessions) "
+            "older than retention_days. Off by default so upgrades never "
+            "silently remove history; enable it in production or the "
+            "executions/execution_events tables grow without bound."
+        ),
+    )
+    retention_days: int = Field(
+        default=30,
+        description="Age (days since last event) after which terminal executions are deleted",
+    )
+    sweep_interval: int = Field(
+        default=3600,
+        description="Seconds between retention sweeps",
+    )
+    batch_size: int = Field(
+        default=500,
+        description="Executions deleted per transaction during a sweep",
+    )
+
+
 class DispatchConfig(BaseConfig):
     """Configuration for server-side execution dispatch."""
 
@@ -266,6 +292,7 @@ class FluxConfig(BaseSettings):
     )  # type: ignore[name-defined]
     mcp: MCPConfig = Field(default_factory=MCPConfig)
     dispatch: DispatchConfig = Field(default_factory=DispatchConfig)
+    retention: RetentionConfig = Field(default_factory=RetentionConfig)
     scheduling: SchedulingConfig = Field(default_factory=SchedulingConfig)
     observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
 

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -11,7 +11,6 @@ from sqlalchemy.orm import Session
 
 from flux import ExecutionContext
 from flux.domain import ExecutionState
-from flux.domain import ResourceRequest
 from flux.errors import ExecutionContextNotFoundError, ExecutionError, StaleClaimError
 from flux.models import ExecutionEventModel
 from flux.models import ExecutionContextModel
@@ -316,16 +315,9 @@ class DatabaseContextManager(ContextManager):
         return session.execute(stmt).scalar_one_or_none()
 
     def _worker_matches_workflow(self, worker: WorkerInfo, workflow: WorkflowModel) -> bool:
-        if workflow.affinity is not None:
-            if not ResourceRequest.matches_labels(worker.labels, workflow.affinity):
-                return False
-        if workflow.requests is not None:
-            requests = ResourceRequest(**(workflow.requests or {}))
-            if worker.resources is None:
-                return False
-            if not requests.matches_worker(worker.resources, worker.packages):
-                return False
-        return True
+        from flux.domain.resource_request import worker_matches
+
+        return worker_matches(worker, workflow.requests, workflow.affinity)
 
     def _next_matching_execution(
         self,

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 from flux import ExecutionContext
 from flux.domain import ExecutionState
 from flux.domain import ResourceRequest
-from flux.errors import ExecutionContextNotFoundError, ExecutionError
+from flux.errors import ExecutionContextNotFoundError, ExecutionError, StaleClaimError
 from flux.models import ExecutionEventModel
 from flux.models import ExecutionContextModel
 from flux.models import RepositoryFactory
@@ -93,7 +93,14 @@ class ContextManager(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def update(self, ctx: ExecutionContext) -> ExecutionContext:  # pragma: no cover
+    def update(
+        self,
+        ctx: ExecutionContext,
+        expected_claim_generation: int | None = None,
+    ) -> ExecutionContext:  # pragma: no cover
+        """Persist a checkpoint. When ``expected_claim_generation`` is given,
+        reject it with ``StaleClaimError`` if the row has since been reassigned
+        (fencing against partitioned-but-alive workers)."""
         raise NotImplementedError()
 
     @abstractmethod
@@ -145,6 +152,11 @@ class ContextManager(ABC):
         workers: list[WorkerInfo],
         limit: int,
     ) -> list[tuple[ExecutionContext, str]]:  # pragma: no cover
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_claim_generation(self, execution_id: str) -> int:  # pragma: no cover
+        """Current fencing generation for an execution (0 if never assigned)."""
         raise NotImplementedError()
 
     @abstractmethod
@@ -264,11 +276,24 @@ class DatabaseContextManager(ContextManager):
                 session.rollback()
             raise
 
-    def update(self, ctx: ExecutionContext) -> ExecutionContext:
+    def update(
+        self,
+        ctx: ExecutionContext,
+        expected_claim_generation: int | None = None,
+    ) -> ExecutionContext:
         with self.session() as session:
             model = self._lock_for_write(session, ctx.execution_id)
             if not model:
                 raise ExecutionContextNotFoundError(ctx.execution_id)
+            if (
+                expected_claim_generation is not None
+                and (model.claim_generation or 0) != expected_claim_generation
+            ):
+                raise StaleClaimError(
+                    ctx.execution_id,
+                    expected=expected_claim_generation,
+                    actual=model.claim_generation or 0,
+                )
             if _accept_state_write(ctx.state, model.state):
                 model.state = ctx.state
                 model.output = ctx.output
@@ -359,6 +384,7 @@ class DatabaseContextManager(ContextManager):
                 ctx.schedule(worker)
                 model.state = ctx.state
                 model.worker_name = ctx.current_worker
+                model.claim_generation = (model.claim_generation or 0) + 1
                 session.add_all(self._get_additional_events(ctx, session))
                 session.commit()
                 return ctx
@@ -456,6 +482,7 @@ class DatabaseContextManager(ContextManager):
             ctx.resume_schedule(worker)
             model.state = ctx.state
             model.worker_name = ctx.current_worker
+            model.claim_generation = (model.claim_generation or 0) + 1
             session.add_all(self._get_additional_events(ctx, session))
             session.commit()
 
@@ -493,6 +520,16 @@ class DatabaseContextManager(ContextManager):
         if not cap:
             return True
         return loads.get(worker.name, 0) < cap
+
+    def get_claim_generation(self, execution_id: str) -> int:
+        """Current fencing generation for an execution (0 if never assigned)."""
+        with self.session() as session:
+            row = (
+                session.query(ExecutionContextModel.claim_generation)
+                .filter(ExecutionContextModel.execution_id == execution_id)
+                .scalar()
+            )
+            return row or 0
 
     def _worker_load_map(self, session: Session, worker_names: list[str]) -> dict[str, int]:
         """Active-execution counts for the given workers, one aggregate query."""
@@ -556,6 +593,7 @@ class DatabaseContextManager(ContextManager):
                 ctx.schedule(worker)
                 model.state = ctx.state
                 model.worker_name = ctx.current_worker
+                model.claim_generation = (model.claim_generation or 0) + 1
                 session.add_all(self._get_additional_events(ctx, session))
                 loads[worker.name] = loads.get(worker.name, 0) + 1
                 assignments.append((ctx, worker.name))
@@ -607,6 +645,7 @@ class DatabaseContextManager(ContextManager):
                 ctx.resume_schedule(worker)
                 model.state = ctx.state
                 model.worker_name = ctx.current_worker
+                model.claim_generation = (model.claim_generation or 0) + 1
                 session.add_all(self._get_additional_events(ctx, session))
                 loads[worker.name] = loads.get(worker.name, 0) + 1
                 assignments.append((ctx, worker.name))
@@ -835,13 +874,20 @@ class DatabaseContextManager(ContextManager):
         # every save. The execution_id filter rides the FK index.
         from sqlalchemy import select
 
+        # Restrict the membership read to the ids in the incoming payload:
+        # with delta checkpoints the payload carries only unacknowledged
+        # events, so this read is O(delta) instead of O(full history).
+        incoming_ids = [e.id for e in ctx.events]
         existing = {
             (event_id, event_type)
             for event_id, event_type in session.execute(
                 select(
                     ExecutionEventModel.event_id,
                     ExecutionEventModel.type,
-                ).where(ExecutionEventModel.execution_id == ctx.execution_id),
+                ).where(
+                    ExecutionEventModel.execution_id == ctx.execution_id,
+                    ExecutionEventModel.event_id.in_(incoming_ids),
+                ),
             ).all()
         }
         return [

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -390,6 +390,11 @@ class DatabaseContextManager(ContextManager):
         if worker.name not in load_map:
             load_map[worker.name] = 0
 
+        # A worker at its advertised capacity never takes new work, regardless
+        # of how loaded the rest of the fleet is.
+        if not self._has_free_slot(worker, load_map):
+            return False
+
         if len(load_map) <= 1:
             return True
 
@@ -477,6 +482,18 @@ class DatabaseContextManager(ContextManager):
 
             return ctx
 
+    @staticmethod
+    def _has_free_slot(worker: WorkerInfo, loads: dict[str, int]) -> bool:
+        """Whether the worker's advertised capacity admits one more execution.
+
+        ``max_concurrent_executions`` of None or 0 means unlimited (legacy
+        workers that predate the field).
+        """
+        cap = getattr(worker, "max_concurrent_executions", None)
+        if not cap:
+            return True
+        return loads.get(worker.name, 0) < cap
+
     def _worker_load_map(self, session: Session, worker_names: list[str]) -> dict[str, int]:
         """Active-execution counts for the given workers, one aggregate query."""
         active_states = [
@@ -527,7 +544,11 @@ class DatabaseContextManager(ContextManager):
                 .limit(limit)
             )
             for model, workflow in query:
-                eligible = [w for w in workers if self._worker_matches_workflow(w, workflow)]
+                eligible = [
+                    w
+                    for w in workers
+                    if self._has_free_slot(w, loads) and self._worker_matches_workflow(w, workflow)
+                ]
                 if not eligible:
                     continue
                 worker = min(eligible, key=lambda w: loads.get(w.name, 0))
@@ -615,7 +636,12 @@ class DatabaseContextManager(ContextManager):
                     .limit(remaining)
                 )
                 for model, workflow in unassigned:
-                    eligible = [w for w in workers if self._worker_matches_workflow(w, workflow)]
+                    eligible = [
+                        w
+                        for w in workers
+                        if self._has_free_slot(w, loads)
+                        and self._worker_matches_workflow(w, workflow)
+                    ]
                     if not eligible:
                         continue
                     _assign(model, min(eligible, key=lambda w: loads.get(w.name, 0)))

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -118,6 +118,36 @@ class ContextManager(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def next_executions_batch(
+        self,
+        workers: list[WorkerInfo],
+        limit: int,
+    ) -> list[tuple[ExecutionContext, str]]:  # pragma: no cover
+        """Claim up to ``limit`` pending executions and assign them across workers.
+
+        Event-dispatch counterpart of ``next_execution``: one transaction claims
+        a batch and spreads it over the eligible least-loaded workers. Returns
+        ``(context, worker_name)`` pairs.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def next_cancellations_batch(
+        self,
+        worker_names: list[str],
+        limit: int,
+    ) -> list[ExecutionContext]:  # pragma: no cover
+        raise NotImplementedError()
+
+    @abstractmethod
+    def next_resumes_batch(
+        self,
+        workers: list[WorkerInfo],
+        limit: int,
+    ) -> list[tuple[ExecutionContext, str]]:  # pragma: no cover
+        raise NotImplementedError()
+
+    @abstractmethod
     def claim(self, execution_id: str, worker: WorkerInfo) -> ExecutionContext:
         raise NotImplementedError()
 
@@ -446,6 +476,152 @@ class DatabaseContextManager(ContextManager):
                     )
 
             return ctx
+
+    def _worker_load_map(self, session: Session, worker_names: list[str]) -> dict[str, int]:
+        """Active-execution counts for the given workers, one aggregate query."""
+        active_states = [
+            ExecutionState.RUNNING,
+            ExecutionState.CLAIMED,
+            ExecutionState.SCHEDULED,
+        ]
+        rows = (
+            session.query(
+                ExecutionContextModel.worker_name,
+                func.count(ExecutionContextModel.execution_id),
+            )
+            .filter(
+                ExecutionContextModel.state.in_(active_states),
+                ExecutionContextModel.worker_name.in_(worker_names),
+            )
+            .group_by(ExecutionContextModel.worker_name)
+            .all()
+        )
+        loads = {name: 0 for name in worker_names}
+        loads.update(dict(rows))
+        return loads
+
+    def next_executions_batch(
+        self,
+        workers: list[WorkerInfo],
+        limit: int,
+    ) -> list[tuple[ExecutionContext, str]]:
+        """Claim up to ``limit`` pending executions and assign them across workers.
+
+        One transaction per call: rows are locked with ``SKIP LOCKED`` (so
+        concurrent dispatchers on other replicas pass over each other's
+        claims), matched against each worker's labels/resources, and assigned
+        to the least-loaded eligible worker. The load aggregate runs once per
+        batch — not once per worker per poll tick as in ``next_execution``.
+        Unmatched rows keep state CREATED and their locks release at commit.
+        """
+        if not workers or limit <= 0:
+            return []
+        assignments: list[tuple[ExecutionContext, str]] = []
+        with self.session() as session:
+            loads = self._worker_load_map(session, [w.name for w in workers])
+            query = (
+                session.query(ExecutionContextModel, WorkflowModel)
+                .join(WorkflowModel)
+                .filter(ExecutionContextModel.state == ExecutionState.CREATED)
+                .with_for_update(skip_locked=True, of=ExecutionContextModel)
+                .limit(limit)
+            )
+            for model, workflow in query:
+                eligible = [w for w in workers if self._worker_matches_workflow(w, workflow)]
+                if not eligible:
+                    continue
+                worker = min(eligible, key=lambda w: loads.get(w.name, 0))
+                ctx = model.to_plain()
+                ctx.schedule(worker)
+                model.state = ctx.state
+                model.worker_name = ctx.current_worker
+                session.add_all(self._get_additional_events(ctx, session))
+                loads[worker.name] = loads.get(worker.name, 0) + 1
+                assignments.append((ctx, worker.name))
+            session.commit()
+        return assignments
+
+    def next_cancellations_batch(
+        self,
+        worker_names: list[str],
+        limit: int,
+    ) -> list[ExecutionContext]:
+        """Pending cancellations for the given workers.
+
+        Read-only like ``next_cancellation``; the state flips when the worker
+        checkpoints the cancelled context, so re-delivery on later wakeups is
+        possible and workers treat cancellation events idempotently.
+        """
+        if not worker_names or limit <= 0:
+            return []
+        with self.session() as session:
+            models = (
+                session.query(ExecutionContextModel)
+                .filter(
+                    ExecutionContextModel.state == ExecutionState.CANCELLING,
+                    ExecutionContextModel.worker_name.in_(worker_names),
+                )
+                .with_for_update(skip_locked=True)
+                .limit(limit)
+                .all()
+            )
+            return [model.to_plain() for model in models]
+
+    def next_resumes_batch(
+        self,
+        workers: list[WorkerInfo],
+        limit: int,
+    ) -> list[tuple[ExecutionContext, str]]:
+        """Schedule pending resumes: sticky ones to their original worker,
+        unassigned ones to the least-loaded matching worker."""
+        if not workers or limit <= 0:
+            return []
+        by_name = {w.name: w for w in workers}
+        assignments: list[tuple[ExecutionContext, str]] = []
+        with self.session() as session:
+            loads = self._worker_load_map(session, list(by_name))
+
+            def _assign(model, worker: WorkerInfo):
+                ctx = model.to_plain()
+                ctx.resume_schedule(worker)
+                model.state = ctx.state
+                model.worker_name = ctx.current_worker
+                session.add_all(self._get_additional_events(ctx, session))
+                loads[worker.name] = loads.get(worker.name, 0) + 1
+                assignments.append((ctx, worker.name))
+
+            sticky = (
+                session.query(ExecutionContextModel)
+                .filter(
+                    ExecutionContextModel.state == ExecutionState.RESUMING,
+                    ExecutionContextModel.worker_name.in_(list(by_name)),
+                )
+                .with_for_update(skip_locked=True)
+                .limit(limit)
+            )
+            for model in sticky:
+                _assign(model, by_name[model.worker_name])
+
+            remaining = limit - len(assignments)
+            if remaining > 0:
+                unassigned = (
+                    session.query(ExecutionContextModel, WorkflowModel)
+                    .join(WorkflowModel)
+                    .filter(
+                        ExecutionContextModel.state == ExecutionState.RESUMING,
+                        ExecutionContextModel.worker_name.is_(None),
+                    )
+                    .with_for_update(skip_locked=True, of=ExecutionContextModel)
+                    .limit(remaining)
+                )
+                for model, workflow in unassigned:
+                    eligible = [w for w in workers if self._worker_matches_workflow(w, workflow)]
+                    if not eligible:
+                        continue
+                    _assign(model, min(eligible, key=lambda w: loads.get(w.name, 0)))
+
+            session.commit()
+        return assignments
 
     def claim(self, execution_id: str, worker: WorkerInfo) -> ExecutionContext:
         with self.session() as session:

--- a/flux/dispatcher.py
+++ b/flux/dispatcher.py
@@ -33,6 +33,10 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 _NOTIFY_CHANNEL = "flux_work"
+# Carries an execution_id payload when a checkpoint reaches a state a caller
+# may be waiting on (finished/paused), so sync/stream waiters on OTHER
+# replicas wake immediately instead of hitting their 30s poll fallback.
+_EXEC_CHANNEL = "flux_exec"
 
 
 @dataclass
@@ -91,6 +95,22 @@ class Dispatcher:
         this is purely the cross-replica signal and is skipped on SQLite
         (single-node by definition).
         """
+        self._fire_notify(f"NOTIFY {_NOTIFY_CHANNEL}")
+
+    def notify_execution_update(self, execution_id: str) -> None:
+        """Wake sync/stream waiters for one execution on every replica.
+
+        The local waiter is set directly by the checkpoint route; this relays
+        the same signal cross-replica so a caller held open on replica A wakes
+        as soon as the worker checkpoints through replica B, instead of
+        waiting out the 30s poll fallback.
+        """
+        self._fire_notify(
+            "SELECT pg_notify(:channel, :payload)",
+            {"channel": _EXEC_CHANNEL, "payload": execution_id},
+        )
+
+    def _fire_notify(self, statement: str, params: dict | None = None) -> None:
         if not self._is_postgresql:
             return
 
@@ -100,13 +120,13 @@ class Dispatcher:
 
                 def _notify():
                     with manager.session() as session:
-                        session.execute(text(f"NOTIFY {_NOTIFY_CHANNEL}"))
+                        session.execute(text(statement), params or {})
                         session.commit()
 
                 await asyncio.to_thread(_notify)
             except Exception as e:
-                # Best-effort: the fallback tick on every replica covers it.
-                logger.debug(f"NOTIFY {_NOTIFY_CHANNEL} failed: {e}")
+                # Best-effort: the fallback tick / poll fallback covers it.
+                logger.debug(f"NOTIFY failed ({statement}): {e}")
 
         asyncio.create_task(_send())
 
@@ -126,10 +146,16 @@ class Dispatcher:
                 conn = await psycopg.AsyncConnection.connect(dsn, autocommit=True)
                 try:
                     await conn.execute(f"LISTEN {_NOTIFY_CHANNEL}")
+                    await conn.execute(f"LISTEN {_EXEC_CHANNEL}")
                     backoff = 1.0
-                    logger.debug(f"LISTEN {_NOTIFY_CHANNEL} established")
-                    async for _ in conn.notifies():
-                        self._server._work_available.set()
+                    logger.debug(f"LISTEN {_NOTIFY_CHANNEL}/{_EXEC_CHANNEL} established")
+                    async for notice in conn.notifies():
+                        if notice.channel == _EXEC_CHANNEL:
+                            waiter = self._server._execution_events.get(notice.payload)
+                            if waiter:
+                                waiter.set()
+                        else:
+                            self._server._work_available.set()
                 finally:
                     await conn.close()
             except asyncio.CancelledError:

--- a/flux/dispatcher.py
+++ b/flux/dispatcher.py
@@ -138,8 +138,15 @@ class Dispatcher:
         """
         import psycopg
 
-        # psycopg accepts postgresql:// URIs; strip any SQLAlchemy dialect tag.
-        dsn = self._database_url.replace("postgresql+psycopg://", "postgresql://", 1)
+        from flux.models import normalize_postgresql_url
+
+        # psycopg accepts postgresql:// URIs; normalize legacy dialect tags
+        # (postgresql+psycopg2://) first, then strip the driver marker.
+        dsn = normalize_postgresql_url(self._database_url).replace(
+            "postgresql+psycopg://",
+            "postgresql://",
+            1,
+        )
         backoff = 1.0
         while True:
             try:

--- a/flux/dispatcher.py
+++ b/flux/dispatcher.py
@@ -1,0 +1,258 @@
+"""Event-driven execution dispatcher.
+
+One ``Dispatcher`` task runs per server replica (``[flux.dispatch] mode =
+"event"``). It replaces the legacy per-worker poll loops — which cost ~5 DB
+queries per connected worker every 0.5s — with batch claims triggered by
+wakeups: local work signals, PostgreSQL LISTEN/NOTIFY from other replicas,
+and a slow safety-net tick.
+
+Notifications are pure wakeups. The executions table remains the source of
+truth, claimed with ``SELECT … FOR UPDATE SKIP LOCKED`` so concurrent
+dispatchers on other replicas coordinate without locking each other out; a
+missed NOTIFY is covered by the fallback tick.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from sqlalchemy import text
+
+from flux.api.schemas import _inject_trace_context
+from flux.config import Configuration
+from flux.context_managers import ContextManager
+from flux.utils import get_logger
+from flux.utils import to_json
+
+if TYPE_CHECKING:
+    from flux.server import Server
+
+logger = get_logger(__name__)
+
+_NOTIFY_CHANNEL = "flux_work"
+
+
+@dataclass
+class DispatchFrame:
+    """An SSE frame queued for one worker, with enough metadata to release
+    the underlying execution if the frame is never delivered."""
+
+    kind: str  # execution_scheduled | execution_resumed | execution_cancelled
+    execution_id: str
+    frame: dict[str, Any]
+
+
+class Dispatcher:
+    def __init__(self, server: Server):
+        self._server = server
+        settings = Configuration.get().settings
+        self._batch_size = settings.dispatch.batch_size
+        self._fallback_interval = settings.dispatch.fallback_interval
+        self._is_postgresql = settings.database_type == "postgresql"
+        self._database_url = settings.database_url
+        self._task: asyncio.Task | None = None
+        self._listener_task: asyncio.Task | None = None
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def start(self) -> None:
+        self._task = asyncio.create_task(self._run(), name="flux-dispatcher")
+        if self._is_postgresql:
+            self._listener_task = asyncio.create_task(
+                self._listen_for_notifications(),
+                name="flux-dispatch-listener",
+            )
+        logger.info(
+            f"Event dispatcher started (batch_size={self._batch_size}, "
+            f"fallback_interval={self._fallback_interval}s, "
+            f"listen_notify={self._is_postgresql})",
+        )
+
+    async def stop(self) -> None:
+        for task in (self._task, self._listener_task):
+            if task and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+        self._task = None
+        self._listener_task = None
+
+    # -- wakeups -----------------------------------------------------------
+
+    def notify_remote_replicas(self) -> None:
+        """Fire-and-forget NOTIFY so dispatchers on other replicas wake.
+
+        The local dispatcher is woken separately via the in-process event;
+        this is purely the cross-replica signal and is skipped on SQLite
+        (single-node by definition).
+        """
+        if not self._is_postgresql:
+            return
+
+        async def _send():
+            try:
+                manager = ContextManager.create()
+
+                def _notify():
+                    with manager.session() as session:
+                        session.execute(text(f"NOTIFY {_NOTIFY_CHANNEL}"))
+                        session.commit()
+
+                await asyncio.to_thread(_notify)
+            except Exception as e:
+                # Best-effort: the fallback tick on every replica covers it.
+                logger.debug(f"NOTIFY {_NOTIFY_CHANNEL} failed: {e}")
+
+        asyncio.create_task(_send())
+
+    async def _listen_for_notifications(self):
+        """Hold a dedicated LISTEN connection; wake the dispatcher on NOTIFY.
+
+        Best-effort with reconnect backoff — when the connection is down the
+        fallback tick keeps dispatch moving.
+        """
+        import psycopg
+
+        # psycopg accepts postgresql:// URIs; strip any SQLAlchemy dialect tag.
+        dsn = self._database_url.replace("postgresql+psycopg://", "postgresql://", 1)
+        backoff = 1.0
+        while True:
+            try:
+                conn = await psycopg.AsyncConnection.connect(dsn, autocommit=True)
+                try:
+                    await conn.execute(f"LISTEN {_NOTIFY_CHANNEL}")
+                    backoff = 1.0
+                    logger.debug(f"LISTEN {_NOTIFY_CHANNEL} established")
+                    async for _ in conn.notifies():
+                        self._server._work_available.set()
+                finally:
+                    await conn.close()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.warning(
+                    f"Dispatch LISTEN connection lost ({type(e).__name__}: {e}); "
+                    f"reconnecting in {backoff:.0f}s",
+                )
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+
+    # -- dispatch loop -----------------------------------------------------
+
+    async def _run(self):
+        while True:
+            try:
+                await asyncio.wait_for(
+                    self._server._work_available.wait(),
+                    timeout=self._fallback_interval,
+                )
+            except TimeoutError:
+                pass
+            except asyncio.CancelledError:
+                raise
+            self._server._work_available.clear()
+            try:
+                await self._dispatch_cycle()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.error("Dispatch cycle failed", exc_info=True)
+
+    def _connected_workers(self):
+        """Snapshot of workers with a live SSE queue on this replica."""
+        return [
+            info
+            for name, info in list(self._server._worker_info.items())
+            if name in self._server._worker_queues
+        ]
+
+    async def _dispatch_cycle(self):
+        workers = self._connected_workers()
+        if not workers:
+            return
+        manager = ContextManager.create()
+
+        # New executions: keep claiming while full batches come back.
+        while True:
+            assignments = await asyncio.to_thread(
+                manager.next_executions_batch,
+                workers,
+                self._batch_size,
+            )
+            for ctx, worker_name in assignments:
+                await self._deliver(manager, ctx, worker_name, "execution_scheduled")
+            if len(assignments) < self._batch_size:
+                break
+            workers = self._connected_workers()
+            if not workers:
+                return
+
+        resumes = await asyncio.to_thread(
+            manager.next_resumes_batch,
+            workers,
+            self._batch_size,
+        )
+        for ctx, worker_name in resumes:
+            await self._deliver(manager, ctx, worker_name, "execution_resumed")
+
+        cancellations = await asyncio.to_thread(
+            manager.next_cancellations_batch,
+            [w.name for w in workers],
+            self._batch_size,
+        )
+        for ctx in cancellations:
+            queue = self._server._worker_queues.get(ctx.current_worker or "")
+            if queue is None:
+                continue
+            queue.put_nowait(
+                DispatchFrame(
+                    kind="execution_cancelled",
+                    execution_id=ctx.execution_id,
+                    frame={
+                        "id": f"{ctx.execution_id}_{uuid4().hex}",
+                        "event": "execution_cancelled",
+                        "data": _inject_trace_context(to_json({"context": ctx})),
+                    },
+                ),
+            )
+
+    async def _deliver(self, manager, ctx, worker_name: str, event: str):
+        """Build the dispatch payload and enqueue it on the worker's SSE queue.
+
+        If the worker's queue vanished (disconnect race) or the payload build
+        fails, release the execution so another worker picks it up.
+        """
+        try:
+            payload = await asyncio.to_thread(self._server._build_dispatch_payload, ctx)
+            queue = self._server._worker_queues.get(worker_name)
+            if queue is None:
+                raise RuntimeError(f"worker {worker_name} disconnected before delivery")
+            queue.put_nowait(
+                DispatchFrame(
+                    kind=event,
+                    execution_id=ctx.execution_id,
+                    frame={
+                        "id": f"{ctx.execution_id}_{uuid4().hex}",
+                        "event": event,
+                        "data": _inject_trace_context(to_json(payload)),
+                    },
+                ),
+            )
+        except Exception as e:
+            logger.warning(
+                f"Failed to deliver {ctx.execution_id} to {worker_name} "
+                f"({type(e).__name__}: {e}); releasing for redispatch",
+            )
+            try:
+                await asyncio.to_thread(manager.unclaim, ctx.execution_id)
+                self._server._work_available.set()
+            except Exception:
+                logger.error(
+                    f"Failed to release execution {ctx.execution_id}",
+                    exc_info=True,
+                )

--- a/flux/domain/execution_context.py
+++ b/flux/domain/execution_context.py
@@ -52,6 +52,18 @@ class ExecutionContext(Generic[WorkflowInputType]):
         self._current_worker = current_worker or ""
         self._progress_callback = progress_callback or (lambda *_: None)
         self._exec_token: str | None = None
+        # Transient executions never persist: checkpoint stays the no-op and
+        # durable-only features (pause, approvals) must refuse to engage.
+        # In-memory only — deliberately absent from to_dict()/pickle.
+        self._transient = False
+
+    def mark_transient(self) -> ExecutionContext:
+        self._transient = True
+        return self
+
+    @property
+    def is_transient(self) -> bool:
+        return getattr(self, "_transient", False)
 
     @staticmethod
     async def get() -> ExecutionContext:

--- a/flux/domain/resource_request.py
+++ b/flux/domain/resource_request.py
@@ -302,3 +302,19 @@ class ResourceRequest:
 
         # Unsupported operator
         return False
+
+
+def worker_matches(worker, requests: dict | None, affinity: dict | None) -> bool:
+    """Whether a worker satisfies a workflow's affinity labels and resource
+    requests. Shared by the SQL dispatch paths and the transient (no-row)
+    dispatch, which has no session to hang the check on."""
+    if affinity is not None:
+        if not ResourceRequest.matches_labels(worker.labels, affinity):
+            return False
+    if requests is not None:
+        resource_request = ResourceRequest(**(requests or {}))
+        if worker.resources is None:
+            return False
+        if not resource_request.matches_worker(worker.resources, worker.packages):
+            return False
+    return True

--- a/flux/errors.py
+++ b/flux/errors.py
@@ -144,3 +144,23 @@ class PostgreSQLConnectionError(DatabaseConnectionError):
 
     def __init__(self, message: str, original_error: Exception | None = None):
         super().__init__(message, "postgresql", original_error)
+
+
+class StaleClaimError(Exception):
+    """A checkpoint arrived from a worker whose claim was superseded.
+
+    Raised when the checkpoint's claim generation does not match the
+    execution row's current generation — the execution was unclaimed (e.g.
+    by the eviction reaper after a network partition) and reassigned. The
+    fenced worker must abort its local copy; the new claim owns the row.
+    """
+
+    def __init__(self, execution_id: str, expected: int = -1, actual: int = -1):
+        # Defaults cover the worker side, which learns only *that* it was
+        # fenced (409 from the server), not the row's current generation.
+        self.execution_id = execution_id
+        super().__init__(
+            f"Stale claim for execution {execution_id}: checkpoint carries "
+            f"generation {expected} but the row is at {actual}; the execution "
+            f"was reassigned",
+        )

--- a/flux/errors.py
+++ b/flux/errors.py
@@ -164,3 +164,23 @@ class StaleClaimError(Exception):
             f"generation {expected} but the row is at {actual}; the execution "
             f"was reassigned",
         )
+
+
+class TransientDurabilityError(ExecutionError):
+    """A transient execution reached a feature that requires durability.
+
+    Pause, approvals, and cross-worker resume all need persisted state that a
+    transient execution deliberately does not have. Fail loudly instead of
+    silently losing an approval or stranding a pause.
+    """
+
+    def __init__(self, execution_id: str, feature: str):
+        self.execution_id = execution_id
+        self.feature = feature
+        super().__init__(
+            message=(
+                f"Transient execution {execution_id} attempted to use '{feature}', "
+                f"which requires durability. Register the workflow without "
+                f"durability='transient' to use it."
+            ),
+        )

--- a/flux/migrations/versions/0004_worker_last_seen_index.py
+++ b/flux/migrations/versions/0004_worker_last_seen_index.py
@@ -1,0 +1,44 @@
+"""Index workers.last_seen_at for the heartbeat reaper sweep.
+
+Every server replica's reaper runs ``find_stale`` each heartbeat interval
+(default 10s), filtering workers on ``last_seen_at < threshold``. Without an
+index that is a full scan of the workers table per sweep per replica, which
+compounds at large fleet sizes.
+
+Guarded like 0002: created only if absent, so databases that already picked
+the index up from the ORM (fresh ``create_all`` schemas) upgrade cleanly.
+
+Revision ID: 0004_worker_last_seen_index
+Revises: 0003_worker_last_seen
+Create Date: 2026-07-03
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0004_worker_last_seen_index"
+down_revision: str | None = "0003_worker_last_seen"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "workers"
+_INDEX = "ix_workers_last_seen_at"
+_COLUMN = "last_seen_at"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    present = {ix["name"] for ix in sa.inspect(bind).get_indexes(_TABLE)}
+    if _INDEX not in present:
+        op.create_index(_INDEX, _TABLE, [_COLUMN])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    present = {ix["name"] for ix in sa.inspect(bind).get_indexes(_TABLE)}
+    if _INDEX in present:
+        op.drop_index(_INDEX, table_name=_TABLE)

--- a/flux/migrations/versions/0005_worker_capacity.py
+++ b/flux/migrations/versions/0005_worker_capacity.py
@@ -1,0 +1,40 @@
+"""Add workers.max_concurrent_executions for capacity-aware dispatch.
+
+Workers advertise their capacity at registration; the dispatcher and the
+poll-mode matching queries never assign more concurrent executions than a
+worker's slot count. NULL (legacy workers that predate the field) and 0 both
+mean unlimited, so the column is additive and needs no backfill.
+
+Revision ID: 0005_worker_capacity
+Revises: 0004_worker_last_seen_index
+Create Date: 2026-07-03
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0005_worker_capacity"
+down_revision: str | None = "0004_worker_last_seen_index"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "workers"
+_COLUMN = "max_concurrent_executions"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    if _COLUMN not in existing:
+        op.add_column(_TABLE, sa.Column(_COLUMN, sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    if _COLUMN in existing:
+        op.drop_column(_TABLE, _COLUMN)

--- a/flux/migrations/versions/0006_claim_generation.py
+++ b/flux/migrations/versions/0006_claim_generation.py
@@ -1,0 +1,46 @@
+"""Add executions.claim_generation as a split-brain fencing token.
+
+Bumped every time an execution is (re)assigned to a worker. Checkpoints carry
+the generation they were claimed under; the server rejects a mismatch, so a
+worker that was unclaimed while network-partitioned (but still running) cannot
+interleave its writes with the new owner's.
+
+Additive with a server default of 0, so existing rows and legacy workers
+(which send no generation and are exempt from the check) are unaffected.
+
+Revision ID: 0006_claim_generation
+Revises: 0005_worker_capacity
+Create Date: 2026-07-03
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0006_claim_generation"
+down_revision: str | None = "0005_worker_capacity"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "executions"
+_COLUMN = "claim_generation"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    if _COLUMN not in existing:
+        op.add_column(
+            _TABLE,
+            sa.Column(_COLUMN, sa.Integer(), nullable=False, server_default="0"),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    if _COLUMN in existing:
+        op.drop_column(_TABLE, _COLUMN)

--- a/flux/models.py
+++ b/flux/models.py
@@ -602,6 +602,12 @@ class ExecutionContextModel(Base):
     state = Column(SqlEnum(ExecutionState), nullable=False)
     worker_name = Column(String, ForeignKey("workers.name"), nullable=True)
     exec_token = Column(String, nullable=True)
+    # Fencing token: bumped every time the execution is (re)assigned to a
+    # worker. Checkpoints carry the generation they were claimed under; a
+    # mismatch means the sender was unclaimed (e.g. evicted after a network
+    # partition) and its writes are rejected instead of interleaving with
+    # the new owner's (split-brain prevention).
+    claim_generation = Column(Integer, nullable=False, default=0, server_default="0")
     scheduling_subject = Column(String, nullable=True)
     scheduling_principal_issuer = Column(String, nullable=True)
     # Set when the execution was dispatched by a schedule; lets schedule

--- a/flux/models.py
+++ b/flux/models.py
@@ -499,6 +499,9 @@ class WorkerModel(Base):
     # when the replica a worker was attached to dies. Indexed because the reaper
     # filters on it every heartbeat interval on every replica.
     last_seen_at = Column(DateTime, nullable=True, index=True)
+    # Capacity advertised at registration; dispatch never assigns beyond it.
+    # NULL/0 means unlimited (legacy workers that predate the field).
+    max_concurrent_executions = Column(Integer, nullable=True)
 
     runtime = relationship("WorkerRuntimeModel", back_populates="worker", uselist=False)
     packages = relationship("WorkerPackageModel", back_populates="worker")
@@ -517,12 +520,14 @@ class WorkerModel(Base):
         packages: list[WorkerPackageModel] | None = None,
         resources: WorkerResourcesModel | None = None,
         labels: dict[str, str] | None = None,
+        max_concurrent_executions: int | None = None,
     ):
         self.name = name
         self.runtime = runtime
         self.packages = packages or []
         self.resources = resources
         self.labels = labels or {}
+        self.max_concurrent_executions = max_concurrent_executions
 
 
 class WorkflowModel(Base):

--- a/flux/models.py
+++ b/flux/models.py
@@ -480,8 +480,9 @@ class WorkerModel(Base):
     # Wall-clock UTC timestamp of the worker's last heartbeat. Persisted (rather
     # than tracked in per-process memory) so that any server replica's reaper
     # sees a global view of worker liveness and can reclaim orphaned executions
-    # when the replica a worker was attached to dies.
-    last_seen_at = Column(DateTime, nullable=True)
+    # when the replica a worker was attached to dies. Indexed because the reaper
+    # filters on it every heartbeat interval on every replica.
+    last_seen_at = Column(DateTime, nullable=True, index=True)
 
     runtime = relationship("WorkerRuntimeModel", back_populates="worker", uselist=False)
     packages = relationship("WorkerPackageModel", back_populates="worker")

--- a/flux/models.py
+++ b/flux/models.py
@@ -107,6 +107,21 @@ class SQLiteRepository(DatabaseRepository):
         return engine
 
 
+def normalize_postgresql_url(url: str) -> str:
+    """Pin PostgreSQL URLs to the psycopg (v3) dialect.
+
+    SQLAlchemy resolves a bare ``postgresql://`` to psycopg2, which is no
+    longer shipped. Configs keep the driverless form (and legacy
+    ``postgresql+psycopg2://`` values keep working); the driver choice is
+    made here, in one place.
+    """
+    if url.startswith("postgresql://"):
+        return url.replace("postgresql://", "postgresql+psycopg://", 1)
+    if url.startswith("postgresql+psycopg2://"):
+        return url.replace("postgresql+psycopg2://", "postgresql+psycopg://", 1)
+    return url
+
+
 class PostgreSQLRepository(DatabaseRepository):
     def _create_engine(self) -> Engine:
         try:
@@ -115,6 +130,7 @@ class PostgreSQLRepository(DatabaseRepository):
 
             # Validate URL format
             self._validate_postgresql_url(url)
+            url = normalize_postgresql_url(url)
 
             # PostgreSQL-specific engine configuration
             engine_kwargs = {
@@ -157,7 +173,7 @@ class PostgreSQLRepository(DatabaseRepository):
 
     def _validate_postgresql_url(self, url: str) -> None:
         """Validate PostgreSQL URL format"""
-        if not url.startswith("postgresql://"):
+        if not url.startswith(("postgresql://", "postgresql+psycopg://", "postgresql+psycopg2://")):
             raise ValueError("PostgreSQL URL must start with 'postgresql://'")
 
         # Additional validation for required components

--- a/flux/observability/metrics.py
+++ b/flux/observability/metrics.py
@@ -255,30 +255,32 @@ class FluxMetrics:
                 {"workflow_namespace": namespace, "workflow_name": workflow_name},
             )
 
+    # Worker names (and schedule names) are caller-controlled and unbounded, so
+    # they must not become metric labels: thousands of churning workers would
+    # blow up time-series cardinality in Prometheus/OTel — a memory-DoS vector.
+    # The signatures keep the name parameter for call-site context/logging.
+
     def record_worker_registered(self, worker_name: str):
-        self.worker_registrations.add(1, {"worker_name": worker_name})
+        self.worker_registrations.add(1)
 
     def record_worker_connected(self, worker_name: str):
         self.workers_active.add(1)
 
     def record_worker_disconnected(self, worker_name: str, reason: str):
-        self.worker_disconnections.add(1, {"worker_name": worker_name, "reason": reason})
+        self.worker_disconnections.add(1, {"reason": reason})
         self.workers_active.add(-1)
 
     def record_worker_execution_started(self, worker_name: str):
-        self.worker_executions_active.add(1, {"worker_name": worker_name})
+        self.worker_executions_active.add(1)
 
     def record_worker_execution_ended(self, worker_name: str):
-        self.worker_executions_active.add(-1, {"worker_name": worker_name})
+        self.worker_executions_active.add(-1)
 
     def record_worker_auth_event(self, worker_name: str, event: str):
-        self.worker_auth_events.add(
-            1,
-            {"worker_name": worker_name, "event": event},
-        )
+        self.worker_auth_events.add(1, {"event": event})
 
     def record_schedule_trigger(self, schedule_name: str, outcome: str):
-        self.schedule_triggers.add(1, {"schedule_name": schedule_name, "outcome": outcome})
+        self.schedule_triggers.add(1, {"outcome": outcome})
 
     def record_http_request(self, method: str, endpoint: str, status_code: int, duration: float):
         endpoint = _normalize_path(endpoint)

--- a/flux/retention.py
+++ b/flux/retention.py
@@ -1,0 +1,182 @@
+"""Execution-history retention: bounded growth for the event-sourced store.
+
+Without retention, ``executions`` and ``execution_events`` grow without bound
+— every task of every execution is a persisted event row. When enabled
+(``[flux.retention] enabled = true``), a background sweep deletes terminal
+executions (COMPLETED / FAILED / CANCELLED) whose most recent event is older
+than ``retention_days``, together with their dependent rows.
+
+Cross-replica safety mirrors the scheduler: one sweep at a time fleet-wide via
+a PostgreSQL advisory lock (SQLite is single-node, so the lock is a no-op).
+Dependent rows are deleted explicitly rather than relying on FK cascades:
+SQLite does not enforce them, and ``approval_requests`` has no cascade at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from collections.abc import Iterator
+
+from sqlalchemy import func
+
+from flux.config import Configuration
+from flux.domain import ExecutionState
+from flux.utils import get_logger
+
+logger = get_logger(__name__)
+
+# "FLUXR" — distinct from the scheduler's 0x464C555853 ("FLUXS").
+_RETENTION_LOCK_KEY = 0x464C555852
+
+_TERMINAL_STATES = (
+    ExecutionState.COMPLETED,
+    ExecutionState.FAILED,
+    ExecutionState.CANCELLED,
+)
+
+
+class RetentionJob:
+    def __init__(self):
+        settings = Configuration.get().settings.retention
+        self._retention_days = settings.retention_days
+        self._sweep_interval = settings.sweep_interval
+        self._batch_size = settings.batch_size
+        self._task: asyncio.Task | None = None
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def start(self) -> None:
+        self._task = asyncio.create_task(self._run(), name="flux-retention")
+        logger.info(
+            f"Retention job started (retention_days={self._retention_days}, "
+            f"sweep_interval={self._sweep_interval}s)",
+        )
+
+    async def stop(self) -> None:
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        self._task = None
+
+    # -- sweep loop --------------------------------------------------------
+
+    async def _run(self):
+        while True:
+            try:
+                deleted = await asyncio.to_thread(self._sweep)
+                if deleted:
+                    logger.info(f"Retention sweep deleted {deleted} execution(s)")
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.error("Retention sweep failed", exc_info=True)
+            await asyncio.sleep(self._sweep_interval)
+
+    def _sweep(self) -> int:
+        """Delete expired terminal executions in batches; returns the count.
+
+        Runs entirely in a worker thread. Each batch is one transaction, so a
+        crash mid-sweep loses nothing and the next sweep resumes where this
+        one stopped.
+        """
+        from flux.models import RepositoryFactory
+
+        repository = RepositoryFactory.create_repository()
+        with self._sweep_lock(repository._engine) as acquired:
+            if not acquired:
+                logger.debug("Another replica is sweeping; skipping this cycle")
+                return 0
+
+            cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(
+                days=self._retention_days,
+            )
+            total = 0
+            while True:
+                deleted = self._delete_batch(repository, cutoff)
+                total += deleted
+                if deleted < self._batch_size:
+                    return total
+
+    def _delete_batch(self, repository, cutoff: datetime) -> int:
+        from flux.models import (
+            AgentSessionModel,
+            ApprovalRequestModel,
+            ExecutionContextModel,
+            ExecutionEventModel,
+        )
+
+        with repository.session() as session:
+            last_event = (
+                session.query(
+                    ExecutionEventModel.execution_id.label("execution_id"),
+                    func.max(ExecutionEventModel.time).label("last_time"),
+                )
+                .group_by(ExecutionEventModel.execution_id)
+                .subquery()
+            )
+            rows = (
+                session.query(ExecutionContextModel.execution_id)
+                .join(
+                    last_event,
+                    last_event.c.execution_id == ExecutionContextModel.execution_id,
+                )
+                .filter(
+                    ExecutionContextModel.state.in_(_TERMINAL_STATES),
+                    last_event.c.last_time < cutoff,
+                )
+                .limit(self._batch_size)
+                .all()
+            )
+            ids = [row[0] for row in rows]
+            if not ids:
+                return 0
+
+            for model in (ExecutionEventModel, AgentSessionModel, ApprovalRequestModel):
+                session.query(model).filter(model.execution_id.in_(ids)).delete(
+                    synchronize_session=False,
+                )
+            session.query(ExecutionContextModel).filter(
+                ExecutionContextModel.execution_id.in_(ids),
+            ).delete(synchronize_session=False)
+            session.commit()
+            return len(ids)
+
+    @staticmethod
+    @contextmanager
+    def _sweep_lock(engine) -> Iterator[bool]:
+        """One retention sweep fleet-wide, via a PG session advisory lock.
+
+        Same pattern as the scheduler's dispatch lock: held on a dedicated
+        connection for the sweep's duration; if this replica dies mid-sweep,
+        the connection drops and PostgreSQL releases the lock. SQLite is
+        single-node and always acquires.
+        """
+        if engine.dialect.name != "postgresql":
+            yield True
+            return
+
+        connection = engine.connect()
+        try:
+            acquired = bool(
+                connection.exec_driver_sql(
+                    "SELECT pg_try_advisory_lock(%(key)s)",
+                    {"key": _RETENTION_LOCK_KEY},
+                ).scalar(),
+            )
+            connection.commit()
+            try:
+                yield acquired
+            finally:
+                if acquired:
+                    connection.exec_driver_sql(
+                        "SELECT pg_advisory_unlock(%(key)s)",
+                        {"key": _RETENTION_LOCK_KEY},
+                    )
+                    connection.commit()
+        finally:
+            connection.close()

--- a/flux/security/config.py
+++ b/flux/security/config.py
@@ -31,6 +31,15 @@ class OIDCConfig(_BaseConfig):
 
 class APIKeyAuthConfig(_BaseConfig):
     enabled: bool = False
+    worker_key_ttl: int = Field(
+        default=604800,
+        description=(
+            "Lifetime in seconds of API keys minted for workers at "
+            "registration (default 7 days; 0 = never expire). Workers "
+            "re-register automatically on 401, so expiry rotates keys "
+            "without operator action."
+        ),
+    )
 
 
 class AuthConfig(_BaseConfig):
@@ -91,8 +100,12 @@ class SecurityConfig(_BaseConfig):
         description="HMAC secret for signing execution tokens. Required in production.",
     )
     execution_token_ttl: int = Field(
-        default=604800,
-        description="Execution token TTL in seconds (default: 7 days).",
+        default=86400,
+        description=(
+            "Execution token TTL in seconds (default: 24 hours). The token is "
+            "scoped to a single execution and minted fresh on every dispatch "
+            "and resume, so it only needs to outlive one continuous run."
+        ),
     )
 
     model_config = {"arbitrary_types_allowed": True}

--- a/flux/security/execution_token.py
+++ b/flux/security/execution_token.py
@@ -15,7 +15,7 @@ logger = get_logger(__name__)
 EXECUTION_TOKEN_ISSUER = "flux-server"
 EXECUTION_TOKEN_SCOPE = "execution"
 
-_DEFAULT_EXECUTION_TOKEN_TTL = 604800
+_DEFAULT_EXECUTION_TOKEN_TTL = 86400
 
 _ephemeral_secret: str | None = None
 

--- a/flux/server.py
+++ b/flux/server.py
@@ -137,6 +137,7 @@ class Server(
         self._pending_heartbeats: set[str] = set()
         self._dispatch_mode = Configuration.get().settings.dispatch.mode
         self._dispatcher = None
+        self._retention_job = None
         self._reaper_task: asyncio.Task | None = None
 
         config = Configuration.get().settings.scheduling
@@ -249,6 +250,12 @@ class Server(
 
                 self._dispatcher = Dispatcher(self)
                 self._dispatcher.start()
+
+            if Configuration.get().settings.retention.enabled:
+                from flux.retention import RetentionJob
+
+                self._retention_job = RetentionJob()
+                self._retention_job.start()
 
         try:
             config = uvicorn.Config(
@@ -1092,6 +1099,9 @@ class Server(
             if self._dispatcher is not None:
                 await self._dispatcher.stop()
                 self._dispatcher = None
+            if self._retention_job is not None:
+                await self._retention_job.stop()
+                self._retention_job = None
             if db_executor is not None:
                 db_executor.shutdown(wait=False, cancel_futures=True)
 

--- a/flux/server.py
+++ b/flux/server.py
@@ -923,6 +923,42 @@ class Server(
     # End Scheduler Methods
     # ===========================================
 
+    @staticmethod
+    def _validate_security_config(settings) -> None:
+        """Fail fast on security misconfiguration instead of erroring mid-traffic.
+
+        With auth enabled, a missing execution-token secret used to surface only
+        when the first worker token was minted, and a missing encryption key when
+        the first secret was stored. Debug mode is exempt (execution-token secrets
+        are auto-generated ephemerally there).
+        """
+        security = settings.security
+        if security.auth.enabled and not settings.debug:
+            problems = []
+            if not security.execution_token_secret:
+                problems.append(
+                    "[flux.security] execution_token_secret is required when auth is "
+                    "enabled (FLUX_SECURITY__EXECUTION_TOKEN_SECRET)",
+                )
+            if not security.encryption.encryption_key:
+                problems.append(
+                    "[flux.security.encryption] encryption_key is required when auth "
+                    "is enabled: without it the secrets store is unusable and at-rest "
+                    "pickle payloads are unsigned "
+                    "(FLUX_SECURITY__ENCRYPTION__ENCRYPTION_KEY)",
+                )
+            if problems:
+                raise RuntimeError(
+                    "Refusing to start with incomplete security configuration:\n- "
+                    + "\n- ".join(problems),
+                )
+        elif not security.encryption.encryption_key and not settings.debug:
+            logger.critical(
+                "No encryption key configured: the secrets store is unavailable and "
+                "at-rest pickle integrity signing is DISABLED. Set "
+                "FLUX_SECURITY__ENCRYPTION__ENCRYPTION_KEY before production use.",
+            )
+
     def _create_api(self) -> FastAPI:
         from contextlib import asynccontextmanager
 
@@ -936,6 +972,7 @@ class Server(
             from flux.security.bootstrap_token import resolve_or_generate
 
             startup_settings = Configuration.get().settings
+            self._validate_security_config(startup_settings)
             token, _ = resolve_or_generate(
                 home=startup_settings.home,
                 configured=startup_settings.workers.bootstrap_token,

--- a/flux/server.py
+++ b/flux/server.py
@@ -173,28 +173,52 @@ class Server(
         ~60s eviction path — so the dispatcher can reassign them. Cancellation
         frames are simply dropped: the row is still CANCELLING and will be
         re-delivered wherever the execution lands.
+
+        Draining the queue is pure memory work; the unclaim writes are DB
+        round-trips and run in a background thread hop so a slow database (or
+        a long queue) never blocks the event loop mid-SSE-teardown.
         """
         queue = self._worker_queues.pop(name, None)
         if queue is None:
             return
-        released = 0
+        to_release: list[str] = []
         while not queue.empty():
             try:
                 item = queue.get_nowait()
             except asyncio.QueueEmpty:
                 break
             if getattr(item, "kind", None) in ("execution_scheduled", "execution_resumed"):
+                to_release.append(item.execution_id)
+        if not to_release:
+            return
+
+        def _release() -> int:
+            manager = ContextManager.create()
+            released = 0
+            for execution_id in to_release:
                 try:
-                    ContextManager.create().unclaim(item.execution_id)
+                    manager.unclaim(execution_id)
                     released += 1
                 except Exception:
                     logger.error(
-                        f"Failed to release undelivered execution {item.execution_id}",
+                        f"Failed to release undelivered execution {execution_id}",
                         exc_info=True,
                     )
-        if released:
-            logger.info(f"Released {released} undelivered execution(s) from worker {name}")
-            self._work_available.set()
+            return released
+
+        async def _release_and_notify():
+            released = await asyncio.to_thread(_release)
+            if released:
+                logger.info(f"Released {released} undelivered execution(s) from worker {name}")
+                self._work_available.set()
+
+        try:
+            asyncio.get_running_loop()
+            asyncio.create_task(_release_and_notify())
+        except RuntimeError:
+            # No loop (tests / teardown): release synchronously.
+            if _release():
+                logger.info(f"Released undelivered execution(s) from worker {name}")
 
     def _notify_next_worker(self):
         """Signal that new work is available.
@@ -779,7 +803,11 @@ class Server(
         run this sweep concurrently for the same orphan.
         """
         deadline_seconds = self.heartbeat_timeout + self.eviction_grace_period
-        threshold = datetime.now(timezone.utc) - timedelta(seconds=deadline_seconds)
+        # Naive UTC to match the stored last_seen_at values (see
+        # WorkerRegistry.record_heartbeat).
+        threshold = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(
+            seconds=deadline_seconds,
+        )
         try:
             from flux.worker_registry import WorkerRegistry
 

--- a/flux/server.py
+++ b/flux/server.py
@@ -686,6 +686,41 @@ class Server(
                 except RuntimeError:
                     logger.warning(f"Cannot revoke API key for {name}: no event loop")
 
+    def _gc_worker_principal(self, name: str) -> None:
+        """Disable a pruned worker's principal and revoke its API keys.
+
+        Runs as a fire-and-forget task off the reaper. Registration re-enables
+        the principal if the worker ever returns, so this is reversible.
+        """
+        from flux.security.dependencies import _get_auth_service
+        from flux.security.principals import PrincipalRegistry
+
+        auth_service = _get_auth_service()
+        if auth_service is None:
+            return
+
+        async def _gc():
+            try:
+
+                def _find_and_disable():
+                    registry = PrincipalRegistry(session_factory=self._get_db_session)
+                    principal = registry.find(subject=name, external_issuer="flux")
+                    if principal and principal.enabled:
+                        registry.set_enabled(principal.id, False)
+                    return principal
+
+                principal = await asyncio.to_thread(_find_and_disable)
+                if principal:
+                    await auth_service.revoke_all_api_keys(principal.id)
+                    logger.info(f"Disabled principal and revoked keys for pruned worker {name}")
+            except Exception as e:
+                logger.warning(f"Principal GC for pruned worker {name} failed: {e}")
+
+        try:
+            asyncio.create_task(_gc())
+        except RuntimeError:
+            logger.warning(f"Cannot GC principal for {name}: no event loop")
+
     def _unclaim_worker_executions(self, worker_name: str) -> None:
         """Recover all executions assigned to an evicted worker.
 
@@ -820,6 +855,11 @@ class Server(
                 for name in expired:
                     self._worker_offline_since.pop(name, None)
                     self._worker_cache.pop(name, None)
+                    # Credential GC: a pruned worker's principal would otherwise
+                    # accumulate forever (one service-account row per unique
+                    # worker name). Disable it and revoke its keys; a genuine
+                    # comeback re-registers and re-enables the same principal.
+                    self._gc_worker_principal(name)
                     logger.debug(f"Pruned offline worker {name} (exceeded {self.offline_ttl}s TTL)")
         except asyncio.CancelledError:
             logger.info("Heartbeat reaper stopped")

--- a/flux/server.py
+++ b/flux/server.py
@@ -134,8 +134,10 @@ class Server(
         # the database (SKIP LOCKED) and LISTEN/NOTIFY wakeups.
         self._worker_queues: dict[str, asyncio.Queue] = {}
         self._worker_info: dict[str, object] = {}
+        self._pending_heartbeats: set[str] = set()
         self._dispatch_mode = Configuration.get().settings.dispatch.mode
         self._dispatcher = None
+        self._reaper_task: asyncio.Task | None = None
 
         config = Configuration.get().settings.scheduling
         self.poll_interval = config.poll_interval
@@ -569,12 +571,16 @@ class Server(
 
     async def _stop_reaper(self):
         """Stop the heartbeat reaper task."""
-        if hasattr(self, "_reaper_task") and self._reaper_task:
+        if self._reaper_task:
             self._reaper_task.cancel()
             try:
                 await self._reaper_task
             except asyncio.CancelledError:
                 pass
+            self._reaper_task = None
+            # Persist any pongs buffered since the last tick so the fleet's
+            # liveness view stays fresh across a server restart.
+            await self._flush_heartbeats()
             logger.info("Heartbeat reaper stopped")
 
     def _persist_worker_heartbeat(self, name: str) -> None:
@@ -588,15 +594,38 @@ class Server(
         The in-memory ``_worker_last_pong`` drives this replica's round-robin
         and local stale tracking; the persisted ``last_seen_at`` gives every
         replica's reaper a global view of liveness so orphaned executions can
-        be reclaimed when the replica a worker was attached to dies. Persisting
-        runs off the event loop and never fails the request.
+        be reclaimed when the replica a worker was attached to dies.
+
+        While the reaper is running, persistence is batched: pongs buffer in
+        memory and the reaper tick flushes them as ONE statement per interval
+        — at fleet scale this replaces one commit per worker per interval.
+        The persist delay is at most one heartbeat interval, well inside the
+        cross-replica staleness threshold (heartbeat_timeout + grace). Without
+        a reaper (embedded/test use) each heartbeat persists immediately.
         """
         self._worker_last_pong[name] = time.monotonic()
         self._worker_stale_since.pop(name, None)
+        if self._reaper_task is not None and not self._reaper_task.done():
+            self._pending_heartbeats.add(name)
+            return
         try:
             await asyncio.to_thread(self._persist_worker_heartbeat, name)
         except Exception as e:
             logger.debug(f"Failed to persist heartbeat for worker {name}: {e}")
+
+    async def _flush_heartbeats(self) -> None:
+        """Persist all buffered pongs in one batched UPDATE."""
+        if not self._pending_heartbeats:
+            return
+        names = list(self._pending_heartbeats)
+        self._pending_heartbeats.clear()
+        try:
+            from flux.worker_registry import WorkerRegistry
+
+            registry = WorkerRegistry.create()
+            await asyncio.to_thread(registry.record_heartbeats, names)
+        except Exception as e:
+            logger.debug(f"Failed to persist {len(names)} heartbeat(s): {e}")
 
     def _disconnect_worker(self, name: str, reason: str = "disconnect") -> None:
         """Remove a worker from the connected set and mark it offline in cache."""
@@ -737,6 +766,10 @@ class Server(
             while True:
                 await asyncio.sleep(self.heartbeat_interval)
                 now = time.monotonic()
+
+                # Persist the interval's buffered pongs first, so cross-replica
+                # staleness views are as fresh as possible before we sweep.
+                await self._flush_heartbeats()
 
                 for name, last_pong in list(self._worker_last_pong.items()):
                     if (now - last_pong) > self.heartbeat_timeout:

--- a/flux/server.py
+++ b/flux/server.py
@@ -128,6 +128,15 @@ class Server(
         self._bootstrap_token: str | None = None
         self._worker_connection_gen: dict[str, int] = {}
 
+        # Event-dispatch state: per-worker SSE frame queues and the WorkerInfo
+        # snapshots the dispatcher matches against. Populated only for workers
+        # connected to THIS replica; cross-replica coordination happens through
+        # the database (SKIP LOCKED) and LISTEN/NOTIFY wakeups.
+        self._worker_queues: dict[str, asyncio.Queue] = {}
+        self._worker_info: dict[str, object] = {}
+        self._dispatch_mode = Configuration.get().settings.dispatch.mode
+        self._dispatcher = None
+
         config = Configuration.get().settings.scheduling
         self.poll_interval = config.poll_interval
 
@@ -153,8 +162,49 @@ class Server(
         repo = RepositoryFactory.create_repository()
         return repo.session()
 
+    def _drain_worker_queue(self, name: str) -> None:
+        """Release executions whose dispatch frames were never delivered.
+
+        A disconnecting worker may leave assigned-but-unsent frames in its SSE
+        queue. Unclaim those executions right away — instead of waiting the
+        ~60s eviction path — so the dispatcher can reassign them. Cancellation
+        frames are simply dropped: the row is still CANCELLING and will be
+        re-delivered wherever the execution lands.
+        """
+        queue = self._worker_queues.pop(name, None)
+        if queue is None:
+            return
+        released = 0
+        while not queue.empty():
+            try:
+                item = queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if getattr(item, "kind", None) in ("execution_scheduled", "execution_resumed"):
+                try:
+                    ContextManager.create().unclaim(item.execution_id)
+                    released += 1
+                except Exception:
+                    logger.error(
+                        f"Failed to release undelivered execution {item.execution_id}",
+                        exc_info=True,
+                    )
+        if released:
+            logger.info(f"Released {released} undelivered execution(s) from worker {name}")
+            self._work_available.set()
+
     def _notify_next_worker(self):
-        """Signal the next connected worker in round-robin order."""
+        """Signal that new work is available.
+
+        Poll mode: wake the next connected worker's loop in round-robin order.
+        Event mode: wake this replica's dispatcher and NOTIFY other replicas.
+        """
+        if self._dispatch_mode == "event":
+            self._work_available.set()
+            if self._dispatcher is not None:
+                self._dispatcher.notify_remote_replicas()
+            return
+
         if not self._worker_names:
             self._work_available.set()
             return
@@ -191,6 +241,12 @@ class Server(
                 f"Heartbeat reaper started (interval={self.heartbeat_interval}s, "
                 f"timeout={self.heartbeat_timeout}s)",
             )
+
+            if self._dispatch_mode == "event":
+                from flux.dispatcher import Dispatcher
+
+                self._dispatcher = Dispatcher(self)
+                self._dispatcher.start()
 
         try:
             config = uvicorn.Config(
@@ -546,6 +602,8 @@ class Server(
         """Remove a worker from the connected set and mark it offline in cache."""
         self._worker_events.pop(name, None)
         self._worker_last_pong.pop(name, None)
+        self._worker_info.pop(name, None)
+        self._drain_worker_queue(name)
         if name in self._worker_names:
             self._worker_names.remove(name)
         self._worker_offline_since[name] = time.monotonic()
@@ -998,6 +1056,9 @@ class Server(
             yield
             await self._stop_scheduler()
             await self._stop_reaper()
+            if self._dispatcher is not None:
+                await self._dispatcher.stop()
+                self._dispatcher = None
             if db_executor is not None:
                 db_executor.shutdown(wait=False, cancel_futures=True)
 

--- a/flux/server.py
+++ b/flux/server.py
@@ -942,9 +942,27 @@ class Server(
             )
             self._bootstrap_token = token
 
+            # All blocking DB work reaches the loop through asyncio.to_thread,
+            # which uses the loop's default executor — normally capped at
+            # min(32, cpu+4) threads, an invisible throughput ceiling shared
+            # with everything else. Install an explicitly sized executor so DB
+            # concurrency is a deliberate knob paired with the connection pool.
+            db_executor = None
+            executor_threads = startup_settings.database_executor_threads
+            if executor_threads > 0:
+                from concurrent.futures import ThreadPoolExecutor
+
+                db_executor = ThreadPoolExecutor(
+                    max_workers=executor_threads,
+                    thread_name_prefix="flux-db",
+                )
+                asyncio.get_running_loop().set_default_executor(db_executor)
+
             yield
             await self._stop_scheduler()
             await self._stop_reaper()
+            if db_executor is not None:
+                db_executor.shutdown(wait=False, cancel_futures=True)
 
             from flux.observability import shutdown as shutdown_observability
 

--- a/flux/task.py
+++ b/flux/task.py
@@ -502,6 +502,14 @@ class task:
         if self.requires_approval is False:
             return False
 
+        if ctx.is_transient:
+            # The gate's verdict lives in a durable row another process
+            # decides on later — impossible without persistence. Fail loudly
+            # instead of silently losing the approval.
+            from flux.errors import TransientDurabilityError
+
+            raise TransientDurabilityError(ctx.execution_id, "requires_approval")
+
         from flux.approvals import ApprovalManager, ApprovalRejected
 
         try:

--- a/flux/tasks/ai/memory/providers/sqlalchemy.py
+++ b/flux/tasks/ai/memory/providers/sqlalchemy.py
@@ -38,7 +38,9 @@ class SqlAlchemyProvider:
 
     def _get_engine(self) -> Engine:
         if self._engine is None:
-            self._engine = create_engine(self._url)
+            from flux.models import normalize_postgresql_url
+
+            self._engine = create_engine(normalize_postgresql_url(self._url))
             _metadata.create_all(self._engine)
         return self._engine
 

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel
 from flux import ExecutionContext
 from flux.config import Configuration
 from flux.domain.events import ExecutionEvent
-from flux.errors import WorkflowNotFoundError
+from flux.errors import StaleClaimError, WorkflowNotFoundError
 from flux.utils import get_logger
 from flux import workflow
 
@@ -96,6 +96,10 @@ class _CheckpointOutbox:
         self.sender: asyncio.Task | None = None
         self.delivered = asyncio.Event()  # set once a terminal snapshot is acked
         self.closed = False  # handler ended; sender exits after catching up
+        # Event ids already acknowledged by the server. Snapshots are
+        # cumulative, so each send carries only events NOT in this set —
+        # O(delta) payloads instead of O(history) per checkpoint.
+        self.acked_ids: set[str] = set()
 
 
 class Worker:
@@ -120,6 +124,7 @@ class Worker:
         self.client = httpx.AsyncClient(timeout=config.http_timeout or None)
         self._running_workflows: dict[str, asyncio.Task] = {}
         self._checkpoint_outboxes: dict[str, _CheckpointOutbox] = {}
+        self._claim_generations: dict[str, str] = {}
         self._checkpoint_retry_max_delay: float = config.checkpoint_retry_max_delay
         self._terminal_checkpoint_deadline: float = config.terminal_checkpoint_deadline
         self._reauth_lock = asyncio.Lock()
@@ -454,6 +459,9 @@ class Worker:
                 )
 
                 claim_data = response.json()
+                generation = response.headers.get("X-Flux-Claim-Generation")
+                if generation is not None:
+                    self._claim_generations[request.context.execution_id] = generation
                 request.context = ExecutionContext.from_json(claim_data, self._checkpoint)
                 if request.exec_token:
                     request.context.set_exec_token(request.exec_token)
@@ -538,6 +546,9 @@ class Worker:
                 )
                 response.raise_for_status()
                 claim_data = response.json()
+                generation = response.headers.get("X-Flux-Claim-Generation")
+                if generation is not None:
+                    self._claim_generations[request.context.execution_id] = generation
                 request.context = ExecutionContext.from_json(claim_data, self._checkpoint)
                 if request.exec_token:
                     request.context.set_exec_token(request.exec_token)
@@ -779,11 +790,18 @@ class Worker:
                 ctx = box.latest
                 assert ctx is not None
                 try:
-                    await self._send_checkpoint(ctx)
+                    sent_ids = await self._send_checkpoint(
+                        ctx,
+                        exclude_event_ids=box.acked_ids,
+                    )
+                    box.acked_ids.update(sent_ids)
                     box.acked = generation
                     backoff = initial_backoff
                 except asyncio.CancelledError:
                     raise
+                except StaleClaimError:
+                    self._abort_fenced_execution(execution_id, box)
+                    return
                 except Exception as e:
                     delay = backoff * (0.5 + random.random())
                     logger.warning(
@@ -797,10 +815,28 @@ class Worker:
             if latest is not None and latest.has_finished:
                 box.delivered.set()
                 self._checkpoint_outboxes.pop(execution_id, None)
+                self._claim_generations.pop(execution_id, None)
                 return
             if box.closed:
                 self._checkpoint_outboxes.pop(execution_id, None)
+                self._claim_generations.pop(execution_id, None)
                 return
+
+    def _abort_fenced_execution(self, execution_id: str, box: _CheckpointOutbox):
+        """The server rejected our claim generation: another worker owns the
+        execution now. Cancel the local copy and discard its checkpoint state
+        — its writes must not interleave with the new owner's."""
+        logger.warning(
+            f"Execution {execution_id} was reassigned (stale claim); aborting the local copy",
+        )
+        task = self._running_workflows.get(execution_id)
+        if task and not task.done():
+            task.cancel()
+        # Unblock any terminal-checkpoint waiter; the result is discarded
+        # server-side anyway.
+        box.delivered.set()
+        self._checkpoint_outboxes.pop(execution_id, None)
+        self._claim_generations.pop(execution_id, None)
 
     def _close_checkpoint_outbox(self, execution_id: str):
         """Release checkpoint state once an execution's handler has ended.
@@ -829,7 +865,12 @@ class Worker:
         returned to the caller (whose raise_for_status surfaces it).
         """
         token_used = self.session_token
-        response = await self.client.post(url, headers=self._auth_headers(), **kwargs)
+        extra_headers = kwargs.pop("headers", None) or {}
+        response = await self.client.post(
+            url,
+            headers={**self._auth_headers(), **extra_headers},
+            **kwargs,
+        )
         if response.status_code not in (401, 403) or not self._registered:
             return response
 
@@ -838,24 +879,54 @@ class Worker:
                 logger.warning("Session token rejected mid-operation, re-registering...")
                 self._registered = False
                 await self._register()
-        return await self.client.post(url, headers=self._auth_headers(), **kwargs)
+        return await self.client.post(
+            url,
+            headers={**self._auth_headers(), **extra_headers},
+            **kwargs,
+        )
 
-    async def _send_checkpoint(self, ctx: ExecutionContext):
+    async def _send_checkpoint(
+        self,
+        ctx: ExecutionContext,
+        exclude_event_ids: set[str] | None = None,
+    ) -> list[str]:
+        """POST one checkpoint; returns the ids of the events it carried.
+
+        ``exclude_event_ids`` (the outbox's acknowledged set) turns the payload
+        into a delta: snapshots are cumulative, so already-acknowledged events
+        can be omitted — the server reconciles by event id either way. Raises
+        ``StaleClaimError`` if the server fences the claim (409): the
+        execution was reassigned and this worker's copy must abort.
+        """
         base_url = f"{self.base_url}/{self.name}"
         try:
             logger.info(f"Checkpointing execution '{ctx.workflow_name}' ({ctx.execution_id})...")
             logger.debug(f"Checkpoint URL: {base_url}/checkpoint/{ctx.execution_id}")
             logger.debug(f"Checkpoint state: {ctx.state.value}")
-            logger.debug(f"Number of events: {len(ctx.events)}")
 
             ctx_dict = ctx.to_dict()
-            logger.debug(f"Sending checkpoint data ({len(str(ctx_dict))} bytes)")
+            events = ctx_dict.get("events") or []
+            if exclude_event_ids:
+                events = [e for e in events if e.get("id") not in exclude_event_ids]
+                ctx_dict["events"] = events
+            sent_ids = [e.get("id") for e in events if e.get("id")]
+            logger.debug(
+                f"Sending checkpoint delta: {len(events)} event(s), {len(str(ctx_dict))} bytes",
+            )
+
+            headers = {}
+            generation = self._claim_generations.get(ctx.execution_id)
+            if generation is not None:
+                headers["X-Flux-Claim-Generation"] = generation
 
             checkpoint_start = time.monotonic()
             response = await self._authorized_post(
                 f"{base_url}/checkpoint/{ctx.execution_id}",
                 json=ctx_dict,
+                headers=headers,
             )
+            if response.status_code == 409 and "stale-claim" in response.text:
+                raise StaleClaimError(ctx.execution_id)
             response.raise_for_status()
             checkpoint_duration = time.monotonic() - checkpoint_start
             response_data = response.json()
@@ -871,6 +942,7 @@ class Worker:
             m = get_metrics()
             if m:
                 m.record_checkpoint(ctx.workflow_namespace, ctx.workflow_name, checkpoint_duration)
+            return sent_ids
         except Exception as e:
             logger.error(f"Error during checkpoint: {str(e)}")
             logger.debug(f"Checkpoint error details: {type(e).__name__}: {str(e)}")

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -128,6 +128,9 @@ class Worker:
         self._reconnect_max_delay = config.reconnect_max_delay
         self._module_cache: dict[str, tuple[ModuleType, float]] = {}
         self._module_cache_ttl = config.module_cache_ttl
+        self._max_concurrent = config.max_concurrent_executions
+        self._drain_timeout = config.drain_timeout
+        self._draining = False
         self._registered = False
         self.session_token: str | None = None
 
@@ -172,7 +175,10 @@ class Worker:
         main_task = asyncio.current_task()
 
         def _request_shutdown(signame: str) -> None:
-            logger.info(f"Worker received {signame}, shutting down...")
+            if self._draining:
+                logger.info(f"Worker received {signame} again, aborting drain...")
+            else:
+                logger.info(f"Worker received {signame}, draining before shutdown...")
             if main_task is not None:
                 main_task.cancel()
 
@@ -185,36 +191,79 @@ class Worker:
                 logger.debug(f"Could not install {sig.name} handler via event loop")
 
         backoff = 1
-        while True:
-            try:
-                if not self._registered:
-                    await self._register()
-                else:
-                    logger.info("Reconnecting with existing session...")
-
+        try:
+            while True:
                 try:
-                    await self._connect()
-                except httpx.HTTPStatusError as e:
-                    if e.response.status_code in (401, 403) and self._registered:
-                        logger.warning("Session token rejected, re-registering...")
-                        self._registered = False
+                    if not self._registered:
                         await self._register()
-                        await self._connect()
                     else:
-                        raise
+                        logger.info("Reconnecting with existing session...")
 
-                logger.info("SSE connection closed, reconnecting...")
-                backoff = 1
-            except KeyboardInterrupt:
-                raise
-            except Exception as e:
-                jitter = backoff * (0.5 + random.random())
-                delay = min(jitter, self._reconnect_max_delay)
-                logger.warning(
-                    f"Connection lost ({type(e).__name__}: {e}). Reconnecting in {delay:.1f}s...",
+                    try:
+                        await self._connect()
+                    except httpx.HTTPStatusError as e:
+                        if e.response.status_code in (401, 403) and self._registered:
+                            logger.warning("Session token rejected, re-registering...")
+                            self._registered = False
+                            await self._register()
+                            await self._connect()
+                        else:
+                            raise
+
+                    logger.info("SSE connection closed, reconnecting...")
+                    backoff = 1
+                except KeyboardInterrupt:
+                    raise
+                except Exception as e:
+                    jitter = backoff * (0.5 + random.random())
+                    delay = min(jitter, self._reconnect_max_delay)
+                    logger.warning(
+                        f"Connection lost ({type(e).__name__}: {e}). Reconnecting in {delay:.1f}s...",
+                    )
+                    await asyncio.sleep(delay)
+                    backoff = min(backoff * 2, self._reconnect_max_delay)
+        except asyncio.CancelledError:
+            # First stop signal: the SSE stream is closed (no new work arrives),
+            # so drain what is already running. A second signal cancels again,
+            # which interrupts the drain's awaits and exits immediately.
+            self._draining = True
+            await self._drain()
+
+    async def _drain(self):
+        """Let running executions finish, then flush their checkpoints.
+
+        Bounded by ``drain_timeout``: executions still running at the deadline
+        are cancelled (which checkpoints them as CANCELLED, best-effort), and
+        outstanding checkpoint senders get a short final window so terminal
+        states reach the server instead of waiting on the ~60s reaper path.
+        """
+        running = [t for t in self._running_workflows.values() if not t.done()]
+        if running:
+            if self._drain_timeout > 0:
+                logger.info(
+                    f"Draining {len(running)} running execution(s) "
+                    f"(timeout {self._drain_timeout}s)...",
                 )
-                await asyncio.sleep(delay)
-                backoff = min(backoff * 2, self._reconnect_max_delay)
+                _, pending = await asyncio.wait(running, timeout=self._drain_timeout)
+            else:
+                pending = set(running)
+            if pending:
+                logger.warning(
+                    f"Drain deadline reached; cancelling {len(pending)} execution(s)",
+                )
+                for task in pending:
+                    task.cancel()
+                await asyncio.wait(pending, timeout=30)
+
+        senders = [
+            box.sender
+            for box in self._checkpoint_outboxes.values()
+            if box.sender and not box.sender.done()
+        ]
+        if senders:
+            logger.info(f"Flushing {len(senders)} outstanding checkpoint sender(s)...")
+            await asyncio.wait(senders, timeout=30)
+        logger.info("Drain complete")
 
     async def _register(self):
         try:
@@ -237,6 +286,7 @@ class Worker:
                 "resources": resources,
                 "packages": packages,
                 "labels": self.labels,
+                "max_concurrent_executions": self._max_concurrent or None,
             }
 
             logger.debug("Sending registration request to server...")
@@ -467,6 +517,13 @@ class Worker:
                     "flux.worker.name": self.name,
                 },
             )
+
+        if self._draining:
+            logger.info(
+                f"Draining; not claiming execution {request.context.execution_id} "
+                f"(will be re-dispatched)",
+            )
+            return
 
         try:
             with span_cm as span:

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -125,6 +125,8 @@ class Worker:
         self._running_workflows: dict[str, asyncio.Task] = {}
         self._checkpoint_outboxes: dict[str, _CheckpointOutbox] = {}
         self._claim_generations: dict[str, str] = {}
+        # Transient executions whose RUNNING transition has been persisted.
+        self._transient_started: set[str] = set()
         self._checkpoint_retry_max_delay: float = config.checkpoint_retry_max_delay
         self._terminal_checkpoint_deadline: float = config.terminal_checkpoint_deadline
         self._reauth_lock = asyncio.Lock()
@@ -759,9 +761,16 @@ class Worker:
                     {"type": "TransientDurabilityError", "message": str(error)},
                 )
             elif not ctx.has_finished:
-                # Intermediate (task-level) checkpoint: transient workflows
-                # skip these entirely — only the terminal state persists.
-                return
+                # The outer lifecycle persists like any regular run. The
+                # RUNNING transition only ever travels inside a checkpoint (the
+                # first task's, in durable mode), so let exactly one
+                # intermediate checkpoint through — filtered to WORKFLOW_*
+                # events by _send_checkpoint — and suppress the rest. The row
+                # is observable and cancellable mid-flight; task progress
+                # stays in memory until the terminal transition.
+                if ctx.execution_id in self._transient_started:
+                    return
+                self._transient_started.add(ctx.execution_id)
 
         box = self._checkpoint_outboxes.get(ctx.execution_id)
         if box is None:
@@ -837,10 +846,12 @@ class Worker:
                 box.delivered.set()
                 self._checkpoint_outboxes.pop(execution_id, None)
                 self._claim_generations.pop(execution_id, None)
+                self._transient_started.discard(execution_id)
                 return
             if box.closed:
                 self._checkpoint_outboxes.pop(execution_id, None)
                 self._claim_generations.pop(execution_id, None)
+                self._transient_started.discard(execution_id)
                 return
 
     def _abort_fenced_execution(self, execution_id: str, box: _CheckpointOutbox):
@@ -858,6 +869,7 @@ class Worker:
         box.delivered.set()
         self._checkpoint_outboxes.pop(execution_id, None)
         self._claim_generations.pop(execution_id, None)
+        self._transient_started.discard(execution_id)
 
     def _close_checkpoint_outbox(self, execution_id: str):
         """Release checkpoint state once an execution's handler has ended.

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -533,6 +533,7 @@ class Worker:
             )
             return
 
+        is_transient = bool(event_data.get("transient"))
         try:
             with span_cm as span:
                 logger.info(
@@ -550,6 +551,8 @@ class Worker:
                 if generation is not None:
                     self._claim_generations[request.context.execution_id] = generation
                 request.context = ExecutionContext.from_json(claim_data, self._checkpoint)
+                if is_transient:
+                    request.context.mark_transient()
                 if request.exec_token:
                     request.context.set_exec_token(request.exec_token)
                 logger.debug(f"Claim response: {claim_data}")
@@ -742,6 +745,24 @@ class Worker:
         configured deadline expires, after which the server reaper is the
         fallback).
         """
+        if ctx.is_transient:
+            if ctx.is_paused:
+                # Pause needs task-level history to replay on resume, which a
+                # transient execution deliberately does not persist. Convert to
+                # a terminal failure so nothing is silently stranded.
+                from flux.errors import TransientDurabilityError
+
+                error = TransientDurabilityError(ctx.execution_id, "pause")
+                logger.warning(str(error))
+                ctx.fail(
+                    ctx.execution_id,
+                    {"type": "TransientDurabilityError", "message": str(error)},
+                )
+            elif not ctx.has_finished:
+                # Intermediate (task-level) checkpoint: transient workflows
+                # skip these entirely — only the terminal state persists.
+                return
+
         box = self._checkpoint_outboxes.get(ctx.execution_id)
         if box is None:
             box = self._checkpoint_outboxes[ctx.execution_id] = _CheckpointOutbox()
@@ -906,6 +927,12 @@ class Worker:
 
             ctx_dict = ctx.to_dict()
             events = ctx_dict.get("events") or []
+            if ctx.is_transient:
+                # Only the outer lifecycle persists: workflow-level events stay
+                # (they carry the terminal state and output); task-level events
+                # exist in memory only.
+                events = [e for e in events if not str(e.get("type", "")).startswith("TASK_")]
+                ctx_dict["events"] = events
             if exclude_event_ids:
                 events = [e for e in events if e.get("id") not in exclude_event_ids]
                 ctx_dict["events"] = events

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -78,6 +78,26 @@ class WorkflowExecutionRequest(BaseModel):
         )
 
 
+class _CheckpointOutbox:
+    """Per-execution checkpoint sender state.
+
+    Checkpoints are cumulative full-context snapshots, so the newest snapshot
+    supersedes any unsent older one — coalescing to ``latest`` is lossless.
+    A single sender task per execution serializes sends; in-flight sends are
+    never cancelled, and failures are retried with capped backoff until the
+    snapshot is delivered or superseded.
+    """
+
+    def __init__(self):
+        self.latest: ExecutionContext | None = None
+        self.generation = 0  # bumped on every new snapshot
+        self.acked = 0  # highest generation successfully sent
+        self.wakeup = asyncio.Event()
+        self.sender: asyncio.Task | None = None
+        self.delivered = asyncio.Event()  # set once a terminal snapshot is acked
+        self.closed = False  # handler ended; sender exits after catching up
+
+
 class Worker:
     def __init__(self, name: str, server_url: str, labels: dict[str, str] | None = None):
         self.name = name
@@ -97,9 +117,12 @@ class Worker:
             )
         self.bootstrap_token = bootstrap_token
         self.base_url = f"{server_url or config.server_url}/workers"
-        self.client = httpx.AsyncClient(timeout=config.default_timeout or None)
+        self.client = httpx.AsyncClient(timeout=config.http_timeout or None)
         self._running_workflows: dict[str, asyncio.Task] = {}
-        self._pending_checkpoints: dict[str, asyncio.Task] = {}
+        self._checkpoint_outboxes: dict[str, _CheckpointOutbox] = {}
+        self._checkpoint_retry_max_delay: float = config.checkpoint_retry_max_delay
+        self._terminal_checkpoint_deadline: float = config.terminal_checkpoint_deadline
+        self._reauth_lock = asyncio.Lock()
         self._progress_queues: dict[str, asyncio.Queue] = {}
         self._progress_flushers: dict[str, asyncio.Task | None] = {}
         self._reconnect_max_delay = config.reconnect_max_delay
@@ -257,7 +280,7 @@ class Worker:
                     async for evt in es.aiter_sse():
                         if evt.event == "execution_scheduled":
                             asyncio.create_task(
-                                self._handle_execution_scheduled(base_url, headers, evt),
+                                self._handle_execution_scheduled(base_url, evt),
                                 name=f"handle_execution_scheduled_{evt.id}",
                             )
                         elif evt.event == "execution_cancelled":
@@ -285,9 +308,8 @@ class Worker:
     async def _send_pong(self):
         """Respond to server ping with a pong."""
         base_url = f"{self.base_url}/{self.name}"
-        headers = {"Authorization": f"Bearer {self.session_token}"}
         try:
-            await self.client.post(f"{base_url}/pong", headers=headers)
+            await self._authorized_post(f"{base_url}/pong")
             logger.debug("Pong sent")
         except Exception as e:
             logger.debug(f"Failed to send pong: {e}")
@@ -361,13 +383,11 @@ class Worker:
                 )
 
                 base_url = f"{self.base_url}/{self.name}"
-                headers = {"Authorization": f"Bearer {self.session_token}"}
 
                 logger.debug(f"Claiming resumed execution: {request.context.execution_id}")
                 try:
-                    response = await self.client.post(
+                    response = await self._authorized_post(
                         f"{base_url}/claim/{request.context.execution_id}",
-                        headers=headers,
                     )
                     response.raise_for_status()
                 except httpx.HTTPStatusError as claim_err:
@@ -412,8 +432,10 @@ class Worker:
         except Exception as ex:
             logger.error(f"Error handling execution_resumed event: {str(ex)}")
             logger.debug(f"Exception details: {type(ex).__name__}: {str(ex)}", exc_info=True)
+        finally:
+            self._close_checkpoint_outbox(request.context.execution_id)
 
-    async def _handle_execution_scheduled(self, base_url, headers, e):
+    async def _handle_execution_scheduled(self, base_url, e):
         """Handle execution scheduled event asynchronously.
 
         This method is called as a separate task and should handle its own exceptions.
@@ -454,9 +476,8 @@ class Worker:
                 logger.debug(f"Workflow input: {request.context.input}")
 
                 logger.debug(f"Claiming execution: {request.context.execution_id}")
-                response = await self.client.post(
+                response = await self._authorized_post(
                     f"{base_url}/claim/{request.context.execution_id}",
-                    headers=headers,
                 )
                 response.raise_for_status()
                 claim_data = response.json()
@@ -501,6 +522,8 @@ class Worker:
         except Exception as ex:
             logger.error(f"Error handling execution_scheduled event: {str(ex)}")
             logger.debug(f"Exception details: {type(ex).__name__}: {str(ex)}", exc_info=True)
+        finally:
+            self._close_checkpoint_outbox(request.context.execution_id)
 
     async def _execute_workflow(self, request: WorkflowExecutionRequest) -> ExecutionContext:
         """Execute a workflow from a workflow execution request.
@@ -642,32 +665,126 @@ class Worker:
         return ctx
 
     async def _checkpoint(self, ctx: ExecutionContext):
-        pending = self._pending_checkpoints.pop(ctx.execution_id, None)
+        """Queue a checkpoint for delivery, never dropping durability.
 
-        if pending and not pending.done():
-            pending.cancel()
-            try:
-                await pending
-            except (asyncio.CancelledError, Exception):
-                pass
+        Intermediate checkpoints return immediately: the per-execution sender
+        task delivers the newest snapshot, retrying failures with capped
+        backoff instead of cancelling in-flight sends. Terminal checkpoints
+        block until the finished state is acknowledged by the server (or the
+        configured deadline expires, after which the server reaper is the
+        fallback).
+        """
+        box = self._checkpoint_outboxes.get(ctx.execution_id)
+        if box is None:
+            box = self._checkpoint_outboxes[ctx.execution_id] = _CheckpointOutbox()
+
+        box.latest = ctx
+        box.generation += 1
+        box.wakeup.set()
+
+        if box.sender is None or box.sender.done():
+            box.sender = asyncio.create_task(
+                self._drain_checkpoints(ctx.execution_id, box),
+            )
 
         if ctx.has_finished:
-            await self._send_checkpoint(ctx)
-        else:
-            task = asyncio.create_task(self._send_checkpoint(ctx))
-            task.add_done_callback(self._handle_checkpoint_error)
-            self._pending_checkpoints[ctx.execution_id] = task
+            try:
+                await asyncio.wait_for(
+                    box.delivered.wait(),
+                    timeout=self._terminal_checkpoint_deadline or None,
+                )
+            except TimeoutError:
+                logger.critical(
+                    f"Terminal checkpoint for execution {ctx.execution_id} "
+                    f"({ctx.workflow_name}, state={ctx.state.value}) not delivered within "
+                    f"{self._terminal_checkpoint_deadline}s; giving up. The server reaper "
+                    f"will requeue the execution.",
+                )
+                if box.sender and not box.sender.done():
+                    box.sender.cancel()
+                self._checkpoint_outboxes.pop(ctx.execution_id, None)
 
-    def _handle_checkpoint_error(self, task: asyncio.Task):
-        if task.cancelled():
+    async def _drain_checkpoints(self, execution_id: str, box: _CheckpointOutbox):
+        """Deliver checkpoint snapshots for one execution, in order, until terminal.
+
+        Runs as a dedicated task per execution: waits for new snapshots, sends
+        the newest one, and retries failed sends with jittered capped backoff.
+        Ends when a terminal snapshot is acknowledged.
+        """
+        initial_backoff = min(1.0, self._checkpoint_retry_max_delay or 1.0)
+        backoff = initial_backoff
+        while True:
+            await box.wakeup.wait()
+            box.wakeup.clear()
+
+            while box.acked < box.generation:
+                generation = box.generation
+                ctx = box.latest
+                assert ctx is not None
+                try:
+                    await self._send_checkpoint(ctx)
+                    box.acked = generation
+                    backoff = initial_backoff
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    delay = backoff * (0.5 + random.random())
+                    logger.warning(
+                        f"Checkpoint for execution {execution_id} failed "
+                        f"({type(e).__name__}: {e}); retrying in {delay:.1f}s",
+                    )
+                    await asyncio.sleep(delay)
+                    backoff = min(backoff * 2, self._checkpoint_retry_max_delay)
+
+            latest = box.latest
+            if latest is not None and latest.has_finished:
+                box.delivered.set()
+                self._checkpoint_outboxes.pop(execution_id, None)
+                return
+            if box.closed:
+                self._checkpoint_outboxes.pop(execution_id, None)
+                return
+
+    def _close_checkpoint_outbox(self, execution_id: str):
+        """Release checkpoint state once an execution's handler has ended.
+
+        On normal completion the sender already removed the outbox after the
+        terminal checkpoint was acknowledged, making this a no-op. For
+        non-terminal endings (pause, handler error) the sender is asked to
+        exit after delivering whatever is still pending — never cancelled, so
+        an in-flight PAUSED or partial snapshot is not lost.
+        """
+        box = self._checkpoint_outboxes.get(execution_id)
+        if box is None:
             return
-        exc = task.exception()
-        if exc:
-            logger.error(f"Checkpoint task failed: {exc}")
+        box.closed = True
+        box.wakeup.set()
+
+    def _auth_headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.session_token}"}
+
+    async def _authorized_post(self, url: str, **kwargs) -> httpx.Response:
+        """POST with the session token; on 401/403 re-register once and retry.
+
+        Only the SSE connect path used to recover from token rejection, so a
+        key rotated or revoked mid-execution silently broke checkpoints,
+        claims, pongs, and progress. Persistent rejection after one refresh is
+        returned to the caller (whose raise_for_status surfaces it).
+        """
+        token_used = self.session_token
+        response = await self.client.post(url, headers=self._auth_headers(), **kwargs)
+        if response.status_code not in (401, 403) or not self._registered:
+            return response
+
+        async with self._reauth_lock:
+            if self.session_token == token_used:
+                logger.warning("Session token rejected mid-operation, re-registering...")
+                self._registered = False
+                await self._register()
+        return await self.client.post(url, headers=self._auth_headers(), **kwargs)
 
     async def _send_checkpoint(self, ctx: ExecutionContext):
         base_url = f"{self.base_url}/{self.name}"
-        headers = {"Authorization": f"Bearer {self.session_token}"}
         try:
             logger.info(f"Checkpointing execution '{ctx.workflow_name}' ({ctx.execution_id})...")
             logger.debug(f"Checkpoint URL: {base_url}/checkpoint/{ctx.execution_id}")
@@ -678,10 +795,9 @@ class Worker:
             logger.debug(f"Sending checkpoint data ({len(str(ctx_dict))} bytes)")
 
             checkpoint_start = time.monotonic()
-            response = await self.client.post(
+            response = await self._authorized_post(
                 f"{base_url}/checkpoint/{ctx.execution_id}",
                 json=ctx_dict,
-                headers=headers,
             )
             response.raise_for_status()
             checkpoint_duration = time.monotonic() - checkpoint_start
@@ -705,7 +821,6 @@ class Worker:
 
     async def _flush_progress(self, queue: asyncio.Queue, execution_id: str):
         base_url = f"{self.base_url}/{self.name}"
-        headers = {"Authorization": f"Bearer {self.session_token}"}
         try:
             while True:
                 batch = []
@@ -719,10 +834,9 @@ class Worker:
                         batch.append(queue.get_nowait())
                     if batch:
                         try:
-                            await self.client.post(
+                            await self._authorized_post(
                                 f"{base_url}/progress/{execution_id}",
                                 json=batch,
-                                headers=headers,
                             )
                         except Exception:
                             logger.warning(
@@ -734,10 +848,9 @@ class Worker:
                     return
 
                 try:
-                    await self.client.post(
+                    await self._authorized_post(
                         f"{base_url}/progress/{execution_id}",
                         json=batch,
-                        headers=headers,
                     )
                 except Exception:
                     logger.warning(

--- a/flux/worker_registry.py
+++ b/flux/worker_registry.py
@@ -202,7 +202,11 @@ class DatabaseWorkerRegistry(WorkerRegistry):
     def record_heartbeat(self, name: str) -> None:
         from flux.models import WorkerModel
 
-        now = datetime.now(timezone.utc)
+        # Naive UTC, matching the column type and every comparison site
+        # (reaper threshold, /workers liveness). Writing an aware datetime
+        # into TIMESTAMP WITHOUT TIME ZONE round-trips correctly only when
+        # the session TimeZone happens to be UTC — make it explicit instead.
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
         with self.session() as session:
             # Targeted UPDATE — cheap enough to run on every pong, and avoids
             # loading the worker's runtime/packages/resources relationships.
@@ -217,7 +221,8 @@ class DatabaseWorkerRegistry(WorkerRegistry):
             return
         from flux.models import WorkerModel
 
-        now = datetime.now(timezone.utc)
+        # Naive UTC — see record_heartbeat.
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
         with self.session() as session:
             session.query(WorkerModel).filter(WorkerModel.name.in_(list(names))).update(
                 {WorkerModel.last_seen_at: now},

--- a/flux/worker_registry.py
+++ b/flux/worker_registry.py
@@ -102,6 +102,16 @@ class WorkerRegistry(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def record_heartbeats(self, names: Sequence[str]) -> None:  # pragma: no cover
+        """Persist heartbeats for many workers in one statement.
+
+        All names get the same (current) timestamp — callers buffer pongs for
+        at most one heartbeat interval, which is well inside the staleness
+        thresholds, and one UPDATE per interval replaces one commit per pong.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def find_stale(self, threshold: datetime) -> Sequence[str]:  # pragma: no cover
         """Names of workers whose last heartbeat predates ``threshold``.
 
@@ -181,6 +191,19 @@ class DatabaseWorkerRegistry(WorkerRegistry):
             # Targeted UPDATE — cheap enough to run on every pong, and avoids
             # loading the worker's runtime/packages/resources relationships.
             session.query(WorkerModel).filter(WorkerModel.name == name).update(
+                {WorkerModel.last_seen_at: now},
+                synchronize_session=False,
+            )
+            session.commit()
+
+    def record_heartbeats(self, names: Sequence[str]) -> None:
+        if not names:
+            return
+        from flux.models import WorkerModel
+
+        now = datetime.now(timezone.utc)
+        with self.session() as session:
+            session.query(WorkerModel).filter(WorkerModel.name.in_(list(names))).update(
                 {WorkerModel.last_seen_at: now},
                 synchronize_session=False,
             )

--- a/flux/worker_registry.py
+++ b/flux/worker_registry.py
@@ -68,6 +68,7 @@ class WorkerInfo:
         session_token: str | None = None,
         labels: dict[str, str] | None = None,
         max_concurrent_executions: int | None = None,
+        last_seen_at: datetime | None = None,
     ):
         self.name = name
         self.runtime = runtime
@@ -77,6 +78,8 @@ class WorkerInfo:
         self.labels = labels or {}
         # Advertised capacity; None/0 means unlimited (legacy workers).
         self.max_concurrent_executions = max_concurrent_executions
+        # Persisted heartbeat timestamp; None until the first pong lands.
+        self.last_seen_at = last_seen_at
 
 
 class WorkerRegistry(ABC):
@@ -310,4 +313,5 @@ class DatabaseWorkerRegistry(WorkerRegistry):
             session_token=model.session_token,
             labels=model.labels if model.labels else {},
             max_concurrent_executions=model.max_concurrent_executions,
+            last_seen_at=model.last_seen_at,
         )

--- a/flux/worker_registry.py
+++ b/flux/worker_registry.py
@@ -67,6 +67,7 @@ class WorkerInfo:
         resources: WorkerResourcesInfo | None = None,
         session_token: str | None = None,
         labels: dict[str, str] | None = None,
+        max_concurrent_executions: int | None = None,
     ):
         self.name = name
         self.runtime = runtime
@@ -74,6 +75,8 @@ class WorkerInfo:
         self.resources = resources
         self.session_token = session_token
         self.labels = labels or {}
+        # Advertised capacity; None/0 means unlimited (legacy workers).
+        self.max_concurrent_executions = max_concurrent_executions
 
 
 class WorkerRegistry(ABC):
@@ -89,6 +92,7 @@ class WorkerRegistry(ABC):
         packages: list[dict[str, str]],
         resources: WorkerResourcesInfo | None,
         labels: dict[str, str] | None = None,
+        max_concurrent_executions: int | None = None,
     ) -> WorkerInfo:  # pragma: no cover
         raise NotImplementedError()
 
@@ -154,6 +158,7 @@ class DatabaseWorkerRegistry(WorkerRegistry):
         packages: list[dict[str, str]],
         resources: WorkerResourcesInfo | None,
         labels: dict[str, str] | None = None,
+        max_concurrent_executions: int | None = None,
     ) -> WorkerInfo:
         # Import here to avoid circular imports
         from flux.models import WorkerModel
@@ -165,9 +170,17 @@ class DatabaseWorkerRegistry(WorkerRegistry):
                     # generate a new session token
                     model.session_token = uuid4().hex
                     model.labels = labels or {}
+                    model.max_concurrent_executions = max_concurrent_executions
                 else:
                     # Creates a new model and assigns the session token
-                    model = self._from_info(name, runtime, packages, resources, labels=labels)
+                    model = self._from_info(
+                        name,
+                        runtime,
+                        packages,
+                        resources,
+                        labels=labels,
+                        max_concurrent_executions=max_concurrent_executions,
+                    )
                     session.add(model)
                 session.commit()
                 return self._to_info(model)
@@ -223,7 +236,15 @@ class DatabaseWorkerRegistry(WorkerRegistry):
             )
             return [row[0] for row in rows]
 
-    def _from_info(self, name, runtime, packages, resources, labels=None):
+    def _from_info(
+        self,
+        name,
+        runtime,
+        packages,
+        resources,
+        labels=None,
+        max_concurrent_executions=None,
+    ):
         # Import here to avoid circular imports
         from flux.models import (
             WorkerModel,
@@ -258,6 +279,7 @@ class DatabaseWorkerRegistry(WorkerRegistry):
                 ],
             ),
             labels=labels,
+            max_concurrent_executions=max_concurrent_executions,
         )
 
     def _to_info(self, model: WorkerModel) -> WorkerInfo:
@@ -287,4 +309,5 @@ class DatabaseWorkerRegistry(WorkerRegistry):
             ),
             session_token=model.session_token,
             labels=model.labels if model.labels else {},
+            max_concurrent_executions=model.max_concurrent_executions,
         )

--- a/flux/workflow.py
+++ b/flux/workflow.py
@@ -29,6 +29,7 @@ class workflow:
         requests: ResourceRequest | None = None,
         affinity: dict[str, str] | None = None,
         schedule: Schedule | None = None,
+        durability: str = "durable",
     ) -> Callable[[F], workflow]:
         """
         A decorator to configure options for a workflow function.
@@ -56,6 +57,7 @@ class workflow:
                 requests=requests,
                 affinity=affinity,
                 schedule=schedule,
+                durability=durability,
             )
 
         return wrapper
@@ -70,7 +72,18 @@ class workflow:
         requests: ResourceRequest | None = None,
         affinity: dict[str, str] | None = None,
         schedule: Schedule | None = None,
+        durability: str = "durable",
     ):
+        if durability not in ("durable", "transient"):
+            raise ValueError(
+                f"durability must be 'durable' or 'transient', got: '{durability}'",
+            )
+        if durability == "transient" and schedule is not None:
+            raise ValueError(
+                "durability='transient' cannot be combined with a schedule: "
+                "scheduled runs have no caller holding the connection, so their "
+                "results would be silently discarded.",
+            )
         self._func = func
         self._name = name if name else func.__name__
         self._namespace = validate_namespace(namespace)
@@ -79,6 +92,7 @@ class workflow:
         self._requests = requests
         self._affinity = affinity
         self._schedule = schedule
+        self._durability = durability
         wraps(func)(self)
 
     @property
@@ -88,6 +102,10 @@ class workflow:
     @property
     def namespace(self) -> str:
         return self._namespace
+
+    @property
+    def durability(self) -> str:
+        return self._durability
 
     @property
     def qualified_name(self) -> str:

--- a/poetry.lock
+++ b/poetry.lock
@@ -3440,82 +3440,116 @@ dev = ["abi3audit", "black", "check-manifest", "colorama ; os_name == \"nt\"", "
 test = ["psleak", "pytest", "pytest-instafail", "pytest-xdist", "pywin32 ; os_name == \"nt\" and implementation_name != \"pypy\"", "setuptools", "wheel ; os_name == \"nt\" and implementation_name != \"pypy\"", "wmi ; os_name == \"nt\" and implementation_name != \"pypy\""]
 
 [[package]]
-name = "psycopg2-binary"
-version = "2.9.12"
-description = "psycopg2 - Python-PostgreSQL Database Adapter"
+name = "psycopg"
+version = "3.3.4"
+description = "PostgreSQL database adapter for Python"
 optional = true
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"postgresql\""
 files = [
-    {file = "psycopg2_binary-2.9.12-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b818ceff717f98851a64bffd4c5eb5b3059ae280276dcecc52ac658dcf006a4"},
-    {file = "psycopg2_binary-2.9.12-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d2fa0d7caca8635c56e373055094eeda3208d901d55dd0ff5abc1d4e47f82b56"},
-    {file = "psycopg2_binary-2.9.12-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:864c261b3690e1207d14bbfe0a61e27567981b80c47a778561e49f676f7ce433"},
-    {file = "psycopg2_binary-2.9.12-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c5ee5213445dd45312459029b8c4c0a695461eb517b753d2582315bd07995f5e"},
-    {file = "psycopg2_binary-2.9.12-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6f9cae1f848779b5b01f417e762c40d026ea93eb0648249a604728cda991dde3"},
-    {file = "psycopg2_binary-2.9.12-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:63a3ebbd543d3d1eda088ac99164e8c5bac15293ee91f20281fd17d050aee1c4"},
-    {file = "psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d6fcbba8c9fed08a73b8ac61ea79e4821e45b1e92bb466230c5e746bbf3d5256"},
-    {file = "psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:36512911ebb2b60a0c3e44d0bb5048c1980aced91235d133b7874f3d1d93487c"},
-    {file = "psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:8ffdb59fe88f99589e34354a130217aa1fd2d615612402d6edc8b3dbc7a44463"},
-    {file = "psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a46fe069b65255df410f856d842bc235f90e22ffdf532dda625fd4213d3fd9b1"},
-    {file = "psycopg2_binary-2.9.12-cp310-cp310-win_amd64.whl", hash = "sha256:ab29414b25dcb698bf26bf213e3348abdcd07bbd5de032a5bec15bd75b298b03"},
-    {file = "psycopg2_binary-2.9.12-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5c8ce6c61bd1b1f6b9c24ee32211599f6166af2c55abb19456090a21fd16554b"},
-    {file = "psycopg2_binary-2.9.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b4a9eaa6e7f4ff91bec10aa3fb296878e75187bced5cc4bafe17dc40915e1326"},
-    {file = "psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c6528cefc8e50fcc6f4a107e27a672058b36cc5736d665476aeb413ba88dbb06"},
-    {file = "psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e4e184b1fb6072bf05388aa41c697e1b2d01b3473f107e7ec44f186a32cfd0b8"},
-    {file = "psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4766ab678563054d3f1d064a4db19cc4b5f9e3a8d9018592a8285cf200c248f3"},
-    {file = "psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5a0253224780c978746cb9be55a946bcdaf40fe3519c0f622924cdabdafe2c39"},
-    {file = "psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0dc9228d47c46bda253d2ecd6bb93b56a9f2d7ad33b684a1fa3622bf74ffe30c"},
-    {file = "psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f921f3cd87035ef7df233383011d7a53ea1d346224752c1385f1edfd790ceb6a"},
-    {file = "psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d999bd982a723113c1a45b55a7a6a90d64d0ed2278020ed625c490ff7bef96c"},
-    {file = "psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29d4d134bd0ab46ffb04e94aa3c5fa3ef582e9026609165e2f758ff76fc3a3be"},
-    {file = "psycopg2_binary-2.9.12-cp311-cp311-win_amd64.whl", hash = "sha256:cb4a1dacdd48077150dc762a9e5ddbf32c256d66cb46f80839391aa458774936"},
-    {file = "psycopg2_binary-2.9.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5cdc05117180c5fa9c40eea8ea559ce64d73824c39d928b7da9fb5f6a9392433"},
-    {file = "psycopg2_binary-2.9.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3227a3bc228c10d21011a99245edca923e4e8bf461857e869a507d9a41fe9f6"},
-    {file = "psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:995ce929eede89db6254b50827e2b7fd61e50d11f0b116b29fffe4a2e53c4580"},
-    {file = "psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9fe06d93e72f1c048e731a2e3e7854a5bfaa58fc736068df90b352cefe66f03f"},
-    {file = "psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40e7b28b63aaf737cb3a1edc3a9bbc9a9f4ad3dcb7152e8c1130e4050eddcb7d"},
-    {file = "psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:89d19a9f7899e8eb0656a2b3a08e0da04c720a06db6e0033eab5928aabe60fa9"},
-    {file = "psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:612b965daee295ae2da8f8218ce1d274645dc76ef3f1abf6a0a94fd57eff876d"},
-    {file = "psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b9a339b79d37c1b45f3235265f07cdeb0cb5ad7acd2ac7720a5920989c17c24e"},
-    {file = "psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:3471336e1acfd9c7fe507b8bad5af9317b6a89294f9eb37bd9a030bb7bebcdc6"},
-    {file = "psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7af18183109e23502c8b2ae7f6926c0882766f35b5175a4cd737ad825e4d7a1b"},
-    {file = "psycopg2_binary-2.9.12-cp312-cp312-win_amd64.whl", hash = "sha256:398fcd4db988c7d7d3713e2b8e18939776fd3fb447052daae4f24fa39daede4c"},
-    {file = "psycopg2_binary-2.9.12-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7c729a73c7b1b84de3582f73cdd27d905121dc2c531f3d9a3c32a3011033b965"},
-    {file = "psycopg2_binary-2.9.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4413d0caef93c5cf50b96863df4c2efe8c269bf2267df353225595e7e15e8df7"},
-    {file = "psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4dfcf8e45ebb0c663be34a3442f65e17311f3367089cd4e5e3a3e8e62c978777"},
-    {file = "psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c41321a14dd74aceb6a9a643b9253a334521babfa763fa873e33d89cfa122fb5"},
-    {file = "psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83946ba43979ebfdc99a3cd0ee775c89f221df026984ba19d46133d8d75d3cd9"},
-    {file = "psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:411e85815652d13560fbe731878daa5d92378c4995a22302071890ec3397d019"},
-    {file = "psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c8ad4c08e00f7679559eaed7aff1edfffc60c086b976f93972f686384a95e2c"},
-    {file = "psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:00814e40fa23c2b37ef0a1e3c749d89982c73a9cb5046137f0752a22d432e82f"},
-    {file = "psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:98062447aebc20ed20add1f547a364fd0ef8933640d5372ff1873f8deb9b61be"},
-    {file = "psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:66a7685d7e548f10fb4ce32fb01a7b7f4aa702134de92a292c7bd9e0d3dbd290"},
-    {file = "psycopg2_binary-2.9.12-cp313-cp313-win_amd64.whl", hash = "sha256:b6937f5fe4e180aeee87de907a2fa982ded6f7f15d7218f78a083e4e1d68f2a0"},
-    {file = "psycopg2_binary-2.9.12-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f3b3de8a74ef8db215f22edffb19e32dc6fa41340456de7ec99efdc8a7b3ec2"},
-    {file = "psycopg2_binary-2.9.12-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1006fb62f0f0bc5ce256a832356c6262e91be43f5e4eb15b5eaf38079464caf2"},
-    {file = "psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:840066105706cd2eb29b9a1c2329620056582a4bf3e8169dec5c447042d0869f"},
-    {file = "psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:863f5d12241ebe1c76a72a04c2113b6dc905f90b9cef0e9be0efd994affd9354"},
-    {file = "psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a99eaab34a9010f1a086b126de467466620a750634d114d20455f3a824aae033"},
-    {file = "psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ffdd7dc5463ccd61845ac37b7012d0f35a1548df9febe14f8dd549be4a0bc81e"},
-    {file = "psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:54a0dfecab1b48731f934e06139dfe11e24219fb6d0ceb32177cf0375f14c7b5"},
-    {file = "psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:96937c9c5d891f772430f418a7a8b4691a90c3e6b93cf72b5bd7cad8cbca32a5"},
-    {file = "psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:77b348775efd4cdab410ec6609d81ccecd1139c90265fa583a7255c8064bc03d"},
-    {file = "psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:527e6342b3e44c2f0544f6b8e927d60de7f163f5723b8f1dfa7d2a84298738cd"},
-    {file = "psycopg2_binary-2.9.12-cp314-cp314-win_amd64.whl", hash = "sha256:f12ae41fcafadb39b2785e64a40f9db05d6de2ac114077457e0e7c597f3af980"},
-    {file = "psycopg2_binary-2.9.12-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ee2d84ef5eb6c04702d2e9c372ad557fb027f26a5d82804f749dfb14c7fdd2ab"},
-    {file = "psycopg2_binary-2.9.12-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:cfa2517c94ea3af6deb46f81e1bbd884faa63e28481eb2f889989dd8d95e5f03"},
-    {file = "psycopg2_binary-2.9.12-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:ba3df2fc42a1cfa45b72cf096d4acb2b885937eedc61461081d53538d4a82a86"},
-    {file = "psycopg2_binary-2.9.12-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:718e1fc18edf573b02cb8aea868de8d8d33f99ce9620206aa9144b67b0985e94"},
-    {file = "psycopg2_binary-2.9.12-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5c7cb4cbf894a1d36c720d713de507952c7c58f66d30834708f03dbe5c822ccf"},
-    {file = "psycopg2_binary-2.9.12-cp39-cp39-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:049366c6d884bdcd65d66e6ca1fdbebe670b56c6c9ba46f164e6667e90881964"},
-    {file = "psycopg2_binary-2.9.12-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fb1828cf3da68f99e45ebce1355d65d2d12b6a78fb5dfb16247aad6bdef5f5d2"},
-    {file = "psycopg2_binary-2.9.12-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:127467c6e476dd876634f17c3d870530e73ff454ff99bff73d36e80af28e1115"},
-    {file = "psycopg2_binary-2.9.12-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:ace94261f43850e9e79f6c56636c5e0147978ab79eda5e5e5ebf13ae146fc8fe"},
-    {file = "psycopg2_binary-2.9.12-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a7e39a65b7d2a20e4ba2e0aaad1960b61cc2888d6ab047769f8347bd3c9ad915"},
-    {file = "psycopg2_binary-2.9.12-cp39-cp39-win_amd64.whl", hash = "sha256:f625abb7020e4af3432d95342daa1aa0db3fa369eed19807aa596367ba791b10"},
-    {file = "psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c"},
+    {file = "psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a"},
+    {file = "psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc"},
 ]
+
+[package.dependencies]
+psycopg-binary = {version = "3.3.4", optional = true, markers = "implementation_name != \"pypy\" and extra == \"binary\""}
+psycopg-pool = {version = "*", optional = true, markers = "extra == \"pool\""}
+typing-extensions = {version = ">=4.6", markers = "python_version < \"3.13\""}
+tzdata = {version = "*", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+binary = ["psycopg-binary (==3.3.4) ; implementation_name != \"pypy\""]
+c = ["psycopg-c (==3.3.4) ; implementation_name != \"pypy\""]
+dev = ["ast-comments (>=1.1.2)", "black (>=26.1.0)", "codespell (>=2.2)", "cython-lint (>=0.16)", "dnspython (>=2.1)", "flake8 (>=4.0)", "isort-psycopg", "isort[colors] (>=6.0)", "mypy (>=1.19.0)", "pre-commit (>=4.0.1)", "types-setuptools (>=57.4)", "types-shapely (>=2.0)", "wheel (>=0.37)"]
+docs = ["Sphinx (>=9.1)", "furo (==2025.12.19)", "sphinx-autobuild (>=2025.8.25)", "sphinx-autodoc-typehints (>=3.10.2)"]
+pool = ["psycopg-pool"]
+test = ["anyio (>=4.0)", "mypy (>=1.19.0) ; implementation_name != \"pypy\"", "pproxy (>=2.7)", "pytest (>=6.2.5)", "pytest-cov (>=3.0)", "pytest-randomly (>=3.5)"]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+description = "PostgreSQL database adapter for Python -- C optimisation distribution"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "implementation_name != \"pypy\" and extra == \"postgresql\""
+files = [
+    {file = "psycopg_binary-3.3.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b7bfff1ca23732b488cbca3076fc11bc98d520ee122514fdb17a8e20d3338f5a"},
+    {file = "psycopg_binary-3.3.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:32a6fbf8481e3a370d0d72b860d35948a693cb01281da217f7b2f307636e591a"},
+    {file = "psycopg_binary-3.3.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bdef84570ebbce1d42b4e7ea952d21c414c5f118ad02fee00c5625f35e134429"},
+    {file = "psycopg_binary-3.3.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbc10768a796c96d3243656016bf4e337c81c71097270bb7b0ad6210d9765"},
+    {file = "psycopg_binary-3.3.4-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf7f73a4a792bc5db58a4b385d8a1467e8d468f7548702fb0ed1e9b7501b1c13"},
+    {file = "psycopg_binary-3.3.4-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d7b4d40c153fa352ab3cca530f3a0baedf7621b2ebcbd7f084009522c21788fc"},
+    {file = "psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f9b1c2533af01cd7648378599f82b0b8ae32f293296e6eec5753a625bc97ef28"},
+    {file = "psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ad3bc94054876155549fdaedf4a46d1ec69d39a5bcee377148afe498e84c4b8e"},
+    {file = "psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:eb4eed2079c01a4850bf467deacfab56d356d4225040170af03dc9958321242d"},
+    {file = "psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f80e3f2b5331dbbf0901bcb658056c03eeb2c1ef31d774afb0d61598b242e744"},
+    {file = "psycopg_binary-3.3.4-cp310-cp310-win_amd64.whl", hash = "sha256:574ea21a9651958f1535c5a1c649c7409e9168bcbffa29a3f2f961f58b322949"},
+    {file = "psycopg_binary-3.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:612a627d733f695b1de1f9b4bd511c15f999a5d8b915d444bbd7dd71cf3370da"},
+    {file = "psycopg_binary-3.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:13a7f380824c35896dcac7fe0f61440f7ca49d6dc73f3c13a9a4471e6a3b302e"},
+    {file = "psycopg_binary-3.3.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:276904e3452d6a23d474ef9a21eee19f20eed3d53ddd2576af033827e0ba0992"},
+    {file = "psycopg_binary-3.3.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab8cca8ef8fb1ccf5b048ae5bd78ba55b9e4b5d472e3ce5ca39ff4d2a9c249e4"},
+    {file = "psycopg_binary-3.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7465bfe6087d2d5b42d4c53b9b11ca9f218e477317a4a162a10e3c19e984ba8e"},
+    {file = "psycopg_binary-3.3.4-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22cdbf5f91ef7bb91fe0c5757e1962d3127a8010256eefd9c61fcaf441802097"},
+    {file = "psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2631da29253a98bd496e6c4813b24e09a4fe3fb2a9e88513305d6f8747cce95"},
+    {file = "psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7f7668f30b9dd5163197e5cbf4e0efd54e00f0a859cc566ce56cfc31f4054839"},
+    {file = "psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:cffc3408d77a27973f33e5d909b624cce683db5fc25964b02fe0aae7886c1007"},
+    {file = "psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0579252a1202cd73e4da137a1426e2dae993ae44e757605344282af3a082848c"},
+    {file = "psycopg_binary-3.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:41f2ec0fea529832982bcb6c9415de3c86264ebe562b77a467c0fbcd7efbba8d"},
+    {file = "psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089"},
+    {file = "psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578"},
+    {file = "psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9"},
+    {file = "psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d"},
+    {file = "psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b"},
+    {file = "psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070"},
+    {file = "psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68"},
+    {file = "psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16"},
+    {file = "psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652"},
+    {file = "psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e"},
+    {file = "psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4"},
+    {file = "psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7"},
+    {file = "psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31"},
+    {file = "psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70"},
+    {file = "psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3"},
+    {file = "psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c"},
+    {file = "psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae"},
+    {file = "psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc"},
+    {file = "psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf"},
+    {file = "psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260"},
+    {file = "psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf"},
+    {file = "psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38"},
+    {file = "psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97"},
+    {file = "psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829"},
+    {file = "psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7"},
+    {file = "psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277"},
+    {file = "psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6"},
+    {file = "psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41"},
+    {file = "psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228"},
+    {file = "psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9"},
+    {file = "psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014"},
+    {file = "psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e"},
+    {file = "psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8"},
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+description = "Connection Pool for Psycopg"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"postgresql\""
+files = [
+    {file = "psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5"},
+    {file = "psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.6"
+
+[package.extras]
+test = ["anyio (>=4.0)", "mypy (>=1.14)", "pproxy (>=2.7)", "pytest (>=6.2.5)", "pytest-cov (>=3.0)", "pytest-randomly (>=3.5)"]
 
 [[package]]
 name = "ptyprocess"
@@ -5695,9 +5729,9 @@ dev = ["pytest", "setuptools"]
 [extras]
 ai = ["anthropic", "google-genai", "ollama", "openai"]
 observability = ["opentelemetry-api", "opentelemetry-exporter-otlp", "opentelemetry-exporter-prometheus", "opentelemetry-sdk", "prometheus-client"]
-postgresql = ["psycopg2-binary"]
+postgresql = ["psycopg"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "695f0492ed572e9adf24a7680639a3caf842790ab2080d0f3545ceee0c7212dc"
+content-hash = "3d3a3058c7e95c17f800924f4574157d689b71baff83cc624ecbabc657303c28"

--- a/poetry.lock
+++ b/poetry.lock
@@ -243,6 +243,28 @@ test-tox = ["celery", "click", "docutils (>=0.22.0)", "equinox ; sys_platform ==
 test-tox-coverage = ["coverage (>=5.5)"]
 
 [[package]]
+name = "burner-redis"
+version = "0.1.7"
+description = "An embedded, in-process Redis-compatible database"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "burner_redis-0.1.7-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f80c866996e0455d584eb3c0f3b067e411c632fb0519eab454e0968edf01e62c"},
+    {file = "burner_redis-0.1.7-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a3d9569a376b690fb5876d454e4904443332dc3ad5c0057e149fc2ad220bf599"},
+    {file = "burner_redis-0.1.7-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20eba1917e3bca9eea5957d5700ff8defcb5a209e57a7841d005549aa0151f44"},
+    {file = "burner_redis-0.1.7-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39111467059b8a28f15ea061d2414ec25c3e57c65759983f90f4d358e7d6a72d"},
+    {file = "burner_redis-0.1.7-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9b5adfe99aeb8407f468078f3769b2a63e9168fea12f7709df5d2a3b152706e4"},
+    {file = "burner_redis-0.1.7-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:591a9d20685f9d6d22bf0c863b50b12dfcf328b06111b3f62c33cd3185d48ce0"},
+    {file = "burner_redis-0.1.7-cp310-abi3-win_amd64.whl", hash = "sha256:f6cf4ac666766b32fd63940aad0c120847905fd3102c17e5b6b305f91a21d079"},
+    {file = "burner_redis-0.1.7-cp310-abi3-win_arm64.whl", hash = "sha256:458f88feeddfb40a586cc3fcbd8e9384bbdfd2a4512a695af4900e06052570d4"},
+    {file = "burner_redis-0.1.7.tar.gz", hash = "sha256:7474ff092669fd11ef765411572cdafcc3d89b8054aef4ca0617be6d6be4c680"},
+]
+
+[package.extras]
+dev = ["maturin", "pytest", "pytest-asyncio", "redis"]
+
+[[package]]
 name = "cachetools"
 version = "7.1.4"
 description = "Extensible memoizing collections and decorators"
@@ -532,6 +554,18 @@ files = [
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+description = "Pickler class to extend the standard pickle.Pickler functionality"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a"},
+    {file = "cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414"},
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -692,6 +726,17 @@ files = [
 
 [package.dependencies]
 python-dateutil = "*"
+
+[[package]]
+name = "cronsim"
+version = "2.7"
+description = "Cron expression parser and evaluator"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "cronsim-2.7-py3-none-any.whl", hash = "sha256:1e1431fa08c51dc7f72e67e571c7c7a09af26420169b607badd4ca9677ffad1e"},
+]
 
 [[package]]
 name = "cryptography"
@@ -1032,6 +1077,31 @@ numpy = ">=1.25"
 packaging = "*"
 
 [[package]]
+name = "fakeredis"
+version = "2.34.1"
+description = "Python implementation of redis API, can be used for testing purposes."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "fakeredis-2.34.1-py3-none-any.whl", hash = "sha256:0107ec99d48913e7eec2a5e3e2403d1bd5f8aa6489d1a634571b975289c48f12"},
+    {file = "fakeredis-2.34.1.tar.gz", hash = "sha256:4ff55606982972eecce3ab410e03d746c11fe5deda6381d913641fbd8865ea9b"},
+]
+
+[package.dependencies]
+lupa = {version = ">=2.1", optional = true, markers = "extra == \"lua\""}
+redis = {version = ">=4.3", markers = "python_version > \"3.8\""}
+sortedcontainers = ">=2"
+
+[package.extras]
+bf = ["pyprobables (>=0.6)"]
+cf = ["pyprobables (>=0.6)"]
+json = ["jsonpath-ng (>=1.6)"]
+lua = ["lupa (>=2.1)"]
+probabilistic = ["pyprobables (>=0.6)"]
+valkey = ["valkey (>=6) ; python_version >= \"3.8\""]
+
+[[package]]
 name = "fastapi"
 version = "0.136.3"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
@@ -1057,27 +1127,31 @@ standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[stand
 
 [[package]]
 name = "fastmcp"
-version = "2.13.3"
+version = "2.14.7"
 description = "The fast, Pythonic way to build MCP servers and clients."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "fastmcp-2.13.3-py3-none-any.whl", hash = "sha256:5173d335f4e6aabcfb5a5131af3fa092f604b303130fd3a49226b7a844a48e65"},
-    {file = "fastmcp-2.13.3.tar.gz", hash = "sha256:ebca59e99412c596dd75ebdd5147800f6abc2490d025af76fa8ea4fc5f68781d"},
+    {file = "fastmcp-2.14.7-py3-none-any.whl", hash = "sha256:e081a5222a6d302a148871d89fd714b13130cee6594f53a3e1afd7518f0096c0"},
+    {file = "fastmcp-2.14.7.tar.gz", hash = "sha256:0d2e83b9d1c5fe0af32036979de3bb99a38f05dc1476d60f1b3259168e139cd0"},
 ]
 
 [package.dependencies]
 authlib = ">=1.6.5"
 cyclopts = ">=4.0.0"
 exceptiongroup = ">=1.2.2"
+fakeredis = {version = "<2.35.0", extras = ["lua"]}
 httpx = ">=0.28.1"
+jsonref = ">=1.1.0"
 jsonschema-path = ">=0.3.4"
-mcp = ">=1.19.0,<1.21.1 || >1.21.1,<1.23"
+mcp = ">=1.24.0,<2.0"
 openapi-pydantic = ">=0.5.1"
+packaging = ">=20.0"
 platformdirs = ">=4.0.0"
-py-key-value-aio = {version = ">=0.2.8,<0.4.0", extras = ["disk", "memory"]}
+py-key-value-aio = {version = ">=0.3.0,<0.4.0", extras = ["disk", "keyring", "memory"]}
 pydantic = {version = ">=2.11.7", extras = ["email"]}
+pydocket = ">=0.17.2"
 pyperclip = ">=1.9.0"
 python-dotenv = ">=1.1.0"
 rich = ">=13.9.4"
@@ -1085,6 +1159,7 @@ uvicorn = ">=0.35"
 websockets = ">=15.0.1"
 
 [package.extras]
+anthropic = ["anthropic (>=0.40.0)"]
 openai = ["openai (>=1.102.0)"]
 
 [[package]]
@@ -1518,31 +1593,6 @@ files = [
 all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
-name = "importlib-metadata"
-version = "8.5.0"
-description = "Read metadata from Python packages"
-optional = true
-python-versions = ">=3.8"
-groups = ["main"]
-markers = "extra == \"observability\""
-files = [
-    {file = "importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b"},
-    {file = "importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"},
-]
-
-[package.dependencies]
-zipp = ">=3.20"
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-perf = ["ipython"]
-test = ["flufl.flake8", "importlib-resources (>=1.3) ; python_version < \"3.9\"", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
-type = ["pytest-mypy"]
-
-[[package]]
 name = "iniconfig"
 version = "2.3.0"
 description = "brain-dead simple config-ini parsing"
@@ -1652,6 +1702,68 @@ files = [
 colors = ["colorama"]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+description = "Utility functions for Python class constructs"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790"},
+    {file = "jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd"},
+]
+
+[package.dependencies]
+more-itertools = "*"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+description = "Useful decorators and context managers"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535"},
+    {file = "jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3"},
+]
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.14)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=3.4)"]
+test = ["jaraco.test (>=5.6.0)", "portend", "pytest (>=6,!=8.1.*)"]
+type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.5.0"
+description = "Functools like those found in stdlib"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "jaraco_functools-4.5.0-py3-none-any.whl", hash = "sha256:79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4"},
+    {file = "jaraco_functools-4.5.0.tar.gz", hash = "sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03"},
+]
+
+[package.dependencies]
+more_itertools = "*"
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.14)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=3.4)"]
+test = ["jaraco.classes", "pytest (>=6,!=8.1.*)"]
+type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
+
+[[package]]
 name = "jedi"
 version = "0.20.0"
 description = "An autocompletion tool for Python that can be used for text editors."
@@ -1669,6 +1781,23 @@ parso = ">=0.8.6,<0.9.0"
 [package.extras]
 dev = ["Django", "attrs", "colorama", "docopt", "flake8 (==7.1.2)", "pytest (<9.0.0)", "types-setuptools (==80.9.0.20250529)", "typing-extensions", "zuban (==0.7.0)"]
 docs = ["Jinja2 (==3.1.6)", "MarkupSafe (==3.0.3)", "Pygments (==2.20.0)", "Sphinx (==9.1.0)", "alabaster (==1.0.0)", "babel (==2.18.0)", "certifi (==2026.4.22)", "charset-normalizer (==3.4.7)", "docutils (==0.22.4)", "idna (==3.13)", "imagesize (==2.0.0)", "iniconfig (==2.3.0)", "packaging (==26.2)", "pluggy (==1.6.0)", "pytest (==9.0.3)", "requests (==2.33.1)", "roman-numerals (==4.1.0)", "snowballstemmer (==3.0.1)", "sphinx-rtd-theme (==3.1.0)", "sphinxcontrib-applehelp (==2.0.0)", "sphinxcontrib-devhelp (==2.0.0)", "sphinxcontrib-htmlhelp (==2.1.0)", "sphinxcontrib-jquery (==4.1)", "sphinxcontrib-jsmath (==1.0.1)", "sphinxcontrib-qthelp (==2.0.0)", "sphinxcontrib-serializinghtml (==2.0.0)", "urllib3 (==2.6.3)"]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+description = "Low-level, pure Python DBus protocol wrapper."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "sys_platform == \"linux\""
+files = [
+    {file = "jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683"},
+    {file = "jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732"},
+]
+
+[package.extras]
+test = ["async-timeout ; python_version < \"3.11\"", "pytest", "pytest-asyncio (>=0.17)", "pytest-trio", "testpath", "trio"]
+trio = ["trio"]
 
 [[package]]
 name = "jinja2"
@@ -1827,6 +1956,18 @@ cryptography = ">=45.0.1"
 drafts = ["pycryptodome"]
 
 [[package]]
+name = "jsonref"
+version = "1.1.0"
+description = "jsonref is a library for automatic dereferencing of JSON Reference objects for Python."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9"},
+    {file = "jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552"},
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 description = "An implementation of JSON Schema validation for Python"
@@ -1930,6 +2071,35 @@ docs = ["intersphinx-registry", "myst-parser", "pydata-sphinx-theme", "sphinx-au
 test = ["ipykernel", "pre-commit", "pytest (<9)", "pytest-cov", "pytest-timeout"]
 
 [[package]]
+name = "keyring"
+version = "25.7.0"
+description = "Store and access your passwords safely."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f"},
+    {file = "keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b"},
+]
+
+[package.dependencies]
+"jaraco.classes" = "*"
+"jaraco.context" = "*"
+"jaraco.functools" = "*"
+jeepney = {version = ">=0.4.2", markers = "sys_platform == \"linux\""}
+pywin32-ctypes = {version = ">=0.2.0", markers = "sys_platform == \"win32\""}
+SecretStorage = {version = ">=3.2", markers = "sys_platform == \"linux\""}
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+completion = ["shtab (>=1.1.0)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=3.4)"]
+test = ["pyfakefs", "pytest (>=6,!=8.1.*)"]
+type = ["pygobject-stubs", "pytest-mypy (>=1.0.1)", "shtab", "types-pywin32"]
+
+[[package]]
 name = "limits"
 version = "5.8.0"
 description = "Rate limiting utilities"
@@ -1977,6 +2147,83 @@ benchmark = ["pytest", "pytest-benchmark"]
 dev = ["black", "flake8", "isort", "pre-commit", "pyproject-flake8"]
 doc = ["myst-parser", "sphinx", "sphinx_book_theme"]
 test = ["coverage", "pytest", "pytest-cov"]
+
+[[package]]
+name = "lupa"
+version = "2.8"
+description = "Python wrapper around Lua and LuaJIT"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "lupa-2.8-cp310-abi3-win32.whl", hash = "sha256:c2a5fd15dc62374e1661a55f01744c9ec1c56f291ba4a0749d3af2174556e78f"},
+    {file = "lupa-2.8-cp310-abi3-win_arm64.whl", hash = "sha256:9e304fb1c50cf23fd8882afbe1aa87525ef8a72667bcab3b37b2bbb2bc542269"},
+    {file = "lupa-2.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:97bd01e90b8031e56a5fd5bb70605aea09f1dba675c1140308a52780f93d06f1"},
+    {file = "lupa-2.8-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b5ebe1a13c45767919c86750b84fe2da9f6288b6f3cea4ce7660bb2abc9d921"},
+    {file = "lupa-2.8-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:097e7d0f1719a88020b67c82e05d53d7973c166952393afcecfd8434c7e19a15"},
+    {file = "lupa-2.8-cp310-cp310-win_amd64.whl", hash = "sha256:7bb223ee8f72d0dc076b0d65296ee72f1c69450f9d2fed5315f7707d98c4a03d"},
+    {file = "lupa-2.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b12e43c1fb787189dfc28cd604aef0baa2cb95e27da19498d520361d0ace070a"},
+    {file = "lupa-2.8-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6f603391dffb256e36a79fd2044084d5f4b8a0a4c0e5ad291cd3ab3aaf1fd0a"},
+    {file = "lupa-2.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9f6f41c91366e7d0d474f87d81c1274af861f40812bf729c9f97ab4c8f3c7ac8"},
+    {file = "lupa-2.8-cp311-cp311-win_amd64.whl", hash = "sha256:f5a6af145b0ea818f01d27bfe2583a4b538570bef61d22c8773e0eccf011234c"},
+    {file = "lupa-2.8-cp312-abi3-macosx_10_13_x86_64.whl", hash = "sha256:f4342f4de76ae7ce2ab0672d36003bdb7e1a33252f293b569298ddd792e70e33"},
+    {file = "lupa-2.8-cp312-abi3-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:4203fa1659315e939a5304e75001b8cc14234fb3cbb3ed86c049b0cc5d90fcee"},
+    {file = "lupa-2.8-cp312-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:81f2d843ce668b653146c007467570210ae44be51dac6926666c51d49536f307"},
+    {file = "lupa-2.8-cp312-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d3d0cde2c77588d1c60875a4f34f059513476c6e1775351897195b51e0f3df08"},
+    {file = "lupa-2.8-cp312-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9e0d11b8f3a8dac6413f704fef7161d048bb10c58bdac6cbffa5e60efa56e9a3"},
+    {file = "lupa-2.8-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:54cff414f21f8cd8c6be4aae52541f3b9cd39602b59e3a3db9b5c9f9f674ff18"},
+    {file = "lupa-2.8-cp312-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:24b4d8af5558e549b70daf1547f5c1c1d664ecea9fc790f83efe5d75e9a93797"},
+    {file = "lupa-2.8-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:ce86dff1ee7f7cf45f5622065ae991949dd7bb1703581cbc58a630137bb7ccf9"},
+    {file = "lupa-2.8-cp312-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:f4d01b2a08c70bbb883a9e082b6b36b89121ed5910b710f1ba11c73295ff4fba"},
+    {file = "lupa-2.8-cp312-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:7f210d5a8353e510ea1199c42cf3cbdd630553bf2bc8fb4c00fea06fdec7c798"},
+    {file = "lupa-2.8-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4f81a02806e7c7ad26d8c6fa222c8bef1b0c1b124347c879be880b41339d41e4"},
+    {file = "lupa-2.8-cp312-abi3-win32.whl", hash = "sha256:360056453a7a4eaa4ac5a204c31a5a014b1eb2ee5490603234d2ba831684f1f2"},
+    {file = "lupa-2.8-cp312-abi3-win_arm64.whl", hash = "sha256:1628371c6592a6d5650497a9e31fb2bb3a7e9883c1f301d1111265e484045af9"},
+    {file = "lupa-2.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:450650f91c48c2415b0d59ab3abfcfda3b6efb5b858205f4d4bda8ad141fa529"},
+    {file = "lupa-2.8-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:27044f3363047f946b3d3aab9157cbd172b3538ada9ec1baef43432bf7d03a78"},
+    {file = "lupa-2.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8cf4f064a0e5531afce2d7d750120c10c10f9529139af6ca6150d13151034398"},
+    {file = "lupa-2.8-cp312-cp312-win_amd64.whl", hash = "sha256:281bedc5deb92d31e649a3552edd662449365a635904fa4d5cb4509c7245e34e"},
+    {file = "lupa-2.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45fc9da0145ecb0083ef5ff9975116cc784bd0258bdc2bd131ba15483ce18398"},
+    {file = "lupa-2.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:58e18afed57955b41130e269c78f53d4123ab86e236b53816f4cbffa25cb5d30"},
+    {file = "lupa-2.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fc47f536ac13a79cef47d29a2b205576a22841f042a2bcec1676b95806e7706a"},
+    {file = "lupa-2.8-cp313-cp313-win_amd64.whl", hash = "sha256:ce9404c661dbac65cc9bed351ad45e797af93d30d70be309a3fa8209ac86d93b"},
+    {file = "lupa-2.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:348c3f8ecabb6324dcbc05c2740d762ef8fcec7b06c79e45262ab97a217684e3"},
+    {file = "lupa-2.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:951496471056061598a7d1729a6cdf48d662fec777a9f2d8aa5a1e62fd30e5a5"},
+    {file = "lupa-2.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a591b9947ca347b41a63370e121d6e2b1458fe6dde9ae065029ec10a37f25ff4"},
+    {file = "lupa-2.8-cp314-cp314-win_amd64.whl", hash = "sha256:3903c9cf628dae2f56405503247b77a61a3a61bd2dda470e336950c74776d55d"},
+    {file = "lupa-2.8-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f711a8ab0486b9ac6fdda94a22ddcfbc9f0d4a27e3a8cf1bf79c6e48b33017c1"},
+    {file = "lupa-2.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc51250e76367a3e27fcd01dc769b9bfcbbc34f48df48dde53d6af6e75b7eaa5"},
+    {file = "lupa-2.8-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8a22088a552828958603323f0a5c4b3e11e03b75d0bf4c965ef879de9b60a8d"},
+    {file = "lupa-2.8-cp314-cp314t-win32.whl", hash = "sha256:4f7c553c1d8cfffbe85d81daef730d12cae4b6002d457542914da0ac8a1145b3"},
+    {file = "lupa-2.8-cp314-cp314t-win_amd64.whl", hash = "sha256:d8766aff03a78c80ad2d188a8bdb216de5ec838359cd87e05bbdfa56394a6105"},
+    {file = "lupa-2.8-cp314-cp314t-win_arm64.whl", hash = "sha256:91d622777febda3ab1bed1d45295f2f32a4680c7b3d7caf8c669998ed5c44118"},
+    {file = "lupa-2.8-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:81b283bfb13cc43fa4910fc98ec110ab861bcb39680f48b266f99d6e3be1049e"},
+    {file = "lupa-2.8-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5caf45d15d424cee52fd67341e96e2b1dde0658ae90eb156ac56aa0d8330bc38"},
+    {file = "lupa-2.8-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:33e7e5aebca64b154b0a1679caf79e19254ff37bba51e87abab6848f97cb2de1"},
+    {file = "lupa-2.8-cp38-cp38-win32.whl", hash = "sha256:e8d4f4dd4acf4a0e42adc6b1ad220e1c86fe3028402c2f78bd0728a6d241bbe9"},
+    {file = "lupa-2.8-cp38-cp38-win_amd64.whl", hash = "sha256:1ac2b1ec7504e6148cba1bc35ac36c74d18a0ca6d367ffe7e78a3773c2694c0e"},
+    {file = "lupa-2.8-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b036738282a5acd2e71fdddb317c9df8b87c1673aa57f403d05fcc2be8abc4ba"},
+    {file = "lupa-2.8-cp39-abi3-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:ac6b6e8d0e617e26a98cbb44880bcd75de5d32b3ad7b3b3793583909292b47ed"},
+    {file = "lupa-2.8-cp39-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ba3a7dd839f90c3d2e53bebe3c192b1f3f9fd720a6781256405123211fd0dce6"},
+    {file = "lupa-2.8-cp39-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d7edb13a7a5250b5c6c22d1495d9e842b5c9fc5081c8fe6b5efe2112fe3e41f9"},
+    {file = "lupa-2.8-cp39-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:891f72e0bffbed1e4175f975aeb2a083956586a100066525e1be485f617f7b25"},
+    {file = "lupa-2.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a295f87b5b7ebbfd5191932e8cb0e51df3c7769101ac6b6c7d7c9fb27bfd1307"},
+    {file = "lupa-2.8-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4fe5d7a810b64ea8511eb885fc8cdde042ee5ff7b7d08ae78f32449756acb177"},
+    {file = "lupa-2.8-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:bfc470012ef66ad064c7bd77416af03a3452ef630b04b9012595ea13f2e54518"},
+    {file = "lupa-2.8-cp39-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:250e035fdaffe8c87093e3ebc206ac29a26131b1568ea711d780c26001ce96e7"},
+    {file = "lupa-2.8-cp39-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:b9bddb09acfffb4f828f790f444b11dc0cca591afea1a244d9329eea2d20c003"},
+    {file = "lupa-2.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2e64acbbd47e9b82a64405a39e0d2b36a5a7dad8ab41c0f3437f572f7d282ba3"},
+    {file = "lupa-2.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f6ddca4774d5ca451768a95e378a3aa041076e29f4613b8562f8e98efb6690fd"},
+    {file = "lupa-2.8-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ffcfd8e19f943ad459136b3f60f085ae4948f024192a93ca4b4ac3023ec88d8"},
+    {file = "lupa-2.8-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9f3f3955f65f9fde2dc6eda3041ccd394cf54d4bf083f0cdf6feb3d58e5f38d3"},
+    {file = "lupa-2.8-cp39-cp39-win32.whl", hash = "sha256:9e76e45057cfcaa20ee3422c2289a91f9d51783d020da3570ee226de8f6e71cd"},
+    {file = "lupa-2.8-cp39-cp39-win_amd64.whl", hash = "sha256:6fbcc9911f05c67affbd225fc024268e61e98a18ad1b1c2aed6c8796e4056554"},
+    {file = "lupa-2.8-cp39-cp39-win_arm64.whl", hash = "sha256:6c817d5421094507662e5f8feb8cd1e154c10879921c06079b6063be9d8f33c5"},
+    {file = "lupa-2.8-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32e4e5103bbddcdd2458fb2ccae6c8ba11c9997c711d7e379e0d45551d109c76"},
+    {file = "lupa-2.8-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7667001804657496dee9feced2daae5000b4604a3218dd8e6b7b754982ba88b8"},
+    {file = "lupa-2.8-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:86f6f668966965b15247dc32d064cfe7be67b71e584ccfacbe2f637575296878"},
+    {file = "lupa-2.8.tar.gz", hash = "sha256:d8022641b9ec8ecf2c5ecbe9f47e5a70e0b87c4b5ae921b92cb02a638e0acd08"},
+]
 
 [[package]]
 name = "mako"
@@ -2188,28 +2435,37 @@ files = [
 
 [[package]]
 name = "mcp"
-version = "1.22.0"
+version = "1.28.1"
 description = "Model Context Protocol SDK"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "mcp-1.22.0-py3-none-any.whl", hash = "sha256:bed758e24df1ed6846989c909ba4e3df339a27b4f30f1b8b627862a4bade4e98"},
-    {file = "mcp-1.22.0.tar.gz", hash = "sha256:769b9ac90ed42134375b19e777a2858ca300f95f2e800982b3e2be62dfc0ba01"},
+    {file = "mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df"},
+    {file = "mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683"},
 ]
 
 [package.dependencies]
 anyio = ">=4.5"
-httpx = ">=0.27.1"
+httpx = ">=0.27.1,<1.0.0"
 httpx-sse = ">=0.4"
 jsonschema = ">=4.20.0"
-pydantic = ">=2.11.0,<3.0.0"
+pydantic = [
+    {version = ">=2.11.0,<3.0.0", markers = "python_version < \"3.14\""},
+    {version = ">=2.12.0,<3.0.0", markers = "python_version >= \"3.14\""},
+]
 pydantic-settings = ">=2.5.2"
 pyjwt = {version = ">=2.10.1", extras = ["crypto"]}
 python-multipart = ">=0.0.9"
-pywin32 = {version = ">=310", markers = "sys_platform == \"win32\""}
+pywin32 = [
+    {version = ">=310", markers = "sys_platform == \"win32\" and python_version < \"3.14\""},
+    {version = ">=311", markers = "sys_platform == \"win32\" and python_version >= \"3.14\""},
+]
 sse-starlette = ">=1.6.1"
-starlette = ">=0.27"
+starlette = [
+    {version = ">=0.27", markers = "python_version < \"3.14\""},
+    {version = ">=0.48.0", markers = "python_version >= \"3.14\""},
+]
 typing-extensions = ">=4.9.0"
 typing-inspection = ">=0.4.1"
 uvicorn = {version = ">=0.31.1", markers = "sys_platform != \"emscripten\""}
@@ -2414,6 +2670,18 @@ mkdocs-autorefs = ">=1.4"
 mkdocstrings = ">=0.30"
 
 [[package]]
+name = "more-itertools"
+version = "11.1.0"
+description = "More routines for operating on iterables, beyond itertools"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192"},
+    {file = "more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d"},
+]
+
+[[package]]
 name = "nest-asyncio2"
 version = "1.7.2"
 description = "Patch asyncio to allow nested event loops"
@@ -2582,166 +2850,177 @@ pydantic = ">=1.8"
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.28.2"
+version = "1.43.0"
 description = "OpenTelemetry Python API"
-optional = true
-python-versions = ">=3.8"
+optional = false
+python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"observability\""
 files = [
-    {file = "opentelemetry_api-1.28.2-py3-none-any.whl", hash = "sha256:6fcec89e265beb258fe6b1acaaa3c8c705a934bd977b9f534a2b7c0d2d4275a6"},
-    {file = "opentelemetry_api-1.28.2.tar.gz", hash = "sha256:ecdc70c7139f17f9b0cf3742d57d7020e3e8315d6cffcdf1a12a905d45b19cc0"},
+    {file = "opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd"},
+    {file = "opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1"},
 ]
 
 [package.dependencies]
-deprecated = ">=1.2.6"
-importlib-metadata = ">=6.0,<=8.5.0"
+typing-extensions = ">=4.5.0"
 
 [[package]]
 name = "opentelemetry-exporter-otlp"
-version = "1.28.2"
+version = "1.43.0"
 description = "OpenTelemetry Collector Exporters"
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"observability\""
 files = [
-    {file = "opentelemetry_exporter_otlp-1.28.2-py3-none-any.whl", hash = "sha256:b50f6d4a80e6bcd329e36f360ac486ecfa106ea704d6226ceea05d3a48455f70"},
-    {file = "opentelemetry_exporter_otlp-1.28.2.tar.gz", hash = "sha256:45f8d7fe4cdd41526464b542ce91b1fd1ae661be92d2c6cba71a3d948b2bdf70"},
+    {file = "opentelemetry_exporter_otlp-1.43.0-py3-none-any.whl", hash = "sha256:70f3fe740a64596d4157588a2ee7e4fd37d2acc0c0f522a2882b8c29316cd0f0"},
+    {file = "opentelemetry_exporter_otlp-1.43.0.tar.gz", hash = "sha256:65aded6c50ee7dd2b9948c9d0e59ddb4ed4eea6e8532fba95cbe6a4a64a566ba"},
 ]
 
 [package.dependencies]
-opentelemetry-exporter-otlp-proto-grpc = "1.28.2"
-opentelemetry-exporter-otlp-proto-http = "1.28.2"
+opentelemetry-exporter-otlp-proto-grpc = "1.43.0"
+opentelemetry-exporter-otlp-proto-http = "1.43.0"
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.28.2"
+version = "1.43.0"
 description = "OpenTelemetry Protobuf encoding"
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"observability\""
 files = [
-    {file = "opentelemetry_exporter_otlp_proto_common-1.28.2-py3-none-any.whl", hash = "sha256:545b1943b574f666c35b3d6cc67cb0b111060727e93a1e2866e346b33bff2a12"},
-    {file = "opentelemetry_exporter_otlp_proto_common-1.28.2.tar.gz", hash = "sha256:7aebaa5fc9ff6029374546df1f3a62616fda07fccd9c6a8b7892ec130dd8baca"},
+    {file = "opentelemetry_exporter_otlp_proto_common-1.43.0-py3-none-any.whl", hash = "sha256:123c3f9cc87218562490c63b36f497bf3a722faf174a515d1443f31ababa6264"},
+    {file = "opentelemetry_exporter_otlp_proto_common-1.43.0.tar.gz", hash = "sha256:c4e32ba6d6b13bdb2b8f6764c4fd28d00192826561aa04f6d14eedfce7ac076f"},
 ]
 
 [package.dependencies]
-opentelemetry-proto = "1.28.2"
+opentelemetry-proto = "1.43.0"
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.28.2"
+version = "1.43.0"
 description = "OpenTelemetry Collector Protobuf over gRPC Exporter"
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"observability\""
 files = [
-    {file = "opentelemetry_exporter_otlp_proto_grpc-1.28.2-py3-none-any.whl", hash = "sha256:6083d9300863aab35bfce7c172d5fc1007686e6f8dff366eae460cd9a21592e2"},
-    {file = "opentelemetry_exporter_otlp_proto_grpc-1.28.2.tar.gz", hash = "sha256:07c10378380bbb01a7f621a5ce833fc1fab816e971140cd3ea1cd587840bc0e6"},
+    {file = "opentelemetry_exporter_otlp_proto_grpc-1.43.0-py3-none-any.whl", hash = "sha256:6a10d1feacffffda19acacbf277b736094b1e2f4dbb98c90ccb2c6e1962e2ec6"},
+    {file = "opentelemetry_exporter_otlp_proto_grpc-1.43.0.tar.gz", hash = "sha256:1b3e0627daa9bc21884d4a13946807c255eb558bfe5bdd543dffb6f4c9faee0d"},
 ]
 
 [package.dependencies]
-deprecated = ">=1.2.6"
-googleapis-common-protos = ">=1.52,<2.0"
-grpcio = ">=1.63.2,<2.0.0"
+googleapis-common-protos = ">=1.57,<2.0"
+grpcio = [
+    {version = ">=1.63.2,<2.0.0", markers = "python_version < \"3.13\""},
+    {version = ">=1.66.2,<2.0.0", markers = "python_version == \"3.13\""},
+    {version = ">=1.75.1,<2.0.0", markers = "python_version >= \"3.14\""},
+]
 opentelemetry-api = ">=1.15,<2.0"
-opentelemetry-exporter-otlp-proto-common = "1.28.2"
-opentelemetry-proto = "1.28.2"
-opentelemetry-sdk = ">=1.28.2,<1.29.0"
+opentelemetry-exporter-otlp-proto-common = "1.43.0"
+opentelemetry-proto = "1.43.0"
+opentelemetry-sdk = ">=1.43.0,<1.44.0"
+typing-extensions = ">=4.6.0"
+
+[package.extras]
+gcp-auth = ["opentelemetry-exporter-credential-provider-gcp (>=0.59b0)"]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.28.2"
+version = "1.43.0"
 description = "OpenTelemetry Collector Protobuf over HTTP Exporter"
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"observability\""
 files = [
-    {file = "opentelemetry_exporter_otlp_proto_http-1.28.2-py3-none-any.whl", hash = "sha256:af921c18212a56ef4be68458ba475791c0517ebfd8a2ff04669c9cd477d90ff2"},
-    {file = "opentelemetry_exporter_otlp_proto_http-1.28.2.tar.gz", hash = "sha256:d9b353d67217f091aaf4cfe8693c170973bb3e90a558992570d97020618fda79"},
+    {file = "opentelemetry_exporter_otlp_proto_http-1.43.0-py3-none-any.whl", hash = "sha256:647f603aa8efdbdb4dbff842e0729d0406a6fff26b295a72d3d60e7d963b2610"},
+    {file = "opentelemetry_exporter_otlp_proto_http-1.43.0.tar.gz", hash = "sha256:fa8a42bb7d00ee5391f4c0b04d8e6a46c03caa437903296ab73a81dc11ba118f"},
 ]
 
 [package.dependencies]
-deprecated = ">=1.2.6"
 googleapis-common-protos = ">=1.52,<2.0"
 opentelemetry-api = ">=1.15,<2.0"
-opentelemetry-exporter-otlp-proto-common = "1.28.2"
-opentelemetry-proto = "1.28.2"
-opentelemetry-sdk = ">=1.28.2,<1.29.0"
+opentelemetry-exporter-otlp-proto-common = "1.43.0"
+opentelemetry-proto = "1.43.0"
+opentelemetry-sdk = ">=1.43.0,<1.44.0"
 requests = ">=2.7,<3.0"
+typing-extensions = ">=4.5.0"
+
+[package.extras]
+gcp-auth = ["opentelemetry-exporter-credential-provider-gcp (>=0.59b0)"]
 
 [[package]]
 name = "opentelemetry-exporter-prometheus"
-version = "0.49b2"
+version = "0.64b0"
 description = "Prometheus Metric Exporter for OpenTelemetry"
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"observability\""
 files = [
-    {file = "opentelemetry_exporter_prometheus-0.49b2-py3-none-any.whl", hash = "sha256:307594007ee20ec3a51c42548a4dbd66e46701f8523a7780d5e12a8f986a7783"},
-    {file = "opentelemetry_exporter_prometheus-0.49b2.tar.gz", hash = "sha256:70ca3a462ce1ba0d756e4be8a87c04f7196687825fd2d151a428f6c18ef6fd2d"},
+    {file = "opentelemetry_exporter_prometheus-0.64b0-py3-none-any.whl", hash = "sha256:9979a15f8d007d442bc7a6e16f4cbde5e8e0c5e99689887ceb5f33da251f0655"},
+    {file = "opentelemetry_exporter_prometheus-0.64b0.tar.gz", hash = "sha256:96fec79be9527cb9dc994d7e663051df35161eb936fe2d41954725e4595abbc1"},
 ]
 
 [package.dependencies]
 opentelemetry-api = ">=1.12,<2.0"
-opentelemetry-sdk = ">=1.28.2,<1.29.0"
+opentelemetry-sdk = ">=1.43.0,<1.44.0"
 prometheus-client = ">=0.5.0,<1.0.0"
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.28.2"
+version = "1.43.0"
 description = "OpenTelemetry Python Proto"
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"observability\""
 files = [
-    {file = "opentelemetry_proto-1.28.2-py3-none-any.whl", hash = "sha256:0837498f59db55086462915e5898d0b1a18c1392f6db4d7e937143072a72370c"},
-    {file = "opentelemetry_proto-1.28.2.tar.gz", hash = "sha256:7c0d125a6b71af88bfeeda16bfdd0ff63dc2cf0039baf6f49fa133b203e3f566"},
+    {file = "opentelemetry_proto-1.43.0-py3-none-any.whl", hash = "sha256:c58f1f7ef84bc7dc2834016c0c37fe0081dde7ca9f6339be1970fbf9cdaaa90d"},
+    {file = "opentelemetry_proto-1.43.0.tar.gz", hash = "sha256:224778df17e1f3fafeaaa21d874236ca5f6ffc2f86e0899298ec7351aac27924"},
 ]
 
 [package.dependencies]
-protobuf = ">=5.0,<6.0"
+protobuf = ">=5.0,<8.0"
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.28.2"
+version = "1.43.0"
 description = "OpenTelemetry Python SDK"
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"observability\""
 files = [
-    {file = "opentelemetry_sdk-1.28.2-py3-none-any.whl", hash = "sha256:93336c129556f1e3ccd21442b94d3521759541521861b2214c499571b85cb71b"},
-    {file = "opentelemetry_sdk-1.28.2.tar.gz", hash = "sha256:5fed24c5497e10df30282456fe2910f83377797511de07d14cec0d3e0a1a3110"},
+    {file = "opentelemetry_sdk-1.43.0-py3-none-any.whl", hash = "sha256:d1323a547c1ce69d6a069a17a44b7da82bb8b332051ecb074041f87642c86823"},
+    {file = "opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9"},
 ]
 
 [package.dependencies]
-opentelemetry-api = "1.28.2"
-opentelemetry-semantic-conventions = "0.49b2"
-typing-extensions = ">=3.7.4"
+opentelemetry-api = "1.43.0"
+opentelemetry-semantic-conventions = "0.64b0"
+typing-extensions = ">=4.5.0"
+
+[package.extras]
+file-configuration = ["jsonschema (>=4.0)", "pyyaml (>=6.0)"]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.49b2"
+version = "0.64b0"
 description = "OpenTelemetry Semantic Conventions"
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"observability\""
 files = [
-    {file = "opentelemetry_semantic_conventions-0.49b2-py3-none-any.whl", hash = "sha256:51e7e1d0daa958782b6c2a8ed05e5f0e7dd0716fc327ac058777b8659649ee54"},
-    {file = "opentelemetry_semantic_conventions-0.49b2.tar.gz", hash = "sha256:44e32ce6a5bb8d7c0c617f84b9dc1c8deda1045a07dc16a688cc7cbeab679997"},
+    {file = "opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6"},
+    {file = "opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c"},
 ]
 
 [package.dependencies]
-deprecated = ">=1.2.6"
-opentelemetry-api = "1.28.2"
+opentelemetry-api = "1.43.0"
+typing-extensions = ">=4.5.0"
 
 [[package]]
 name = "packaging"
@@ -3038,10 +3317,9 @@ virtualenv = ">=20.10.0"
 name = "prometheus-client"
 version = "0.25.0"
 description = "Python client for the Prometheus monitoring system."
-optional = true
+optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"observability\""
 files = [
     {file = "prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1"},
     {file = "prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28"},
@@ -3283,8 +3561,10 @@ files = [
 beartype = ">=0.20.0"
 cachetools = {version = ">=5.0.0", optional = true, markers = "extra == \"memory\""}
 diskcache = {version = ">=5.0.0", optional = true, markers = "extra == \"disk\""}
+keyring = {version = ">=25.6.0", optional = true, markers = "extra == \"keyring\""}
 pathvalidate = {version = ">=3.3.1", optional = true, markers = "extra == \"disk\""}
 py-key-value-shared = "0.3.0"
+redis = {version = ">=4.3.0", optional = true, markers = "extra == \"redis\""}
 
 [package.extras]
 disk = ["diskcache (>=5.0.0)", "pathvalidate (>=3.3.1)"]
@@ -3372,7 +3652,7 @@ files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
 ]
-markers = {main = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\"", dev = "(platform_python_implementation != \"PyPy\" or implementation_name == \"pypy\") and implementation_name != \"PyPy\""}
+markers = {main = "implementation_name != \"PyPy\" and platform_python_implementation != \"PyPy\"", dev = "(platform_python_implementation != \"PyPy\" or implementation_name == \"pypy\") and implementation_name != \"PyPy\""}
 
 [[package]]
 name = "pycryptodome"
@@ -3583,14 +3863,14 @@ typing-extensions = ">=4.14.1"
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 description = "Settings management using Pydantic"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de"},
-    {file = "pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa"},
+    {file = "pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440"},
+    {file = "pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f"},
 ]
 
 [package.dependencies]
@@ -3604,6 +3884,36 @@ azure-key-vault = ["azure-identity (>=1.16.0)", "azure-keyvault-secrets (>=4.8.0
 gcp-secret-manager = ["google-cloud-secret-manager (>=2.23.1)"]
 toml = ["tomli (>=2.0.1)"]
 yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
+name = "pydocket"
+version = "0.22.0"
+description = "A distributed background task system for Python functions"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "pydocket-0.22.0-py3-none-any.whl", hash = "sha256:a8ee4d08be5eb40b99b945ba72583364b26a5c6b197520bb2379216b79f36a07"},
+    {file = "pydocket-0.22.0.tar.gz", hash = "sha256:de6a6011df94e3da30279ff0b9732a793feaf77f9e6b23a09f2ae12b134993d6"},
+]
+
+[package.dependencies]
+burner-redis = ">=0.1.7"
+cloudpickle = ">=3.1.1"
+cronsim = ">=2.6"
+opentelemetry-api = ">=1.33.0"
+prometheus-client = ">=0.21.1"
+py-key-value-aio = {version = ">=0.3.0", extras = ["memory", "redis"]}
+python-json-logger = ">=2.0.7"
+redis = ">=5"
+rich = ">=13.9.4"
+typer = ">=0.15.1"
+typing-extensions = ">=4.12.0"
+tzdata = {version = ">=2025.2", markers = "sys_platform == \"win32\""}
+uncalled-for = ">=0.3.2"
+
+[package.extras]
+metrics = ["opentelemetry-sdk (>=1.33.0)"]
 
 [[package]]
 name = "pydocstyle"
@@ -3925,6 +4235,21 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
+name = "python-json-logger"
+version = "4.1.0"
+description = "JSON Log Formatter for the Python Logging Package"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2"},
+    {file = "python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195"},
+]
+
+[package.extras]
+dev = ["black", "build", "freezegun", "mdx_truly_sane_lists", "mike", "mkdocs", "mkdocs-awesome-pages-plugin", "mkdocs-gen-files", "mkdocs-literate-nav", "mkdocs-material (>=8.5)", "mkdocstrings[python]", "msgspec ; implementation_name != \"pypy\"", "mypy", "orjson ; implementation_name != \"pypy\"", "pylint", "pytest", "tzdata", "validate-pyproject[all]"]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.32"
 description = "A streaming multipart parser for Python"
@@ -3966,6 +4291,19 @@ files = [
     {file = "pywin32-312-cp39-cp39-win32.whl", hash = "sha256:d620900033cc7531e50727c3c8333091df5dd3ffe6d68cdca38c03f5821408d5"},
     {file = "pywin32-312-cp39-cp39-win_amd64.whl", hash = "sha256:dc90147579a905b8635e1b0ec6514967dcb07e6e0d9c42f1477feef14cac23bb"},
     {file = "pywin32-312-cp39-cp39-win_arm64.whl", hash = "sha256:02ebca0f0242b75292e218065004310d6a477407c09fa449bfe4f6022bc0c0fc"},
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+description = "A (partial) reimplementation of pywin32 using ctypes/cffi"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+markers = "sys_platform == \"win32\""
+files = [
+    {file = "pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755"},
+    {file = "pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8"},
 ]
 
 [[package]]
@@ -4189,6 +4527,26 @@ mando = ">=0.6,<0.8"
 
 [package.extras]
 toml = ["tomli (>=2.0.1)"]
+
+[[package]]
+name = "redis"
+version = "8.0.1"
+description = "Python client for Redis database and key-value store"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "redis-8.0.1-py3-none-any.whl", hash = "sha256:47daa35a058c23468d6437f17a8c76882cb316b838ef763036af99b96cedd743"},
+    {file = "redis-8.0.1.tar.gz", hash = "sha256:afc5a7a2f5a084f5b1880dec548dd45be17db7e43c82a30d84f952aefb05cfb0"},
+]
+
+[package.extras]
+circuit-breaker = ["pybreaker (>=1.4.0)"]
+hiredis = ["hiredis (>=3.2.0)"]
+jwt = ["pyjwt (>=2.13.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (>=20.0.1)", "requests (>=2.31.0)"]
+otel = ["opentelemetry-api (>=1.39.1)", "opentelemetry-exporter-otlp-proto-http (>=1.39.1)", "opentelemetry-sdk (>=1.39.1)"]
+xxhash = ["xxhash (>=3.6.0,<3.7.0)"]
 
 [[package]]
 name = "referencing"
@@ -4455,6 +4813,23 @@ files = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.5.0"
+description = "Python bindings to FreeDesktop.org Secret Service API"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform == \"linux\""
+files = [
+    {file = "secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137"},
+    {file = "secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be"},
+]
+
+[package.dependencies]
+cryptography = ">=2.0"
+jeepney = ">=0.6"
+
+[[package]]
 name = "semver"
 version = "3.0.4"
 description = "Python helper for Semantic Versioning (https://semver.org)"
@@ -4480,6 +4855,18 @@ files = [
 
 [package.extras]
 yaml = ["pyyaml"]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+description = "Tool to Detect Surrounding Shell"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
+    {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
+]
 
 [[package]]
 name = "six"
@@ -4534,6 +4921,18 @@ groups = ["dev"]
 files = [
     {file = "snowballstemmer-3.1.1-py3-none-any.whl", hash = "sha256:7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752"},
     {file = "snowballstemmer-3.1.1.tar.gz", hash = "sha256:e07bbc54a0d798fe6010a12398422e62a8bfbba95c394fd0956ef58cb4d3e260"},
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
 
 [[package]]
@@ -4888,6 +5287,24 @@ docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 test = ["argcomplete (>=3.0.3)", "mypy (>=1.17.0,<1.19)", "pre-commit", "pytest (>=7.0,<8.2)", "pytest-mock", "pytest-mypy-testing"]
 
 [[package]]
+name = "typer"
+version = "0.26.8"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "typer-0.26.8-py3-none-any.whl", hash = "sha256:3512ca79ac5c11113414b36e80281b872884477722440691c89d1112e321a49c"},
+    {file = "typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e"},
+]
+
+[package.dependencies]
+annotated-doc = ">=0.0.2"
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+rich = ">=13.8.0"
+shellingham = ">=1.3.0"
+
+[[package]]
 name = "types-croniter"
 version = "6.2.2.20260518"
 description = "Typing stubs for croniter"
@@ -4956,12 +5373,12 @@ version = "2026.2"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
-groups = ["dev"]
-markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\""
+groups = ["main", "dev"]
 files = [
     {file = "tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7"},
     {file = "tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10"},
 ]
+markers = {main = "sys_platform == \"win32\"", dev = "sys_platform == \"win32\" or sys_platform == \"emscripten\""}
 
 [[package]]
 name = "uc-micro-py"
@@ -4977,6 +5394,18 @@ files = [
 
 [package.extras]
 test = ["coverage", "pytest", "pytest-cov"]
+
+[[package]]
+name = "uncalled-for"
+version = "0.3.2"
+description = "Async dependency injection for Python functions"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e"},
+    {file = "uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2"},
+]
 
 [[package]]
 name = "urllib3"
@@ -5263,27 +5692,6 @@ files = [
 [package.extras]
 dev = ["pytest", "setuptools"]
 
-[[package]]
-name = "zipp"
-version = "4.1.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = true
-python-versions = ">=3.10"
-groups = ["main"]
-markers = "extra == \"observability\""
-files = [
-    {file = "zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"},
-    {file = "zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602"},
-]
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.14)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=3.4)"]
-test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
-type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
-
 [extras]
 ai = ["anthropic", "google-genai", "ollama", "openai"]
 observability = ["opentelemetry-api", "opentelemetry-exporter-otlp", "opentelemetry-exporter-prometheus", "opentelemetry-sdk", "prometheus-client"]
@@ -5292,4 +5700,4 @@ postgresql = ["psycopg2-binary"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "2d6ab8015dd339b48413205172da496b412f2c0ebe0b780143b50311d9298895"
+content-hash = "695f0492ed572e9adf24a7680639a3caf842790ab2080d0f3545ceee0c7212dc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.50.5"
+version = "0.51.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.50.4"
+version = "0.50.5"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,10 @@ types-setuptools = ">=80.7.0.20250516,<83.0.0.0"
 # (OpenAPI provider SSRF, OAuth confused-deputy, Gemini CLI) are in features
 # Flux does not use; they resolve with the 3.x migration.
 fastmcp = ">=2.14.2,<3.0.0"
-psycopg2-binary = {version = "^2.9.0", optional = true}
+# psycopg v3: one driver for both sync SQLAlchemy engines and the async
+# LISTEN/NOTIFY listener the event-driven dispatcher needs (psycopg2 has no
+# async path). URLs stay `postgresql://`; the dialect is normalized in code.
+psycopg = {version = "^3.2", extras = ["binary", "pool"], optional = true}
 croniter = "^6.2.2"
 types-croniter = "^6.0.0.20250809"
 textual = "^8.2.7"
@@ -157,7 +160,7 @@ help = "Run E2E tests excluding Ollama/AI examples"
 cmd = "poetry run pytest tests/e2e/ -m 'not ollama' -v"
 
 [tool.poetry.extras]
-postgresql = ["psycopg2-binary"]
+postgresql = ["psycopg"]
 observability = [
     "opentelemetry-api",
     "opentelemetry-sdk",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,11 @@ gputil = "^1.4.0"
 types-setuptools = ">=80.7.0.20250516,<83.0.0.0"
 # fastmcp 3.x is a restructured meta-package (fastmcp-slim) whose import layout
 # breaks `from fastmcp import FastMCP`; migrating is feature work, not a bump.
-fastmcp = ">=2.5.1,<3.0.0"
+# Floor at 2.14.2: fixes GHSA-5h2m-4q8j-pqpj (OAuth token reuse) and pulls
+# mcp>=1.23 (GHSA-9h52-p55h-vw2f, DNS rebinding). The 3.2.0-only advisories
+# (OpenAPI provider SSRF, OAuth confused-deputy, Gemini CLI) are in features
+# Flux does not use; they resolve with the 3.x migration.
+fastmcp = ">=2.14.2,<3.0.0"
 psycopg2-binary = {version = "^2.9.0", optional = true}
 croniter = "^6.2.2"
 types-croniter = "^6.0.0.20250809"
@@ -38,7 +42,7 @@ textual = "^8.2.7"
 opentelemetry-api = {version = "^1.28", optional = true}
 opentelemetry-sdk = {version = "^1.28", optional = true}
 opentelemetry-exporter-otlp = {version = "^1.28", optional = true}
-opentelemetry-exporter-prometheus = {version = "^0.49b0", optional = true}
+opentelemetry-exporter-prometheus = {version = ">=0.54b0,<1.0", optional = true}
 prometheus-client = {version = ">=0.20", optional = true}
 ollama = {version = "^0.6.0", optional = true}
 openai = {version = "^2.6.0", optional = true}

--- a/scripts/stress_dispatch.py
+++ b/scripts/stress_dispatch.py
@@ -124,10 +124,16 @@ class Fleet:
                 self.dispatch_latencies.append(time.monotonic() - self.enqueue_time)
             ctx = ExecutionContext.from_json(cr.json())
             ctx.start(name).complete(name, "done")
+            # Echo the fencing token like a real worker, so the stress run
+            # exercises the claim-generation check on every checkpoint.
+            ck_headers = dict(headers)
+            generation = cr.headers.get("X-Flux-Claim-Generation")
+            if generation is not None:
+                ck_headers["X-Flux-Claim-Generation"] = generation
             ck = await client.post(
                 f"{SERVER}/workers/{name}/checkpoint/{eid}",
                 json=ctx.to_dict(),
-                headers=headers,
+                headers=ck_headers,
             )
             if ck.status_code == 200:
                 self.completed += 1

--- a/scripts/stress_dispatch.py
+++ b/scripts/stress_dispatch.py
@@ -1,0 +1,291 @@
+"""Dispatch-plane stress test: poll mode vs event mode on PostgreSQL.
+
+Spawns a real Flux server (subprocess) and N protocol-level simulated workers
+in-process (register -> SSE connect -> pong -> claim -> checkpoint COMPLETED).
+No workflow code executes on the workers; this isolates the dispatch plane.
+
+Measures, per mode:
+  1. Idle DB load: PostgreSQL transactions/sec with N connected, idle workers.
+  2. Dispatch throughput: time to drain M executions across the fleet.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import statistics
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+from httpx_sse import aconnect_sse
+
+PORT = int(os.environ.get("STRESS_PORT", "8022"))
+SERVER = f"http://localhost:{PORT}"
+BOOTSTRAP = "stress-bootstrap-token"
+# Admin DSN for creating scratch databases and reading pg_stat_database.
+PG_ADMIN = os.environ.get(
+    "STRESS_PG_ADMIN_URL",
+    "postgresql://flux_test_user:flux_test_password@localhost:5433/postgres",
+)
+PG_HOSTPORT = PG_ADMIN.rsplit("@", 1)[1].split("/", 1)[0]
+PG_CREDS = PG_ADMIN.split("//", 1)[1].rsplit("@", 1)[0]
+WORKERS = int(sys.argv[2]) if len(sys.argv) > 2 else 200
+EXECUTIONS = int(sys.argv[3]) if len(sys.argv) > 3 else 400
+IDLE_SECONDS = 20
+
+WORKFLOW_SRC = b"""
+from flux import ExecutionContext
+from flux.workflow import workflow
+
+
+@workflow
+async def stress_noop(ctx: ExecutionContext[str]):
+    return "done"
+"""
+
+
+def pg_xacts(dbname: str) -> int:
+    import psycopg
+
+    with psycopg.connect(PG_ADMIN, autocommit=True) as conn:
+        row = conn.execute(
+            "SELECT xact_commit + xact_rollback FROM pg_stat_database WHERE datname = %s",
+            (dbname,),
+        ).fetchone()
+        return row[0] if row else 0
+
+
+class Fleet:
+    def __init__(self, n: int):
+        self.n = n
+        self.connected = 0
+        self.completed = 0
+        self.dispatch_latencies: list[float] = []
+        self.enqueue_time: float | None = None
+        self.all_done = asyncio.Event()
+        self.stop = asyncio.Event()
+        self._clients: list[httpx.AsyncClient] = []
+
+    def client(self, i: int) -> httpx.AsyncClient:
+        # Spread workers over a few clients; unlimited pool per client.
+        idx = i % 8
+        while len(self._clients) <= idx:
+            self._clients.append(
+                httpx.AsyncClient(
+                    timeout=httpx.Timeout(30, read=None),
+                    limits=httpx.Limits(max_connections=None),
+                ),
+            )
+        return self._clients[idx]
+
+    async def close(self):
+        for c in self._clients:
+            await c.aclose()
+
+    async def worker(self, i: int):
+        from flux.domain.execution_context import ExecutionContext
+
+        name = f"sim-{i:04d}"
+        client = self.client(i)
+        reg = {
+            "name": name,
+            "runtime": {"os_name": "linux", "os_version": "1", "python_version": "3.12"},
+            "packages": [],
+            "resources": {
+                "cpu_total": 1,
+                "cpu_available": 1,
+                "memory_total": 1,
+                "memory_available": 1,
+                "disk_total": 1,
+                "disk_free": 1,
+                "gpus": [],
+            },
+        }
+        r = await client.post(
+            f"{SERVER}/workers/register",
+            json=reg,
+            headers={"Authorization": f"Bearer {BOOTSTRAP}"},
+        )
+        r.raise_for_status()
+        headers = {"Authorization": f"Bearer {r.json()['session_token']}"}
+
+        async def handle(evt_data: str):
+            data = json.loads(evt_data)
+            eid = data["context"]["execution_id"]
+            cr = await client.post(f"{SERVER}/workers/{name}/claim/{eid}", headers=headers)
+            if cr.status_code != 200:
+                return
+            if self.enqueue_time is not None:
+                self.dispatch_latencies.append(time.monotonic() - self.enqueue_time)
+            ctx = ExecutionContext.from_json(cr.json())
+            ctx.start(name).complete(name, "done")
+            ck = await client.post(
+                f"{SERVER}/workers/{name}/checkpoint/{eid}",
+                json=ctx.to_dict(),
+                headers=headers,
+            )
+            if ck.status_code == 200:
+                self.completed += 1
+                if self.completed >= EXECUTIONS:
+                    self.all_done.set()
+
+        while not self.stop.is_set():
+            try:
+                async with aconnect_sse(
+                    client,
+                    "GET",
+                    f"{SERVER}/workers/{name}/connect",
+                    headers=headers,
+                ) as es:
+                    self.connected += 1
+                    try:
+                        async for evt in es.aiter_sse():
+                            if self.stop.is_set():
+                                return
+                            if evt.event == "ping":
+                                asyncio.ensure_future(
+                                    client.post(f"{SERVER}/workers/{name}/pong", headers=headers),
+                                )
+                            elif evt.event == "execution_scheduled":
+                                asyncio.ensure_future(handle(evt.data))
+                    finally:
+                        self.connected -= 1
+            except Exception:
+                if self.stop.is_set():
+                    return
+                await asyncio.sleep(1)
+
+
+async def run_mode(mode: str) -> dict:
+    dbname = f"flux_stress_{mode}"
+    import psycopg
+
+    with psycopg.connect(PG_ADMIN, autocommit=True) as admin:
+        admin.execute(f"DROP DATABASE IF EXISTS {dbname}")
+        admin.execute(f"CREATE DATABASE {dbname}")
+
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": "/root",
+        "FLUX_SERVER_PORT": str(PORT),
+        "FLUX_DATABASE_URL": f"postgresql://{PG_CREDS}@{PG_HOSTPORT}/{dbname}",
+        "FLUX_DISPATCH__MODE": mode,
+        "FLUX_WORKERS__BOOTSTRAP_TOKEN": BOOTSTRAP,
+        "FLUX_WORKERS__REGISTER_RATE_LIMIT": "",
+        "FLUX_SECURITY__AUTH__ENABLED": "false",
+        "FLUX_SECURITY__AUTH__ALLOW_ANONYMOUS": "true",
+        "FLUX_SECURITY__ENCRYPTION__ENCRYPTION_KEY": "stress-key",
+        "FLUX_HOME": f"/tmp/flux-stress-{mode}",
+    }
+    log = open(f"/tmp/flux-stress-server-{mode}.log", "w")
+    srv = subprocess.Popen(
+        [shutil.which("flux") or "flux", "start", "server", "--port", str(PORT)],
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        env=env,
+    )
+    result: dict = {"mode": mode, "workers": WORKERS, "executions": EXECUTIONS}
+    fleet = Fleet(WORKERS)
+    tasks: list[asyncio.Task] = []
+    try:
+        async with httpx.AsyncClient(timeout=5) as probe:
+            for _ in range(120):
+                try:
+                    if (await probe.get(f"{SERVER}/health")).status_code == 200:
+                        break
+                except Exception:
+                    pass
+                await asyncio.sleep(0.5)
+            else:
+                raise RuntimeError("server never became healthy")
+
+            files = {"file": ("stress_noop.py", WORKFLOW_SRC, "text/x-python")}
+            (await probe.post(f"{SERVER}/workflows", files=files)).raise_for_status()
+
+        # -- connect fleet -------------------------------------------------
+        t0 = time.monotonic()
+        tasks = [asyncio.create_task(fleet.worker(i)) for i in range(WORKERS)]
+        while fleet.connected < WORKERS:
+            if time.monotonic() - t0 > 120:
+                raise RuntimeError(f"only {fleet.connected}/{WORKERS} workers connected")
+            await asyncio.sleep(0.25)
+        result["connect_seconds"] = round(time.monotonic() - t0, 1)
+
+        # -- idle load sample ----------------------------------------------
+        await asyncio.sleep(3)  # settle
+        x0 = pg_xacts(dbname)
+        await asyncio.sleep(IDLE_SECONDS)
+        x1 = pg_xacts(dbname)
+        result["idle_db_xacts_per_sec"] = round((x1 - x0) / IDLE_SECONDS, 1)
+
+        # -- throughput ----------------------------------------------------
+        async with httpx.AsyncClient(timeout=30) as submit:
+            sem = asyncio.Semaphore(25)
+
+            async def enqueue(_):
+                async with sem:
+                    r = await submit.post(
+                        f"{SERVER}/workflows/default/stress_noop/run/async",
+                        json="x",
+                    )
+                    r.raise_for_status()
+
+            fleet.enqueue_time = time.monotonic()
+            outcomes = await asyncio.gather(
+                *[enqueue(i) for i in range(EXECUTIONS)],
+                return_exceptions=True,
+            )
+            failures = [o for o in outcomes if isinstance(o, Exception)]
+            result["enqueue_seconds"] = round(time.monotonic() - fleet.enqueue_time, 1)
+            if failures:
+                result["enqueue_failures"] = len(failures)
+                result["control_plane_error"] = type(failures[0]).__name__
+
+        submitted = EXECUTIONS - result.get("enqueue_failures", 0)
+        if submitted <= 0:
+            return result
+        if result.get("enqueue_failures"):
+            # Only wait for what was actually accepted.
+            while fleet.completed < submitted:
+                await asyncio.sleep(1)
+                if time.monotonic() - fleet.enqueue_time > 600:
+                    result["drain_timeout"] = True
+                    return result
+        else:
+            await asyncio.wait_for(fleet.all_done.wait(), timeout=600)
+        drain = time.monotonic() - fleet.enqueue_time
+        result["drain_seconds"] = round(drain, 1)
+        result["throughput_per_sec"] = round(EXECUTIONS / drain, 1)
+        if fleet.dispatch_latencies:
+            lats = sorted(fleet.dispatch_latencies)
+            result["first_dispatch_ms"] = round(lats[0] * 1000)
+            result["median_dispatch_s"] = round(statistics.median(lats), 2)
+    finally:
+        fleet.stop.set()
+        for t in tasks:
+            t.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        await fleet.close()
+        srv.terminate()
+        try:
+            srv.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            srv.kill()
+        log.close()
+    return result
+
+
+async def main():
+    mode = sys.argv[1]
+    result = await run_mode(mode)
+    print(json.dumps(result, indent=2))
+    Path(f"/tmp/stress-result-{mode}.json").write_text(json.dumps(result))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -551,7 +551,9 @@ def cli(tmp_path_factory):
     env = {
         **os.environ,
         "FLUX_SERVER_PORT": str(E2E_PORT),
-        "FLUX_DATABASE_URL": f"sqlite:///{db_path}",
+        # Default is a throwaway SQLite file; export FLUX_E2E_DATABASE_URL to run
+        # the whole suite against another backend (e.g. a scratch PostgreSQL DB).
+        "FLUX_DATABASE_URL": os.environ.get("FLUX_E2E_DATABASE_URL", f"sqlite:///{db_path}"),
         "FLUX_WORKERS__SERVER_URL": E2E_SERVER_URL,
         "FLUX_WORKERS__BOOTSTRAP_TOKEN": "e2e-test-bootstrap-token",
         "FLUX_SECURITY__AUTH__ENABLED": "false",

--- a/tests/e2e/fixtures/transient_workflow.py
+++ b/tests/e2e/fixtures/transient_workflow.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from flux import ExecutionContext
+from flux.task import task
+from flux.workflow import workflow
+
+
+@task
+async def double(n: int):
+    return n * 2
+
+
+@workflow.with_options(durability="transient")
+async def transient_double(ctx: ExecutionContext[int]):
+    a = await double(ctx.input)
+    return await double(a)
+
+
+@workflow.with_options(durability="transient")
+async def transient_pause_attempt(ctx: ExecutionContext[str]):
+    from flux.tasks import pause
+
+    await pause("never-allowed")
+    return "unreachable"

--- a/tests/e2e/fixtures/transient_workflow.py
+++ b/tests/e2e/fixtures/transient_workflow.py
@@ -1,13 +1,36 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from flux import ExecutionContext
 from flux.task import task
+from flux.tasks import call, sleep
 from flux.workflow import workflow
 
 
 @task
 async def double(n: int):
     return n * 2
+
+
+@task
+async def boom():
+    raise ValueError("boom")
+
+
+@task.with_options(retry_max_attempts=3, retry_delay=1)
+async def flaky_once(path: str):
+    """Fails on the first attempt, succeeds on retry — driven by a marker file."""
+    marker = Path(path)
+    if not marker.exists():
+        marker.write_text("attempted")
+        raise RuntimeError("first attempt fails")
+    return "recovered"
+
+
+@task.with_options(requires_approval=True)
+async def gated(n: int):
+    return n
 
 
 @workflow.with_options(durability="transient")
@@ -22,3 +45,41 @@ async def transient_pause_attempt(ctx: ExecutionContext[str]):
 
     await pause("never-allowed")
     return "unreachable"
+
+
+@workflow.with_options(durability="transient")
+async def transient_failing(ctx: ExecutionContext[str]):
+    await boom()
+    return "unreachable"
+
+
+@workflow.with_options(durability="transient")
+async def transient_retry(ctx: ExecutionContext[str]):
+    return await flaky_once(ctx.input)
+
+
+@workflow.with_options(durability="transient")
+async def transient_approval_attempt(ctx: ExecutionContext[int]):
+    return await gated(ctx.input)
+
+
+@workflow.with_options(durability="transient")
+async def transient_slow(ctx: ExecutionContext[str]):
+    # Distinct durations per iteration: identical args would give identical
+    # deterministic task ids, and every call after the first would replay
+    # from the in-memory event log instead of sleeping.
+    for i in range(60):
+        await sleep(1 + i / 1000)
+    return "done"
+
+
+@workflow
+async def durable_sibling(ctx: ExecutionContext[int]):
+    """Durable control: registered from the same file, must keep TASK events."""
+    return await double(ctx.input)
+
+
+@workflow
+async def durable_calls_transient(ctx: ExecutionContext[int]):
+    """Mesh hop: a durable parent invoking a transient child via call()."""
+    return await call("transient_double", ctx.input)

--- a/tests/e2e/test_transient.py
+++ b/tests/e2e/test_transient.py
@@ -1,0 +1,53 @@
+"""E2E: transient executions keep the outer lifecycle, drop task-level state.
+
+A transient workflow runs like any other (row, dispatch, terminal state,
+visible in execution list) but the worker suppresses every intermediate
+checkpoint and the terminal checkpoint carries no TASK_* events.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_transient_run_completes_with_outer_lifecycle_only(cli):
+    cli.register(str(FIXTURES / "transient_workflow.py"))
+
+    result = cli.run("transient_double", "5", mode="sync", timeout=60)
+
+    assert result["state"] == "COMPLETED"
+    assert result["output"] == 20
+    execution_id = result["execution_id"]
+
+    # The execution row exists like any regular run...
+    shown = cli.execution_show(execution_id, detailed=True)
+    assert shown["state"] == "COMPLETED"
+
+    # ...but no task-level events were persisted: outer lifecycle only.
+    types = [e["type"] for e in shown.get("events", [])]
+    assert any(t.startswith("WORKFLOW_") for t in types)
+    assert not any(t.startswith("TASK_") for t in types), types
+
+
+def test_transient_pause_becomes_terminal_failure(cli):
+    cli.register(str(FIXTURES / "transient_workflow.py"))
+
+    result = cli.run("transient_pause_attempt", '"x"', mode="sync", timeout=60)
+
+    assert result["state"] == "FAILED"
+    assert "TransientDurability" in str(result.get("output"))
+
+
+def test_transient_runs_repeatedly(cli):
+    cli.register(str(FIXTURES / "transient_workflow.py"))
+
+    for n in (1, 2, 3):
+        result = cli.run("transient_double", str(n), mode="sync", timeout=60)
+        assert result["state"] == "COMPLETED"
+        assert result["output"] == n * 4

--- a/tests/e2e/test_transient.py
+++ b/tests/e2e/test_transient.py
@@ -2,11 +2,16 @@
 
 A transient workflow runs like any other (row, dispatch, terminal state,
 visible in execution list) but the worker suppresses every intermediate
-checkpoint and the terminal checkpoint carries no TASK_* events.
+checkpoint and the terminal checkpoint carries no TASK_* events. These tests
+cover the full scenario matrix: sync/async completion, failure, in-memory
+retry, cancellation, the durability guards (pause, approval), the durable
+regression control, and a durable->transient mesh hop via call().
 """
 
 from __future__ import annotations
 
+import tempfile
+import time
 from pathlib import Path
 
 import pytest
@@ -16,23 +21,61 @@ pytestmark = pytest.mark.e2e
 FIXTURES = Path(__file__).parent / "fixtures"
 
 
-def test_transient_run_completes_with_outer_lifecycle_only(cli):
+def _event_types(cli, exec_id: str) -> list[str]:
+    shown = cli.execution_show(exec_id, detailed=True)
+    return [e["type"] for e in shown.get("events", [])]
+
+
+def _assert_outer_lifecycle_only(cli, exec_id: str):
+    types = _event_types(cli, exec_id)
+    assert any(t.startswith("WORKFLOW_") for t in types), types
+    assert not any(t.startswith("TASK_") for t in types), types
+
+
+def test_transient_sync_completes_with_outer_lifecycle_only(cli):
     cli.register(str(FIXTURES / "transient_workflow.py"))
 
     result = cli.run("transient_double", "5", mode="sync", timeout=60)
 
     assert result["state"] == "COMPLETED"
     assert result["output"] == 20
-    execution_id = result["execution_id"]
-
-    # The execution row exists like any regular run...
-    shown = cli.execution_show(execution_id, detailed=True)
+    shown = cli.execution_show(result["execution_id"], detailed=True)
     assert shown["state"] == "COMPLETED"
+    _assert_outer_lifecycle_only(cli, result["execution_id"])
 
-    # ...but no task-level events were persisted: outer lifecycle only.
-    types = [e["type"] for e in shown.get("events", [])]
-    assert any(t.startswith("WORKFLOW_") for t in types)
-    assert not any(t.startswith("TASK_") for t in types), types
+
+def test_transient_async_mode(cli):
+    cli.register(str(FIXTURES / "transient_workflow.py"))
+
+    r = cli.run("transient_double", "7", mode="async", timeout=30)
+    final = cli.wait_for_state("transient_double", r["execution_id"], "COMPLETED", timeout=60)
+
+    assert final["state"] == "COMPLETED"
+    _assert_outer_lifecycle_only(cli, r["execution_id"])
+
+
+def test_transient_failure_persists_terminal_state(cli):
+    cli.register(str(FIXTURES / "transient_workflow.py"))
+
+    result = cli.run("transient_failing", '"x"', mode="sync", timeout=60)
+
+    assert result["state"] == "FAILED"
+    assert "boom" in str(result.get("output"))
+    _assert_outer_lifecycle_only(cli, result["execution_id"])
+
+
+def test_transient_task_retry_works_in_memory(cli):
+    """Task retry/fallback semantics run in-memory: a task failing its first
+    attempt recovers on retry, and none of it is persisted."""
+    cli.register(str(FIXTURES / "transient_workflow.py"))
+    marker = Path(tempfile.mkdtemp(prefix="flux-transient-")) / "attempt"
+
+    result = cli.run("transient_retry", f'"{marker}"', mode="sync", timeout=60)
+
+    assert result["state"] == "COMPLETED"
+    assert result["output"] == "recovered"
+    assert marker.exists()  # first attempt really ran and failed
+    _assert_outer_lifecycle_only(cli, result["execution_id"])
 
 
 def test_transient_pause_becomes_terminal_failure(cli):
@@ -44,10 +87,49 @@ def test_transient_pause_becomes_terminal_failure(cli):
     assert "TransientDurability" in str(result.get("output"))
 
 
-def test_transient_runs_repeatedly(cli):
+def test_transient_approval_gate_is_a_hard_error(cli):
     cli.register(str(FIXTURES / "transient_workflow.py"))
 
-    for n in (1, 2, 3):
-        result = cli.run("transient_double", str(n), mode="sync", timeout=60)
-        assert result["state"] == "COMPLETED"
-        assert result["output"] == n * 4
+    result = cli.run("transient_approval_attempt", "1", mode="sync", timeout=60)
+
+    assert result["state"] == "FAILED"
+    output = str(result.get("output"))
+    assert "TransientDurability" in output or "requires_approval" in output
+
+
+def test_transient_cancellation(cli):
+    cli.register(str(FIXTURES / "transient_workflow.py"))
+
+    r = cli.run("transient_slow", '"x"', mode="async", timeout=30)
+    exec_id = r["execution_id"]
+    cli.wait_for_state("transient_slow", exec_id, "RUNNING", timeout=60)
+    # Give the workflow a beat to be genuinely executing on the worker.
+    time.sleep(2)
+
+    cli.cancel("transient_slow", exec_id)
+    final = cli.wait_for_state("transient_slow", exec_id, "CANCELLED", timeout=60)
+
+    assert final["state"] == "CANCELLED"
+    _assert_outer_lifecycle_only(cli, exec_id)
+
+
+def test_durable_sibling_still_persists_task_events(cli):
+    """Regression control: durability suppression must not leak to durable
+    workflows registered from the same source file."""
+    cli.register(str(FIXTURES / "transient_workflow.py"))
+
+    result = cli.run("durable_sibling", "5", mode="sync", timeout=60)
+
+    assert result["state"] == "COMPLETED"
+    types = _event_types(cli, result["execution_id"])
+    assert any(t.startswith("TASK_") for t in types), types
+
+
+def test_durable_parent_calls_transient_child(cli):
+    """Mesh hop: a durable workflow invokes a transient one via call()."""
+    cli.register(str(FIXTURES / "transient_workflow.py"))
+
+    result = cli.run("durable_calls_transient", "3", mode="sync", timeout=90)
+
+    assert result["state"] == "COMPLETED"
+    assert result["output"] == 12

--- a/tests/flux/observability/test_metrics.py
+++ b/tests/flux/observability/test_metrics.py
@@ -112,7 +112,9 @@ class TestFluxMetrics:
         registrations = self._get_metric(reader, "flux_worker_registrations_total")
         assert registrations is not None
         dp = registrations.data.data_points[0]
-        assert dp.attributes["worker_name"] == "worker-1"
+        # Worker names are caller-controlled and must NOT be metric labels
+        # (unbounded cardinality); the counter is aggregate-only.
+        assert "worker_name" not in dp.attributes
         assert dp.value == 1
 
     def test_record_worker_connected(self):
@@ -129,7 +131,7 @@ class TestFluxMetrics:
         metric = self._get_metric(reader, "flux_worker_disconnections_total")
         assert metric is not None
         dp = metric.data.data_points[0]
-        assert dp.attributes["worker_name"] == "worker-1"
+        assert "worker_name" not in dp.attributes
         assert dp.attributes["reason"] == "evicted"
         assert dp.value == 1
 
@@ -148,7 +150,7 @@ class TestFluxMetrics:
         metric = self._get_metric(reader, "flux_worker_auth_events_total")
         assert metric is not None
         dp = metric.data.data_points[0]
-        assert dp.attributes["worker_name"] == "worker-1"
+        assert "worker_name" not in dp.attributes
         assert dp.attributes["event"] == "principal_provisioned"
         assert dp.value == 1
 
@@ -159,7 +161,7 @@ class TestFluxMetrics:
         metric = self._get_metric(reader, "flux_schedule_triggers_total")
         assert metric is not None
         dp = metric.data.data_points[0]
-        assert dp.attributes["schedule_name"] == "nightly"
+        assert "schedule_name" not in dp.attributes
         assert dp.attributes["outcome"] == "success"
 
     def test_record_http_request(self):

--- a/tests/flux/test_checkpoint_fencing.py
+++ b/tests/flux/test_checkpoint_fencing.py
@@ -1,0 +1,143 @@
+"""Tests for claim-generation fencing (split-brain prevention)."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from flux.context_managers import DatabaseContextManager
+from flux.domain.execution_context import ExecutionContext
+from flux.errors import StaleClaimError
+from flux.worker_registry import (
+    DatabaseWorkerRegistry,
+    WorkerResourcesInfo,
+    WorkerRuntimeInfo,
+)
+
+
+@pytest.fixture
+def env():
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as f:
+        db_path = f.name
+    db_url = f"sqlite:///{db_path}"
+    with patch("flux.config.Configuration.get") as mock_config:
+        mock_config.return_value.settings.database_url = db_url
+        mock_config.return_value.settings.database_type = "sqlite"
+        mock_config.return_value.settings.security.auth.enabled = False
+        yield DatabaseContextManager(), DatabaseWorkerRegistry()
+    if os.path.exists(db_path):
+        os.unlink(db_path)
+
+
+def _register(registry, name):
+    registry.register(
+        name=name,
+        runtime=WorkerRuntimeInfo(os_name="Linux", os_version="6", python_version="3.12"),
+        packages=[],
+        resources=WorkerResourcesInfo(
+            cpu_total=1,
+            cpu_available=1,
+            memory_total=1,
+            memory_available=1,
+            disk_total=1,
+            disk_free=1,
+            gpus=[],
+        ),
+    )
+    return registry.get(name)
+
+
+def _create_workflow(cm):
+    from flux.models import RepositoryFactory, WorkflowModel
+
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        session.add(
+            WorkflowModel(
+                id="default/wf",
+                name="wf",
+                version=1,
+                imports=[],
+                source=b"async def p(ctx): pass",
+                namespace="default",
+            ),
+        )
+        session.commit()
+    return "default/wf"
+
+
+def _dispatch(cm, worker):
+    ctx = cm.next_execution(worker)
+    assert ctx is not None
+    return cm.claim(ctx.execution_id, worker)
+
+
+def test_generation_starts_at_zero_and_bumps_on_dispatch(env):
+    cm, registry = env
+    w1 = _register(registry, "w1")
+    wf_id = _create_workflow(cm)
+    ctx = cm.save(
+        ExecutionContext(workflow_id=wf_id, workflow_namespace="default", workflow_name="wf"),
+    )
+
+    assert cm.get_claim_generation(ctx.execution_id) == 0
+    _dispatch(cm, w1)
+    assert cm.get_claim_generation(ctx.execution_id) == 1
+
+
+def test_generation_bumps_again_on_reassignment(env):
+    cm, registry = env
+    w1 = _register(registry, "w1")
+    wf_id = _create_workflow(cm)
+    saved = cm.save(
+        ExecutionContext(workflow_id=wf_id, workflow_namespace="default", workflow_name="wf"),
+    )
+
+    _dispatch(cm, w1)
+    cm.unclaim(saved.execution_id)  # eviction path: back to CREATED
+    _dispatch(cm, w1)
+
+    assert cm.get_claim_generation(saved.execution_id) == 2
+
+
+def test_update_rejects_stale_generation(env):
+    cm, registry = env
+    w1 = _register(registry, "w1")
+    wf_id = _create_workflow(cm)
+    cm.save(ExecutionContext(workflow_id=wf_id, workflow_namespace="default", workflow_name="wf"))
+    ctx = _dispatch(cm, w1)  # generation is now 1
+
+    # A checkpoint claimed under generation 0 (pre-reassignment) is fenced.
+    with pytest.raises(StaleClaimError):
+        cm.update(ctx, expected_claim_generation=0)
+
+    # The current generation passes.
+    cm.update(ctx, expected_claim_generation=1)
+
+
+def test_update_without_generation_is_unfenced(env):
+    """Legacy workers send no generation header and keep working."""
+    cm, registry = env
+    w1 = _register(registry, "w1")
+    wf_id = _create_workflow(cm)
+    cm.save(ExecutionContext(workflow_id=wf_id, workflow_namespace="default", workflow_name="wf"))
+    ctx = _dispatch(cm, w1)
+
+    cm.update(ctx)  # no expected generation: accepted
+
+
+def test_batch_dispatch_bumps_generation(env):
+    cm, registry = env
+    w1 = _register(registry, "w1")
+    wf_id = _create_workflow(cm)
+    saved = cm.save(
+        ExecutionContext(workflow_id=wf_id, workflow_namespace="default", workflow_name="wf"),
+    )
+
+    assignments = cm.next_executions_batch([w1], limit=10)
+
+    assert len(assignments) == 1
+    assert cm.get_claim_generation(saved.execution_id) == 1

--- a/tests/flux/test_database_repositories.py
+++ b/tests/flux/test_database_repositories.py
@@ -81,7 +81,8 @@ class TestPostgreSQLRepository:
                 mock_create.assert_called_once()
                 args, kwargs = mock_create.call_args
 
-                assert args[0] == "postgresql://test_user:test_pass@localhost:5432/test_db"
+                # The bare postgresql:// config URL is pinned to the psycopg (v3) dialect.
+                assert args[0] == "postgresql+psycopg://test_user:test_pass@localhost:5432/test_db"
                 assert kwargs["pool_size"] == 5
                 assert kwargs["max_overflow"] == 10
                 assert kwargs["pool_timeout"] == 30
@@ -161,7 +162,7 @@ class TestPostgreSQLRepository:
     def test_missing_driver_error(self, mock_postgresql_config):
         """Test error when PostgreSQL driver is not installed."""
         with patch("flux.models.create_engine") as mock_create:
-            mock_create.side_effect = ImportError("No module named 'psycopg2'")
+            mock_create.side_effect = ImportError("No module named 'psycopg'")
 
             with pytest.raises(PostgreSQLConnectionError) as exc_info:
                 PostgreSQLRepository()

--- a/tests/flux/test_dispatch_batch.py
+++ b/tests/flux/test_dispatch_batch.py
@@ -230,3 +230,75 @@ def test_batch_with_no_workers_is_a_noop(clean_env):
     assert cm.next_cancellations_batch([], limit=10) == []
     assert cm.next_resumes_batch([], limit=10) == []
     assert _states(cm)[e.execution_id][0] == ExecutionState.CREATED
+
+
+def _register_capped_worker(registry, name, capacity, labels=None):
+    registry.register(
+        name=name,
+        runtime=_make_runtime(),
+        packages=[],
+        resources=_make_resources(),
+        labels=labels,
+        max_concurrent_executions=capacity,
+    )
+    return registry.get(name)
+
+
+def test_batch_never_exceeds_worker_capacity(clean_env):
+    cm, registry = clean_env
+    w1 = _register_capped_worker(registry, "w1", capacity=2)
+    wf_id = _create_workflow("plain")
+    for _ in range(5):
+        _create_execution(cm, wf_id, name="plain")
+
+    assignments = cm.next_executions_batch([w1], limit=10)
+
+    assert len(assignments) == 2
+    states = _states(cm)
+    created = [s for s, _ in states.values() if s == ExecutionState.CREATED]
+    assert len(created) == 3  # held back, not lost
+
+
+def test_batch_overflows_to_worker_with_free_slots(clean_env):
+    cm, registry = clean_env
+    capped = _register_capped_worker(registry, "capped", capacity=1)
+    roomy = _register_capped_worker(registry, "roomy", capacity=10)
+    wf_id = _create_workflow("plain")
+    for _ in range(4):
+        _create_execution(cm, wf_id, name="plain")
+
+    assignments = cm.next_executions_batch([capped, roomy], limit=10)
+
+    per_worker: dict[str, int] = {}
+    for _, worker_name in assignments:
+        per_worker[worker_name] = per_worker.get(worker_name, 0) + 1
+    assert len(assignments) == 4
+    assert per_worker["capped"] == 1
+    assert per_worker["roomy"] == 3
+
+
+def test_poll_path_respects_capacity(clean_env):
+    cm, registry = clean_env
+    w1 = _register_capped_worker(registry, "w1", capacity=1)
+    wf_id = _create_workflow("plain")
+
+    busy = _create_execution(cm, wf_id, name="plain")
+    _force_state(busy.execution_id, ExecutionState.RUNNING, worker_name="w1")
+    _create_execution(cm, wf_id, name="plain")
+
+    # w1 is at capacity: the legacy poll query must not hand it more work.
+    assert cm.next_execution(w1) is None
+
+    _force_state(busy.execution_id, ExecutionState.COMPLETED, worker_name="w1")
+    assert cm.next_execution(w1) is not None
+
+
+def test_unlimited_capacity_workers_keep_legacy_behavior(clean_env):
+    cm, registry = clean_env
+    w1 = _register_worker(registry, "w1")  # no capacity advertised -> unlimited
+    wf_id = _create_workflow("plain")
+    for _ in range(3):
+        _create_execution(cm, wf_id, name="plain")
+
+    assignments = cm.next_executions_batch([w1], limit=10)
+    assert len(assignments) == 3

--- a/tests/flux/test_dispatch_batch.py
+++ b/tests/flux/test_dispatch_batch.py
@@ -1,0 +1,232 @@
+"""Tests for the batch dispatch queries used by the event-driven dispatcher."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from flux.context_managers import DatabaseContextManager
+from flux.domain import ExecutionState
+from flux.domain.execution_context import ExecutionContext
+from flux.models import ExecutionContextModel, RepositoryFactory
+from flux.worker_registry import (
+    DatabaseWorkerRegistry,
+    WorkerResourcesInfo,
+    WorkerRuntimeInfo,
+)
+
+
+@pytest.fixture
+def clean_env():
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as f:
+        db_path = f.name
+
+    db_url = f"sqlite:///{db_path}"
+    with patch("flux.config.Configuration.get") as mock_config:
+        mock_config.return_value.settings.database_url = db_url
+        mock_config.return_value.settings.database_type = "sqlite"
+        mock_config.return_value.settings.security.auth.enabled = False
+
+        cm = DatabaseContextManager()
+        registry = DatabaseWorkerRegistry()
+        yield cm, registry
+
+    if os.path.exists(db_path):
+        os.unlink(db_path)
+
+
+def _make_runtime():
+    return WorkerRuntimeInfo(os_name="Linux", os_version="6.0", python_version="3.12.0")
+
+
+def _make_resources():
+    return WorkerResourcesInfo(
+        cpu_total=4,
+        cpu_available=4,
+        memory_total=8_000_000_000,
+        memory_available=8_000_000_000,
+        disk_total=100_000_000_000,
+        disk_free=100_000_000_000,
+        gpus=[],
+    )
+
+
+def _register_worker(registry, name, labels=None):
+    registry.register(
+        name=name,
+        runtime=_make_runtime(),
+        packages=[],
+        resources=_make_resources(),
+        labels=labels,
+    )
+    return registry.get(name)
+
+
+def _create_workflow(name, namespace="default", affinity=None, requests=None):
+    from flux.models import WorkflowModel
+
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        wf = WorkflowModel(
+            id=f"{namespace}/{name}",
+            name=name,
+            version=1,
+            imports=[],
+            source=b"async def placeholder(ctx): pass",
+            namespace=namespace,
+            affinity=affinity,
+            requests=requests,
+        )
+        session.add(wf)
+        session.commit()
+        return wf.id
+
+
+def _create_execution(cm, workflow_id, namespace="default", name="test"):
+    ctx = ExecutionContext(
+        workflow_id=workflow_id,
+        workflow_namespace=namespace,
+        workflow_name=name,
+    )
+    return cm.save(ctx)
+
+
+def _force_state(execution_id, state, worker_name=None):
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        model = session.get(ExecutionContextModel, execution_id)
+        model.state = state
+        model.worker_name = worker_name
+        session.commit()
+
+
+def _states(cm):
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        rows = session.query(
+            ExecutionContextModel.execution_id,
+            ExecutionContextModel.state,
+            ExecutionContextModel.worker_name,
+        ).all()
+        return {r[0]: (r[1], r[2]) for r in rows}
+
+
+def test_batch_spreads_work_across_workers(clean_env):
+    cm, registry = clean_env
+    w1 = _register_worker(registry, "w1")
+    w2 = _register_worker(registry, "w2")
+    wf_id = _create_workflow("plain")
+    for _ in range(4):
+        _create_execution(cm, wf_id, name="plain")
+
+    assignments = cm.next_executions_batch([w1, w2], limit=10)
+
+    assert len(assignments) == 4
+    per_worker = {"w1": 0, "w2": 0}
+    for ctx, worker_name in assignments:
+        assert ctx.state == ExecutionState.SCHEDULED
+        per_worker[worker_name] += 1
+    assert per_worker == {"w1": 2, "w2": 2}
+
+
+def test_batch_respects_limit_and_leaves_rest_created(clean_env):
+    cm, registry = clean_env
+    w1 = _register_worker(registry, "w1")
+    wf_id = _create_workflow("plain")
+    ids = [_create_execution(cm, wf_id, name="plain").execution_id for _ in range(5)]
+
+    assignments = cm.next_executions_batch([w1], limit=3)
+
+    assert len(assignments) == 3
+    states = _states(cm)
+    created = [i for i in ids if states[i][0] == ExecutionState.CREATED]
+    assert len(created) == 2
+
+
+def test_batch_respects_affinity_and_skips_unmatchable(clean_env):
+    cm, registry = clean_env
+    plain_worker = _register_worker(registry, "plain-worker")
+    gpu_worker = _register_worker(registry, "gpu-worker", labels={"gpu": "true"})
+
+    gpu_wf = _create_workflow("gpu-flow", affinity={"gpu": "true"})
+    tpu_wf = _create_workflow("tpu-flow", affinity={"tpu": "true"})
+    gpu_exec = _create_execution(cm, gpu_wf, name="gpu-flow")
+    tpu_exec = _create_execution(cm, tpu_wf, name="tpu-flow")
+
+    assignments = cm.next_executions_batch([plain_worker, gpu_worker], limit=10)
+
+    assert [(c.execution_id, w) for c, w in assignments] == [
+        (gpu_exec.execution_id, "gpu-worker"),
+    ]
+    states = _states(cm)
+    assert states[tpu_exec.execution_id][0] == ExecutionState.CREATED
+
+
+def test_batch_prefers_least_loaded_worker(clean_env):
+    cm, registry = clean_env
+    w1 = _register_worker(registry, "w1")
+    w2 = _register_worker(registry, "w2")
+    wf_id = _create_workflow("plain")
+
+    # w1 already runs two executions; a single new one must land on w2.
+    for _ in range(2):
+        busy = _create_execution(cm, wf_id, name="plain")
+        _force_state(busy.execution_id, ExecutionState.RUNNING, worker_name="w1")
+    pending = _create_execution(cm, wf_id, name="plain")
+
+    assignments = cm.next_executions_batch([w1, w2], limit=10)
+
+    assert assignments[0][0].execution_id == pending.execution_id
+    assert assignments[0][1] == "w2"
+
+
+def test_cancellations_batch_only_returns_targeted_workers(clean_env):
+    cm, registry = clean_env
+    _register_worker(registry, "w1")
+    _register_worker(registry, "w2")
+    wf_id = _create_workflow("plain")
+    e1 = _create_execution(cm, wf_id, name="plain")
+    e2 = _create_execution(cm, wf_id, name="plain")
+    _force_state(e1.execution_id, ExecutionState.CANCELLING, worker_name="w1")
+    _force_state(e2.execution_id, ExecutionState.CANCELLING, worker_name="w2")
+
+    result = cm.next_cancellations_batch(["w1"], limit=10)
+
+    assert [c.execution_id for c in result] == [e1.execution_id]
+
+
+def test_resumes_batch_sticky_then_unassigned(clean_env):
+    cm, registry = clean_env
+    w1 = _register_worker(registry, "w1")
+    w2 = _register_worker(registry, "w2")
+    wf_id = _create_workflow("plain")
+
+    sticky = _create_execution(cm, wf_id, name="plain")
+    _force_state(sticky.execution_id, ExecutionState.RESUMING, worker_name="w1")
+    floating = _create_execution(cm, wf_id, name="plain")
+    _force_state(floating.execution_id, ExecutionState.RESUMING, worker_name=None)
+
+    assignments = cm.next_resumes_batch([w1, w2], limit=10)
+
+    by_id = {ctx.execution_id: (ctx, worker) for ctx, worker in assignments}
+    assert by_id[sticky.execution_id][1] == "w1"
+    assert by_id[sticky.execution_id][0].state == ExecutionState.RESUME_SCHEDULED
+    # The floating resume lands on some connected worker.
+    assert by_id[floating.execution_id][1] in ("w1", "w2")
+    states = _states(cm)
+    assert states[sticky.execution_id][0] == ExecutionState.RESUME_SCHEDULED
+    assert states[floating.execution_id][0] == ExecutionState.RESUME_SCHEDULED
+
+
+def test_batch_with_no_workers_is_a_noop(clean_env):
+    cm, registry = clean_env
+    wf_id = _create_workflow("plain")
+    e = _create_execution(cm, wf_id, name="plain")
+
+    assert cm.next_executions_batch([], limit=10) == []
+    assert cm.next_cancellations_batch([], limit=10) == []
+    assert cm.next_resumes_batch([], limit=10) == []
+    assert _states(cm)[e.execution_id][0] == ExecutionState.CREATED

--- a/tests/flux/test_heartbeat.py
+++ b/tests/flux/test_heartbeat.py
@@ -520,3 +520,55 @@ class TestWorkerReconnect:
         ):
             # Should not raise
             await worker._send_pong()
+
+
+class TestHeartbeatBatching:
+    """Pongs buffer in memory while the reaper runs; the tick flushes one batch."""
+
+    @pytest.fixture
+    def server(self):
+        with patch("flux.server.Configuration") as mock_conf:
+            settings = MagicMock()
+            settings.scheduling.poll_interval = 30.0
+            settings.workers.heartbeat_interval = 2
+            settings.workers.heartbeat_timeout = 5
+            settings.workers.offline_ttl = 10
+            settings.workers.eviction_grace_period = 10
+            settings.observability.enabled = False
+            mock_conf.get.return_value.settings = settings
+            s = Server(host="localhost", port=8000)
+        return s
+
+    @pytest.mark.asyncio
+    async def test_pong_buffers_while_reaper_active(self, server):
+        server._reaper_task = MagicMock()
+        server._reaper_task.done.return_value = False
+        with patch.object(server, "_persist_worker_heartbeat") as persist:
+            await server._record_heartbeat("w1")
+        persist.assert_not_called()
+        assert server._pending_heartbeats == {"w1"}
+        assert "w1" in server._worker_last_pong
+
+    @pytest.mark.asyncio
+    async def test_pong_persists_immediately_without_reaper(self, server):
+        assert server._reaper_task is None
+        with patch.object(server, "_persist_worker_heartbeat") as persist:
+            await server._record_heartbeat("w1")
+        persist.assert_called_once_with("w1")
+        assert server._pending_heartbeats == set()
+
+    @pytest.mark.asyncio
+    async def test_flush_persists_batch_and_clears(self, server):
+        server._pending_heartbeats = {"w1", "w2"}
+        with patch("flux.worker_registry.WorkerRegistry.create") as create:
+            registry = create.return_value
+            await server._flush_heartbeats()
+        registry.record_heartbeats.assert_called_once()
+        assert sorted(registry.record_heartbeats.call_args[0][0]) == ["w1", "w2"]
+        assert server._pending_heartbeats == set()
+
+    @pytest.mark.asyncio
+    async def test_flush_is_noop_when_empty(self, server):
+        with patch("flux.worker_registry.WorkerRegistry.create") as create:
+            await server._flush_heartbeats()
+        create.assert_not_called()

--- a/tests/flux/test_heartbeat.py
+++ b/tests/flux/test_heartbeat.py
@@ -432,6 +432,9 @@ class TestWorkerReconnect:
         mock_settings.workers.bootstrap_token = "test-token"
         mock_settings.workers.server_url = "http://localhost:8000"
         mock_settings.workers.default_timeout = 0
+        mock_settings.workers.http_timeout = 0
+        mock_settings.workers.checkpoint_retry_max_delay = 30
+        mock_settings.workers.terminal_checkpoint_deadline = 300
         mock_settings.workers.reconnect_max_delay = 4
         mock_settings.workers.module_cache_ttl = 300
 

--- a/tests/flux/test_migrations.py
+++ b/tests/flux/test_migrations.py
@@ -13,7 +13,7 @@ import flux.security.models  # noqa: F401
 from flux.migrations.runner import current_revision, run_migrations
 from flux.models import Base
 
-HEAD = "0004_worker_last_seen_index"
+HEAD = "0005_worker_capacity"
 BASELINE = "0001_baseline"
 
 # A representative index added after the original create_all schema, used to

--- a/tests/flux/test_migrations.py
+++ b/tests/flux/test_migrations.py
@@ -13,7 +13,7 @@ import flux.security.models  # noqa: F401
 from flux.migrations.runner import current_revision, run_migrations
 from flux.models import Base
 
-HEAD = "0005_worker_capacity"
+HEAD = "0006_claim_generation"
 BASELINE = "0001_baseline"
 
 # A representative index added after the original create_all schema, used to

--- a/tests/flux/test_migrations.py
+++ b/tests/flux/test_migrations.py
@@ -13,7 +13,7 @@ import flux.security.models  # noqa: F401
 from flux.migrations.runner import current_revision, run_migrations
 from flux.models import Base
 
-HEAD = "0003_worker_last_seen"
+HEAD = "0004_worker_last_seen_index"
 BASELINE = "0001_baseline"
 
 # A representative index added after the original create_all schema, used to
@@ -91,6 +91,9 @@ def test_legacy_database_gains_worker_last_seen_at(tmp_path):
     engine = _engine(tmp_path, "no_last_seen.db")
     Base.metadata.create_all(engine)
     with engine.begin() as conn:
+        # A pre-0003 schema has neither the index (0004) nor the column; the
+        # index must go first or SQLite refuses the column drop.
+        conn.exec_driver_sql("DROP INDEX IF EXISTS ix_workers_last_seen_at")
         conn.exec_driver_sql("ALTER TABLE workers DROP COLUMN last_seen_at")
 
     cols = {c["name"] for c in inspect(engine).get_columns("workers")}
@@ -100,6 +103,25 @@ def test_legacy_database_gains_worker_last_seen_at(tmp_path):
 
     cols = {c["name"] for c in inspect(engine).get_columns("workers")}
     assert "last_seen_at" in cols
+    assert current_revision(engine) == HEAD
+
+
+def test_legacy_database_gains_worker_last_seen_index(tmp_path):
+    """A pre-0004 database missing the last_seen_at index gains it on upgrade."""
+    engine = _engine(tmp_path, "no_last_seen_index.db")
+    Base.metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.exec_driver_sql("DROP INDEX IF EXISTS ix_workers_last_seen_at")
+
+    assert "ix_workers_last_seen_at" not in {
+        ix["name"] for ix in inspect(engine).get_indexes("workers")
+    }
+
+    run_migrations(engine)
+
+    assert "ix_workers_last_seen_at" in {
+        ix["name"] for ix in inspect(engine).get_indexes("workers")
+    }
     assert current_revision(engine) == HEAD
 
 

--- a/tests/flux/test_migrations_postgresql.py
+++ b/tests/flux/test_migrations_postgresql.py
@@ -28,7 +28,7 @@ pytestmark = [
     ),
 ]
 
-HEAD = "0005_worker_capacity"
+HEAD = "0006_claim_generation"
 _BACKFILL_INDEX = "ix_executions_workflow_id"
 
 

--- a/tests/flux/test_migrations_postgresql.py
+++ b/tests/flux/test_migrations_postgresql.py
@@ -28,7 +28,7 @@ pytestmark = [
     ),
 ]
 
-HEAD = "0004_worker_last_seen_index"
+HEAD = "0005_worker_capacity"
 _BACKFILL_INDEX = "ix_executions_workflow_id"
 
 

--- a/tests/flux/test_migrations_postgresql.py
+++ b/tests/flux/test_migrations_postgresql.py
@@ -27,7 +27,7 @@ pytestmark = [
     ),
 ]
 
-HEAD = "0003_worker_last_seen"
+HEAD = "0004_worker_last_seen_index"
 _BACKFILL_INDEX = "ix_executions_workflow_id"
 
 

--- a/tests/flux/test_migrations_postgresql.py
+++ b/tests/flux/test_migrations_postgresql.py
@@ -15,9 +15,10 @@ import pytest
 from sqlalchemy import create_engine, inspect, text
 
 from flux.migrations.runner import current_revision, run_migrations
-from flux.models import Base
+from flux.models import Base, normalize_postgresql_url
 
 _DB_URL = os.environ.get("FLUX_DATABASE_URL", "")
+_ENGINE_URL = normalize_postgresql_url(_DB_URL)
 
 pytestmark = [
     pytest.mark.postgresql,
@@ -34,10 +35,10 @@ _BACKFILL_INDEX = "ix_executions_workflow_id"
 def _fresh_schema_engine():
     """An engine pointed at a brand-new, empty PostgreSQL schema (search_path)."""
     schema = f"mig_test_{uuid.uuid4().hex[:12]}"
-    admin = create_engine(_DB_URL)
+    admin = create_engine(_ENGINE_URL)
     with admin.begin() as conn:
         conn.execute(text(f'CREATE SCHEMA "{schema}"'))
-    engine = create_engine(_DB_URL, connect_args={"options": f"-csearch_path={schema}"})
+    engine = create_engine(_ENGINE_URL, connect_args={"options": f"-csearch_path={schema}"})
     return engine, schema, admin
 
 

--- a/tests/flux/test_ops_endpoints.py
+++ b/tests/flux/test_ops_endpoints.py
@@ -1,0 +1,66 @@
+"""Tests for operational endpoints and lifecycle GC added for production readiness."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from flux.server import Server
+
+
+@pytest.fixture
+def client():
+    server = Server(host="localhost", port=8000)
+    return TestClient(server._create_api(), raise_server_exceptions=False)
+
+
+class TestReadinessProbe:
+    def test_ready_returns_200_when_database_reachable(self, client):
+        response = client.get("/ready")
+        assert response.status_code == 200
+        assert response.json() == {"status": "ready", "database": True}
+
+    def test_ready_returns_503_when_database_down(self, client):
+        with patch("flux.api.system_routes.WorkflowCatalog.create") as create:
+            create.return_value.health_check.side_effect = RuntimeError("db down")
+            response = client.get("/ready")
+        assert response.status_code == 503
+        assert response.json()["status"] == "not-ready"
+
+    def test_health_stays_available_as_before(self, client):
+        # /health keeps its existing contract; /ready is the new probe.
+        assert client.get("/health").status_code == 200
+
+
+class TestWorkerPrincipalGC:
+    @pytest.mark.asyncio
+    async def test_prune_disables_principal_and_revokes_keys(self):
+        server = Server(host="localhost", port=8000)
+        auth_service = MagicMock()
+        auth_service.revoke_all_api_keys = AsyncMock()
+
+        principal = MagicMock()
+        principal.id = "p-1"
+        principal.enabled = True
+
+        with (
+            patch("flux.security.dependencies._get_auth_service", return_value=auth_service),
+            patch("flux.security.principals.PrincipalRegistry") as registry_cls,
+        ):
+            registry = registry_cls.return_value
+            registry.find.return_value = principal
+
+            server._gc_worker_principal("dead-worker")
+            await asyncio.sleep(0.05)  # let the fire-and-forget task run
+
+        registry.set_enabled.assert_called_once_with("p-1", False)
+        auth_service.revoke_all_api_keys.assert_awaited_once_with("p-1")
+
+    @pytest.mark.asyncio
+    async def test_prune_without_auth_service_is_a_noop(self):
+        server = Server(host="localhost", port=8000)
+        with patch("flux.security.dependencies._get_auth_service", return_value=None):
+            server._gc_worker_principal("dead-worker")  # must not raise

--- a/tests/flux/test_postgresql_config.py
+++ b/tests/flux/test_postgresql_config.py
@@ -98,8 +98,8 @@ class TestPostgreSQLConfiguration:
     def test_default_pool_configuration(self):
         """Test default connection pool settings."""
         config = FluxConfig()
-        assert config.database_pool_size == 5
-        assert config.database_max_overflow == 10
+        assert config.database_pool_size == 20
+        assert config.database_max_overflow == 20
         assert config.database_pool_timeout == 30
         assert config.database_pool_recycle == 3600
         assert config.database_health_check_interval == 300

--- a/tests/flux/test_postgresql_errors.py
+++ b/tests/flux/test_postgresql_errors.py
@@ -68,7 +68,7 @@ class TestPostgreSQLRepositoryErrorHandling:
     def test_import_error_handling(self, mock_postgresql_config):
         """Test handling of missing PostgreSQL driver."""
         with patch("flux.models.create_engine") as mock_create:
-            mock_create.side_effect = ImportError("No module named 'psycopg2'")
+            mock_create.side_effect = ImportError("No module named 'psycopg'")
 
             with pytest.raises(PostgreSQLConnectionError) as exc_info:
                 PostgreSQLRepository()
@@ -190,7 +190,7 @@ class TestErrorMessageQuality:
     def test_driver_installation_message_helpful(self, mock_postgresql_config):
         """Test driver installation error message is helpful."""
         with patch("flux.models.create_engine") as mock_create:
-            mock_create.side_effect = ImportError("No module named 'psycopg2'")
+            mock_create.side_effect = ImportError("No module named 'psycopg'")
 
             with pytest.raises(PostgreSQLConnectionError) as exc_info:
                 PostgreSQLRepository()

--- a/tests/flux/test_retention.py
+++ b/tests/flux/test_retention.py
@@ -1,0 +1,160 @@
+"""Tests for the execution-history retention sweep."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from flux.domain import ExecutionState
+from flux.domain.events import ExecutionEvent, ExecutionEventType
+from flux.domain.execution_context import ExecutionContext
+from flux.models import (
+    ApprovalRequestModel,
+    ExecutionContextModel,
+    ExecutionEventModel,
+    RepositoryFactory,
+)
+from flux.retention import RetentionJob
+
+
+@pytest.fixture
+def env():
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as f:
+        db_path = f.name
+    db_url = f"sqlite:///{db_path}"
+    with patch("flux.config.Configuration.get") as mock_config:
+        settings = mock_config.return_value.settings
+        settings.database_url = db_url
+        settings.database_type = "sqlite"
+        settings.security.auth.enabled = False
+        settings.retention.enabled = True
+        settings.retention.retention_days = 30
+        settings.retention.sweep_interval = 3600
+        settings.retention.batch_size = 2  # small, to exercise batching
+        yield RepositoryFactory.create_repository()
+    if os.path.exists(db_path):
+        os.unlink(db_path)
+
+
+def _create_workflow(repo, name="wf"):
+    from flux.models import WorkflowModel
+
+    with repo.session() as session:
+        wf = WorkflowModel(
+            id=f"default/{name}",
+            name=name,
+            version=1,
+            imports=[],
+            source=b"async def placeholder(ctx): pass",
+            namespace="default",
+        )
+        session.add(wf)
+        session.commit()
+        return wf.id
+
+
+def _create_execution(repo, wf_id, state, age_days, name="wf"):
+    ctx = ExecutionContext(workflow_id=wf_id, workflow_namespace="default", workflow_name=name)
+    ctx.events.append(
+        ExecutionEvent(
+            type=ExecutionEventType.WORKFLOW_COMPLETED,
+            source_id="test",
+            name=name,
+            value=None,
+        ),
+    )
+    with repo.session() as session:
+        model = ExecutionContextModel.from_plain(ctx)
+        model.state = state
+        session.add(model)
+        session.commit()
+        stamp = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=age_days)
+        session.query(ExecutionEventModel).filter(
+            ExecutionEventModel.execution_id == ctx.execution_id,
+        ).update({ExecutionEventModel.time: stamp}, synchronize_session=False)
+        session.commit()
+    return ctx.execution_id
+
+
+def _remaining_ids(repo):
+    with repo.session() as session:
+        return {row[0] for row in session.query(ExecutionContextModel.execution_id).all()}
+
+
+def test_sweep_deletes_only_old_terminal_executions(env):
+    repo = env
+    wf_id = _create_workflow(repo)
+    old_done = _create_execution(repo, wf_id, ExecutionState.COMPLETED, age_days=45)
+    old_failed = _create_execution(repo, wf_id, ExecutionState.FAILED, age_days=45)
+    old_running = _create_execution(repo, wf_id, ExecutionState.RUNNING, age_days=45)
+    fresh_done = _create_execution(repo, wf_id, ExecutionState.COMPLETED, age_days=5)
+
+    deleted = RetentionJob()._sweep()
+
+    assert deleted == 2
+    remaining = _remaining_ids(repo)
+    assert old_done not in remaining
+    assert old_failed not in remaining
+    assert old_running in remaining  # non-terminal is never touched
+    assert fresh_done in remaining  # inside the retention window
+
+
+def test_sweep_removes_dependent_rows(env):
+    repo = env
+    wf_id = _create_workflow(repo)
+    old = _create_execution(repo, wf_id, ExecutionState.COMPLETED, age_days=45)
+    with repo.session() as session:
+        from flux.models import ApprovalStatus
+
+        session.add(
+            ApprovalRequestModel(
+                id="appr-1",
+                execution_id=old,
+                task_call_id="call-1",
+                task_name="approve_step",
+                workflow_namespace="default",
+                workflow_name="wf",
+                requested_at=datetime.now(timezone.utc),
+                status=ApprovalStatus.PENDING,
+            ),
+        )
+        session.commit()
+
+    assert RetentionJob()._sweep() == 1
+
+    with repo.session() as session:
+        assert (
+            session.query(ExecutionEventModel)
+            .filter(ExecutionEventModel.execution_id == old)
+            .count()
+            == 0
+        )
+        assert (
+            session.query(ApprovalRequestModel)
+            .filter(ApprovalRequestModel.execution_id == old)
+            .count()
+            == 0
+        )
+
+
+def test_sweep_batches_until_drained(env):
+    repo = env
+    wf_id = _create_workflow(repo)
+    ids = [_create_execution(repo, wf_id, ExecutionState.COMPLETED, age_days=45) for _ in range(5)]
+
+    # batch_size is 2, so a full sweep needs three transactions internally.
+    assert RetentionJob()._sweep() == 5
+    assert _remaining_ids(repo).isdisjoint(ids)
+
+
+def test_sweep_with_nothing_expired_is_a_noop(env):
+    repo = env
+    wf_id = _create_workflow(repo)
+    fresh = _create_execution(repo, wf_id, ExecutionState.COMPLETED, age_days=1)
+
+    assert RetentionJob()._sweep() == 0
+    assert fresh in _remaining_ids(repo)

--- a/tests/flux/test_server_cancellation.py
+++ b/tests/flux/test_server_cancellation.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 from flux import ExecutionContext
 from flux.domain.events import ExecutionState
 from flux.errors import WorkerNotFoundError
-from flux.server import Server, WorkerResponse
+from flux.server import Server
 
 
 @pytest.fixture
@@ -356,19 +356,30 @@ class TestExecutionEndpoints:
 class TestWorkerEndpoints:
     """Tests for worker management endpoints."""
 
-    def test_workers_list(self, server_instance, test_client):
-        """Test listing all workers from in-memory cache."""
-        server_instance._worker_cache["worker-1"] = WorkerResponse(
-            name="worker-1",
-            status="online",
-        )
+    @patch("flux.api.worker_routes.WorkerRegistry.create")
+    def test_workers_list(self, mock_registry_create, server_instance, test_client):
+        """Workers are listed fleet-wide from the DB, with liveness derived
+        from the persisted heartbeat (not this replica's in-memory cache)."""
+        from datetime import datetime, timezone
+
+        fresh = MagicMock()
+        fresh.name = "worker-1"
+        fresh.last_seen_at = datetime.now(timezone.utc).replace(tzinfo=None)
+        stale = MagicMock()
+        stale.name = "worker-2"
+        stale.last_seen_at = None  # never heartbeated -> offline
+        mock_registry = MagicMock()
+        mock_registry.list.return_value = [fresh, stale]
+        mock_registry_create.return_value = mock_registry
 
         response = test_client.get("/workers")
 
         assert response.status_code == 200
-        data = response.json()
-        assert len(data) == 1
-        assert data[0]["name"] == "worker-1"
+        data = {w["name"]: w["status"] for w in response.json()}
+        assert data == {"worker-1": "online", "worker-2": "offline"}
+
+        response = test_client.get("/workers?status=online")
+        assert [w["name"] for w in response.json()] == ["worker-1"]
 
     @patch("flux.server.WorkerRegistry.create")
     def test_workers_list_empty(self, mock_registry_create, test_client):
@@ -557,8 +568,13 @@ class TestAPIEdgeCases:
         assert response.status_code == 500
         assert "error" in response.text.lower()
 
-    def test_workers_list_empty_cache(self, test_client):
-        """Test workers list returns empty when cache is empty."""
+    @patch("flux.api.worker_routes.WorkerRegistry.create")
+    def test_workers_list_empty_cache(self, mock_registry_create, test_client):
+        """Test workers list returns empty when no workers are registered."""
+        mock_registry = MagicMock()
+        mock_registry.list.return_value = []
+        mock_registry_create.return_value = mock_registry
+
         response = test_client.get("/workers")
 
         assert response.status_code == 200

--- a/tests/flux/test_transient.py
+++ b/tests/flux/test_transient.py
@@ -50,7 +50,7 @@ class TestCatalogDurabilityExtraction:
     def test_parse_static_extracts_durability(self):
         from flux.catalogs import DatabaseWorkflowCatalog
 
-        source = b'''
+        source = b"""
 from flux import ExecutionContext
 from flux.workflow import workflow
 
@@ -58,7 +58,7 @@ from flux.workflow import workflow
 @workflow.with_options(durability="transient")
 async def mesh_hop(ctx: ExecutionContext[str]):
     return ctx.input
-'''
+"""
         # Bypass __init__ (which opens a database) — parse_static only needs
         # the AST helper methods on the instance.
         catalog = DatabaseWorkflowCatalog.__new__(DatabaseWorkflowCatalog)
@@ -68,18 +68,45 @@ async def mesh_hop(ctx: ExecutionContext[str]):
 
 class TestTransientCheckpointSuppression:
     @pytest.mark.asyncio
-    async def test_intermediate_checkpoints_are_skipped(self):
-        """Task-level checkpoints during a transient run never leave the worker."""
+    async def test_only_one_intermediate_checkpoint_persists_running(self):
+        """The first intermediate checkpoint goes through (persisting the
+        RUNNING transition, filtered to WORKFLOW_* events); every later
+        task-level checkpoint stays on the worker."""
         worker = make_worker()
-        worker.client.post = AsyncMock(return_value=ok_response())
+        payloads = []
 
-        ctx = make_ctx()
-        ctx.is_transient = True
-        ctx.is_paused = False
-        await worker._checkpoint(ctx)
+        async def capture_post(url, **kwargs):
+            payloads.append(kwargs["json"])
+            return ok_response()
 
-        worker.client.post.assert_not_called()
-        assert ctx.execution_id not in worker._checkpoint_outboxes
+        worker.client.post = capture_post
+
+        def snapshot():
+            ctx = make_ctx()
+            ctx.is_transient = True
+            ctx.is_paused = False
+            task_event = MagicMock()
+            task_event.type.value = "TASK_COMPLETED"
+            ctx.events = [task_event]
+            ctx.to_dict.return_value = {
+                "execution_id": "exec-1",
+                "events": [
+                    {"id": "e1", "type": "WORKFLOW_STARTED"},
+                    {"id": "e2", "type": "TASK_COMPLETED"},
+                ],
+            }
+            return ctx
+
+        await worker._checkpoint(snapshot())  # first: persists RUNNING
+        box = worker._checkpoint_outboxes.get("exec-1")
+        while box and box.acked < box.generation:
+            await asyncio.sleep(0.005)
+        await worker._checkpoint(snapshot())  # second: suppressed
+        await worker._checkpoint(snapshot())  # third: suppressed
+        await asyncio.sleep(0.02)
+
+        assert len(payloads) == 1
+        assert [e["type"] for e in payloads[0]["events"]] == ["WORKFLOW_STARTED"]
 
     @pytest.mark.asyncio
     async def test_terminal_checkpoint_is_sent_without_task_events(self):

--- a/tests/flux/test_transient.py
+++ b/tests/flux/test_transient.py
@@ -1,0 +1,194 @@
+"""Tests for transient (non-durable-tasks) executions.
+
+A transient workflow keeps its outer lifecycle — execution row, dispatch,
+claim, terminal state — but suppresses all intermediate task-level
+checkpoints and never persists TASK_* events.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from flux.domain.execution_context import ExecutionContext
+from tests.flux.test_worker_checkpoint import make_ctx, make_worker, ok_response
+
+
+class TestWorkflowDurabilityOption:
+    def test_transient_option_is_stored(self):
+        from flux.workflow import workflow
+
+        @workflow.with_options(durability="transient")
+        async def wf(ctx):
+            return 1
+
+        assert wf.durability == "transient"
+
+    def test_invalid_durability_rejected(self):
+        from flux.workflow import workflow
+
+        with pytest.raises(ValueError, match="durability must be"):
+
+            @workflow.with_options(durability="sometimes")
+            async def wf(ctx):
+                return 1
+
+    def test_transient_with_schedule_rejected(self):
+        from flux.domain.schedule import interval
+        from flux.workflow import workflow
+
+        with pytest.raises(ValueError, match="schedule"):
+
+            @workflow.with_options(durability="transient", schedule=interval(seconds=60))
+            async def wf(ctx):
+                return 1
+
+
+class TestCatalogDurabilityExtraction:
+    def test_parse_static_extracts_durability(self):
+        from flux.catalogs import DatabaseWorkflowCatalog
+
+        source = b'''
+from flux import ExecutionContext
+from flux.workflow import workflow
+
+
+@workflow.with_options(durability="transient")
+async def mesh_hop(ctx: ExecutionContext[str]):
+    return ctx.input
+'''
+        # Bypass __init__ (which opens a database) — parse_static only needs
+        # the AST helper methods on the instance.
+        catalog = DatabaseWorkflowCatalog.__new__(DatabaseWorkflowCatalog)
+        workflows = catalog.parse_static(source)
+        assert workflows[0].metadata["durability"] == "transient"
+
+
+class TestTransientCheckpointSuppression:
+    @pytest.mark.asyncio
+    async def test_intermediate_checkpoints_are_skipped(self):
+        """Task-level checkpoints during a transient run never leave the worker."""
+        worker = make_worker()
+        worker.client.post = AsyncMock(return_value=ok_response())
+
+        ctx = make_ctx()
+        ctx.is_transient = True
+        ctx.is_paused = False
+        await worker._checkpoint(ctx)
+
+        worker.client.post.assert_not_called()
+        assert ctx.execution_id not in worker._checkpoint_outboxes
+
+    @pytest.mark.asyncio
+    async def test_terminal_checkpoint_is_sent_without_task_events(self):
+        """The terminal checkpoint persists, carrying only WORKFLOW_* events."""
+        worker = make_worker()
+        payloads = []
+
+        async def capture_post(url, **kwargs):
+            payloads.append(kwargs["json"])
+            return ok_response()
+
+        worker.client.post = capture_post
+
+        ctx = make_ctx(finished=True)
+        ctx.is_transient = True
+        ctx.is_paused = False
+        ctx.to_dict.return_value = {
+            "execution_id": "exec-1",
+            "events": [
+                {"id": "e1", "type": "WORKFLOW_STARTED"},
+                {"id": "e2", "type": "TASK_STARTED"},
+                {"id": "e3", "type": "TASK_COMPLETED"},
+                {"id": "e4", "type": "WORKFLOW_COMPLETED"},
+            ],
+        }
+        await worker._checkpoint(ctx)
+
+        assert len(payloads) == 1
+        types = [e["type"] for e in payloads[0]["events"]]
+        assert types == ["WORKFLOW_STARTED", "WORKFLOW_COMPLETED"]
+
+    @pytest.mark.asyncio
+    async def test_transient_pause_converts_to_terminal_failure(self):
+        """Pause needs replayable task history; a transient run fails instead."""
+        worker = make_worker()
+        worker.client.post = AsyncMock(return_value=ok_response())
+
+        ctx = ExecutionContext(
+            workflow_id="default/wf",
+            workflow_namespace="default",
+            workflow_name="wf",
+        ).mark_transient()
+        ctx.start("w")
+        ctx.pause("gate", "gate")
+
+        await worker._checkpoint(ctx)
+
+        assert ctx.has_failed
+        worker.client.post.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_durable_context_still_checkpoints_intermediates(self):
+        """Regression guard: suppression only applies to transient contexts."""
+        worker = make_worker()
+        worker.client.post = AsyncMock(return_value=ok_response())
+
+        ctx = make_ctx()  # MagicMock: is_transient truthiness must not trigger
+        ctx.is_transient = False
+        ctx.is_paused = False
+        await worker._checkpoint(ctx)
+        box = worker._checkpoint_outboxes.get(ctx.execution_id)
+        assert box is not None
+        while box.acked < box.generation:
+            await asyncio.sleep(0.005)
+        worker.client.post.assert_called()
+
+
+class TestApprovalGuard:
+    @pytest.mark.asyncio
+    async def test_transient_execution_refuses_approval_gate(self):
+        from flux.errors import TransientDurabilityError
+        from flux.task import task
+
+        @task.with_options(requires_approval=True)
+        async def gated():
+            return 1
+
+        ctx = ExecutionContext(
+            workflow_id="default/wf",
+            workflow_namespace="default",
+            workflow_name="wf",
+        ).mark_transient()
+
+        with pytest.raises(TransientDurabilityError, match="requires_approval"):
+            await gated._approval_gate(ctx, "call-1", "gated", (), {})
+
+
+class TestDispatchPayloadFlag:
+    def test_payload_flags_transient_workflows(self):
+        from flux.server import Server
+
+        server = Server(host="localhost", port=8000)
+        with (
+            pytest.MonkeyPatch.context() as mp,
+        ):
+            workflow_info = MagicMock()
+            workflow_info.source = b"src"
+            workflow_info.metadata = {"durability": "transient"}
+            catalog = MagicMock()
+            catalog.get.return_value = workflow_info
+            mp.setattr("flux.api.worker_routes.WorkflowCatalog", MagicMock(create=lambda: catalog))
+            session = MagicMock()
+            session.get.return_value = None
+            mp.setattr(server, "_get_db_session", lambda: session)
+
+            ctx = MagicMock()
+            ctx.workflow_namespace = "default"
+            ctx.workflow_name = "wf"
+            ctx.execution_id = "e1"
+            payload = server._build_dispatch_payload(ctx)
+
+        assert payload.get("transient") is True

--- a/tests/flux/test_worker_checkpoint.py
+++ b/tests/flux/test_worker_checkpoint.py
@@ -1,0 +1,210 @@
+"""Tests for the worker checkpoint outbox: retry, coalescing, terminal delivery, reauth."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from flux.worker import Worker
+
+
+def make_worker() -> Worker:
+    worker = Worker.__new__(Worker)
+    worker.name = "test-worker"
+    worker.base_url = "http://localhost:19000/workers"
+    worker.session_token = "tok"
+    worker.client = AsyncMock()
+    worker._running_workflows = {}
+    worker._checkpoint_outboxes = {}
+    worker._registered = True
+    worker._reauth_lock = asyncio.Lock()
+    worker._checkpoint_retry_max_delay = 0.01
+    worker._terminal_checkpoint_deadline = 5
+    worker._progress_queues = {}
+    worker._progress_flushers = {}
+    worker._module_cache = {}
+    worker._module_cache_ttl = 0
+    return worker
+
+
+def make_ctx(execution_id: str = "exec-1", finished: bool = False) -> MagicMock:
+    ctx = MagicMock()
+    ctx.execution_id = execution_id
+    ctx.workflow_name = "test_wf"
+    ctx.workflow_namespace = "default"
+    ctx.has_finished = finished
+    ctx.state.value = "COMPLETED" if finished else "RUNNING"
+    ctx.events = []
+    ctx.to_dict.return_value = {"execution_id": execution_id, "finished": finished}
+    return ctx
+
+
+def ok_response() -> MagicMock:
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status = MagicMock()
+    response.json.return_value = {"status": "ok"}
+    return response
+
+
+@pytest.mark.asyncio
+async def test_intermediate_checkpoint_retries_until_delivered():
+    """A failed intermediate checkpoint is retried, not dropped."""
+    worker = make_worker()
+    attempts = 0
+
+    async def flaky_post(url, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise ConnectionError("server unreachable")
+        return ok_response()
+
+    worker.client.post = flaky_post
+
+    ctx = make_ctx()
+    await worker._checkpoint(ctx)
+
+    box = worker._checkpoint_outboxes[ctx.execution_id]
+    await asyncio.wait_for(_wait_for_ack(box), timeout=5)
+    assert attempts == 3
+
+
+@pytest.mark.asyncio
+async def test_terminal_checkpoint_blocks_until_delivered():
+    """A terminal checkpoint blocks the caller until the server acknowledges it."""
+    worker = make_worker()
+    attempts = 0
+
+    async def flaky_post(url, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ConnectionError("server unreachable")
+        return ok_response()
+
+    worker.client.post = flaky_post
+
+    ctx = make_ctx(finished=True)
+    await worker._checkpoint(ctx)
+
+    assert attempts == 2
+    assert ctx.execution_id not in worker._checkpoint_outboxes
+
+
+@pytest.mark.asyncio
+async def test_terminal_checkpoint_gives_up_at_deadline_without_raising():
+    """Persistent failure past the deadline logs and returns; it must not raise."""
+    worker = make_worker()
+    worker._terminal_checkpoint_deadline = 0.1
+    worker.client.post = AsyncMock(side_effect=ConnectionError("server unreachable"))
+
+    ctx = make_ctx(finished=True)
+    await worker._checkpoint(ctx)
+
+    assert ctx.execution_id not in worker._checkpoint_outboxes
+
+
+@pytest.mark.asyncio
+async def test_rapid_checkpoints_never_cancel_inflight_sends():
+    """Rapid successive checkpoints coalesce to the newest snapshot; in-flight
+    sends complete instead of being cancelled, and the terminal snapshot wins."""
+    worker = make_worker()
+    started = 0
+    completed = 0
+    sent_payloads = []
+
+    async def slow_post(url, **kwargs):
+        nonlocal started, completed
+        started += 1
+        await asyncio.sleep(0.02)
+        completed += 1
+        sent_payloads.append(kwargs["json"])
+        return ok_response()
+
+    worker.client.post = slow_post
+
+    for _ in range(3):
+        await worker._checkpoint(make_ctx())
+    await worker._checkpoint(make_ctx(finished=True))
+
+    assert started == completed  # nothing cancelled mid-flight
+    assert sent_payloads[-1]["finished"] is True
+    assert "exec-1" not in worker._checkpoint_outboxes
+
+
+@pytest.mark.asyncio
+async def test_close_outbox_drains_pending_non_terminal_snapshot():
+    """Closing the outbox (pause / handler end) still delivers pending data."""
+    worker = make_worker()
+    gate = asyncio.Event()
+    sent = []
+
+    async def gated_post(url, **kwargs):
+        await gate.wait()
+        sent.append(kwargs["json"])
+        return ok_response()
+
+    worker.client.post = gated_post
+
+    ctx = make_ctx()
+    await worker._checkpoint(ctx)
+    worker._close_checkpoint_outbox(ctx.execution_id)
+    gate.set()
+
+    box_sender = worker._checkpoint_outboxes.get(ctx.execution_id)
+    await asyncio.sleep(0.05)
+    assert sent, "pending snapshot was dropped on close"
+    assert ctx.execution_id not in worker._checkpoint_outboxes
+    assert box_sender is not None
+
+
+@pytest.mark.asyncio
+async def test_authorized_post_reregisters_on_401_and_retries():
+    """A 401 mid-operation triggers one re-registration and a retry with the new token."""
+    worker = make_worker()
+    tokens_seen = []
+
+    rejected = MagicMock()
+    rejected.status_code = 401
+
+    async def post(url, headers=None, **kwargs):
+        tokens_seen.append(headers["Authorization"])
+        if headers["Authorization"] == "Bearer tok":
+            return rejected
+        return ok_response()
+
+    worker.client.post = post
+
+    async def fake_register():
+        worker.session_token = "new-tok"
+        worker._registered = True
+
+    worker._register = fake_register
+
+    response = await worker._authorized_post("http://localhost:19000/workers/x/pong")
+
+    assert response.status_code == 200
+    assert tokens_seen == ["Bearer tok", "Bearer new-tok"]
+
+
+@pytest.mark.asyncio
+async def test_authorized_post_returns_non_auth_errors_unchanged():
+    """Non-auth failures (e.g. 409) pass through without re-registration."""
+    worker = make_worker()
+    conflict = MagicMock()
+    conflict.status_code = 409
+    worker.client.post = AsyncMock(return_value=conflict)
+    worker._register = AsyncMock()
+
+    response = await worker._authorized_post("http://localhost:19000/workers/x/claim/e1")
+
+    assert response.status_code == 409
+    worker._register.assert_not_called()
+
+
+async def _wait_for_ack(box):
+    while box.acked < box.generation:
+        await asyncio.sleep(0.005)

--- a/tests/flux/test_worker_checkpoint.py
+++ b/tests/flux/test_worker_checkpoint.py
@@ -18,6 +18,7 @@ def make_worker() -> Worker:
     worker.client = AsyncMock()
     worker._running_workflows = {}
     worker._checkpoint_outboxes = {}
+    worker._claim_generations = {}
     worker._registered = True
     worker._reauth_lock = asyncio.Lock()
     worker._checkpoint_retry_max_delay = 0.01
@@ -293,3 +294,81 @@ async def test_scheduled_handler_declines_work_while_draining():
     }
     await worker._handle_execution_scheduled("http://localhost:19000/workers/x", evt)
     worker._authorized_post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fenced_checkpoint_aborts_local_execution():
+    """A stale-claim 409 cancels the local run and unblocks terminal waiters."""
+    worker = make_worker()
+    worker._claim_generations["exec-1"] = "1"
+
+    fenced = MagicMock()
+    fenced.status_code = 409
+    fenced.text = '{"detail": "stale-claim: reassigned"}'
+    worker.client.post = AsyncMock(return_value=fenced)
+
+    hung = asyncio.get_running_loop().create_future()
+
+    async def running():
+        await hung  # would run forever unless cancelled
+
+    task = asyncio.create_task(running())
+    worker._running_workflows["exec-1"] = task
+
+    # Terminal checkpoint: must return promptly (fenced), not wait the deadline.
+    ctx = make_ctx(finished=True)
+    await asyncio.wait_for(worker._checkpoint(ctx), timeout=5)
+
+    await asyncio.sleep(0.01)
+    assert task.cancelled()
+    assert "exec-1" not in worker._checkpoint_outboxes
+    assert "exec-1" not in worker._claim_generations
+
+
+@pytest.mark.asyncio
+async def test_delta_checkpoints_send_only_unacked_events():
+    """The second checkpoint carries only events the server has not acked."""
+    worker = make_worker()
+    payloads = []
+
+    async def capture_post(url, **kwargs):
+        payloads.append(kwargs["json"])
+        return ok_response()
+
+    worker.client.post = capture_post
+
+    first = make_ctx()
+    first.to_dict.return_value = {
+        "execution_id": "exec-1",
+        "events": [{"id": "e1"}, {"id": "e2"}],
+    }
+    await worker._checkpoint(first)
+    box = worker._checkpoint_outboxes["exec-1"]
+    await asyncio.wait_for(_wait_for_ack(box), timeout=5)
+
+    second = make_ctx(finished=True)
+    second.to_dict.return_value = {
+        "execution_id": "exec-1",
+        "events": [{"id": "e1"}, {"id": "e2"}, {"id": "e3"}, {"id": "e4"}],
+    }
+    await worker._checkpoint(second)
+
+    assert [e["id"] for e in payloads[0]["events"]] == ["e1", "e2"]
+    assert [e["id"] for e in payloads[1]["events"]] == ["e3", "e4"]
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_includes_claim_generation_header():
+    worker = make_worker()
+    worker._claim_generations["exec-1"] = "7"
+    seen_headers = []
+
+    async def capture_post(url, headers=None, **kwargs):
+        seen_headers.append(headers or {})
+        return ok_response()
+
+    worker.client.post = capture_post
+
+    await worker._checkpoint(make_ctx(finished=True))
+
+    assert seen_headers[0].get("X-Flux-Claim-Generation") == "7"

--- a/tests/flux/test_worker_checkpoint.py
+++ b/tests/flux/test_worker_checkpoint.py
@@ -19,6 +19,7 @@ def make_worker() -> Worker:
     worker._running_workflows = {}
     worker._checkpoint_outboxes = {}
     worker._claim_generations = {}
+    worker._transient_started = set()
     worker._registered = True
     worker._reauth_lock = asyncio.Lock()
     worker._checkpoint_retry_max_delay = 0.01

--- a/tests/flux/test_worker_checkpoint.py
+++ b/tests/flux/test_worker_checkpoint.py
@@ -26,6 +26,8 @@ def make_worker() -> Worker:
     worker._progress_flushers = {}
     worker._module_cache = {}
     worker._module_cache_ttl = 0
+    worker._draining = False
+    worker._drain_timeout = 5
     return worker
 
 
@@ -208,3 +210,86 @@ async def test_authorized_post_returns_non_auth_errors_unchanged():
 async def _wait_for_ack(box):
     while box.acked < box.generation:
         await asyncio.sleep(0.005)
+
+
+@pytest.mark.asyncio
+async def test_drain_waits_for_running_executions():
+    """Drain lets in-flight executions finish instead of cancelling them."""
+    worker = make_worker()
+    finished = []
+
+    async def wf():
+        await asyncio.sleep(0.05)
+        finished.append(True)
+
+    worker._running_workflows["e1"] = asyncio.create_task(wf())
+    await worker._drain()
+    assert finished == [True]
+
+
+@pytest.mark.asyncio
+async def test_drain_cancels_past_deadline():
+    """Executions still running at the drain deadline are cancelled."""
+    worker = make_worker()
+    worker._drain_timeout = 0.05
+    cancelled = []
+
+    async def stuck():
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.append(True)
+            raise
+
+    worker._running_workflows["e1"] = asyncio.create_task(stuck())
+    await worker._drain()
+    assert cancelled == [True]
+
+
+@pytest.mark.asyncio
+async def test_drain_flushes_outstanding_checkpoint_senders():
+    """Terminal checkpoints still in flight get a final delivery window."""
+    from flux.worker import _CheckpointOutbox
+
+    worker = make_worker()
+    delivered = []
+
+    async def sender():
+        await asyncio.sleep(0.05)
+        delivered.append(True)
+
+    box = _CheckpointOutbox()
+    box.sender = asyncio.create_task(sender())
+    worker._checkpoint_outboxes["e1"] = box
+    await worker._drain()
+    assert delivered == [True]
+
+
+@pytest.mark.asyncio
+async def test_scheduled_handler_declines_work_while_draining():
+    """A dispatch that races the drain window is not claimed."""
+    worker = make_worker()
+    worker._draining = True
+    worker._authorized_post = AsyncMock()
+
+    evt = MagicMock()
+    evt.json.return_value = {
+        "workflow": {
+            "id": "wf-1",
+            "namespace": "default",
+            "name": "wf",
+            "version": 1,
+            "source": "",
+        },
+        "context": {
+            "workflow_id": "wf-1",
+            "workflow_namespace": "default",
+            "workflow_name": "wf",
+            "execution_id": "exec-drain",
+            "input": None,
+            "state": "SCHEDULED",
+            "events": [],
+        },
+    }
+    await worker._handle_execution_scheduled("http://localhost:19000/workers/x", evt)
+    worker._authorized_post.assert_not_called()

--- a/tests/flux/test_worker_heartbeat_persistence.py
+++ b/tests/flux/test_worker_heartbeat_persistence.py
@@ -85,6 +85,22 @@ def test_record_heartbeat_unknown_worker_is_noop(registry):
     registry.record_heartbeat("does-not-exist")
 
 
+def test_record_heartbeats_batch_updates_all_named_workers(registry):
+    for name in ("b1", "b2", "b3"):
+        _register(registry, name)
+    before = datetime.now(timezone.utc).replace(tzinfo=None)
+
+    registry.record_heartbeats(["b1", "b2"])
+
+    assert _last_seen_at(registry, "b1") >= before - timedelta(seconds=1)
+    assert _last_seen_at(registry, "b2") >= before - timedelta(seconds=1)
+    assert _last_seen_at(registry, "b3") is None  # not in the batch
+
+
+def test_record_heartbeats_empty_is_noop(registry):
+    registry.record_heartbeats([])
+
+
 def test_find_stale_returns_workers_past_threshold(registry):
     _register(registry, "old")
     _register(registry, "fresh")

--- a/tests/flux/test_worker_resume_claim.py
+++ b/tests/flux/test_worker_resume_claim.py
@@ -21,6 +21,7 @@ async def test_handle_execution_resumed_posts_claim_before_executing():
     worker.client = AsyncMock()
     worker._running_workflows = {}
     worker._checkpoint_outboxes = {}
+    worker._claim_generations = {}
     worker._registered = True
     worker._reauth_lock = asyncio.Lock()
     worker._checkpoint_retry_max_delay = 30
@@ -46,6 +47,7 @@ async def test_handle_execution_resumed_posts_claim_before_executing():
         },
     )
     claim_response.status_code = 200
+    claim_response.headers = {}
 
     async def mock_post(url, **kwargs):
         calls.append(("post", url))
@@ -99,6 +101,7 @@ async def test_handle_execution_resumed_drops_on_409():
     worker.client = AsyncMock()
     worker._running_workflows = {}
     worker._checkpoint_outboxes = {}
+    worker._claim_generations = {}
     worker._registered = True
     worker._reauth_lock = asyncio.Lock()
     worker._checkpoint_retry_max_delay = 30

--- a/tests/flux/test_worker_resume_claim.py
+++ b/tests/flux/test_worker_resume_claim.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -19,7 +20,11 @@ async def test_handle_execution_resumed_posts_claim_before_executing():
     worker.session_token = "tok"
     worker.client = AsyncMock()
     worker._running_workflows = {}
-    worker._pending_checkpoints = {}
+    worker._checkpoint_outboxes = {}
+    worker._registered = True
+    worker._reauth_lock = asyncio.Lock()
+    worker._checkpoint_retry_max_delay = 30
+    worker._terminal_checkpoint_deadline = 300
     worker._progress_queues = {}
     worker._progress_flushers = {}
     worker._module_cache = {}
@@ -93,7 +98,11 @@ async def test_handle_execution_resumed_drops_on_409():
     worker.session_token = "tok"
     worker.client = AsyncMock()
     worker._running_workflows = {}
-    worker._pending_checkpoints = {}
+    worker._checkpoint_outboxes = {}
+    worker._registered = True
+    worker._reauth_lock = asyncio.Lock()
+    worker._checkpoint_retry_max_delay = 30
+    worker._terminal_checkpoint_deadline = 300
     worker._progress_queues = {}
     worker._progress_flushers = {}
     worker._module_cache = {}

--- a/tests/security/test_config.py
+++ b/tests/security/test_config.py
@@ -54,7 +54,7 @@ class TestAuthConfig:
     def test_security_config_has_execution_token_ttl(self):
         config = SecurityConfig()
         assert hasattr(config, "execution_token_ttl")
-        assert config.execution_token_ttl == 604800
+        assert config.execution_token_ttl == 86400
 
     def test_security_config_execution_token_ttl_configurable(self):
         config = SecurityConfig(execution_token_ttl=3600)

--- a/tests/security/test_startup_validation.py
+++ b/tests/security/test_startup_validation.py
@@ -1,0 +1,130 @@
+"""Tests for startup security validation and the /workers/register rate limit."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from flux.config import Configuration
+from flux.server import Server
+
+
+@pytest.fixture(autouse=True)
+def reset_config():
+    yield
+    Configuration.get().reset()
+
+
+def _settings():
+    return Configuration.get().settings
+
+
+class TestSecurityConfigValidation:
+    def test_auth_enabled_without_secrets_refuses_startup(self):
+        Configuration.get().override(
+            security={
+                "auth": {"enabled": True, "api_keys": {"enabled": True}},
+                "execution_token_secret": None,
+                "encryption": {"encryption_key": None},
+            },
+        )
+        with pytest.raises(RuntimeError) as err:
+            Server._validate_security_config(_settings())
+        assert "execution_token_secret" in str(err.value)
+        assert "encryption_key" in str(err.value)
+
+    def test_auth_enabled_with_secrets_passes(self):
+        Configuration.get().override(
+            security={
+                "auth": {"enabled": True, "api_keys": {"enabled": True}},
+                "execution_token_secret": "s3cret",
+                "encryption": {"encryption_key": "k3y"},
+            },
+        )
+        Server._validate_security_config(_settings())
+
+    def test_debug_mode_is_exempt(self):
+        Configuration.get().override(
+            debug=True,
+            security={
+                "auth": {"enabled": True, "api_keys": {"enabled": True}},
+                "execution_token_secret": None,
+                "encryption": {"encryption_key": None},
+            },
+        )
+        Server._validate_security_config(_settings())
+
+    def test_auth_disabled_only_warns(self, caplog):
+        Configuration.get().override(
+            security={
+                "auth": {"enabled": False},
+                "encryption": {"encryption_key": None},
+            },
+        )
+        Server._validate_security_config(_settings())  # must not raise
+        assert any("encryption key" in r.message.lower() for r in caplog.records)
+
+
+class TestRegisterRateLimit:
+    def test_register_is_rate_limited(self):
+        Configuration.get().override(
+            workers={"bootstrap_token": "tok", "register_rate_limit": "3/minute"},
+        )
+        server = Server(host="localhost", port=8000)
+        client = TestClient(server._create_api(), raise_server_exceptions=False)
+
+        payload = {
+            "name": "rl-worker",
+            "runtime": {"os_name": "linux", "os_version": "1", "python_version": "3.12"},
+            "packages": [],
+            "resources": {
+                "cpu_total": 1,
+                "cpu_available": 1,
+                "memory_total": 1,
+                "memory_available": 1,
+                "disk_total": 1,
+                "disk_free": 1,
+                "gpus": [],
+            },
+        }
+        statuses = [
+            client.post(
+                "/workers/register",
+                json=payload,
+                headers={"Authorization": "Bearer wrong-token"},
+            ).status_code
+            for _ in range(4)
+        ]
+        assert statuses[:3] == [403, 403, 403]
+        assert statuses[3] == 429
+
+    def test_register_rate_limit_disabled_by_empty_string(self):
+        Configuration.get().override(
+            workers={"bootstrap_token": "tok", "register_rate_limit": ""},
+        )
+        server = Server(host="localhost", port=8000)
+        client = TestClient(server._create_api(), raise_server_exceptions=False)
+
+        payload = {
+            "name": "rl-worker-2",
+            "runtime": {"os_name": "linux", "os_version": "1", "python_version": "3.12"},
+            "packages": [],
+            "resources": {
+                "cpu_total": 1,
+                "cpu_available": 1,
+                "memory_total": 1,
+                "memory_available": 1,
+                "disk_total": 1,
+                "disk_free": 1,
+                "gpus": [],
+            },
+        }
+        statuses = [
+            client.post(
+                "/workers/register",
+                json=payload,
+                headers={"Authorization": "Bearer wrong-token"},
+            ).status_code
+            for _ in range(5)
+        ]
+        assert all(s == 403 for s in statuses)


### PR DESCRIPTION
## Summary

This PR takes Flux from production-credible-at-tens-of-workers to a measured, hardened foundation for large worker fleets and high-frequency agent-to-agent (&#34;AI mesh&#34;) workloads. It contains a full production-readiness review with a proposed target architecture, every P0/P1 fix from that review implemented and stress-tested, and the first P2 feature: `durability=&#34;transient&#34;` workflows.

The full review, target architecture, and all measured results live in `docs/production-readiness-review.md`; operational guidance in `docs/production-deployment.md`.

## Scale: event-driven dispatch

- **New dispatcher** (`[flux.dispatch] mode = &#34;event&#34;`): one dispatcher task per replica batch-claims work with `FOR UPDATE SKIP LOCKED` on wakeups (PostgreSQL `LISTEN/NOTIFY` + local signals + fallback tick), replacing the legacy per-worker 0.5s poll loop. Poll mode remains the default for one release.
- Pool/executor sizing knobs (`database_executor_threads`, raised pool defaults), heartbeat batching (one UPDATE per interval instead of one commit per pong), `workers.last_seen_at` index.
- **Worker capacity slots** (`max_concurrent_executions`, advertised at registration, enforced on every dispatch path) and **graceful drain** on SIGTERM.

Measured with the committed harness (`scripts/stress_dispatch.py`, protocol-level simulated workers on PostgreSQL 16, 4-core host):

| | poll @ 500 workers | event @ 500 workers |
|---|---:|---:|
| Idle DB transactions/sec | 613 (executor-saturated) | 91 |
| Accepting 600 submissions | 222 s | 12 s |
| First dispatch latency | 11.5 s | 0.6 s |

Also validated with real `flux start worker` processes (8 and 24 workers, ~21 executions/sec sustained, clean SIGTERM drain).

## Durability &amp; correctness

- **Checkpoint outbox**: per-execution sender with retry/backoff; in-flight sends are never cancelled; terminal checkpoints block until acknowledged (bounded by `terminal_checkpoint_deadline`). Real HTTP timeouts (`http_timeout`) and 401→re-register→retry on every worker call.
- **Delta checkpoints**: each POST carries only unacknowledged events — O(K) traffic instead of O(K²) per K-task workflow, backward compatible in both directions.
- **Claim-generation fencing** (migration 0006): checkpoints from a superseded claim are rejected with 409 and the fenced worker aborts its local copy — closing the split-brain window after partitions.
- **Retention job** (opt-in, advisory-lock singleton) bounding `executions`/`execution_events` growth.

## Security &amp; operations

- fastmcp 2.14.7 / mcp 1.28.1 / pydantic-settings 2.14.2 (clears 5 fixable advisories; remaining triage documented in the review).
- psycopg v3 driver (URL dialect normalized in one place; enables the LISTEN/NOTIFY listener).
- Rate-limited `/workers/register` (configurable), fail-fast startup validation of auth secrets, worker API keys with TTL + self-rotation, principal GC for pruned workers, execution-token TTL 7d→24h.
- Bounded metric label cardinality (caller-controlled worker names are no longer labels).
- Fleet-wide `GET /workers` (DB-backed, hybrid liveness), cross-replica sync-waiter wakeups via `NOTIFY flux_exec`, `/ready` readiness probe.

## Transient workflows (AI mesh)

`@workflow.with_options(durability=&#34;transient&#34;)`: the execution keeps its full outer lifecycle — row, dispatch/claim, RUNNING, terminal state, visible in `flux execution list`, cancellable, fenced, reaper-recovered — but persists **no task-level state**: the worker suppresses intermediate checkpoints (one filtered send persists the RUNNING transition) and the terminal checkpoint carries only `WORKFLOW_*` events. Pause/approvals are hard errors (`TransientDurabilityError`); schedules are rejected at decoration time. Works in both dispatch modes with sync/async/stream callers.

Measured on real workers (8-task workflow): **persisted event rows per execution drop from 19.9 to 4.0** with unchanged latency — task-level payloads (e.g. per-step LLM inputs/outputs in agent loops) never reach the database.

## Migrations

Alembic 0004–0006 (heartbeat index, worker capacity, claim generation) — all additive, guarded, and safe on fresh, Alembic-managed, and legacy `create_all` databases.

## Validation

- 2,362 unit tests (≈60 new across dispatch batching, checkpoint outbox, fencing, retention, capacity, drain, transient).
- Full e2e suite green on all four combinations of {SQLite, PostgreSQL 16} × {poll, event}, including a 9-scenario transient matrix (sync/async, failure, in-memory retry, cancellation, pause/approval guards, durable regression control, durable→transient `call()` hop).
- PostgreSQL-marked suite green on a live PostgreSQL 16 via psycopg3; two-replica LISTEN/NOTIFY relay verified with concurrent dispatcher instances.
- Stress/benchmark results reproducible via `scripts/stress_dispatch.py`.

Version bumped to 0.51.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)