### PR TITLE
Agent vocabulary layer: structured output with tools, bounded parallel, token budgets

### DIFF
--- a/docs/advanced-features/ai-agents.md
+++ b/docs/advanced-features/ai-agents.md
@@ -118,7 +118,9 @@ async def agent(
 | `name` | `str \| None` | `None` | Task name used in events and traces. Defaults to `"agent_{provider}_{model}"`. |
 | `tools` | `list[task] \| None` | `None` | Flux `@task` functions the agent can call as tools. |
 | `skills` | `SkillCatalog \| None` | `None` | Skill catalog providing reusable instruction bundles the LLM can activate. |
-| `response_format` | `type[BaseModel] \| None` | `None` | Pydantic model class for structured JSON output. Disables streaming. |
+| `response_format` | `type[BaseModel] \| None` | `None` | Pydantic model class for structured JSON output. Composes with `tools`. Disables streaming. |
+| `max_schema_retries` | `int` | `1` | Corrective turns allowed when the final answer fails schema validation. `0` fails on the first invalid answer. |
+| `budget` | `Budget \| None` | `None` | Token-spend ceiling shared across every agent the instance is passed to. |
 | `working_memory` | `WorkingMemory \| None` | `None` | Conversation history across invocations within the same workflow execution. |
 | `long_term_memory` | `LongTermMemory \| None` | `None` | Persistent fact storage across workflow executions. |
 | `max_tool_calls` | `int` | `10` | Maximum tool call iterations before forcing a final answer. |
@@ -205,6 +207,66 @@ async def analyze(ctx: ExecutionContext):
 When `response_format` is set:
 - The return type changes from `str` to the Pydantic model instance.
 - Streaming is automatically disabled (`stream=True` is ignored).
+
+### Structured Output with Tools
+
+`response_format` composes with `tools`: the agent runs its tool loop as
+usual, and the final (non-tool-call) answer is validated against the schema.
+On the tool-less path, providers with native structured-output support
+enforce the schema at the API level; with tools, the schema travels in the
+system prompt and validation happens post-hoc.
+
+If the final answer fails validation, the validation errors are fed back to
+the model for a corrective turn (tools stripped, so it can only answer).
+`max_schema_retries` (default `1`) controls how many corrective turns are
+allowed before the agent task fails with the field-level validation errors.
+
+```python
+analyst = await agent(
+    "You are a research analyst.",
+    model="openai/gpt-4o",
+    tools=[search_web],
+    response_format=Sentiment,   # validated final answer, even with tools
+    max_schema_retries=2,
+)
+```
+
+## Token Budgets
+
+`Budget` puts a spend ceiling on LLM work. Create one instance and pass it
+to every agent whose usage should count against the same ceiling:
+
+```python
+from flux.tasks.ai import agent, Budget
+
+@workflow
+async def research(ctx: ExecutionContext):
+    budget = Budget(max_tokens=200_000)
+
+    researcher = await agent("...", model="openai/gpt-4o", budget=budget)
+    summarizer = await agent("...", model="openai/gpt-4o", budget=budget)
+
+    findings = await researcher(ctx.input)
+    if budget.remaining() < 20_000:
+        return findings  # not enough left for the summary pass
+    return await summarizer(str(findings))
+```
+
+- `budget.spent()` / `budget.remaining()` report accumulated usage;
+  `Budget()` with no ceiling tracks without enforcing.
+- Enforcement is a **pre-flight gate**: the loop checks the budget before
+  every LLM call and raises `BudgetExceededError` (a catchable
+  `ExecutionError`) once `spent()` reaches `max_tokens`. A call in flight is
+  never interrupted, so overshoot is bounded by one call's usage.
+- Usage is reported by all four built-in providers. Custom providers opt in
+  by populating `LLMResponse.usage`; without it, a budget sees no spend and
+  only tracking-only use is meaningful.
+- Setting a budget disables token-level content streaming for that agent
+  (the final text still arrives as a progress event) because usage is only
+  reported on non-streamed calls.
+- Scope: a budget bounds one run attempt. On resume, replayed LLM calls
+  short-circuit from the event log — their recorded usage is re-counted
+  without re-spending real tokens.
 
 ## Streaming
 

--- a/docs/advanced-features/ai-agents.md
+++ b/docs/advanced-features/ai-agents.md
@@ -262,8 +262,9 @@ async def research(ctx: ExecutionContext):
   by populating `LLMResponse.usage`; without it, a budget sees no spend and
   only tracking-only use is meaningful.
 - Setting a budget disables token-level content streaming for that agent
-  (the final text still arrives as a progress event) because usage is only
-  reported on non-streamed calls.
+  (the final text still arrives as a progress event). The raw token-stream
+  path bypasses the LLM task wrapper and cannot capture usage; the
+  checkpointed call paths — including reasoning streams — report it.
 - Scope: a budget bounds one run attempt. On resume, replayed LLM calls
   short-circuit from the event log — their recorded usage is re-counted
   without re-spending real tokens.

--- a/docs/core-concepts/tasks.md
+++ b/docs/core-concepts/tasks.md
@@ -95,6 +95,38 @@ async def parallel_workflow(ctx: WorkflowExecutionContext):
     return results
 ```
 
+Results come back in input order. Two optional parameters tune large fan-outs:
+
+```python
+results = await parallel(
+    *[process(item) for item in items],
+    max_concurrent=8,        # cap in-flight coroutines; None (default) = unlimited
+    raise_on_error=False,    # default True: first failure fails the batch
+)
+```
+
+With `raise_on_error=False`, a failed item's slot in the result list becomes
+`None` and the remaining items keep running — the failure is still recorded
+on the corresponding task's events, it just doesn't kill the batch. Pauses
+and cancellations always propagate.
+
+For staged per-item flow ("fetch every document, then summarize each, then
+judge each summary") chain the stages in a plain async function and fan it
+out — each item moves through its stages independently, with no barrier
+between stages:
+
+```python
+async def process(doc):
+    fetched = await fetch(doc)
+    summary = await summarize(fetched)
+    return await judge(summary)
+
+results = await parallel(*[process(d) for d in docs], max_concurrent=8)
+```
+
+Each stage is an ordinary task call, so a resumed workflow replays completed
+stage calls and re-runs only what never finished.
+
 ### Pipeline Processing
 ```python
 from flux.tasks import pipeline

--- a/docs/specs/2026-07-15-agent-vocabulary-spec.md
+++ b/docs/specs/2026-07-15-agent-vocabulary-spec.md
@@ -22,11 +22,12 @@ budgets) on Flux's own machinery.
 ### Today
 
 `agent(response_format=SomeModel)` exists and uses native provider
-enforcement — but only on the **tool-less** path. Every structured-output
-branch in the loop is guarded by `response_format and not tools`, so an
-agent that has tools silently returns prose even when a schema was
-requested. There is also no validation-retry: a malformed response raises
-`ValidationError` and fails the task outright.
+enforcement — but only on the **tool-less** path. The schema-communication
+branches in the loop are guarded by `response_format and not tools`, while
+the final `model_validate_json` runs unconditionally — so an agent with
+tools is validated against a schema the model was never shown, and almost
+always fails with a raw `ValidationError` on prose. There is also no
+validation-retry: a malformed response fails the task outright.
 
 ### Design
 
@@ -41,11 +42,14 @@ requested. There is also no validation-retry: a malformed response raises
   a structured error naming the field-level problems. Mirrors how
   harness-side structured output behaves: the model corrects itself on
   mismatch instead of the caller eating a parse failure.
-- **Delegation carries contracts.** `workflow_agent(...)` and `delegate`
-  sub-agents accept `response_format` and surface the validated model to
-  the parent — the parent agent (or authored workflow) receives data, not
-  prose. `DelegationResult.value` is the validated instance when a format
-  was declared.
+- **Delegation carries contracts.** A sub-agent built with
+  `response_format` returns a validated model; `delegate` surfaces it to
+  the parent as plain data (`model_dump()` in `DelegationResult.output`) so
+  the parent LLM sees clean JSON. `workflow_agent(...,
+  response_format=...)` validates a completed workflow's output against the
+  model — a contract violation turns the delegation into a `failed` status
+  instead of handing the parent unchecked data. Direct callers (workflow
+  code awaiting an agent task) receive the validated instance itself.
 - **Replay:** validated models already round-trip through task events
   (pickled outputs); no new event types.
 
@@ -122,13 +126,17 @@ own spend.
 
 ### Design
 
-**Usage plumbing (the bulk of the work).** The `LLMFormatter` ABC gains
-`extract_usage(response) -> Usage | None` where
-`Usage(input_tokens, output_tokens)`; each provider module implements it
-from its native response shape (all four expose token counts). The agent
-loop records usage after every LLM call — including streamed calls, whose
-final usage arrives on the terminal chunk for every supported provider —
-and attaches it to the agent task's progress/telemetry.
+**Usage plumbing (the bulk of the work).** `LLMResponse` gains
+`usage: Usage | None` where `Usage(input_tokens, output_tokens)`; each
+provider module populates it from its native response shape (all four
+expose token counts), including the reasoning-stream paths, whose final
+usage arrives on the terminal chunk. Custom providers opt in by populating
+the field. Usage rides the checkpointed LLM task output, so it is visible
+in the execution's events. The agent loop records it into the budget after
+every LLM call. One consequence: setting a budget disables token-level
+content streaming for that agent (the final text still arrives as a
+progress event), because the raw token-stream path bypasses the LLM task
+and reports no usage.
 
 **The primitive.**
 
@@ -151,11 +159,14 @@ if budget.remaining() < 20_000:
   any task error. A call in flight is never killed mid-stream; the ceiling
   is a pre-flight gate, so overshoot is bounded by one call's output.
 - **Scope & replay semantics (stated honestly):** a `Budget` bounds spend
-  within one *run attempt*. On resume, replayed agent calls short-circuit
-  from the event log without re-spending, and the in-memory counter starts
-  fresh — so the ceiling applies to *new* spend after resume. Durable
-  cumulative accounting across attempts (usage as persisted events) is
-  future work, noted in the doc.
+  within one *run attempt*. On resume, the workflow re-runs and replayed
+  LLM task calls short-circuit from the event log — their recorded usage
+  (it rides `LLMResponse`) is re-counted into the fresh budget in the same
+  order, so a resumed attempt's accounting stays consistent without
+  re-spending real tokens. Sharing one budget across *concurrently running*
+  agents makes the exact enforcement point nondeterministic across replays.
+  Durable cumulative accounting across attempts (usage as persisted
+  events) is future work, noted in the doc.
 
 ## Config
 
@@ -173,10 +184,12 @@ parameter (default 1). Budget is explicit-object-only — no ambient global.
   batch survives, failure event recorded); `max_concurrent` cap actually
   bounds in-flight count; staged per-item idiom replays correctly (pause
   mid-batch, resume, completed stage calls not re-run).
-- **Budget:** per-provider `extract_usage` (fixture responses); accumulation
-  across calls sharing one budget; pre-flight ceiling raises
-  `BudgetExceededError`; `None` ceiling tracks without enforcement;
-  streamed-call usage capture.
+- **Budget:** per-provider usage extraction (fixture responses);
+  accumulation across calls sharing one budget; pre-flight ceiling raises
+  `BudgetExceededError` (catchable in workflow code); `None` ceiling tracks
+  without enforcement; budget forces the usage-reporting path for
+  otherwise-streaming tool-less agents; retry turns count against the
+  budget.
 
 ## Rollout / compatibility
 

