### PR TITLE
Fix retry-attempt replay after approval pause; examples on the public surface

### DIFF
--- a/examples/cancellation.py
+++ b/examples/cancellation.py
@@ -1,18 +1,24 @@
 """Example demonstrating workflow cancellation.
 
-This example simulates a complete cancellation flow including server and worker roles
-in a self-contained script, without requiring external components.
+Runs a cancellable workflow inline and cancels it mid-flight. Cancellation
+in Flux is cooperative asyncio cancellation: tasks receive
+``asyncio.CancelledError`` at their next await point, may clean up, and
+re-raise; the workflow records the terminal ``CANCELLED`` state.
+
+In a deployed system cancellation is server-mediated — request it with
+``flux workflow cancel <workflow> <execution_id>``,
+``FluxClient.cancel_execution(...)``, or
+``GET /workflows/{ns}/{name}/cancel/{execution_id}`` — and the worker
+running the execution delivers exactly the cancellation shown here.
 """
 
 from __future__ import annotations
 
 import asyncio
 from typing import Any
-from uuid import uuid4
 
 from flux import ExecutionContext
 from flux.task import task
-from flux.worker_registry import WorkerInfo
 from flux.workflow import workflow
 
 
@@ -53,178 +59,37 @@ async def cancellable_workflow(ctx: ExecutionContext[dict[str, Any]]):
         raise
 
 
-class SimulatedServer:
-    """Simulates the server component of Flux."""
-
-    def __init__(self):
-        self.contexts: dict[str, ExecutionContext] = {}
-        self.cancellation_queue = asyncio.Queue()
-
-    def register_context(self, ctx: ExecutionContext):
-        """Register an execution context with the server."""
-        self.contexts[ctx.execution_id] = ctx
-        print(f"[SERVER] Registered execution context: {ctx.execution_id}")
-        return ctx
-
-    def request_cancellation(self, execution_id: str):
-        """Request cancellation of a workflow execution."""
-        if execution_id not in self.contexts:
-            print(f"[SERVER] Error: Execution {execution_id} not found")
-            return False
-
-        ctx = self.contexts[execution_id]
-        if ctx.has_finished:
-            print(f"[SERVER] Error: Execution {execution_id} already finished")
-            return False
-
-        # Mark as cancelling
-        ctx.start_cancel()
-        self.contexts[execution_id] = ctx
-        print(f"[SERVER] Execution {execution_id} marked as CANCELLING")
-
-        # Queue for worker to pick up
-        self.cancellation_queue.put_nowait(execution_id)
-        print("[SERVER] Cancellation request queued for worker")
-        return True
-
-    def update_context(self, ctx: ExecutionContext):
-        """Update an execution context in the server."""
-        self.contexts[ctx.execution_id] = ctx
-        print(f"[SERVER] Updated execution context: {ctx.execution_id}, state: {ctx.state.value}")
-        return ctx
-
-    def get_context(self, execution_id: str):
-        """Get an execution context from the server."""
-        return self.contexts.get(execution_id)
-
-
-# --------------------- Simulated Worker Component ---------------------
-
-
-class SimulatedWorker:
-    """Simulates the worker component of Flux."""
-
-    def __init__(self, server: SimulatedServer):
-        self.server = server
-        self.running_workflows: dict[str, asyncio.Task] = {}
-        self.worker_id = f"worker-{uuid4().hex[:6]}"
-
-    async def start_cancellation_listener(self):
-        """Listen for cancellation requests from the server."""
-        print("[WORKER] Starting cancellation listener")
-        while True:
-            execution_id = await self.server.cancellation_queue.get()
-            print(f"[WORKER] Received cancellation request for: {execution_id}")
-            await self.handle_cancellation(execution_id)
-            self.server.cancellation_queue.task_done()
-
-    async def handle_cancellation(self, execution_id: str):
-        """Handle a cancellation request."""
-        if execution_id not in self.running_workflows:
-            print(f"[WORKER] Workflow {execution_id} not running on this worker")
-            return
-
-        task = self.running_workflows[execution_id]
-        print(f"[WORKER] Cancelling workflow task: {execution_id}")
-        task.cancel()
-
-        try:
-            await task
-        except asyncio.CancelledError:
-            print(f"[WORKER] Workflow {execution_id} cancelled successfully")
-        finally:
-            if execution_id in self.running_workflows:
-                self.running_workflows.pop(execution_id)
-
-    async def execute_workflow(self, workflow_func, ctx: ExecutionContext):
-        """Execute a workflow and track it for possible cancellation."""
-        print(f"[WORKER] Starting execution of workflow: {ctx.workflow_name} ({ctx.execution_id})")
-
-        # Claim the execution
-        ctx.claim(WorkerInfo(name=self.worker_id))
-        self.server.update_context(ctx)
-
-        # Start the workflow
-        task = asyncio.create_task(workflow_func(ctx))
-        self.running_workflows[ctx.execution_id] = task
-
-        try:
-            # Wait for the workflow to complete
-            result_ctx = await task
-            print(f"[WORKER] Workflow completed: {ctx.execution_id}")
-            return result_ctx
-        except asyncio.CancelledError:
-            # If cancelled, update the context
-            ctx = self.server.get_context(ctx.execution_id)
-            if ctx:
-                ctx.cancel()
-                self.server.update_context(ctx)
-            print(f"[WORKER] Workflow cancellation completed: {ctx.execution_id}")
-            raise
-        finally:
-            # Clean up
-            if ctx.execution_id in self.running_workflows:
-                self.running_workflows.pop(ctx.execution_id)
-
-
-# --------------------- Main Example ---------------------
-
-
 async def run_cancellation_example():
