### PR TITLE
Fence claim releases and unclaim resets against stale owners

### DIFF
--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -876,11 +876,17 @@ class DatabaseContextManager(ContextManager):
             if model.state in resume_recovery:
                 model.state = ExecutionState.RESUMING
                 model.worker_name = None
+                # Fence the old owner: without the bump, a partitioned-but-
+                # alive worker's late checkpoint (same generation) is accepted
+                # and can drag the reset row back to RUNNING with no owner —
+                # invisible to dispatch (CREATED-only) and to reaping.
+                model.claim_generation = (model.claim_generation or 0) + 1
                 session.commit()
                 return model.to_plain()
             if model.state in initial_recovery:
                 model.state = ExecutionState.CREATED
                 model.worker_name = None
+                model.claim_generation = (model.claim_generation or 0) + 1
                 session.commit()
                 return model.to_plain()
             return model.to_plain()

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -946,6 +946,12 @@ class Worker:
         claim is stale, another worker already owns the execution and there
         is nothing to release.
         """
+        # Capture the fence before flushing: every sender exit path pops
+        # self._claim_generations, and a release without the header bypasses
+        # the server's stale-claim check — a late unfenced release could
+        # unclaim an execution already re-dispatched to another worker.
+        generation = self._claim_generations.get(execution_id)
+
         # Flush pending checkpoints first: they carry the task completions
         # replay resumes from, and after release the bumped claim generation
         # would fence them.
@@ -964,7 +970,6 @@ class Worker:
 
         base_url = f"{self.base_url}/{self.name}"
         headers = {}
-        generation = self._claim_generations.get(execution_id)
         if generation is not None:
             headers["X-Flux-Claim-Generation"] = generation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.56.0"
+version = "0.56.1"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_checkpoint_fencing.py
+++ b/tests/flux/test_checkpoint_fencing.py
@@ -96,10 +96,55 @@ def test_generation_bumps_again_on_reassignment(env):
         ExecutionContext(workflow_id=wf_id, workflow_namespace="default", workflow_name="wf"),
     )
 
-    _dispatch(cm, w1)
-    cm.unclaim(saved.execution_id)  # eviction path: back to CREATED
-    _dispatch(cm, w1)
+    _dispatch(cm, w1)  # generation 1
+    cm.unclaim(saved.execution_id)  # eviction fences the old owner: 2
+    _dispatch(cm, w1)  # re-dispatch: 3
 
+    assert cm.get_claim_generation(saved.execution_id) == 3
+
+
+def test_unclaim_fences_the_old_owner(env):
+    """unclaim() must bump the claim generation: without it, a partitioned
+    worker's late checkpoint (old generation) is accepted after the reaper
+    reset the row, dragging it back to RUNNING with no owner — invisible to
+    dispatch (CREATED-only) and never re-dispatched."""
+    cm, registry = env
+    w1 = _register(registry, "w1")
+    wf_id = _create_workflow(cm)
+    cm.save(ExecutionContext(workflow_id=wf_id, workflow_namespace="default", workflow_name="wf"))
+    ctx = _dispatch(cm, w1)  # generation 1, owned by w1
+
+    cm.unclaim(ctx.execution_id)  # reaper resets the row
+
+    assert cm.get_claim_generation(ctx.execution_id) == 2
+    # The old owner's late checkpoint is fenced instead of accepted.
+    with pytest.raises(StaleClaimError):
+        cm.update(ctx, expected_claim_generation=1)
+
+
+def test_unclaim_resume_recovery_also_fences(env):
+    """The RESUME_SCHEDULED/RESUME_CLAIMED → RESUMING recovery branch fences
+    the old owner too."""
+    from flux.domain import ExecutionState
+    from flux.models import ExecutionContextModel, RepositoryFactory
+
+    cm, registry = env
+    w1 = _register(registry, "w1")
+    wf_id = _create_workflow(cm)
+    saved = cm.save(
+        ExecutionContext(workflow_id=wf_id, workflow_namespace="default", workflow_name="wf"),
+    )
+    _dispatch(cm, w1)  # generation 1
+
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        model = session.get(ExecutionContextModel, saved.execution_id)
+        model.state = ExecutionState.RESUME_SCHEDULED
+        session.commit()
+
+    recovered = cm.unclaim(saved.execution_id)
+
+    assert recovered.state == ExecutionState.RESUMING
     assert cm.get_claim_generation(saved.execution_id) == 2
 
 

--- a/tests/flux/test_worker_checkpoint.py
+++ b/tests/flux/test_worker_checkpoint.py
@@ -381,3 +381,33 @@ async def test_checkpoint_includes_claim_generation_header():
     await worker._checkpoint(make_ctx(finished=True))
 
     assert seen_headers[0].get("X-Flux-Claim-Generation") == "7"
+
+
+@pytest.mark.asyncio
+async def test_release_claim_is_fenced_even_after_sender_drained():
+    """The sender's closed-exit path pops the claim generation; _release_claim
+    must capture the fence BEFORE flushing the outbox, or the release goes out
+    unfenced and can unclaim a re-dispatched execution that another worker is
+    already running."""
+    worker = make_worker()
+    worker._claim_generations["exec-1"] = "3"
+    seen = []
+
+    async def capture_post(url, headers=None, **kwargs):
+        seen.append((url, headers or {}))
+        return ok_response()
+
+    worker.client.post = capture_post
+
+    # Real outbox with a live sender so the release path drains it (and the
+    # sender's closed-exit path pops the generation) before posting.
+    await worker._checkpoint(make_ctx())
+    box = worker._checkpoint_outboxes["exec-1"]
+    await asyncio.wait_for(_wait_for_ack(box), timeout=5)
+
+    await worker._release_claim("exec-1")
+
+    release_calls = [(url, headers) for url, headers in seen if "/release/" in url]
+    assert len(release_calls) == 1
+    assert release_calls[0][1].get("X-Flux-Claim-Generation") == "3"
+    assert "exec-1" not in worker._claim_generations


### PR DESCRIPTION
## What

Closes two gaps in the claim-generation fence that let a worker which no longer owns an execution corrupt its state. Both were found in a code-level review of the dispatch/claim plane and both are split-brain hazards under worker partition or crash-recovery timing.

**1. Claim releases always went out unfenced** (`flux/worker.py`)

`_release_claim` flushed the checkpoint outbox first and only then read `self._claim_generations[execution_id]` — but every sender exit path pops that entry, so by the time the release POST was built the generation was gone. The server's release route only performs the stale-claim check when the `X-Flux-Claim-Generation` header is present, so the release executed unconditionally.

Failure: a durable runner child crashes; the worker's release is delayed (checkpoint flush retries); meanwhile the reaper evicts the worker and re-dispatches the execution to worker B. The late unfenced release unclaims B's RUNNING execution back to CREATED, and it dispatches to worker C while B is still running it — duplicate concurrent execution with interleaved event history, exactly what the fence exists to prevent.

Fix: capture the generation before flushing the outbox.

**2. `unclaim()` never bumped the claim generation** (`flux/context_managers.py`)

The reaper's reset path cleared state and worker assignment but left `claim_generation` unchanged, so the old owner's in-flight checkpoints still passed the fence.

Failure: worker A is network-partitioned; the reaper unclaims its execution (CREATED, no worker). A's partition heals and its outbox retries a checkpoint carrying the old generation — accepted, and the row flips back to RUNNING with `worker_name` NULL. Dispatch only scans CREATED and reaping only matches assigned workers, so if A then dies the execution is stranded in RUNNING forever.

Fix: bump `claim_generation` in both recovery branches (initial → CREATED and resume → RESUMING), mirroring what every claim/assign path already does.

## Tests

- `test_release_claim_is_fenced_even_after_sender_drained` — real outbox + sender; the release POST must carry the generation captured before the drain.
- `test_unclaim_fences_the_old_owner` — after unclaim, the old owner's checkpoint with the previous generation raises `StaleClaimError`.
- `test_unclaim_resume_recovery_also_fences` — the RESUME_SCHEDULED → RESUMING branch bumps too.
- All three verified to fail without the fixes; `test_generation_bumps_again_on_reassignment` updated for the new bump count.
- Full unit suite (2557 passed) and full e2e suite (124 passed) green locally.

Version bumped to 0.56.1.