--- a/docs/specs/2026-07-15-agent-vocabulary-spec.md
+++ b/docs/specs/2026-07-15-agent-vocabulary-spec.md
@@ -1,0 +1,172 @@
+# Spec: agent vocabulary layer — structured output, staged pipeline, budget
+
+**Date:** 2026-07-15 · **Status:** draft for review (PR 3 of the
+dynamic-workflows series) · **Depends on:** nothing at runtime — composes
+with #130/#131 but each primitive stands alone.
+
+## Motivation
+
+PR 1 gave model-authored code a safe place to run; PR 2 gave agents a way to
+author workflows. This PR makes what they author (and what agent loops do in
+general) *expressive and bounded*: subagent calls that return validated
+structured data instead of prose to re-parse, a fan-out combinator that
+streams items through stages without artificial barriers, and a spend
+ceiling that turns "the agent looped and burned tokens all night" into a
+structured, catchable failure.
+
+Each primitive replicates a proven shape from orchestration harnesses
+(schema-forced subagent output, per-item pipelines, shared token budgets)
+on Flux's own machinery.
+
+## 1. Structured output that survives tools
+
+### Today
+
+`agent(response_format=SomeModel)` exists and uses native provider
+enforcement — but only on the **tool-less** path. Every structured-output
+branch in the loop is guarded by `response_format and not tools`, so an
+agent that has tools silently returns prose even when a schema was
+requested. There is also no validation-retry: a malformed response raises
+`ValidationError` and fails the task outright.
+
+### Design
+
+- **Tools + schema compose.** When `response_format` is set and the agent
+  has tools, the tool loop runs as usual; when the model produces its final
+  (non-tool-call) answer, the loop validates it against the schema. If the
+  final turn used native structured output the parse is a formality;
+  otherwise the schema is appended to the system prompt as today.
+- **Validation retry.** On `ValidationError`, feed the error back once —
+  one additional turn with the validation message and the schema
+  (`max_schema_retries`, default 1, config-able per call) — then fail with
+  a structured error naming the field-level problems. Mirrors how
+  harness-side structured output behaves: the model corrects itself on
+  mismatch instead of the caller eating a parse failure.
+- **Delegation carries contracts.** `workflow_agent(...)` and `delegate`
+  sub-agents accept `response_format` and surface the validated model to
+  the parent — the parent agent (or authored workflow) receives data, not
+  prose. `DelegationResult.value` is the validated instance when a format
+  was declared.
+- **Replay:** validated models already round-trip through task events
+  (pickled outputs); no new event types.
+
+### Out of scope
+
+Streaming structured output (stream stays auto-disabled when a format is
+set, as today).
+
+## 2. `pipeline_map` — per-item staged fan-out
+
+### Today
+
+`parallel(*coros)` is a gather (barrier at the end); `pipeline(*tasks,
+input)` threads ONE value through a chain. There is no way to run N items
+through M stages where item A can be in stage 3 while item B is still in
+stage 1 — the natural shape for "summarize every document, then judge every
+summary".
+
+### Design
+
+```python
+results = await pipeline_map(
+    items,
+    fetch,        # stage 1: receives (item)
+    summarize,    # stage 2+: receives (previous_result, item, index)
+    judge,
+    max_concurrent=8,
+    on_error="none",   # "none" (default) | "raise"
+)
+```
+
+- Each item flows through all stages **independently** — no barrier between
+  stages. Wall-clock is the slowest single-item chain, not the sum of the
+  slowest stage per phase.
+- Stage 1 receives the item; later stages receive
+  `(previous_result, item, index)` so context need not be threaded through
+  return values. Callables with a single parameter are called with just the
+  previous result (inspected once, at submission).
+- **Failure policy:** `on_error="none"` (default) — a stage exception drops
+  that item's result to `None` and skips its remaining stages, so one bad
+  item never kills the batch; the exception is recorded as a task event as
+  usual. `on_error="raise"` propagates the first failure.
+- `max_concurrent` caps in-flight items (semaphore); default unlimited.
+- Results return in input order, `None` for dropped items.
+- Composition with replay is free: stages are ordinary task calls, each with
+  per-call occurrence identity, so a resumed pipeline replays completed
+  stage calls and re-runs only what never finished.
+
+Ships in `flux/tasks/builtins.py` next to `parallel`/`pipeline`; exported
+from `flux.tasks`.
+
+## 3. Budget — a spend ceiling for LLM work
+
+### Today
+
+No provider reports usage anywhere in the AI stack: `formatter.py` has no
+usage hook, the agent loop counts tool *calls* but not tokens. An agent loop
+(or an authored workflow full of `agent()` calls) has no way to bound its
+own spend.
+
+### Design
+
+**Usage plumbing (the bulk of the work).** The `LLMFormatter` ABC gains
+`extract_usage(response) -> Usage | None` where
+`Usage(input_tokens, output_tokens)`; each provider module implements it
+from its native response shape (all four expose token counts). The agent
+loop records usage after every LLM call — including streamed calls, whose
+final usage arrives on the terminal chunk for every supported provider —
+and attaches it to the agent task's progress/telemetry.
+
+**The primitive.**
+
+```python
+budget = Budget(max_tokens=200_000)
+
+result = await agent("...", model=..., budget=budget)(task_input)
+# later, in workflow code:
+if budget.remaining() < 20_000:
+    return partial_result
+```
+
+- `Budget` is a plain object: `spent()`, `remaining()`, `max_tokens`
+  (`None` = tracking only, no ceiling). Passed explicitly to `agent()` /
+  `workflow_agent()` / `delegate` — one budget instance can be shared across
+  every agent call in a workflow, which is the point.
+- **Enforcement:** checked *before* each LLM call; when `spent() >=
+  max_tokens` the call raises `BudgetExceededError` (an `ExecutionError`
+  subclass) — catchable in workflow code, mapped through retry/fallback like
+  any task error. A call in flight is never killed mid-stream; the ceiling
+  is a pre-flight gate, so overshoot is bounded by one call's output.
+- **Scope & replay semantics (stated honestly):** a `Budget` bounds spend
+  within one *run attempt*. On resume, replayed agent calls short-circuit
+  from the event log without re-spending, and the in-memory counter starts
+  fresh — so the ceiling applies to *new* spend after resume. Durable
+  cumulative accounting across attempts (usage as persisted events) is
+  future work, noted in the doc.
+
+## Config
+
+No new config section. `max_schema_retries` is a per-call `agent()`
+parameter (default 1). Budget is explicit-object-only — no ambient global.
+
+## Testing
+
+- **Structured output:** schema + tools returns validated model (mock
+  provider); malformed-then-corrected retry path; retry exhaustion fails
+  with field-level detail; delegation surfaces validated instances;
+  tool-less path unchanged (existing tests keep passing).
+- **pipeline_map:** ordering, no-barrier interleaving (stage timestamps),
+  single-param stage calling convention, error-drop vs error-raise,
+  max_concurrent cap, replay-resume mid-pipeline (pause between stages,
+  resume, completed stage calls not re-run).
+- **Budget:** per-provider `extract_usage` (fixture responses); accumulation
+  across calls sharing one budget; pre-flight ceiling raises
+  `BudgetExceededError`; `None` ceiling tracks without enforcement;
+  streamed-call usage capture.
+
+## Rollout / compatibility
+
+Additive: new combinator, new optional parameters, a new formatter method
+with a `None`-returning default (existing custom formatters keep working;
+budget enforcement simply sees no usage from them and only tracking-only
+budgets are useful until they implement it). Version: 0.59.0.

--- a/docs/specs/2026-07-15-agent-vocabulary-spec.md
+++ b/docs/specs/2026-07-15-agent-vocabulary-spec.md
@@ -1,4 +1,4 @@
-# Spec: agent vocabulary layer — structured output, staged pipeline, budget
+# Spec: agent vocabulary layer — structured output, bounded fan-out, budget
 
 **Date:** 2026-07-15 · **Status:** draft for review (PR 3 of the
 dynamic-workflows series) · **Depends on:** nothing at runtime — composes
@@ -9,14 +9,13 @@ with #130/#131 but each primitive stands alone.
 PR 1 gave model-authored code a safe place to run; PR 2 gave agents a way to
 author workflows. This PR makes what they author (and what agent loops do in
 general) *expressive and bounded*: subagent calls that return validated
-structured data instead of prose to re-parse, a fan-out combinator that
-streams items through stages without artificial barriers, and a spend
-ceiling that turns "the agent looped and burned tokens all night" into a
-structured, catchable failure.
+structured data instead of prose to re-parse, fan-out that survives one bad
+item and caps its own concurrency, and a spend ceiling that turns "the agent
+looped and burned tokens all night" into a structured, catchable failure.
 
 Each primitive replicates a proven shape from orchestration harnesses
-(schema-forced subagent output, per-item pipelines, shared token budgets)
-on Flux's own machinery.
+(schema-forced subagent output, bounded map over items, shared token
+budgets) on Flux's own machinery.
 
 ## 1. Structured output that survives tools
 
@@ -55,48 +54,64 @@ requested. There is also no validation-retry: a malformed response raises
 Streaming structured output (stream stays auto-disabled when a format is
 set, as today).
 
-## 2. `pipeline_map` — per-item staged fan-out
+## 2. `parallel` — bounded, partial-failure-tolerant fan-out
 
 ### Today
 
-`parallel(*coros)` is a gather (barrier at the end); `pipeline(*tasks,
-input)` threads ONE value through a chain. There is no way to run N items
-through M stages where item A can be in stage 3 while item B is still in
-stage 1 — the natural shape for "summarize every document, then judge every
-summary".
+`parallel(*coros)` is a bare `asyncio.gather`. Two gaps for agent-scale
+fan-out:
+
+1. **No concurrency cap.** 200 items where each is an `agent()` call means
+   200 concurrent LLM requests — there is no primitive to bound in-flight
+   work.
+2. **All-or-nothing failure.** `gather` without `return_exceptions`
+   propagates the first exception, and since `parallel` is itself a
+   `@task`, one bad item fails the whole combinator — retry then re-runs
+   the entire batch, including everything that already succeeded.
+
+Notably, *staged* per-item flow ("summarize every document, then judge
+every summary" with no barrier between stages) needs **no new combinator**:
+chain the stages in a plain async function and fan it out —
+
+```python
+async def process(doc):
+    fetched = await fetch(doc)
+    summary = await summarize(fetched)
+    return await judge(summary)
+
+results = await parallel(*[process(d) for d in docs])
+```
+
+Each stage is an ordinary task call with per-call occurrence identity, so
+replay/resume of a half-finished batch works for free. This idiom is the
+recommended shape and gets documented; an earlier draft proposed a
+dedicated `pipeline_map` combinator, rejected as sugar over the above.
 
 ### Design
 
+Close the two real gaps in `parallel` itself:
+
 ```python
-results = await pipeline_map(
-    items,
-    fetch,        # stage 1: receives (item)
-    summarize,    # stage 2+: receives (previous_result, item, index)
-    judge,
-    max_concurrent=8,
-    on_error="none",   # "none" (default) | "raise"
+results = await parallel(
+    *[process(d) for d in docs],
+    max_concurrent=8,        # semaphore; None (default) = unlimited
+    raise_on_error=False,    # default
 )
 ```
 
-- Each item flows through all stages **independently** — no barrier between
-  stages. Wall-clock is the slowest single-item chain, not the sum of the
-  slowest stage per phase.
-- Stage 1 receives the item; later stages receive
-  `(previous_result, item, index)` so context need not be threaded through
-  return values. Callables with a single parameter are called with just the
-  previous result (inspected once, at submission).
-- **Failure policy:** `on_error="none"` (default) — a stage exception drops
-  that item's result to `None` and skips its remaining stages, so one bad
-  item never kills the batch; the exception is recorded as a task event as
-  usual. `on_error="raise"` propagates the first failure.
-- `max_concurrent` caps in-flight items (semaphore); default unlimited.
+- **`max_concurrent`** — caps in-flight coroutines with a semaphore;
+  `None` (default) preserves today's unbounded behavior.
+- **`raise_on_error=False`** (default) — a failed coroutine's slot in the
+  result list becomes `None` and the remaining items keep running; the
+  exception is recorded on the corresponding task's events as usual, so
+  nothing is silently swallowed — the failure is visible in the execution
+  log, it just doesn't kill the batch. `raise_on_error=True` restores
+  fail-fast propagation (the pre-change behavior).
 - Results return in input order, `None` for dropped items.
-- Composition with replay is free: stages are ordinary task calls, each with
-  per-call occurrence identity, so a resumed pipeline replays completed
-  stage calls and re-runs only what never finished.
-
-Ships in `flux/tasks/builtins.py` next to `parallel`/`pipeline`; exported
-from `flux.tasks`.
+- **Compatibility note:** the *default* failure behavior changes — code
+  that relied on `parallel` raising on the first item failure must now
+  pass `raise_on_error=True` or check for `None` entries. Called out in
+  the changelog; the failure events themselves are unchanged.
 
 ## 3. Budget — a spend ceiling for LLM work
 
@@ -155,10 +170,11 @@ parameter (default 1). Budget is explicit-object-only — no ambient global.
   provider); malformed-then-corrected retry path; retry exhaustion fails
   with field-level detail; delegation surfaces validated instances;
   tool-less path unchanged (existing tests keep passing).