-    """Run the complete cancellation example."""
+    """Start the workflow, cancel it mid-flight, inspect the final state."""
     print("Starting cancellation example...\n")
 
-    # Create the server and worker
-    server = SimulatedServer()
-    worker = SimulatedWorker(server)
+    ctx = ExecutionContext(
+        workflow_id="cancellable_workflow",
+        workflow_namespace="default",
+        workflow_name="cancellable_workflow",
+        input={"iterations": 5},
+    )
 
-    # Start the cancellation listener
-    listener_task = asyncio.create_task(worker.start_cancellation_listener())
+    # Run the workflow as an asyncio task so it can be cancelled — the same
+    # thing a worker does when the server relays a cancellation request.
+    workflow_task = asyncio.create_task(cancellable_workflow(ctx))
+
+    # Let a few iterations run.
+    await asyncio.sleep(3)
+
+    print("\n[CLIENT] Requesting workflow cancellation...\n")
+    workflow_task.cancel()
 
     try:
-        # Create execution context
-        ctx = ExecutionContext(
-            workflow_id="cancellable_workflow",
-            workflow_namespace="default",
-            workflow_name="cancellable_workflow",
-            input={"iterations": 5},  # Run for 5 iterations
-        )
+        await workflow_task
+        print("[CLIENT] Workflow completed normally (unexpected)")
+    except asyncio.CancelledError:
+        print("[CLIENT] Workflow was cancelled as expected")
 
-        # Register with server
-        server.register_context(ctx)
-
-        # Start the workflow on the worker
-        workflow_task = asyncio.create_task(worker.execute_workflow(cancellable_workflow, ctx))
-
-        # Wait a bit to let the workflow start
-        await asyncio.sleep(3)
-
-        # Request cancellation
-        print("\n[CLIENT] Requesting workflow cancellation...\n")
-        server.request_cancellation(ctx.execution_id)
-
-        # Wait for the workflow to complete or be cancelled
-        try:
-            await workflow_task
-            print("[CLIENT] Workflow completed normally (unexpected)")
-        except asyncio.CancelledError:
-            print("[CLIENT] Workflow was cancelled as expected")
-
-        # Check final state
-        final_ctx = server.get_context(ctx.execution_id)
-        print(f"\n[SUMMARY] Final workflow state: {final_ctx.state.value}")
-        print(f"[SUMMARY] Is cancelled: {final_ctx.is_cancelled}")
-        print(f"[SUMMARY] Has finished: {final_ctx.has_finished}")
-
-    finally:
-        # Clean up
-        listener_task.cancel()
-        try:
-            await listener_task
-        except asyncio.CancelledError:
-            pass
+    print(f"\n[SUMMARY] Final workflow state: {ctx.state.value}")
+    print(f"[SUMMARY] Is cancelled: {ctx.is_cancelled}")
+    print(f"[SUMMARY] Has finished: {ctx.has_finished}")
 
 
 if __name__ == "__main__":
-    # Run the example
     asyncio.run(run_cancellation_example())

--- a/examples/pause_with_input.py
+++ b/examples/pause_with_input.py
@@ -89,8 +89,6 @@ async def conditional_pause_workflow(ctx: ExecutionContext):
 
 
 if __name__ == "__main__":  # pragma: no cover
-    from flux.context_managers import ContextManager
-
     # Example 1: Basic pause with input
     print("=== Basic Pause with Input ===")
     ctx = pause_with_input_workflow.run()
@@ -98,18 +96,12 @@ if __name__ == "__main__":  # pragma: no cover
     print(f"Execution ID: {ctx.execution_id}")
     print("Workflow is paused, waiting for input...")
 
-    # Simulate providing input and resuming
+    # Provide input on resume — workflow.resume accepts it directly and the
+    # pause(...) call inside the workflow returns it. (Across processes, use
+    # FluxClient.resume_execution_sync or `flux workflow resume`.)
     user_input = {"multiplier": 5, "comment": "Adding multiplier value"}
     print(f"Providing input: {user_input}")