-- **pipeline_map:** ordering, no-barrier interleaving (stage timestamps),
-  single-param stage calling convention, error-drop vs error-raise,
-  max_concurrent cap, replay-resume mid-pipeline (pause between stages,
-  resume, completed stage calls not re-run).
+- **parallel:** ordering preserved; error-drop default (`None` slot, batch
+  survives, failure event recorded) vs `raise_on_error=True` fail-fast;
+  `max_concurrent` cap actually bounds in-flight count; staged per-item
+  idiom replays correctly (pause mid-batch, resume, completed stage calls
+  not re-run).
 - **Budget:** per-provider `extract_usage` (fixture responses); accumulation
   across calls sharing one budget; pre-flight ceiling raises
   `BudgetExceededError`; `None` ceiling tracks without enforcement;
@@ -166,7 +182,9 @@ parameter (default 1). Budget is explicit-object-only — no ambient global.
 
 ## Rollout / compatibility
 
-Additive: new combinator, new optional parameters, a new formatter method
-with a `None`-returning default (existing custom formatters keep working;
-budget enforcement simply sees no usage from them and only tracking-only
-budgets are useful until they implement it). Version: 0.59.0.
+Mostly additive: new optional parameters and a new formatter method with a
+`None`-returning default (existing custom formatters keep working; budget
+enforcement simply sees no usage from them and only tracking-only budgets
+are useful until they implement it). One behavior change: `parallel`'s
+default failure mode moves from fail-fast to drop-to-`None`
+(`raise_on_error=True` restores the old behavior). Version: 0.59.0.

--- a/docs/specs/2026-07-15-agent-vocabulary-spec.md
+++ b/docs/specs/2026-07-15-agent-vocabulary-spec.md
@@ -95,23 +95,21 @@ Close the two real gaps in `parallel` itself:
 results = await parallel(
     *[process(d) for d in docs],
     max_concurrent=8,        # semaphore; None (default) = unlimited
-    raise_on_error=False,    # default
+    raise_on_error=False,    # default True = today's fail-fast behavior
 )
 ```
 
 - **`max_concurrent`** — caps in-flight coroutines with a semaphore;
   `None` (default) preserves today's unbounded behavior.
-- **`raise_on_error=False`** (default) — a failed coroutine's slot in the
-  result list becomes `None` and the remaining items keep running; the
-  exception is recorded on the corresponding task's events as usual, so
-  nothing is silently swallowed — the failure is visible in the execution
-  log, it just doesn't kill the batch. `raise_on_error=True` restores
-  fail-fast propagation (the pre-change behavior).
+- **`raise_on_error=True`** (default) — fail-fast propagation, exactly
+  today's behavior. With `raise_on_error=False`, a failed coroutine's slot
+  in the result list becomes `None` and the remaining items keep running;
+  the exception is recorded on the corresponding task's events as usual,
+  so nothing is silently swallowed — the failure is visible in the
+  execution log, it just doesn't kill the batch.
 - Results return in input order, `None` for dropped items.
-- **Compatibility note:** the *default* failure behavior changes — code
-  that relied on `parallel` raising on the first item failure must now
-  pass `raise_on_error=True` or check for `None` entries. Called out in
-  the changelog; the failure events themselves are unchanged.
+- Fully backwards compatible: both parameters default to today's
+  semantics.
 
 ## 3. Budget — a spend ceiling for LLM work
 
@@ -170,11 +168,11 @@ parameter (default 1). Budget is explicit-object-only — no ambient global.
   provider); malformed-then-corrected retry path; retry exhaustion fails
   with field-level detail; delegation surfaces validated instances;
   tool-less path unchanged (existing tests keep passing).
-- **parallel:** ordering preserved; error-drop default (`None` slot, batch
-  survives, failure event recorded) vs `raise_on_error=True` fail-fast;
-  `max_concurrent` cap actually bounds in-flight count; staged per-item
-  idiom replays correctly (pause mid-batch, resume, completed stage calls
-  not re-run).
+- **parallel:** ordering preserved; fail-fast default unchanged (existing
+  tests keep passing) vs `raise_on_error=False` error-drop (`None` slot,
+  batch survives, failure event recorded); `max_concurrent` cap actually
+  bounds in-flight count; staged per-item idiom replays correctly (pause
+  mid-batch, resume, completed stage calls not re-run).
 - **Budget:** per-provider `extract_usage` (fixture responses); accumulation
   across calls sharing one budget; pre-flight ceiling raises
   `BudgetExceededError`; `None` ceiling tracks without enforcement;
@@ -182,9 +180,8 @@ parameter (default 1). Budget is explicit-object-only — no ambient global.
 
 ## Rollout / compatibility
 
-Mostly additive: new optional parameters and a new formatter method with a
-`None`-returning default (existing custom formatters keep working; budget
-enforcement simply sees no usage from them and only tracking-only budgets
-are useful until they implement it). One behavior change: `parallel`'s
-default failure mode moves from fail-fast to drop-to-`None`
-(`raise_on_error=True` restores the old behavior). Version: 0.59.0.
+Additive: new optional parameters (all defaulting to today's semantics)
+and a new formatter method with a `None`-returning default (existing
+custom formatters keep working; budget enforcement simply sees no usage
+from them and only tracking-only budgets are useful until they implement
+it). Version: 0.59.0.

--- a/flux/errors.py
+++ b/flux/errors.py
@@ -72,6 +72,35 @@ class ExecutionTimeoutError(ExecutionError):
         return (self.__class__, (self._type, self._name, self._id, self._timeout))
 
 
+class BudgetExceededError(ExecutionError):
+    """Raised before an LLM call when a Budget's ceiling has been reached.
+
+    The gate is pre-flight: a call in flight is never interrupted, so the
+    overshoot is bounded by a single call's usage.
+    """
+
+    def __init__(self, spent_tokens: int, max_tokens: int):
+        super().__init__(
+            message=(
+                f"LLM token budget exceeded: {spent_tokens} tokens spent "
+                f"of a {max_tokens}-token ceiling."
+            ),
+        )
+        self._spent_tokens = spent_tokens
+        self._max_tokens = max_tokens
+
+    @property
+    def spent_tokens(self) -> int:
+        return self._spent_tokens
+
+    @property
+    def max_tokens(self) -> int:
+        return self._max_tokens
+
+    def __reduce__(self):
+        return (self.__class__, (self._spent_tokens, self._max_tokens))
+
+
 class PauseRequested(ExecutionError):
     def __init__(self, name: str, output: Any = None):
         super().__init__(

--- a/flux/tasks/ai/__init__.py
+++ b/flux/tasks/ai/__init__.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from flux.tasks.ai.agent import agent
 from flux.tasks.ai.agent_plan import AgentPlan, AgentStep
+from flux.tasks.ai.budget import Budget
 from flux.tasks.ai.delegation import DelegationResult, workflow_agent
-from flux.tasks.ai.models import LLMResponse, ToolCall
+from flux.tasks.ai.models import LLMResponse, ToolCall, Usage
 from flux.tasks.ai.memory import in_memory, long_term_memory, postgresql, sqlite, working_memory
 from flux.tasks.ai.skills import Skill, SkillCatalog
 from flux.tasks.ai.tools import system_tools
@@ -24,4 +25,6 @@ __all__ = [
     "DelegationResult",
     "LLMResponse",
     "ToolCall",
+    "Budget",
+    "Usage",
 ]

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -93,7 +93,8 @@ async def agent(
             loop checks it before every LLM call and raises BudgetExceededError
             once spent() reaches max_tokens. Setting a budget disables token-level
             content streaming (the final text still arrives as progress) because
-            usage is only reported on non-streamed calls.
+            the raw token-stream path bypasses the LLM task wrapper and cannot
+            capture the usage the budget needs.
 
     Returns:
         A Flux @task callable with signature (instruction: str, *, context: str = "") -> str | BaseModel

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -10,6 +10,7 @@ from flux.task import task
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from flux.tasks.ai.budget import Budget
     from flux.tasks.ai.memory.long_term_memory import LongTermMemory
     from flux.tasks.ai.memory.working_memory import WorkingMemory
     from flux.tasks.ai.skills import SkillCatalog
@@ -31,6 +32,7 @@ async def agent(
     strict_dependencies: bool = False,
     approve_plan: bool = False,
     response_format: type[BaseModel] | None = None,
+    max_schema_retries: int = 1,
     working_memory: WorkingMemory | None = None,
     long_term_memory: LongTermMemory | None = None,
     max_tool_calls: int = 10,
@@ -41,6 +43,7 @@ async def agent(
     on_complete: list[Callable] | None = None,
     on_pause: list[Callable] | None = None,
     reasoning_effort: str | None = None,
+    budget: Budget | None = None,
 ) -> task:
     """Create a Flux @task that calls an LLM.
 
@@ -65,6 +68,11 @@ async def agent(
         approve_plan: If True, pause for human approval before activating a new plan.
             Defaults to False.
         response_format: Pydantic BaseModel subclass for structured JSON output.
+            Composes with tools: the final (non-tool-call) answer is validated
+            against the schema.
+        max_schema_retries: Corrective turns allowed when the final answer fails
+            schema validation — the validation errors are fed back and the model
+            answers again. 0 fails on the first invalid answer. Defaults to 1.
         working_memory: WorkingMemory instance for conversation history across invocations.
         long_term_memory: LongTermMemory instance for persistent fact storage.
         max_tool_calls: Maximum tool call iterations before forcing a final answer.
@@ -80,6 +88,12 @@ async def agent(
             Same signature as on_complete. Fired before the pause propagates.
         reasoning_effort: Configure reasoning/thinking depth. "low", "medium", "high",
             or None (disabled). Provider-specific mapping is applied internally.
+        budget: Budget instance this agent's token spend counts against. Share one
+            instance across several agents to give them a collective ceiling; the
+            loop checks it before every LLM call and raises BudgetExceededError
+            once spent() reaches max_tokens. Setting a budget disables token-level
+            content streaming (the final text still arrives as progress) because
+            usage is only reported on non-streamed calls.
 
     Returns:
         A Flux @task callable with signature (instruction: str, *, context: str = "") -> str | BaseModel
@@ -181,6 +195,7 @@ async def agent(
                 tools=tools,
                 tool_schemas=ollama_tools,
                 response_format=response_format,
+                max_schema_retries=max_schema_retries,
                 working_memory=working_memory,
                 max_tool_calls=max_tool_calls,
                 max_concurrent_tools=max_concurrent_tools,
@@ -190,6 +205,7 @@ async def agent(
                 on_complete=on_complete,
                 on_pause=on_pause,
                 agent_name=task_name,
+                budget=budget,
             )
 
         result = _ollama_agent
@@ -221,6 +237,7 @@ async def agent(
                 tools=tools,
                 tool_schemas=openai_tools,
                 response_format=response_format,
+                max_schema_retries=max_schema_retries,
                 working_memory=working_memory,
                 max_tool_calls=max_tool_calls,
                 max_concurrent_tools=max_concurrent_tools,
@@ -230,6 +247,7 @@ async def agent(
                 on_complete=on_complete,
                 on_pause=on_pause,
                 agent_name=task_name,
+                budget=budget,
             )
 
         result = _openai_agent
@@ -261,6 +279,7 @@ async def agent(
                 tools=tools,
                 tool_schemas=anthropic_tools,
                 response_format=response_format,
+                max_schema_retries=max_schema_retries,
                 working_memory=working_memory,
                 max_tool_calls=max_tool_calls,
                 max_concurrent_tools=max_concurrent_tools,
@@ -270,6 +289,7 @@ async def agent(
                 on_complete=on_complete,
                 on_pause=on_pause,
                 agent_name=task_name,
+                budget=budget,
             )
 
         result = _anthropic_agent
@@ -301,6 +321,7 @@ async def agent(
                 tools=tools,
                 tool_schemas=gemini_tools,
                 response_format=response_format,
+                max_schema_retries=max_schema_retries,
                 working_memory=working_memory,
                 max_tool_calls=max_tool_calls,
                 max_concurrent_tools=max_concurrent_tools,
@@ -310,6 +331,7 @@ async def agent(
                 on_complete=on_complete,
                 on_pause=on_pause,
                 agent_name=task_name,
+                budget=budget,
             )
 
         result = _google_agent

--- a/flux/tasks/ai/agent_loop.py
+++ b/flux/tasks/ai/agent_loop.py
@@ -5,7 +5,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from flux.errors import PauseRequested
 from flux.tasks.ai.models import LLMResponse
@@ -14,6 +14,7 @@ from flux.tasks.progress import progress
 
 if TYPE_CHECKING:
     from flux.task import task as TaskType
+    from flux.tasks.ai.budget import Budget
     from flux.tasks.ai.formatter import LLMFormatter
     from flux.tasks.ai.memory.working_memory import WorkingMemory
 
@@ -65,7 +66,10 @@ async def _call_llm(
     working_memory: Any,
     stream: bool,
     call_counter: int,
+    budget: Budget | None = None,
 ) -> LLMResponse:
+    if budget is not None:
+        budget.check()
     if stream and formatter.supports_reasoning_stream:
         from flux.domain.execution_context import CURRENT_CONTEXT
 
@@ -105,6 +109,8 @@ async def _call_llm(
         response = _ensure_llm_response(result)
         if stream and response.reasoning and response.reasoning.text:
             await progress({"type": "reasoning", "text": response.reasoning.text})
+    if budget is not None:
+        budget.record(response.usage)
     await _store_reasoning(working_memory, response)
     return response
 
@@ -119,6 +125,7 @@ async def run_agent_loop(
     tools: list[Any] | None = None,
     tool_schemas: list[Any] | None = None,
     response_format: type[BaseModel] | None = None,
+    max_schema_retries: int = 1,
     working_memory: WorkingMemory | None = None,
     max_tool_calls: int = 10,
     max_concurrent_tools: int | None = None,
@@ -128,13 +135,14 @@ async def run_agent_loop(
     on_complete: list[Any] | None = None,
     on_pause: list[Any] | None = None,
     agent_name: str = "agent",
+    budget: Budget | None = None,
 ) -> str | BaseModel:
     user_content = instruction
     if context:
         user_content = f"{instruction}\n\nContext from previous work:\n\n{context}"
 
     sys_prompt = system_prompt
-    if response_format and not tools:
+    if response_format:
         schema_json = json.dumps(response_format.model_json_schema())
         sys_prompt += f"\n\nRespond with JSON matching this schema:\n{schema_json}"
 
@@ -142,7 +150,10 @@ async def run_agent_loop(
 
     if response_format and not tools:
         # Let providers with native structured-output support enforce the
-        # schema at the API level rather than relying only on the prompt.
+        # schema at the API level. Only possible on the tool-less path:
+        # Anthropic's enforcement is a forced tool call, which commandeers
+        # the tools/tool_choice kwargs. With tools, the schema in the system
+        # prompt plus post-hoc validation (with retry) takes over.
         formatter.apply_structured_output(response_format, call_kwargs)
 
     if tool_schemas:
@@ -150,7 +161,10 @@ async def run_agent_loop(
 
     call_counter = 0
 
-    if stream and not tools:
+    # Token-level streaming bypasses the LLM task wrapper, so provider usage
+    # is never captured on this path — with a budget, fall through to the
+    # non-streaming call (the final text is still emitted as progress).
+    if stream and not tools and budget is None:
         content = ""
         async for token in formatter.stream(messages, call_kwargs):
             content += token
@@ -161,7 +175,7 @@ async def run_agent_loop(
             await working_memory.memorize("assistant", content)
 
         if response_format:
-            return_value = response_format.model_validate_json(content)
+            return_value = response_format.model_validate_json(_json_candidate(content))
             await _fire_hooks(on_complete, agent_name, return_value)
             return return_value
 
@@ -176,6 +190,7 @@ async def run_agent_loop(
         working_memory,
         stream,
         call_counter,
+        budget,
     )
     call_counter += 1
 
@@ -276,6 +291,7 @@ async def run_agent_loop(
             working_memory,
             stream,
             call_counter,
+            budget,
         )
         call_counter += 1
 
@@ -299,6 +315,7 @@ async def run_agent_loop(
                 working_memory,
                 stream,
                 call_counter,
+                budget,
             )
             call_counter += 1
 
@@ -318,6 +335,7 @@ async def run_agent_loop(
             working_memory,
             stream,
             call_counter,
+            budget,
         )
         call_counter += 1
 
@@ -340,11 +358,67 @@ async def run_agent_loop(
         await working_memory.memorize("assistant", content)
 
     if response_format:
-        return_value = response_format.model_validate_json(content)
+        retries_left = max_schema_retries
+        while True:
+            try:
+                return_value = response_format.model_validate_json(_json_candidate(content))
+                break
+            except ValidationError as validation_error:
+                if retries_left <= 0:
+                    raise
+                retries_left -= 1
+                # Feed the validation errors back for a corrective turn.
+                # Tools are stripped (same pattern as the forced final
+                # answer) so the model can only answer, not act.
+                if content:
+                    messages.append(
+                        formatter.format_assistant_message(LLMResponse(text=content)),
+                    )
+                schema_json = json.dumps(response_format.model_json_schema())
+                messages.append(
+                    formatter.format_user_message(
+                        "Your response did not match the required schema. "
+                        f"Validation errors:\n{validation_error}\n\n"
+                        "Respond again with ONLY valid JSON matching this "
+                        f"schema:\n{schema_json}",
+                    ),
+                )
+                no_tool_kwargs = formatter.remove_tools_from_kwargs(call_kwargs)
+                response = await _call_llm(
+                    llm_task,
+                    formatter,
+                    messages,
+                    no_tool_kwargs,
+                    working_memory,
+                    stream,
+                    call_counter,
+                    budget,
+                )
+                call_counter += 1
+                content = response.text
+                if working_memory:
+                    await working_memory.memorize("assistant", content)
         await _fire_hooks(on_complete, agent_name, return_value)
         return return_value
 
     await _fire_hooks(on_complete, agent_name, content)
+    return content
+
+
+def _json_candidate(content: str) -> str:
+    """Strip a markdown code fence around an otherwise-JSON answer.
+
+    Models answering mid-conversation (especially after tool use, where no
+    native structured output constrains them) routinely wrap JSON in
+    ```json fences. Anything more exotic still fails validation and goes
+    through the corrective retry.
+    """
+    stripped = content.strip()
+    if stripped.startswith("```") and stripped.endswith("```"):
+        stripped = stripped[3:-3]
+        if stripped.startswith("json"):
+            stripped = stripped[4:]
+        return stripped.strip()
     return content
 
 

--- a/flux/tasks/ai/anthropic.py
+++ b/flux/tasks/ai/anthropic.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from flux.task import task
 from flux.tasks.ai.formatter import LLMFormatter
-from flux.tasks.ai.models import LLMResponse, ReasoningContent, ToolCall
+from flux.tasks.ai.models import LLMResponse, ReasoningContent, ToolCall, Usage
 
 try:
     from anthropic import AsyncAnthropic
@@ -265,10 +265,18 @@ def _to_llm_response(response: Any) -> LLMResponse:
                 tool_calls.append(
                     ToolCall(id=block.id, name=block.name, arguments=block.input),
                 )
+    usage: Usage | None = None
+    raw_usage = getattr(response, "usage", None)
+    if raw_usage is not None:
+        usage = Usage(
+            input_tokens=getattr(raw_usage, "input_tokens", 0) or 0,
+            output_tokens=getattr(raw_usage, "output_tokens", 0) or 0,
+        )
     return LLMResponse(
         text="\n".join(text_parts) if text_parts else "",
         tool_calls=tool_calls,
         reasoning=reasoning,
+        usage=usage,
     )
 
 

--- a/flux/tasks/ai/budget.py
+++ b/flux/tasks/ai/budget.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from flux.errors import BudgetExceededError
+from flux.tasks.ai.models import Usage
+
+
+class Budget:
+    """A shared token-spend ceiling for LLM work.
+
+    Create one instance and pass it to every ``agent()`` call whose spend
+    should count against the same ceiling. ``max_tokens=None`` tracks usage
+    without enforcing anything.
+
+    Enforcement is a pre-flight gate: the agent loop calls :meth:`check`
+    before each LLM call and raises :class:`BudgetExceededError` once
+    ``spent() >= max_tokens``. A call already in flight is never interrupted,
+    so overshoot is bounded by one call's usage.
+
+    Scope: a budget bounds spend within one run attempt. On resume, the
+    agent loop's inner LLM task calls replay from the event log — their
+    recorded usage is re-counted into the (fresh) budget in the same order,
+    so accounting stays consistent for a resumed attempt without re-spending
+    real tokens. Sharing one budget across *concurrently running* agents
+    makes the exact enforcement point nondeterministic across replays;
+    durable cumulative accounting is future work.
+    """
+
+    def __init__(self, max_tokens: int | None = None) -> None:
+        if max_tokens is not None and max_tokens < 1:
+            raise ValueError(f"max_tokens must be >= 1, got {max_tokens}")
+        self.max_tokens = max_tokens
+        self._input_tokens = 0
+        self._output_tokens = 0
+
+    def record(self, usage: Usage | None) -> None:
+        """Add one LLM call's usage. None (provider reported nothing) is a no-op."""
+        if usage is None:
+            return
+        self._input_tokens += usage.input_tokens
+        self._output_tokens += usage.output_tokens
+
+    def spent(self) -> int:
+        """Total tokens (input + output) recorded so far."""
+        return self._input_tokens + self._output_tokens
+
+    def remaining(self) -> int | None:
+        """Tokens left under the ceiling (floored at 0); None when no ceiling is set."""
+        if self.max_tokens is None:
+            return None
+        return max(0, self.max_tokens - self.spent())
+
+    def check(self) -> None:
+        """Raise BudgetExceededError if the ceiling has been reached."""
+        if self.max_tokens is not None and self.spent() >= self.max_tokens:
+            raise BudgetExceededError(spent_tokens=self.spent(), max_tokens=self.max_tokens)
+
+    def __repr__(self) -> str:
+        ceiling = self.max_tokens if self.max_tokens is not None else "unlimited"
+        return f"Budget(spent={self.spent()}, max_tokens={ceiling})"