-
-    # The correct way to resume with input:
-    # 1. Start resuming with input
-    ctx.start_resuming(user_input)
-    # 2. Save the context with the resuming state
-    cm = ContextManager.create()
-    cm.save(ctx)
-    # 3. Resume the workflow
-    resumed_ctx = pause_with_input_workflow.run(execution_id=ctx.execution_id)
+    resumed_ctx = pause_with_input_workflow.resume(ctx.execution_id, user_input)
     print(f"Workflow completed! Output: {resumed_ctx.output}")
 
     # Example 2: Multiple input pauses
@@ -119,23 +111,17 @@ if __name__ == "__main__":  # pragma: no cover
 
     # Resume with config input
     config_input = {"database_url": "localhost:5432", "timeout": 30}
-    ctx.start_resuming(config_input)
-    cm.save(ctx)
-    ctx = multiple_input_pause_workflow.run(execution_id=ctx.execution_id)
+    ctx = multiple_input_pause_workflow.resume(ctx.execution_id, config_input)
     print(f"Second pause at: {ctx.events[-1].value}")
 
     # Resume with parameter input
     param_input = {"batch_size": 100, "parallel_workers": 4}
-    ctx.start_resuming(param_input)
-    cm.save(ctx)
-    ctx = multiple_input_pause_workflow.run(execution_id=ctx.execution_id)
+    ctx = multiple_input_pause_workflow.resume(ctx.execution_id, param_input)
     print(f"Third pause at: {ctx.events[-1].value}")
 
     # Resume with approval input
     approval_input = {"approved": True, "approver": "admin"}
-    ctx.start_resuming(approval_input)
-    cm.save(ctx)
-    final_ctx = multiple_input_pause_workflow.run(execution_id=ctx.execution_id)
+    final_ctx = multiple_input_pause_workflow.resume(ctx.execution_id, approval_input)
     print(f"Final result: {final_ctx.output}")
 
     # Example 3: Conditional pause
@@ -149,9 +135,7 @@ if __name__ == "__main__":  # pragma: no cover
 
     # Resume with approval
     approval = {"approved": True, "reason": "Looks good to proceed"}
-    ctx.start_resuming(approval)
-    cm.save(ctx)
-    approved_ctx = conditional_pause_workflow.run(execution_id=ctx.execution_id)
+    approved_ctx = conditional_pause_workflow.resume(ctx.execution_id, approval)
     print(f"Approval result: {approved_ctx.output}")
 
     # Example 4: Rejection scenario
@@ -160,7 +144,5 @@ if __name__ == "__main__":  # pragma: no cover
 
     # Resume with rejection
     rejection = {"approved": False, "reason": "Needs more review"}
-    ctx.start_resuming(rejection)
-    cm.save(ctx)
-    rejected_ctx = conditional_pause_workflow.run(execution_id=ctx.execution_id)
+    rejected_ctx = conditional_pause_workflow.resume(ctx.execution_id, rejection)
     print(f"Rejection result: {rejected_ctx.output}")

--- a/flux/task.py
+++ b/flux/task.py
@@ -951,11 +951,11 @@ class task:
             }
 
             try:
-                await asyncio.sleep(current_delay)
-
                 # Idempotent across replays: a resumed interrupted attempt
-                # already has its STARTED event in the log.
+                # already waited its backoff and has its STARTED event in
+                # the log — sleeping again would double-apply the delay.
                 if attempt not in started_attempts:
+                    await asyncio.sleep(current_delay)
                     started_attempts.add(attempt)
                     ctx.events.append(
                         ExecutionEvent(

--- a/flux/task.py
+++ b/flux/task.py
@@ -267,6 +267,49 @@ class task:
                 raise retrieved
             return retrieved
 
+        # Mid-retry resume (issue #72): a task suspended at a retry-attempt
+        # approval gate has no terminal event, but its retry history —
+        # including the durable attempt-0 failure marker — is in the log.
+        # Re-enter the retry chain directly instead of re-running the
+        # original attempt (and duplicating its side effects); exhaustion
+        # continues into fallback/rollback exactly like the original run.
+        if self.retry_max_attempts > 0 and any(
+            e.source_id == task_id
+            and e.type
+            in (
+                ExecutionEventType.TASK_RETRY_STARTED,
+                ExecutionEventType.TASK_RETRY_FAILED,
+            )
+            for e in ctx.events
+        ):
+            from flux._task_context import _CURRENT_TASK as _RESUME_TASK
+
+            resume_token = _RESUME_TASK.set((task_id, full_name))
+            try:
+                output = await self.__handle_exception(
+                    ctx,
+                    ExecutionError(
+                        message=f"Task '{full_name}' resumed mid-retry (task_id={task_id})",
+                    ),
+                    task_id,
+                    full_name,
+                    task_args,
+                    args,
+                    kwargs,
+                )
+                ctx.events.append(
+                    ExecutionEvent(
+                        type=ExecutionEventType.TASK_COMPLETED,
+                        source_id=task_id,
+                        name=full_name,
+                        value=self.output_storage.store(task_id, output),
+                    ),
+                )
+                await ctx.checkpoint()
+                return output
+            finally:
+                _RESUME_TASK.reset(resume_token)
+
         # Approval gate — evaluated after auth and the replay short-circuit.
         # ``task_id`` doubles as the approval ``task_call_id`` for the
         # initial call; each retry attempt is gated under its own id.
@@ -793,6 +836,31 @@ class task:
                 )
                 raise ex
 
+    def __recorded_retry_attempts(
+        self,
+        ctx: ExecutionContext,
+        task_id: str,
+    ) -> tuple[set[int], set[int]]:
+        """(started, failed) attempt numbers recorded for this task call.
+
+        Attempt 0 is the original body; attempts 1..retry_max_attempts are
+        the retry loop's. This is the durable state replay resumes from
+        after a mid-retry suspension (issue #72).
+        """
+        started: set[int] = set()
+        failed: set[int] = set()
+        for event in ctx.events:
+            if event.source_id != task_id or not isinstance(event.value, dict):
+                continue
+            attempt = event.value.get("current_attempt")
+            if not isinstance(attempt, int):
+                continue
+            if event.type == ExecutionEventType.TASK_RETRY_STARTED:
+                started.add(attempt)
+            elif event.type == ExecutionEventType.TASK_RETRY_FAILED:
+                failed.add(attempt)
+        return started, failed
+
     async def __handle_retry(
         self,
         ctx: ExecutionContext,
@@ -801,10 +869,59 @@ class task:
         args: tuple,
         kwargs: dict,
     ):
-        attempt = 0
+        started_attempts, failed_attempts = self.__recorded_retry_attempts(ctx, task_id)
+
+        # Durably mark the original attempt's failure BEFORE anything here
+        # can suspend (a retry-attempt approval gate). Replay keys off this
+        # marker to resume into the retry loop instead of re-running the
+        # original body and duplicating its side effects. The pause
+        # checkpoint persists it. Idempotent across replays.
+        if 0 not in failed_attempts:
+            failed_attempts.add(0)
+            ctx.events.append(
+                ExecutionEvent(
+                    type=ExecutionEventType.TASK_RETRY_FAILED,
+                    source_id=task_id,
+                    name=task_full_name,
+                    value={
+                        "current_attempt": 0,
+                        "max_attempts": self.retry_max_attempts,
+                        "current_delay": 0,
+                        "backoff": self.retry_backoff,
+                        "original_attempt": True,
+                    },
+                ),
+            )
+
+        # Resume point: one past the highest recorded failure; an attempt
+        # that started but never terminated was interrupted mid-body
+        # (crash) and is re-run. On a fresh (non-replay) call this is 1.
+        resume_from = max(failed_attempts) + 1
+        interrupted = started_attempts - failed_attempts
+        if interrupted:
+            resume_from = min(resume_from, min(interrupted))
+        if resume_from > self.retry_max_attempts:
+            # Every attempt already failed durably — unreachable through the
+            # gates (exhaustion raises before another suspension point), but
+            # a hand-edited or future event log must not fall through to an
+            # implicit None return.
+            raise RetryError(
+                ExecutionError(
+                    message=f"All {self.retry_max_attempts} retry attempts of "
+                    f"'{task_full_name}' already failed before resume",
+                ),
+                self.retry_max_attempts,
+                self.retry_delay,
+                self.retry_backoff,
+            )
+
+        attempt = resume_from - 1
         # current_delay persists across iterations so retry_backoff actually
         # compounds: attempt 1 waits retry_delay, attempt 2 retry_delay*backoff, …
+        # On resume, replay the same compounding for the skipped attempts.
         current_delay = self.retry_delay
+        for _ in range(resume_from - 1):
+            current_delay = min(current_delay * self.retry_backoff, 600)
         while attempt < self.retry_max_attempts:
             attempt += 1
 
@@ -836,14 +953,18 @@ class task:
             try:
                 await asyncio.sleep(current_delay)
 
-                ctx.events.append(
-                    ExecutionEvent(
-                        type=ExecutionEventType.TASK_RETRY_STARTED,
-                        source_id=task_id,
-                        name=task_full_name,
-                        value=retry_args,
-                    ),
-                )
+                # Idempotent across replays: a resumed interrupted attempt
+                # already has its STARTED event in the log.
+                if attempt not in started_attempts:
+                    started_attempts.add(attempt)
+                    ctx.events.append(
+                        ExecutionEvent(
+                            type=ExecutionEventType.TASK_RETRY_STARTED,
+                            source_id=task_id,
+                            name=task_full_name,
+                            value=retry_args,
+                        ),
+                    )
                 if self.timeout > 0:
                     try:
                         output = await asyncio.wait_for(

--- a/flux/task.py
+++ b/flux/task.py
@@ -286,6 +286,9 @@ class task:
 
             resume_token = _RESUME_TASK.set((task_id, full_name))
             try:
+                # Same kwargs enrichment as the normal path: a resumed retry
+                # attempt must see its injected secrets/config/metadata.
+                kwargs = await self.__enrich_kwargs(task_id, full_name, task_args, kwargs)
                 output = await self.__handle_exception(
                     ctx,
                     ExecutionError(
@@ -362,19 +365,7 @@ class task:
                         cache_hit = output is not None
 
                     if not cache_hit:
-                        if self.secret_requests:
-                            secrets = await SecretManager.current().get(self.secret_requests)
-                            kwargs = {**kwargs, "secrets": secrets}
-
-                        if self.config_requests:
-                            resolved_keys = [k.format(**task_args) for k in self.config_requests]
-                            from flux.config_manager import ConfigManager
-
-                            configs = await ConfigManager.current().get(resolved_keys)
-                            kwargs = {**kwargs, "config": configs}
-
-                        if self.metadata:
-                            kwargs = {**kwargs, "metadata": TaskMetadata(task_id, full_name)}
+                        kwargs = await self.__enrich_kwargs(task_id, full_name, task_args, kwargs)
 
                         if self.timeout > 0:
                             try:
@@ -835,6 +826,35 @@ class task:
                     ),
                 )
                 raise ex
+
+    async def __enrich_kwargs(
+        self,
+        task_id: str,
+        full_name: str,
+        task_args: dict,
+        kwargs: dict,
+    ) -> dict:
+        """Inject the task's requested secrets/config/metadata into kwargs.
+
+        Shared by the normal execution path and the mid-retry resume path so
+        resumed attempts see exactly the kwargs an attempt run through the
+        normal path would.
+        """
+        if self.secret_requests:
+            secrets = await SecretManager.current().get(self.secret_requests)
+            kwargs = {**kwargs, "secrets": secrets}
+
+        if self.config_requests:
+            resolved_keys = [k.format(**task_args) for k in self.config_requests]
+            from flux.config_manager import ConfigManager
+
+            configs = await ConfigManager.current().get(resolved_keys)
+            kwargs = {**kwargs, "config": configs}
+
+        if self.metadata:
+            kwargs = {**kwargs, "metadata": TaskMetadata(task_id, full_name)}
+
+        return kwargs
 
     def __recorded_retry_attempts(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.55.0"
+version = "0.55.1"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/e2e/fixtures/approval_workflow.py
+++ b/tests/e2e/fixtures/approval_workflow.py
@@ -24,3 +24,23 @@ async def deploy(payload: str) -> str:
 async def approval_e2e(ctx):
     prepared = await prepare(ctx.input or "default")
     return await deploy(prepared)
+
+
+@task.with_options(requires_approval=True, retry_max_attempts=1, retry_delay=1)
+async def flaky_deploy(path: str) -> str:
+    """Fails on the first attempt; the attempt count lives in a marker file
+    so the e2e can observe exactly how many times the body ran across the
+    worker's execution processes."""
+    from pathlib import Path
+
+    marker = Path(path)
+    attempts = int(marker.read_text()) + 1 if marker.exists() else 1
+    marker.write_text(str(attempts))
+    if attempts == 1:
+        raise RuntimeError("first attempt fails")
+    return f"deployed-after-{attempts}-attempts"
+
+
+@workflow
+async def approval_retry_e2e(ctx):
+    return await flaky_deploy(ctx.input)

--- a/tests/e2e/test_approvals.py
+++ b/tests/e2e/test_approvals.py
@@ -129,3 +129,52 @@ def test_workflow_status_blocked_line_on_stderr(cli):
     # session-scoped server. Approve and wait for COMPLETED before returning.
     cli._server_ok(["execution", "approve", exec_id, pending["task_call_id"]])
     cli.wait_for_state("approval_e2e", exec_id, "COMPLETED", timeout=30)
+
+
+def test_retry_approval_resumes_into_the_retry_attempt(cli):
+    """#72 e2e: approving a retry-attempt gate resumes INTO that attempt —
+    the original attempt's side effects are not duplicated by the replay,
+    across real worker processes."""
+    import tempfile
+    import time
+    from pathlib import Path
+
+    cli.register(str(FIXTURES / "approval_workflow.py"))
+    marker = Path(tempfile.mkdtemp(prefix="flux-retry-approval-")) / "attempts"
+
+    r = cli.run("approval_retry_e2e", f'"{marker}"', mode="async")
+    exec_id = r["execution_id"]
+
+    # Original call's gate pauses the workflow; approve it.
+    cli.wait_for_state("approval_retry_e2e", exec_id, "PAUSED", timeout=30)
+    pending = _wait_for_pending_approval(cli, exec_id)
+    cli._server_ok(["execution", "approve", exec_id, pending["task_call_id"]])
+
+    # The body runs once (fails), then the retry attempt pauses at its own
+    # gate — poll for the retry-scoped pending approval.
+    deadline = time.monotonic() + 30
+    retry_pending = None
+    while time.monotonic() < deadline:
+        out = cli._server_json(
+            ["execution", "approvals", "--execution", exec_id, "--json"],
+        )
+        rows = [
+            row
+            for row in out.get("approvals", [])
+            if row.get("status") == "pending" and row["task_call_id"].endswith("~retry1")
+        ]
+        if rows:
+            retry_pending = rows[0]
+            break
+        time.sleep(1)
+    assert retry_pending is not None, "retry-attempt approval never appeared"
+    assert marker.read_text() == "1"
+
+    cli._server_ok(["execution", "approve", exec_id, retry_pending["task_call_id"]])
+
+    final = cli.wait_for_state("approval_retry_e2e", exec_id, "COMPLETED", timeout=60)
+    assert final["state"] == "COMPLETED"
+    assert final.get("output") == "deployed-after-2-attempts"
+    # Exactly two body runs: original + the approved retry. Before the #72
+    # fix the resume replayed the original attempt again (three runs).
+    assert marker.read_text() == "2"

--- a/tests/flux/test_task_approval.py
+++ b/tests/flux/test_task_approval.py
@@ -599,3 +599,160 @@ def test_gate_skips_create_when_execution_already_cancelling(isolated_db):
     from flux.domain.events import ExecutionEventType
 
     assert not any(e.type == ExecutionEventType.TASK_AWAITING_APPROVAL for e in ctx.events)
+
+
+def _approve_single_pending(mgr: ApprovalManager, execution_id: str) -> str:
+    """Approve the one pending approval on an execution; return its call id."""
+    pending = mgr.list(execution_id=execution_id, status=ApprovalStatus.PENDING)
+    assert len(pending) == 1, f"expected one pending approval, got {len(pending)}"
+    with UnitOfWork() as uow:
+        mgr.decide(
+            pending[0].execution_id,
+            pending[0].task_call_id,
+            approver_subject="alice",
+            approver_provider="oidc",
+            approved=True,
+            reason=None,
+            uow=uow,
+        )
+        uow.commit()
+    return pending[0].task_call_id
+
+
+def test_resume_after_retry_approval_does_not_rerun_original_attempt(isolated_db):
+    """#72: approving a retry attempt and resuming must resume INTO that
+    attempt. Before the fix, every resume replayed the original body first —
+    duplicating its side effects — and only reached the approved retry after
+    the original failed again."""
+    from flux.domain.events import ExecutionEventType
+
+    calls = [0]
+
+    @task_decorator.with_options(requires_approval=True, retry_max_attempts=2, retry_delay=0)
+    async def flaky_gated() -> str:
+        calls[0] += 1
+        if calls[0] <= 2:
+            raise ValueError(f"boom {calls[0]}")
+        return "recovered"
+
+    @workflow
+    async def wf_retry_resume(ctx: ExecutionContext):
+        return await flaky_gated()
+
+    mgr = ApprovalManager()
+
+    ctx = wf_retry_resume.run()  # pauses at the original call's gate
+    assert ctx.is_paused
+    assert calls[0] == 0
+    _approve_single_pending(mgr, ctx.execution_id)
+
+    # Original attempt runs (fails), first retry attempt pauses at its gate.
+    ctx = wf_retry_resume.run(execution_id=ctx.execution_id)
+    assert ctx.is_paused
+    assert calls[0] == 1
+    assert _approve_single_pending(mgr, ctx.execution_id).endswith("~retry1")
+
+    # Resume runs ONLY retry attempt 1 (fails) — the original body must not
+    # re-run — then pauses at retry attempt 2's gate.
+    ctx = wf_retry_resume.run(execution_id=ctx.execution_id)
+    assert ctx.is_paused
+    assert calls[0] == 2, f"original attempt re-ran on resume (body calls: {calls[0]})"
+    assert _approve_single_pending(mgr, ctx.execution_id).endswith("~retry2")
+
+    # Final resume runs ONLY retry attempt 2, which succeeds.
+    ctx = wf_retry_resume.run(execution_id=ctx.execution_id)
+    assert ctx.has_succeeded
+    assert ctx.output == "recovered"
+    assert calls[0] == 3, f"attempts duplicated across resumes (body calls: {calls[0]})"
+
+    # Durable retry history, no duplicates from the replays: one failure
+    # marker per failed attempt (0 = original, 1 = first retry) and one
+    # completion for attempt 2.
+    failed = sorted(
+        e.value["current_attempt"]
+        for e in ctx.events
+        if e.type == ExecutionEventType.TASK_RETRY_FAILED
+    )
+    completed = [
+        e.value["current_attempt"]
+        for e in ctx.events
+        if e.type == ExecutionEventType.TASK_RETRY_COMPLETED
+    ]
+    assert failed == [0, 1]
+    assert completed == [2]
+
+
+def test_resume_consumes_approved_retry_when_original_would_succeed(isolated_db):
+    """#72 second manifestation: replay must not give the original body a
+    second chance to succeed and orphan the approved retry row — the retry
+    attempt itself must run."""
+    from flux.domain.events import ExecutionEventType
+
+    calls = [0]
+
+    @task_decorator.with_options(requires_approval=True, retry_max_attempts=1, retry_delay=0)
+    async def flaky_once_gated() -> str:
+        calls[0] += 1
+        if calls[0] == 1:
+            raise ValueError("boom")
+        return f"attempt-{calls[0]}"
+
+    @workflow
+    async def wf_flaky_once(ctx: ExecutionContext):
+        return await flaky_once_gated()
+
+    mgr = ApprovalManager()
+
+    ctx = wf_flaky_once.run()
+    assert ctx.is_paused
+    _approve_single_pending(mgr, ctx.execution_id)
+
+    ctx = wf_flaky_once.run(execution_id=ctx.execution_id)  # original fails
+    assert ctx.is_paused
+    assert _approve_single_pending(mgr, ctx.execution_id).endswith("~retry1")
+
+    ctx = wf_flaky_once.run(execution_id=ctx.execution_id)
+    assert ctx.has_succeeded
+    assert ctx.output == "attempt-2"
+    assert calls[0] == 2
+    # The completion came from the retry attempt, not a replayed original.
+    assert any(e.type == ExecutionEventType.TASK_RETRY_COMPLETED for e in ctx.events)
+
+
+def test_retry_exhaustion_on_resume_continues_into_fallback(isolated_db):
+    """Resuming into the retry chain preserves retry -> fallback: exhausting
+    the resumed attempts falls through to the fallback, without re-running
+    the original body."""
+    calls = [0]
+
+    async def use_fallback() -> str:
+        return "fallback-ran"
+
+    @task_decorator.with_options(
+        requires_approval=True,
+        retry_max_attempts=1,
+        retry_delay=0,
+        fallback=use_fallback,
+    )
+    async def always_fails_gated() -> str:
+        calls[0] += 1
+        raise ValueError("boom")
+
+    @workflow
+    async def wf_fallback(ctx: ExecutionContext):
+        return await always_fails_gated()
+
+    mgr = ApprovalManager()
+
+    ctx = wf_fallback.run()
+    assert ctx.is_paused
+    _approve_single_pending(mgr, ctx.execution_id)
+
+    ctx = wf_fallback.run(execution_id=ctx.execution_id)  # original fails
+    assert ctx.is_paused
+    assert _approve_single_pending(mgr, ctx.execution_id).endswith("~retry1")
+
+    ctx = wf_fallback.run(execution_id=ctx.execution_id)
+    assert ctx.has_succeeded
+    assert ctx.output == "fallback-ran"
+    assert calls[0] == 2, f"original attempt re-ran on resume (body calls: {calls[0]})"

--- a/tests/flux/test_task_approval.py
+++ b/tests/flux/test_task_approval.py
@@ -805,3 +805,45 @@ async def test_resumed_interrupted_attempt_skips_backoff_and_started_duplicate(i
         if e.type == ExecutionEventType.TASK_RETRY_STARTED and e.source_id == "tid-interrupted"
     ]
     assert len(started_events) == 1, "STARTED duplicated for the resumed attempt"
+
+
+def test_resumed_retry_attempt_receives_enriched_kwargs(isolated_db):
+    """A retry attempt run via the mid-retry resume path must receive the
+    same injected kwargs (metadata/secrets/config) as attempts run through
+    the normal path."""
+    seen_metadata = []
+
+    @task_decorator.with_options(
+        requires_approval=True,
+        retry_max_attempts=1,
+        retry_delay=0,
+        metadata=True,
+    )
+    async def gated_with_metadata(metadata=None) -> str:
+        seen_metadata.append(metadata)
+        if len(seen_metadata) == 1:
+            raise ValueError("boom")
+        return "ok"
+
+    @workflow
+    async def wf_metadata(ctx: ExecutionContext):
+        return await gated_with_metadata()
+
+    mgr = ApprovalManager()
+
+    ctx = wf_metadata.run()
+    assert ctx.is_paused
+    _approve_single_pending(mgr, ctx.execution_id)
+
+    ctx = wf_metadata.run(execution_id=ctx.execution_id)  # original fails
+    assert ctx.is_paused
+    assert _approve_single_pending(mgr, ctx.execution_id).endswith("~retry1")
+
+    ctx = wf_metadata.run(execution_id=ctx.execution_id)  # resumed retry runs
+    assert ctx.has_succeeded
+    assert ctx.output == "ok"
+    assert len(seen_metadata) == 2
+    # Both the original attempt and the RESUMED retry attempt got the
+    # injected TaskMetadata — the resume path must enrich kwargs too.
+    assert seen_metadata[0] is not None
+    assert seen_metadata[1] is not None, "resumed retry attempt ran without injected kwargs"

--- a/tests/flux/test_task_approval.py
+++ b/tests/flux/test_task_approval.py
@@ -756,3 +756,52 @@ def test_retry_exhaustion_on_resume_continues_into_fallback(isolated_db):
     assert ctx.has_succeeded
     assert ctx.output == "fallback-ran"
     assert calls[0] == 2, f"original attempt re-ran on resume (body calls: {calls[0]})"
+
+
+@pytest.mark.asyncio
+async def test_resumed_interrupted_attempt_skips_backoff_and_started_duplicate(isolated_db):
+    """A resumed attempt that already STARTED (interrupted mid-body) must
+    re-run without re-applying its backoff delay or duplicating its
+    STARTED event — the original run already did both."""
+    import time as time_mod
+
+    from flux.domain.events import ExecutionEvent, ExecutionEventType
+
+    calls = [0]
+
+    @task_decorator.with_options(retry_max_attempts=2, retry_delay=5)
+    async def flaky() -> str:
+        calls[0] += 1
+        return "ran"
+
+    ctx = _build_test_ctx()
+    # Durable history of a run interrupted mid-attempt-1: the original body
+    # failed (attempt 0), attempt 1 started (its backoff already waited)
+    # but never terminated.
+    for event_type, attempt in (
+        (ExecutionEventType.TASK_RETRY_FAILED, 0),
+        (ExecutionEventType.TASK_RETRY_STARTED, 1),
+    ):
+        ctx.events.append(
+            ExecutionEvent(
+                type=event_type,
+                source_id="tid-interrupted",
+                name="flaky",
+                value={"current_attempt": attempt, "max_attempts": 2},
+            ),
+        )
+
+    started = time_mod.monotonic()
+    output = await flaky._task__handle_retry(ctx, "tid-interrupted", "flaky", (), {})
+    elapsed = time_mod.monotonic() - started
+
+    assert output == "ran"
+    assert calls[0] == 1
+    # retry_delay is 5s: re-applying it on resume would blow this bound.
+    assert elapsed < 3, f"backoff re-applied on resumed attempt ({elapsed:.1f}s)"
+    started_events = [
+        e
+        for e in ctx.events
+        if e.type == ExecutionEventType.TASK_RETRY_STARTED and e.source_id == "tid-interrupted"
+    ]
+    assert len(started_events) == 1, "STARTED duplicated for the resumed attempt"


### PR DESCRIPTION
Two of the three open issues, one commit each.

## Resume into the correct retry attempt after a mid-retry approval pause (#72)

A task suspended at a retry-attempt approval gate has no terminal event, so replay re-entered it from the top: it re-ran the **original attempt's body — duplicating its side effects on every resume** — and when that replayed attempt happened to succeed, the approved retry row was silently orphaned.

Two changes close the gap, following the fix direction in the issue:

- **Durable attempt state**: `__handle_retry` records the original attempt's failure (a `TASK_RETRY_FAILED` event with `current_attempt=0`) *before* anything can suspend, so the pause checkpoint always carries which attempt is in flight. Idempotent across replays.
- **Resume-aware replay**: task replay detects retry history for the call and re-enters the retry chain directly — resuming at one past the highest recorded failure, re-running an attempt that started but never terminated (crash mid-body), preserving the compounded backoff for skipped attempts, never duplicating `STARTED` events, and continuing into fallback/rollback on exhaustion exactly as on the original run.

Verification is strict — **all four regression tests fail on the pre-fix code**:
- Unit: a two-retry task walked through pause/approve/resume at every gate runs each attempt's body exactly once (pre-fix: 6 body runs instead of 3); the approved retry is consumed rather than orphaned when the original would succeed on replay; retry exhaustion on resume reaches the fallback without re-running the original.
- E2E (real server + worker, subprocess runner): a marker file proves exactly two body runs across worker child processes — the original attempt and the approved retry.

Fixes #72

## Examples use the public surface (#75)

`flux-docs` publishes these files as tutorial pages, so they were teaching readers to import internals for basic control-plane operations:

- **`examples/pause_with_input.py`**: the `ContextManager` incantation (`start_resuming` + `cm.save` + `run(execution_id=...)`, six call sites) is replaced by the public one-liner `workflow.resume(execution_id, input)`, with a pointer to `FluxClient.resume_execution_sync` / `flux workflow resume` for the cross-process case.
- **`examples/cancellation.py`**: the simulated server/worker classes — which constructed `WorkerInfo` and called `ctx.claim()` from user code — are gone. The example now demonstrates the actual mechanism (cooperative asyncio cancellation of the running workflow, exactly what a worker delivers when the server relays a cancel) and references `flux workflow cancel` / `FluxClient.cancel_execution` for the deployed path. Net −153 lines.

No `flux.context_managers` / `flux.worker_registry` imports remain in either file; both run end-to-end and all example tests pass unchanged.

Fixes #75

## Validation

- Lint clean; 2,541 unit tests passed (the new attempt-0 marker broke no existing retry assertions); full e2e suite 123 passed, including the new distributed retry-approval scenario.
- Version 0.55.0 → 0.55.1.