--- a/flux/tasks/ai/delegation.py
+++ b/flux/tasks/ai/delegation.py
@@ -8,6 +8,9 @@ from dataclasses import asdict, dataclass
 from typing import Any, Literal
 from collections.abc import Callable
 
+from pydantic import BaseModel
+from pydantic import ValidationError as PydanticValidationError
+
 from flux.errors import ExecutionError, PauseRequested
 from flux.task import task
 
@@ -201,6 +204,10 @@ def build_delegate(agents: list) -> task:
                     execution_id=raw.execution_id,
                 )
             else:
+                # Sub-agents with a response_format return a validated model;
+                # surface it as plain data so the parent LLM sees clean JSON.
+                if isinstance(raw, BaseModel):
+                    raw = raw.model_dump()
                 result = DelegationResult(
                     agent=agent,
                     status="completed",
@@ -230,11 +237,17 @@ def workflow_agent(
     name: str,
     description: str,
     workflow: str,
+    response_format: type[BaseModel] | None = None,
 ) -> task:
     """Create an agent backed by a remote Flux workflow.
 
     The returned task uses FluxClient to call the workflow synchronously
     and returns a WorkflowAgentResult with status, output, and execution_id.
+
+    When ``response_format`` is set, a completed workflow's output is
+    validated against the model before being surfaced — a contract violation
+    turns the delegation into a failure instead of handing the parent
+    unchecked data.
     """
     _validate_agent_name(name)
 
@@ -260,9 +273,25 @@ def workflow_agent(
                     payload,
                 )
 
+        status = _map_execution_state(response)
+        output = response.get("output")
+        if response_format is not None and status == "completed":
+            try:
+                validated = response_format.model_validate(output)
+            except PydanticValidationError as e:
+                return WorkflowAgentResult(
+                    status="failed",
+                    output=(
+                        f"Workflow '{workflow}' completed but its output did "
+                        f"not match the expected schema "
+                        f"{response_format.__name__}: {e}"
+                    ),
+                    execution_id=response.get("execution_id"),
+                )
+            output = validated.model_dump()
         return WorkflowAgentResult(
-            status=_map_execution_state(response),
-            output=response.get("output"),
+            status=status,
+            output=output,
             execution_id=response.get("execution_id"),
         )
 

--- a/flux/tasks/ai/gemini.py
+++ b/flux/tasks/ai/gemini.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from flux.task import task
 from flux.tasks.ai.formatter import LLMFormatter
-from flux.tasks.ai.models import LLMResponse, ReasoningContent, ToolCall
+from flux.tasks.ai.models import LLMResponse, ReasoningContent, ToolCall, Usage
 
 try:
     from google import genai
@@ -260,12 +260,17 @@ class GeminiFormatter(LLMFormatter):
         reasoning_parts: list[str] = []
         text_parts: list[str] = []
         tool_calls: list[ToolCall] = []
+        usage: Usage | None = None
 
         async for chunk in await self._client.aio.models.generate_content_stream(
             model=model,
             contents=messages,
             config=config,
         ):
+            # usage_metadata is cumulative; the last chunk carries the totals.
+            chunk_usage = _to_usage(chunk)
+            if chunk_usage is not None:
+                usage = chunk_usage
             candidates = getattr(chunk, "candidates", None)
             if not candidates:
                 continue
@@ -292,7 +297,7 @@ class GeminiFormatter(LLMFormatter):
                 opaque={"text": reasoning_text, "thought": True},
             )
 
-        return LLMResponse(text=text, tool_calls=tool_calls, reasoning=reasoning)
+        return LLMResponse(text=text, tool_calls=tool_calls, reasoning=reasoning, usage=usage)
 
 
 def _config_with_tools(config: Any, tools: list) -> Any:
@@ -368,7 +373,24 @@ def _to_llm_response(response: Any) -> LLMResponse:
                     ),
                 )
 
-    return LLMResponse(text=text, tool_calls=tool_calls, reasoning=reasoning)
+    return LLMResponse(
+        text=text,
+        tool_calls=tool_calls,
+        reasoning=reasoning,
+        usage=_to_usage(response),
+    )
+
+
+def _to_usage(response: Any) -> Usage | None:
+    metadata = getattr(response, "usage_metadata", None)
+    if metadata is None:
+        return None
+    input_tokens = getattr(metadata, "prompt_token_count", 0) or 0
+    # Thinking tokens are billed output but reported separately.
+    output_tokens = (getattr(metadata, "candidates_token_count", 0) or 0) + (
+        getattr(metadata, "thoughts_token_count", 0) or 0
+    )
+    return Usage(input_tokens=input_tokens, output_tokens=output_tokens)
 
 
 def _to_gemini_tools(schemas: list[dict[str, Any]]) -> list:

--- a/flux/tasks/ai/models.py
+++ b/flux/tasks/ai/models.py
@@ -16,7 +16,21 @@ class ReasoningContent(BaseModel):
     opaque: Any = None
 
 
+class Usage(BaseModel):
+    """Token usage reported by a provider for a single LLM call."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        return self.input_tokens + self.output_tokens
+
+
 class LLMResponse(BaseModel):
     text: str = ""
     tool_calls: list[ToolCall] = []
     reasoning: ReasoningContent | None = None
+    # Populated by providers that report token usage; None when the provider
+    # (or a custom formatter) does not expose it.
+    usage: Usage | None = None

--- a/flux/tasks/ai/ollama.py
+++ b/flux/tasks/ai/ollama.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 
 from flux.task import task
 from flux.tasks.ai.formatter import LLMFormatter
-from flux.tasks.ai.models import LLMResponse, ReasoningContent, ToolCall
+from flux.tasks.ai.models import LLMResponse, ReasoningContent, ToolCall, Usage
 from flux.tasks.ai.tool_executor import (
     extract_tool_calls_from_content,
     strip_tool_calls_from_content,
@@ -117,9 +117,10 @@ class OllamaFormatter(LLMFormatter):
             messages[-1]["content"] += f"\n\nRespond with JSON matching this schema:\n{schema_json}"
             call_kwargs["format"] = "json"
         elif self._response_format and self._tool_names:
-            logger.warning(
-                "Ollama: response_format is ignored when tools are in use; "
-                "the model output will not be constrained to the schema.",
+            logger.debug(
+                "Ollama: native format constraint is not applied when tools "
+                "are in use; the agent loop validates the final answer "
+                "against the schema instead.",
             )
 
         if self._tool_names:
@@ -195,12 +196,17 @@ class OllamaFormatter(LLMFormatter):
         thinking_parts: list[str] = []
         content_parts: list[str] = []
         tool_calls_raw: list[dict] = []
+        usage: Usage | None = None
 
         async for chunk in await self._client.chat(
             messages=messages,
             **stream_kwargs,
             stream=True,
         ):
+            # Token counts arrive on the terminal (done) chunk.
+            chunk_usage = _to_usage(chunk)
+            if chunk_usage is not None:
+                usage = chunk_usage
             msg = chunk.get("message", {})
             if msg.get("thinking"):
                 thinking_parts.append(msg["thinking"])
@@ -237,7 +243,7 @@ class OllamaFormatter(LLMFormatter):
                 content = strip_tool_calls_from_content(content)
 
         reasoning = ReasoningContent(text=thinking, opaque=None) if thinking else None
-        return LLMResponse(text=content, tool_calls=tool_calls, reasoning=reasoning)
+        return LLMResponse(text=content, tool_calls=tool_calls, reasoning=reasoning, usage=usage)
 
 
 def _to_llm_response(
@@ -273,7 +279,23 @@ def _to_llm_response(
     thinking = message.get("thinking")
     reasoning = ReasoningContent(text=thinking, opaque=None) if thinking else None
 
-    return LLMResponse(text=content, tool_calls=tool_calls, reasoning=reasoning)
+    return LLMResponse(
+        text=content,
+        tool_calls=tool_calls,
+        reasoning=reasoning,
+        usage=_to_usage(response),
+    )
+
+
+def _to_usage(chunk: Any) -> Usage | None:
+    prompt_tokens = chunk.get("prompt_eval_count")
+    completion_tokens = chunk.get("eval_count")
+    if prompt_tokens is None and completion_tokens is None:
+        return None
+    return Usage(
+        input_tokens=prompt_tokens or 0,
+        output_tokens=completion_tokens or 0,
+    )
 
 
 def _to_ollama_tools(schemas: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/flux/tasks/ai/openai.py
+++ b/flux/tasks/ai/openai.py
@@ -218,7 +218,9 @@ class OpenAIFormatter(LLMFormatter):
         usage: Usage | None = None
 
         request_kwargs = dict(call_kwargs)
-        stream_options = {"include_usage": True, **request_kwargs.pop("stream_options", {})}
+        # include_usage is forced last: without it the terminal chunk carries
+        # no usage and Budget accounting silently sees zero spend.
+        stream_options = {**request_kwargs.pop("stream_options", {}), "include_usage": True}
 
         async for chunk in await self._client.chat.completions.create(
             messages=messages,

--- a/flux/tasks/ai/openai.py
+++ b/flux/tasks/ai/openai.py
@@ -217,11 +217,14 @@ class OpenAIFormatter(LLMFormatter):
         tool_calls_by_index: dict[int, dict] = {}
         usage: Usage | None = None
 
+        request_kwargs = dict(call_kwargs)
+        stream_options = {"include_usage": True, **request_kwargs.pop("stream_options", {})}
+
         async for chunk in await self._client.chat.completions.create(
             messages=messages,
-            **call_kwargs,
+            **request_kwargs,
             stream=True,
-            stream_options={"include_usage": True},
+            stream_options=stream_options,
         ):
             if getattr(chunk, "usage", None) is not None:
                 usage = _to_usage(chunk.usage)

--- a/flux/tasks/ai/openai.py
+++ b/flux/tasks/ai/openai.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from flux.task import task
 from flux.tasks.ai.formatter import LLMFormatter
-from flux.tasks.ai.models import LLMResponse, ReasoningContent, ToolCall
+from flux.tasks.ai.models import LLMResponse, ReasoningContent, ToolCall, Usage
 
 try:
     from openai import AsyncOpenAI
@@ -215,12 +215,19 @@ class OpenAIFormatter(LLMFormatter):
         reasoning_parts: list[str] = []
         content_parts: list[str] = []
         tool_calls_by_index: dict[int, dict] = {}
+        usage: Usage | None = None
 
         async for chunk in await self._client.chat.completions.create(
             messages=messages,
             **call_kwargs,
             stream=True,
+            stream_options={"include_usage": True},
         ):
+            if getattr(chunk, "usage", None) is not None:
+                usage = _to_usage(chunk.usage)
+            if not chunk.choices:
+                # The include_usage terminal chunk carries usage only.
+                continue
             delta = chunk.choices[0].delta
             if getattr(delta, "reasoning_content", None):
                 reasoning_parts.append(delta.reasoning_content)
@@ -265,7 +272,7 @@ class OpenAIFormatter(LLMFormatter):
                 opaque={"reasoning_content": reasoning_text},
             )
 
-        return LLMResponse(text=text, tool_calls=tool_calls, reasoning=reasoning)
+        return LLMResponse(text=text, tool_calls=tool_calls, reasoning=reasoning, usage=usage)
 
 
 def _to_llm_response(response: Any) -> LLMResponse:
@@ -288,7 +295,21 @@ def _to_llm_response(response: Any) -> LLMResponse:
             text=reasoning_text,
             opaque={"reasoning_content": reasoning_text},
         )
-    return LLMResponse(text=text, tool_calls=tool_calls, reasoning=reasoning)
+    return LLMResponse(
+        text=text,
+        tool_calls=tool_calls,
+        reasoning=reasoning,
+        usage=_to_usage(getattr(response, "usage", None)),
+    )
+
+
+def _to_usage(usage: Any) -> Usage | None:
+    if usage is None:
+        return None
+    return Usage(
+        input_tokens=getattr(usage, "prompt_tokens", 0) or 0,
+        output_tokens=getattr(usage, "completion_tokens", 0) or 0,
+    )
 
 
 def _to_openai_tools(schemas: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/flux/tasks/builtins.py
+++ b/flux/tasks/builtins.py
@@ -66,18 +66,21 @@ async def parallel(
         async with semaphore:
             return await function
 
-    tasks: list[asyncio.Task] = [asyncio.create_task(bounded(f)) for f in functions]
-    if raise_on_error:
-        return await asyncio.gather(*tasks)
-    results = await asyncio.gather(*tasks, return_exceptions=True)
-    for result in results:
+    async def dropping(function: Coroutine[Any, Any, Any]) -> Any:
         # Pause and cancellation are control flow, not item failures — they
-        # must keep propagating or a paused branch would silently become None.
-        if isinstance(result, (PauseRequested, asyncio.CancelledError)):
-            raise result
-        if isinstance(result, BaseException) and not isinstance(result, Exception):
-            raise result
-    return [None if isinstance(r, BaseException) else r for r in results]
+        # must keep propagating (immediately, through the plain gather below)
+        # or a paused branch would silently become None. CancelledError and
+        # other BaseExceptions are not caught by `except Exception`.
+        try:
+            return await bounded(function)
+        except PauseRequested:
+            raise
+        except Exception:
+            return None
+
+    runner = bounded if raise_on_error else dropping
+    tasks: list[asyncio.Task] = [asyncio.create_task(runner(f)) for f in functions]
+    return await asyncio.gather(*tasks)
 
 
 @task

--- a/flux/tasks/builtins.py
+++ b/flux/tasks/builtins.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from typing import Any
 from collections.abc import Callable
 
+from flux.errors import PauseRequested
 from flux.task import task
 
 
@@ -38,9 +39,45 @@ async def randrange(start: int, stop: int | None = None, step: int = 1):
 
 
 @task
-async def parallel(*functions: Coroutine[Any, Any, Any]) -> list[Any]:
-    tasks: list[asyncio.Task] = [asyncio.create_task(f) for f in functions]
-    return await asyncio.gather(*tasks)
+async def parallel(
+    *functions: Coroutine[Any, Any, Any],
+    max_concurrent: int | None = None,
+    raise_on_error: bool = True,
+) -> list[Any]:
+    """Run coroutines concurrently and return their results in input order.
+
+    :param max_concurrent: Maximum number of coroutines running at once.
+        None (default) runs everything concurrently.
+    :param raise_on_error: If True (default), the first exception propagates
+        and fails the whole batch. If False, a failed coroutine's slot in the
+        result list becomes None and the remaining coroutines keep running;
+        the failure is still recorded on the corresponding task's events.
+    """
+    if max_concurrent is not None and max_concurrent < 1:
+        for function in functions:
+            function.close()
+        raise ValueError(f"max_concurrent must be >= 1, got {max_concurrent}")
+
+    semaphore = asyncio.Semaphore(max_concurrent) if max_concurrent else None
+
+    async def bounded(function: Coroutine[Any, Any, Any]) -> Any:
+        if semaphore is None:
+            return await function
+        async with semaphore:
+            return await function
+
+    tasks: list[asyncio.Task] = [asyncio.create_task(bounded(f)) for f in functions]
+    if raise_on_error:
+        return await asyncio.gather(*tasks)
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    for result in results:
+        # Pause and cancellation are control flow, not item failures — they
+        # must keep propagating or a paused branch would silently become None.
+        if isinstance(result, (PauseRequested, asyncio.CancelledError)):
+            raise result
+        if isinstance(result, BaseException) and not isinstance(result, Exception):
+            raise result
+    return [None if isinstance(r, BaseException) else r for r in results]
 
 
 @task

--- a/flux/tasks/builtins.py
+++ b/flux/tasks/builtins.py
@@ -80,7 +80,16 @@ async def parallel(
 
     runner = bounded if raise_on_error else dropping
     tasks: list[asyncio.Task] = [asyncio.create_task(runner(f)) for f in functions]
-    return await asyncio.gather(*tasks)
+    try:
+        return await asyncio.gather(*tasks)
+    except BaseException:
+        # A propagated failure/pause/cancellation discards the batch — stop
+        # the siblings too, or they would keep running (and emitting events)
+        # after the workflow has already failed or paused past this point.
+        for pending in tasks:
+            pending.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
 
 
 @task

--- a/flux/tasks/builtins.py
+++ b/flux/tasks/builtins.py
@@ -55,7 +55,12 @@ async def parallel(
     """
     if max_concurrent is not None and max_concurrent < 1:
         for function in functions:
-            function.close()
+            # Close bare coroutines so they don't warn about never being
+            # awaited; other awaitables (e.g. tasks) have no close() and
+            # must not mask the ValueError below with an AttributeError.
+            close = getattr(function, "close", None)
+            if close is not None:
+                close()
         raise ValueError(f"max_concurrent must be >= 1, got {max_concurrent}")
 
     semaphore = asyncio.Semaphore(max_concurrent) if max_concurrent else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.58.0"
+version = "0.59.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/tasks/ai/test_budget.py
+++ b/tests/flux/tasks/ai/test_budget.py
@@ -1,0 +1,278 @@
+"""Budget: usage accounting + the pre-flight spend ceiling."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from pydantic import BaseModel
+
+from flux import ExecutionContext, workflow
+from flux.errors import BudgetExceededError
+from flux.task import task
+from flux.tasks.ai.budget import Budget
+from flux.tasks.ai.models import LLMResponse, ToolCall, Usage
+
+from tests.flux.tasks.ai.test_agent_loop import MockFormatter, _make_llm_task
+
+
+@task
+async def get_weather(city: str) -> str:
+    """Look up the weather."""
+    return f"22.5 degrees in {city}"
+
+
+def _run_loop(llm_task, budget, **kwargs):
+    from flux.tasks.ai.agent_loop import run_agent_loop
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        return await run_agent_loop(
+            llm_task=llm_task,
+            formatter=MockFormatter(),
+            system_prompt="You are an agent.",
+            instruction="Do the thing.",
+            budget=budget,
+            **kwargs,
+        )
+
+    return wf.run()
+
+
+class TestBudgetObject:
+    def test_tracking_only_by_default(self):
+        budget = Budget()
+        budget.record(Usage(input_tokens=100, output_tokens=50))
+        assert budget.spent() == 150
+        assert budget.remaining() is None
+        budget.check()  # no ceiling, never raises
+
+    def test_remaining_floors_at_zero(self):
+        budget = Budget(max_tokens=100)
+        budget.record(Usage(input_tokens=90, output_tokens=60))
+        assert budget.spent() == 150
+        assert budget.remaining() == 0
+
+    def test_check_raises_at_ceiling(self):
+        budget = Budget(max_tokens=100)
+        budget.record(Usage(input_tokens=60, output_tokens=40))
+        with pytest.raises(BudgetExceededError) as exc_info:
+            budget.check()
+        assert exc_info.value.spent_tokens == 100
+        assert exc_info.value.max_tokens == 100
+
+    def test_none_usage_is_noop(self):
+        budget = Budget(max_tokens=100)
+        budget.record(None)
+        assert budget.spent() == 0
+        budget.check()
+
+    def test_invalid_ceiling_rejected(self):
+        with pytest.raises(ValueError):
+            Budget(max_tokens=0)
+
+
+class TestAgentLoopAccounting:
+    def test_accumulates_across_calls(self):
+        budget = Budget(max_tokens=10_000)
+        responses = [
+            LLMResponse(
+                text="",
+                tool_calls=[ToolCall(id="1", name="get_weather", arguments={"city": "Paris"})],
+                usage=Usage(input_tokens=100, output_tokens=20),
+            ),
+            LLMResponse(text="done", usage=Usage(input_tokens=150, output_tokens=30)),
+        ]
+        ctx = _run_loop(
+            _make_llm_task(responses),
+            budget,
+            tools=[get_weather],
+            tool_schemas=[{"name": "get_weather"}],
+        )
+
+        assert ctx.has_succeeded, ctx.output
+        assert budget.spent() == 300
+
+    def test_preflight_gate_fails_the_agent(self):
+        budget = Budget(max_tokens=100)
+        responses = [
+            LLMResponse(
+                text="",
+                tool_calls=[ToolCall(id="1", name="get_weather", arguments={"city": "Paris"})],
+                usage=Usage(input_tokens=90, output_tokens=20),  # over the ceiling
+            ),
+            LLMResponse(text="done", usage=Usage(input_tokens=10, output_tokens=10)),
+        ]
+        ctx = _run_loop(
+            _make_llm_task(responses),
+            budget,
+            tools=[get_weather],
+            tool_schemas=[{"name": "get_weather"}],
+        )
+
+        assert ctx.has_failed
+        assert "budget exceeded" in str(ctx.output).lower()
+        # The first call went through; the second never started.
+        assert budget.spent() == 110
+
+    def test_budget_exceeded_is_catchable_in_workflow_code(self):
+        from flux.tasks.ai.agent_loop import run_agent_loop
+
+        budget = Budget(max_tokens=50)
+        budget.record(Usage(input_tokens=40, output_tokens=20))
+
+        @workflow
+        async def wf(ctx: ExecutionContext):
+            try:
+                return await run_agent_loop(
+                    llm_task=_make_llm_task([LLMResponse(text="unreachable")]),
+                    formatter=MockFormatter(),
+                    system_prompt="You are an agent.",
+                    instruction="Do the thing.",
+                    budget=budget,
+                )
+            except BudgetExceededError as e:
+                return f"stopped at {e.spent_tokens}/{e.max_tokens}"
+
+        ctx = wf.run()
+        assert ctx.has_succeeded, ctx.output
+        assert ctx.output == "stopped at 60/50"
+
+    def test_missing_usage_tracks_nothing_but_still_works(self):
+        budget = Budget(max_tokens=100)
+        ctx = _run_loop(
+            _make_llm_task([LLMResponse(text="done")]),  # no usage reported
+            budget,
+        )
+
+        assert ctx.has_succeeded, ctx.output
+        assert budget.spent() == 0
+
+    def test_shared_budget_across_agents(self):
+        budget = Budget(max_tokens=10_000)
+
+        def _one_agent():
+            return _run_loop(
+                _make_llm_task(
+                    [LLMResponse(text="done", usage=Usage(input_tokens=100, output_tokens=50))],
+                ),
+                budget,
+            )
+
+        ctx1 = _one_agent()
+        ctx2 = _one_agent()
+        assert ctx1.has_succeeded and ctx2.has_succeeded
+        assert budget.spent() == 300
+
+    def test_streaming_early_path_bypassed_when_budget_set(self):
+        """With a budget, a tool-less streaming agent must route through the
+        LLM task (which reports usage) instead of the token-stream path."""
+        budget = Budget(max_tokens=10_000)
+        ctx = _run_loop(
+            _make_llm_task(
+                [LLMResponse(text="done", usage=Usage(input_tokens=10, output_tokens=5))],
+            ),
+            budget,
+            stream=True,
+        )
+
+        assert ctx.has_succeeded, ctx.output
+        assert ctx.output == "done"
+        assert budget.spent() == 15
+
+
+class TestProviderUsageExtraction:
+    def test_openai(self):
+        from flux.tasks.ai.openai import _to_llm_response
+
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="hi", tool_calls=None),
+                ),
+            ],
+            usage=SimpleNamespace(prompt_tokens=100, completion_tokens=25),
+        )
+        result = _to_llm_response(response)
+        assert result.usage == Usage(input_tokens=100, output_tokens=25)
+
+    def test_openai_missing_usage(self):
+        from flux.tasks.ai.openai import _to_llm_response
+
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="hi", tool_calls=None),
+                ),
+            ],
+            usage=None,
+        )
+        assert _to_llm_response(response).usage is None
+
+    def test_anthropic(self):
+        from flux.tasks.ai.anthropic import _to_llm_response
+
+        response = SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="hi")],
+            usage=SimpleNamespace(input_tokens=200, output_tokens=50),
+        )
+        result = _to_llm_response(response)
+        assert result.usage == Usage(input_tokens=200, output_tokens=50)
+
+    def test_ollama(self):
+        from flux.tasks.ai.ollama import _to_llm_response
+
+        response = {
+            "message": {"content": "hi"},
+            "prompt_eval_count": 80,
+            "eval_count": 40,
+        }
+        result = _to_llm_response(response)
+        assert result.usage == Usage(input_tokens=80, output_tokens=40)
+
+    def test_ollama_missing_counts(self):
+        from flux.tasks.ai.ollama import _to_llm_response
+
+        assert _to_llm_response({"message": {"content": "hi"}}).usage is None
+
+    def test_gemini(self):
+        from flux.tasks.ai.gemini import _to_usage
+
+        response = SimpleNamespace(
+            usage_metadata=SimpleNamespace(
+                prompt_token_count=300,
+                candidates_token_count=60,
+                thoughts_token_count=40,
+            ),
+        )
+        assert _to_usage(response) == Usage(input_tokens=300, output_tokens=100)
+
+    def test_gemini_missing_metadata(self):
+        from flux.tasks.ai.gemini import _to_usage
+
+        assert _to_usage(SimpleNamespace(usage_metadata=None)) is None
+
+
+class Answer(BaseModel):
+    value: int
+
+
+def test_budget_covers_schema_retry_calls():
+    budget = Budget(max_tokens=10_000)
+    responses = [
+        LLMResponse(text="prose", usage=Usage(input_tokens=100, output_tokens=10)),
+        LLMResponse(
+            text=json.dumps({"value": 42}),
+            usage=Usage(input_tokens=120, output_tokens=10),
+        ),
+    ]
+    ctx = _run_loop(
+        _make_llm_task(responses),
+        budget,
+        response_format=Answer,
+    )
+
+    assert ctx.has_succeeded, ctx.output
+    assert ctx.output.value == 42
+    assert budget.spent() == 240

--- a/tests/flux/tasks/ai/test_structured_output.py
+++ b/tests/flux/tasks/ai/test_structured_output.py
@@ -1,0 +1,328 @@
+"""Structured output composing with tools + validation retry."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from flux import ExecutionContext, workflow
+from flux.task import task
+from flux.tasks.ai.models import LLMResponse, ToolCall
+
+from tests.flux.tasks.ai.test_agent_loop import MockFormatter, _make_llm_task
+
+
+class WeatherReport(BaseModel):
+    temperature: float
+    city: str
+
+
+@task
+async def get_weather(city: str) -> str:
+    """Look up the weather."""
+    return f"22.5 degrees in {city}"
+
+
+class RecordingFormatter(MockFormatter):
+    """MockFormatter that records structured-output and tool-stripping calls."""
+
+    def __init__(self) -> None:
+        self.apply_structured_output_calls = 0
+        self.remove_tools_calls = 0
+        self.captured_messages: list[Any] = []
+
+    def apply_structured_output(self, response_format: Any, call_kwargs: dict) -> None:
+        self.apply_structured_output_calls += 1
+
+    def remove_tools_from_kwargs(self, call_kwargs: dict) -> dict:
+        self.remove_tools_calls += 1
+        return super().remove_tools_from_kwargs(call_kwargs)
+
+    def format_user_message(self, text: str) -> dict:
+        self.captured_messages.append(text)
+        return super().format_user_message(text)
+
+
+def _run_loop(formatter, llm_task, **kwargs):
+    from flux.tasks.ai.agent_loop import run_agent_loop
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        return await run_agent_loop(
+            llm_task=llm_task,
+            formatter=formatter,
+            system_prompt="You are a weather agent.",
+            instruction="What is the weather in Paris?",
+            **kwargs,
+        )
+
+    return wf.run()
+
+
+def test_schema_with_tools_returns_validated_model():
+    responses = [
+        LLMResponse(
+            text="",
+            tool_calls=[ToolCall(id="1", name="get_weather", arguments={"city": "Paris"})],
+        ),
+        LLMResponse(text=json.dumps({"temperature": 22.5, "city": "Paris"})),
+    ]
+    formatter = RecordingFormatter()
+    ctx = _run_loop(
+        formatter,
+        _make_llm_task(responses),
+        tools=[get_weather],
+        tool_schemas=[{"name": "get_weather"}],
+        response_format=WeatherReport,
+    )
+
+    assert ctx.has_succeeded, ctx.output
+    assert isinstance(ctx.output, WeatherReport)
+    assert ctx.output.city == "Paris"
+    # Native enforcement is tool-less only; with tools the schema rides the
+    # system prompt and the final answer is validated post-hoc.
+    assert formatter.apply_structured_output_calls == 0
+
+
+def test_schema_appended_to_system_prompt_with_tools():
+    captured: dict[str, str] = {}
+
+    class PromptCapturingFormatter(MockFormatter):
+        def build_messages(self, system_prompt, user_content, working_memory=None):
+            captured["system_prompt"] = system_prompt
+            return super().build_messages(system_prompt, user_content, working_memory)
+
+    responses = [LLMResponse(text=json.dumps({"temperature": 1.0, "city": "Oslo"}))]
+    ctx = _run_loop(
+        PromptCapturingFormatter(),
+        _make_llm_task(responses),
+        tools=[get_weather],
+        tool_schemas=[{"name": "get_weather"}],
+        response_format=WeatherReport,
+    )
+
+    assert ctx.has_succeeded, ctx.output
+    assert "Respond with JSON matching this schema" in captured["system_prompt"]
+    assert "temperature" in captured["system_prompt"]
+
+
+def test_native_enforcement_still_applied_without_tools():
+    responses = [LLMResponse(text=json.dumps({"temperature": 1.0, "city": "Oslo"}))]
+    formatter = RecordingFormatter()
+    ctx = _run_loop(
+        formatter,
+        _make_llm_task(responses),
+        response_format=WeatherReport,
+    )
+
+    assert ctx.has_succeeded, ctx.output
+    assert formatter.apply_structured_output_calls == 1
+
+
+def test_malformed_then_corrected_retry():
+    responses = [
+        LLMResponse(text="It's 22.5 degrees in Paris!"),  # prose, fails validation
+        LLMResponse(text=json.dumps({"temperature": 22.5, "city": "Paris"})),
+    ]
+    formatter = RecordingFormatter()
+    ctx = _run_loop(
+        formatter,
+        _make_llm_task(responses),
+        response_format=WeatherReport,
+    )
+
+    assert ctx.has_succeeded, ctx.output
+    assert isinstance(ctx.output, WeatherReport)
+    assert ctx.output.temperature == 22.5
+    # The corrective turn strips tools and feeds the validation errors back.
+    assert formatter.remove_tools_calls == 1
+    correction = formatter.captured_messages[-1]
+    assert "did not match the required schema" in correction
+    assert "Respond again with ONLY valid JSON" in correction
+
+
+def test_retry_exhaustion_fails_with_validation_error():
+    responses = [
+        LLMResponse(text="still prose"),
+        LLMResponse(text="more prose"),
+    ]
+    ctx = _run_loop(
+        RecordingFormatter(),
+        _make_llm_task(responses),
+        response_format=WeatherReport,
+        max_schema_retries=1,
+    )
+
+    assert ctx.has_failed
+    assert "validation error" in str(ctx.output).lower()
+
+
+def test_zero_retries_fails_fast():
+    responses = [
+        LLMResponse(text="prose"),
+        LLMResponse(text=json.dumps({"temperature": 1.0, "city": "Oslo"})),
+    ]
+    formatter = RecordingFormatter()
+    ctx = _run_loop(
+        formatter,
+        _make_llm_task(responses),
+        response_format=WeatherReport,
+        max_schema_retries=0,
+    )
+
+    assert ctx.has_failed
+    assert formatter.remove_tools_calls == 0
+
+
+def test_fenced_json_accepted():
+    fenced = f"```json\n{json.dumps({'temperature': 22.5, 'city': 'Paris'})}\n```"
+    ctx = _run_loop(
+        RecordingFormatter(),
+        _make_llm_task([LLMResponse(text=fenced)]),
+        response_format=WeatherReport,
+    )
+
+    assert ctx.has_succeeded, ctx.output
+    assert isinstance(ctx.output, WeatherReport)
+
+
+def test_retry_after_tool_loop():
+    responses = [
+        LLMResponse(
+            text="",
+            tool_calls=[ToolCall(id="1", name="get_weather", arguments={"city": "Paris"})],
+        ),
+        LLMResponse(text="The weather is nice."),  # fails validation
+        LLMResponse(text=json.dumps({"temperature": 22.5, "city": "Paris"})),
+    ]
+    formatter = RecordingFormatter()
+    ctx = _run_loop(
+        formatter,
+        _make_llm_task(responses),
+        tools=[get_weather],
+        tool_schemas=[{"name": "get_weather"}],
+        response_format=WeatherReport,
+    )
+
+    assert ctx.has_succeeded, ctx.output
+    assert isinstance(ctx.output, WeatherReport)
+
+
+def test_plain_text_agents_unchanged():
+    ctx = _run_loop(
+        RecordingFormatter(),
+        _make_llm_task([LLMResponse(text="Just prose.")]),
+    )
+
+    assert ctx.has_succeeded, ctx.output
+    assert ctx.output == "Just prose."
+
+
+class TestJsonCandidate:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ('{"a": 1}', '{"a": 1}'),
+            ('```json\n{"a": 1}\n```', '{"a": 1}'),
+            ('```\n{"a": 1}\n```', '{"a": 1}'),
+            ("  prose  ", "  prose  "),
+        ],
+    )
+    def test_fence_stripping(self, raw: str, expected: str):
+        from flux.tasks.ai.agent_loop import _json_candidate
+
+        assert _json_candidate(raw) == expected
+
+
+class TestWorkflowAgentContract:
+    @staticmethod
+    def _mock_client(response: dict):
+        from unittest.mock import AsyncMock, MagicMock
+
+        client = MagicMock()
+        client.run_workflow_sync = AsyncMock(return_value=response)
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+        return client
+
+    def _run(self, response: dict):
+        from unittest.mock import patch
+
+        from flux.tasks.ai.delegation import workflow_agent
+
+        wa = workflow_agent(
+            name="reporter",
+            description="Reports weather.",
+            workflow="weather_wf",
+            response_format=WeatherReport,
+        )
+
+        mock_client = self._mock_client(response)
+
+        @workflow
+        async def wf(ctx: ExecutionContext):
+            with patch("flux.tasks.ai.delegation._get_client", return_value=mock_client):
+                return await wa("weather please")
+
+        return wf.run()
+
+    def test_valid_output_is_validated_and_surfaced(self):
+        ctx = self._run(
+            {
+                "execution_id": "exec-1",
+                "state": "COMPLETED",
+                "output": {"temperature": 22.5, "city": "Paris"},
+            },
+        )
+        assert ctx.has_succeeded, ctx.output
+        assert ctx.output.status == "completed"
+        assert ctx.output.output == {"temperature": 22.5, "city": "Paris"}
+
+    def test_contract_violation_becomes_failure(self):
+        ctx = self._run(
+            {
+                "execution_id": "exec-1",
+                "state": "COMPLETED",
+                "output": {"wrong": "shape"},
+            },
+        )
+        assert ctx.has_succeeded, ctx.output
+        assert ctx.output.status == "failed"
+        assert "did not match the expected schema" in ctx.output.output
+        assert "WeatherReport" in ctx.output.output
+
+    def test_failed_workflow_output_not_validated(self):
+        ctx = self._run(
+            {
+                "execution_id": "exec-1",
+                "state": "FAILED",
+                "output": "traceback...",
+            },
+        )
+        assert ctx.has_succeeded, ctx.output
+        assert ctx.output.status == "failed"
+        assert ctx.output.output == "traceback..."
+
+
+def test_delegate_surfaces_validated_model_as_data():
+    from flux.tasks.ai.delegation import build_delegate
+
+    @task.with_options(name="reporter")
+    async def reporter(instruction: str, *, context: str = "") -> WeatherReport:
+        return WeatherReport(temperature=22.5, city="Paris")
+
+    reporter.description = "Reports the weather."
+
+    delegate = build_delegate([reporter])
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        return await delegate(agent="reporter", instruction="weather please")
+
+    ctx = wf.run()
+    assert ctx.has_succeeded, ctx.output
+    assert ctx.output["status"] == "completed"
+    assert ctx.output["output"] == {"temperature": 22.5, "city": "Paris"}

--- a/tests/flux/tasks/test_parallel.py
+++ b/tests/flux/tasks/test_parallel.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from flux import ExecutionContext, workflow
+from flux.errors import PauseRequested
+from flux.task import task
+from flux.tasks import parallel
+
+
+@task
+async def echo(value: str) -> str:
+    return value
+
+
+@task
+async def boom(value: str) -> str:
+    raise ValueError(f"boom: {value}")
+
+
+def test_results_in_input_order():
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        return await parallel(echo("a"), echo("b"), echo("c"))
+
+    ctx = wf.run()
+    assert ctx.has_succeeded, ctx.output
+    assert ctx.output == ["a", "b", "c"]
+
+
+def test_raise_on_error_default_fails_batch():
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        return await parallel(echo("a"), boom("b"), echo("c"))
+
+    ctx = wf.run()
+    assert ctx.has_failed
+
+
+def test_error_drop_keeps_batch_alive():
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        return await parallel(
+            echo("a"),
+            boom("b"),
+            echo("c"),
+            raise_on_error=False,
+        )
+
+    ctx = wf.run()
+    assert ctx.has_succeeded, ctx.output
+    assert ctx.output == ["a", None, "c"]
+
+
+def test_pause_propagates_even_with_error_drop():
+    @task
+    async def pausing() -> str:
+        raise PauseRequested(name="gate")
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        return await parallel(echo("a"), pausing(), raise_on_error=False)
+
+    ctx = wf.run()
+    assert ctx.is_paused
+    assert not ctx.has_finished
+
+
+def test_max_concurrent_bounds_in_flight():
+    in_flight = {"now": 0, "peak": 0}
+
+    @task
+    async def tracked(i: int) -> int:
+        in_flight["now"] += 1
+        in_flight["peak"] = max(in_flight["peak"], in_flight["now"])
+        await asyncio.sleep(0.01)
+        in_flight["now"] -= 1
+        return i
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        return await parallel(*[tracked(i) for i in range(10)], max_concurrent=2)
+
+    ctx = wf.run()
+    assert ctx.has_succeeded, ctx.output
+    assert ctx.output == list(range(10))
+    assert in_flight["peak"] <= 2
+
+
+def test_unbounded_by_default():
+    in_flight = {"now": 0, "peak": 0}
+
+    @task
+    async def tracked(i: int) -> int:
+        in_flight["now"] += 1
+        in_flight["peak"] = max(in_flight["peak"], in_flight["now"])
+        await asyncio.sleep(0.01)
+        in_flight["now"] -= 1
+        return i
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        return await parallel(*[tracked(i) for i in range(5)])
+
+    ctx = wf.run()
+    assert ctx.has_succeeded, ctx.output
+    assert in_flight["peak"] == 5
+
+
+def test_invalid_max_concurrent_rejected():
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        return await parallel(echo("a"), max_concurrent=0)
+
+    ctx = wf.run()
+    assert ctx.has_failed
+
+
+def test_error_drop_with_max_concurrent():
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        return await parallel(
+            *[boom(str(i)) if i % 2 else echo(str(i)) for i in range(6)],
+            max_concurrent=2,
+            raise_on_error=False,
+        )
+
+    ctx = wf.run()
+    assert ctx.has_succeeded, ctx.output
+    assert ctx.output == ["0", None, "2", None, "4", None]
+
+
+@pytest.mark.parametrize("raise_on_error", [True, False])
+def test_staged_per_item_idiom(raise_on_error: bool):
+    """The documented shape for staged fan-out: chain stages in a plain
+    async function, fan out with parallel."""
+
+    @task
+    async def fetch(doc: str) -> str:
+        return f"content({doc})"
+
+    @task
+    async def summarize(content: str) -> str:
+        return f"summary({content})"
+
+    async def process(doc: str) -> str:
+        return await summarize(await fetch(doc))
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        return await parallel(
+            *[process(d) for d in ["d1", "d2"]],
+            raise_on_error=raise_on_error,
+        )
+
+    ctx = wf.run()
+    assert ctx.has_succeeded, ctx.output
+    assert ctx.output == ["summary(content(d1))", "summary(content(d2))"]

--- a/tests/flux/tasks/test_parallel.py
+++ b/tests/flux/tasks/test_parallel.py
@@ -94,6 +94,32 @@ def test_pause_is_not_delayed_by_running_siblings():
     assert elapsed < 5, f"pause was delayed {elapsed:.1f}s by a running sibling"
 
 
+def test_siblings_cancelled_on_fail_fast():
+    """When the batch fails, still-running siblings are cancelled instead of
+    running on (and emitting events) past the failure."""
+    finished = {"slow": False}
+
+    @task
+    async def slow() -> str:
+        await asyncio.sleep(10)
+        finished["slow"] = True
+        return "too late"
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        return await parallel(slow(), boom("b"))
+
+    import time
+
+    start = time.monotonic()
+    ctx = wf.run()
+    elapsed = time.monotonic() - start
+
+    assert ctx.has_failed
+    assert not finished["slow"]
+    assert elapsed < 5, f"failure waited {elapsed:.1f}s on a running sibling"
+
+
 def test_max_concurrent_bounds_in_flight():
     in_flight = {"now": 0, "peak": 0}
 

--- a/tests/flux/tasks/test_parallel.py
+++ b/tests/flux/tasks/test_parallel.py
@@ -68,6 +68,32 @@ def test_pause_propagates_even_with_error_drop():
     assert not ctx.has_finished
 
 
+def test_pause_is_not_delayed_by_running_siblings():
+    """A pause must surface as soon as it happens — not after every other
+    item in the batch completes."""
+    import time
+
+    @task
+    async def pausing() -> str:
+        raise PauseRequested(name="gate")
+
+    @task
+    async def slow() -> str:
+        await asyncio.sleep(10)
+        return "too late"
+
+    @workflow
+    async def wf(ctx: ExecutionContext):
+        return await parallel(slow(), pausing(), raise_on_error=False)
+
+    start = time.monotonic()
+    ctx = wf.run()
+    elapsed = time.monotonic() - start
+
+    assert ctx.is_paused
+    assert elapsed < 5, f"pause was delayed {elapsed:.1f}s by a running sibling"
+
+
 def test_max_concurrent_bounds_in_flight():
     in_flight = {"now": 0, "peak": 0}
 


### PR DESCRIPTION
PR 3 of the dynamic-workflows series (after #130 and #131). Makes what agents author — and what agent loops do in general — expressive and bounded. Spec: `docs/specs/2026-07-15-agent-vocabulary-spec.md`. Everything is additive; both new `parallel` parameters default to today's exact semantics.

## 1. Structured output that survives tools

Previously the schema-communication branches in the agent loop were guarded by `response_format and not tools`, while the final `model_validate_json` ran unconditionally — an agent with tools was validated against a schema the model was never shown, and almost always failed with a raw `ValidationError` on prose.

- `response_format` now composes with `tools`: the schema is appended to the system prompt whenever a format is set, the tool loop runs as usual, and the final (non-tool-call) answer is validated. Native API-level enforcement stays tool-less only — Anthropic's implementation is a forced tool call that commandeers `tools`/`tool_choice` (the existing assert documents this).
- **Validation retry:** on `ValidationError`, the field-level errors are fed back for a corrective turn with tools stripped (same pattern as the forced final answer). `max_schema_retries` (new `agent()` parameter, default 1) bounds the corrective turns; exhaustion raises the validation error. Markdown-fenced JSON answers are unwrapped before validation.
- **Delegation carries contracts:** `delegate` surfaces a sub-agent's validated model as plain data (`model_dump()`) so the parent LLM sees clean JSON; `workflow_agent(..., response_format=...)` validates a completed workflow's output and turns a contract violation into a `failed` delegation instead of handing the parent unchecked data.

## 2. `parallel`: `max_concurrent` + `raise_on_error`

Two gaps for agent-scale fan-out, closed in place (an earlier draft proposed a dedicated `pipeline_map` combinator; rejected as sugar — the staged per-item idiom is now documented instead):

- `max_concurrent` caps in-flight coroutines with a semaphore; `None` (default) keeps today's unbounded behavior.
- `raise_on_error=True` (default) is today's fail-fast. With `False`, a failed item's slot becomes `None` and the rest keep running — the failure is still recorded on the task's events, it just doesn't kill the batch. Pauses and cancellations always propagate: a paused branch must pause the workflow, never become a silent `None`.

## 3. `Budget` — a spend ceiling for LLM work

No provider reported token usage anywhere in the AI stack; an agent loop had no way to bound its own spend.

- `LLMResponse` gains `usage: Usage | None`, populated by all four providers (OpenAI, Anthropic, Ollama, Gemini) including the reasoning-stream paths, whose usage arrives on the terminal chunk (OpenAI now requests `stream_options={"include_usage": true}` and guards the usage-only chunk). Custom providers opt in by populating the field. Usage rides the checkpointed LLM task output, so it's visible in execution events.
- `Budget(max_tokens=...)` is a plain shared object (`spent()` / `remaining()`); pass the same instance to every `agent()` whose spend counts against one ceiling. Enforcement is a **pre-flight gate**: `BudgetExceededError` (a catchable `ExecutionError`) is raised before the call once the ceiling is reached, so an in-flight call is never interrupted and overshoot is bounded by one call. `max_tokens=None` tracks without enforcing.
- Setting a budget disables token-level content streaming for that agent (the raw token-stream path bypasses the LLM task and reports no usage); the final text still arrives as progress.
- Scope is one run attempt: on resume, replayed LLM calls short-circuit from the event log and their recorded usage is re-counted in order — consistent accounting without re-spending real tokens. Durable cumulative accounting across attempts is noted as future work.

## Tests

- `tests/flux/tasks/test_parallel.py` — ordering, fail-fast default, error-drop, pause propagation through error-drop, sibling cancellation on batch exit, `max_concurrent` actually bounds in-flight count, staged per-item idiom.
- `tests/flux/tasks/ai/test_structured_output.py` — schema+tools returns validated model, schema rides the system prompt, native enforcement stays tool-less, malformed-then-corrected retry, exhaustion/zero-retry failure, fenced JSON, retry after a tool loop, delegate/workflow_agent contracts.
- `tests/flux/tasks/ai/test_budget.py` — budget object semantics, accumulation across calls/agents, pre-flight gate, catchability, per-provider usage extraction from fixture responses, streaming bypass, retry turns counted.

Local validation: pre-commit clean; unit suite 2728 passed / 9 skipped; e2e 124 passed (the two `github_stars` e2e failures are the sandbox proxy blocking direct `api.github.com` — confirmed 403 via curl, untouched by this diff).

Version: 0.59.0.