### PR TITLE
Airgapped capability knobs: GPUs, read-only mounts, shared memory

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -63,44 +63,44 @@ operations flow through the parent worker over the container's stdio. The
 only credential inside the container is the short-lived, single-execution
 token used for `call()` hops back into the server.
 
-## Local model inference in the airgapped runner
+## Sizing the airgapped runner for heavy workloads
 
-The `docker-airgapped` runner is a natural home for local inference
-(vLLM, llama.cpp, transformers): prompts and outputs never leave the
-sandbox, and the container's only way out is the worker-mediated stdio
-protocol. Three named capability knobs make it practical — each is
-grantable **only** through its config key (the equivalent raw flags are
-rejected in `airgapped_extra_args`), so `flux.toml` is the complete audit
-trail of opened surfaces:
+The `docker-airgapped` runner's defaults are sized for untrusted glue
+code. Data- and compute-heavy sealed workloads — numeric simulation, media
+processing, large dataset transforms — raise the limits and grant the
+capabilities they need. Three named knobs exist, each grantable **only**
+through its config key (the equivalent raw flags are rejected in
+`airgapped_extra_args`), so `flux.toml` is the complete audit trail of
+opened surfaces:
 
 ```toml
 [flux.workers]
 runners = ["docker-airgapped"]
-airgapped_image = "my-registry/flux-vllm:0.60.0"
+airgapped_image = "my-registry/flux-compute:0.60.0"
 
 # Capability grants (all default off)
 airgapped_gpus = "all"                            # or "device=0"
-airgapped_mounts = ["/srv/models:/models"]        # read-only, forced by the runner
-airgapped_shm_size = "8g"                         # /dev/shm for tensor passing
+airgapped_mounts = ["/srv/datasets:/data"]        # read-only, forced by the runner
+airgapped_shm_size = "8g"                         # /dev/shm for large buffers
 
-# Inference-sized limits (defaults are sized for untrusted glue code)
+# Workload-sized limits (defaults are sized for untrusted glue code)
 airgapped_memory = "32g"        # must cover process + tmpfs + shm (tmpfs pages
                                 # count against the container's memory cgroup)
 airgapped_cpus = 8.0
-airgapped_tmp_size = "8g"       # compile/tokenizer caches live here
-airgapped_execution_timeout = 3600   # model load counts against the ceiling
+airgapped_tmp_size = "8g"       # scratch space and caches live here
+airgapped_execution_timeout = 3600
 airgapped_extra_args = [
-    "--env", "HF_HOME=/tmp/hf",         # rootfs is read-only; caches go to /tmp
-    "--env", "XDG_CACHE_HOME=/tmp/cache",
+    "--env", "XDG_CACHE_HOME=/tmp/cache",   # rootfs is read-only; caches go to /tmp
 ]
 ```
 
-Build the image on the official base — weights come from the read-only
-mount, not the image, so a model revision does not mean an image rebuild:
+Build the image on the official base with your workload's libraries;
+reference data comes from the read-only mount, not the image, so a data
+refresh does not mean an image rebuild:
 
 ```dockerfile
 FROM <dockerhub-user>/flux:0.60.0
-RUN pip install --no-cache-dir vllm
+RUN pip install --no-cache-dir numpy scipy pillow
 ```
 
 Notes:
@@ -110,13 +110,13 @@ Notes:
   `readonly`, and `rw` is rejected at worker startup. A read-only bind is
   an input channel — data can enter, results still leave only through the
   stdio protocol. Mounted content is readable by every airgapped workflow
-  on the worker: mount weights and static assets, never secret-bearing
-  directories.
-- **Serving works inside the sandbox.** `--network=none` removes external
-  connectivity but keeps the container's own loopback, so a workflow can
-  run the vLLM engine in-process or spawn `vllm serve` on `127.0.0.1`
-  inside the container and call it from the same workflow. Nothing is
-  reachable from outside.
+  on the worker: mount reference data and static assets, never
+  secret-bearing directories.
+- **Helper processes work inside the sandbox.** `--network=none` removes
+  external connectivity but keeps the container's own loopback, so a
+  workflow can spawn a helper server on `127.0.0.1` inside the container
+  and call it from the same workflow (within the pids/memory limits).
+  Nothing is reachable from outside.
 - **GPUs are a deliberate grant.** A GPU is a compute device, not a data
   path out; in the strictest threat models it is still shared hardware —
   isolate at the worker level (one airgapped worker per GPU tenant) if

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -63,6 +63,65 @@ operations flow through the parent worker over the container's stdio. The
 only credential inside the container is the short-lived, single-execution
 token used for `call()` hops back into the server.
 
+## Local model inference in the airgapped runner
+
+The `docker-airgapped` runner is a natural home for local inference
+(vLLM, llama.cpp, transformers): prompts and outputs never leave the
+sandbox, and the container's only way out is the worker-mediated stdio
+protocol. Three named capability knobs make it practical — each is
+grantable **only** through its config key (the equivalent raw flags are
+rejected in `airgapped_extra_args`), so `flux.toml` is the complete audit
+trail of opened surfaces:
+
+```toml
+[flux.workers]
+runners = ["docker-airgapped"]
+airgapped_image = "my-registry/flux-vllm:0.60.0"
+
+# Capability grants (all default off)
+airgapped_gpus = "all"                            # or "device=0"
+airgapped_mounts = ["/srv/models:/models"]        # read-only, forced by the runner
+airgapped_shm_size = "8g"                         # /dev/shm for tensor passing
+
+# Inference-sized limits (defaults are sized for untrusted glue code)
+airgapped_memory = "32g"        # must cover process + tmpfs + shm (tmpfs pages
+                                # count against the container's memory cgroup)
+airgapped_cpus = 8.0
+airgapped_tmp_size = "8g"       # compile/tokenizer caches live here
+airgapped_execution_timeout = 3600   # model load counts against the ceiling
+airgapped_extra_args = [
+    "--env", "HF_HOME=/tmp/hf",         # rootfs is read-only; caches go to /tmp
+    "--env", "XDG_CACHE_HOME=/tmp/cache",
+]
+```
+
+Build the image on the official base — weights come from the read-only
+mount, not the image, so a model revision does not mean an image rebuild:
+
+```dockerfile
+FROM <dockerhub-user>/flux:0.60.0
+RUN pip install --no-cache-dir vllm
+```
+
+Notes:
+
+- **Mounts are read-only by construction.** Entries are
+  `/host/path:/container/path`; the emitted `--mount` always carries
+  `readonly`, and `rw` is rejected at worker startup. A read-only bind is
+  an input channel — data can enter, results still leave only through the
+  stdio protocol. Mounted content is readable by every airgapped workflow
+  on the worker: mount weights and static assets, never secret-bearing
+  directories.
+- **Serving works inside the sandbox.** `--network=none` removes external
+  connectivity but keeps the container's own loopback, so a workflow can
+  run the vLLM engine in-process or spawn `vllm serve` on `127.0.0.1`
+  inside the container and call it from the same workflow. Nothing is
+  reachable from outside.
+- **GPUs are a deliberate grant.** A GPU is a compute device, not a data
+  path out; in the strictest threat models it is still shared hardware —
+  isolate at the worker level (one airgapped worker per GPU tenant) if
+  that matters to you.
+
 ## Running the Server
 
 ```bash

--- a/docs/advanced-features/airgapped-execution.md
+++ b/docs/advanced-features/airgapped-execution.md
@@ -1,11 +1,12 @@
 # Airgapped Execution
 
 The `docker-airgapped` runner executes workflows you do not trust — above
-all, model-authored (dynamic) workflows. Each execution runs in its own
-container whose **only capability channel is the stdio protocol to the
-parent worker**: checkpoints, secrets, configs, and approval-gate
-operations all flow through the worker, where every request is
-permission-checked. Everything else is closed.
+all, model-authored (dynamic) workflows — and workflows over data that must
+not leave the box. Each execution runs in its own container whose **only
+capability channel is the stdio protocol to the parent worker**:
+checkpoints, secrets, configs, and approval-gate operations all flow
+through the worker, where every request is permission-checked. Everything
+else is closed.
 
 ## The locked profile
 
@@ -51,9 +52,9 @@ async def sealed_keyword_count(ctx: ExecutionContext[str]):
     ...
 ```
 
-See `examples/airgapped.py` for runnable examples (sealed text processing,
-read-only asset mounts with graceful fallback, and the local-inference
-pattern).
+See `examples/airgapped.py` for runnable examples (sealed text processing
+with read-only asset mounts and graceful fallback, and privacy-preserving
+redaction of sensitive data).
 
 ## Capability knobs
 
@@ -66,13 +67,13 @@ for `airgapped_` is the complete audit trail of opened surfaces:
 |---|---|---|
 | `airgapped_gpus` | `--gpus all` / `"device=0"` | a compute device; no data path out |
 | `airgapped_mounts` | read-only bind mounts | an *input* channel — data can enter, results still leave only via the stdio protocol |
-| `airgapped_shm_size` | `/dev/shm` sizing | RAM allocation (tensor passing); accounted next to `airgapped_memory` |
+| `airgapped_shm_size` | `/dev/shm` sizing | RAM allocation (large inter-process buffers); accounted next to `airgapped_memory` |
 
 `airgapped_mounts` entries are `"/host/path:/container/path"`. Read-only
 is **forced by the runner** regardless of what the entry says; `rw`,
 relative paths, missing host paths, and duplicate targets fail worker
 startup. Mounted content is readable by every airgapped workflow on the
-worker — mount model weights and static assets, never directories
+worker — mount reference datasets and static assets, never directories
 containing secrets.
 
 Capability channels are **never** knobs: network, DNS, published ports,
@@ -81,29 +82,30 @@ runner. Operators who need them switch to the plain `docker` runner —
 changing the runner *name*, and therefore the guarantee that dispatch and
 the dynamic-workflows server rely on.
 
-## Local model inference
+## Sizing for data- and compute-heavy workloads
 
-The sealed runner is a natural home for local inference: prompts and
-outputs never leave the container. The working setup (image recipe, sizing
-guidance, cache environment variables for the read-only rootfs, and the
-in-container loopback serving pattern) is documented in DOCKER.md under
-"Local model inference in the airgapped runner". The short version:
+The profile's defaults are sized for untrusted glue code. Heavier sealed
+workloads — numeric simulation, media processing, large dataset
+transforms — raise the limits and grant what they need (image recipe,
+sizing guidance, and cache environment variables for the read-only rootfs
+are documented in DOCKER.md under "Sizing the airgapped runner for heavy
+workloads"):
 
 ```toml
 [flux.workers]
 runners = ["docker-airgapped"]
-airgapped_image = "my-registry/flux-vllm:0.60.0"
-airgapped_gpus = "all"
-airgapped_mounts = ["/srv/models:/models"]   # weights, read-only
-airgapped_shm_size = "8g"
+airgapped_image = "my-registry/flux-compute:0.60.0"
+airgapped_gpus = "all"                        # GPU-accelerated compute
+airgapped_mounts = ["/srv/datasets:/data"]    # reference data, read-only
+airgapped_shm_size = "8g"                     # large inter-process buffers
 airgapped_memory = "32g"
 airgapped_tmp_size = "8g"
 airgapped_execution_timeout = 3600
 ```
 
-`--network=none` keeps the container's own loopback, so a workflow can run
-the inference engine in-process or spawn a server on `127.0.0.1` *inside*
-the sandbox — nothing is reachable from outside.
+`--network=none` keeps the container's own loopback, so a workflow can
+spawn helper processes and talk to them on `127.0.0.1` *inside* the
+sandbox — nothing is reachable from outside.
 
 ## Dynamic workflows run here by default
 

--- a/docs/advanced-features/airgapped-execution.md
+++ b/docs/advanced-features/airgapped-execution.md
@@ -1,0 +1,127 @@
+# Airgapped Execution
+
+The `docker-airgapped` runner executes workflows you do not trust — above
+all, model-authored (dynamic) workflows. Each execution runs in its own
+container whose **only capability channel is the stdio protocol to the
+parent worker**: checkpoints, secrets, configs, and approval-gate
+operations all flow through the worker, where every request is
+permission-checked. Everything else is closed.
+
+## The locked profile
+
+| Surface | Enforcement |
+|---|---|
+| Network | `--network=none` — no egress, no DNS, no `pip install` |
+| Filesystem | `--read-only` rootfs; size-capped tmpfs `/tmp` |
+| Privileges | `--cap-drop=ALL`, `--security-opt=no-new-privileges` |
+| Resources | memory / cpus / pids limits (required, never unlimited) |
+| Time | wall-clock ceiling; on expiry the container is killed and the execution fails terminally for both durabilities |
+| Credentials | none — the child holds no worker or fleet credentials |
+
+The profile is emitted from code *after* any operator `extra_args`, so
+docker's last-wins flag parsing keeps it authoritative; `extra_args` that
+would re-open a closed surface are rejected at worker startup.
+
+## Enabling the runner
+
+```toml
+[flux.workers]
+runners = ["docker-airgapped"]
+airgapped_image = "<registry>/flux:<version>"   # falls back to docker_image
+
+airgapped_memory = "512m"          # required non-empty
+airgapped_cpus = 1.0
+airgapped_pids_limit = 256
+airgapped_tmp_size = "64m"
+airgapped_execution_timeout = 900  # seconds; 0 disables (discouraged)
+```
+
+The image contract is minimal: it must run `python -m flux.runners.child`,
+i.e. have `flux-core` installed at a worker-compatible version. The
+official image satisfies this when its tag matches the worker (see
+DOCKER.md).
+
+Pin workflows to the sealed runner with
+`@workflow.with_options(runner="docker-airgapped")` — this also constrains
+dispatch, so the workflow only reaches workers advertising the runner:
+
+```python
+@workflow.with_options(runner="docker-airgapped")
+async def sealed_keyword_count(ctx: ExecutionContext[str]):
+    ...
+```
+
+See `examples/airgapped.py` for runnable examples (sealed text processing,
+read-only asset mounts with graceful fallback, and the local-inference
+pattern).
+
+## Capability knobs
+
+Three capabilities can be granted. Each is grantable **only through its
+named config key** — the raw flags (`--gpus`, `--shm-size`, and all mount
+flags) are rejected in `airgapped_extra_args` — so a grep of `flux.toml`
+for `airgapped_` is the complete audit trail of opened surfaces:
+
+| Key | Grants | Why it's safe to grant |
+|---|---|---|
+| `airgapped_gpus` | `--gpus all` / `"device=0"` | a compute device; no data path out |
+| `airgapped_mounts` | read-only bind mounts | an *input* channel — data can enter, results still leave only via the stdio protocol |
+| `airgapped_shm_size` | `/dev/shm` sizing | RAM allocation (tensor passing); accounted next to `airgapped_memory` |
+
+`airgapped_mounts` entries are `"/host/path:/container/path"`. Read-only
+is **forced by the runner** regardless of what the entry says; `rw`,
+relative paths, missing host paths, and duplicate targets fail worker
+startup. Mounted content is readable by every airgapped workflow on the
+worker — mount model weights and static assets, never directories
+containing secrets.
+
+Capability channels are **never** knobs: network, DNS, published ports,
+privileges, host namespaces, and writable mounts cannot be enabled on this
+runner. Operators who need them switch to the plain `docker` runner —
+changing the runner *name*, and therefore the guarantee that dispatch and
+the dynamic-workflows server rely on.
+
+## Local model inference
+
+The sealed runner is a natural home for local inference: prompts and
+outputs never leave the container. The working setup (image recipe, sizing
+guidance, cache environment variables for the read-only rootfs, and the
+in-container loopback serving pattern) is documented in DOCKER.md under
+"Local model inference in the airgapped runner". The short version:
+
+```toml
+[flux.workers]
+runners = ["docker-airgapped"]
+airgapped_image = "my-registry/flux-vllm:0.60.0"
+airgapped_gpus = "all"
+airgapped_mounts = ["/srv/models:/models"]   # weights, read-only
+airgapped_shm_size = "8g"
+airgapped_memory = "32g"
+airgapped_tmp_size = "8g"
+airgapped_execution_timeout = 3600
+```
+
+`--network=none` keeps the container's own loopback, so a workflow can run
+the inference engine in-process or spawn a server on `127.0.0.1` *inside*
+the sandbox — nothing is reachable from outside.
+
+## Dynamic workflows run here by default
+
+Workflows registered by agents through the dynamic-registration endpoint
+get `runner="docker-airgapped"` stamped **server-side**
+(`[flux.dynamic_workflows] require_runner`), overriding anything the
+authored source declares. The author is the adversary in that model; the
+sealed runner is what makes accepting model-authored code tenable. Relax
+`require_runner` only in development.
+
+## Failure semantics
+
+- **Crash** (OOM kill, segfault, hard exit): durable executions are
+  released for re-dispatch and deterministic replay resumes from the last
+  checkpoint; transient executions fail terminally.
+- **Wall-clock timeout** (`ExecutionTimedOut`): terminal FAILED for *both*
+  durabilities — a deterministic timeout would re-dispatch forever, so it
+  is a policy violation, not a crash.
+- **Cancellation**: SIGTERM is forwarded into the container
+  (`docker run` sig-proxying), with a grace period before the container is
+  killed.

--- a/docs/specs/2026-07-16-airgapped-capability-knobs.md
+++ b/docs/specs/2026-07-16-airgapped-capability-knobs.md
@@ -1,31 +1,31 @@
 # Spec: airgapped capability knobs — GPUs, read-only mounts, shared memory
 
 **Date:** 2026-07-16 · **Status:** draft for review (follow-up to the
-docker-airgapped runner, #130) · **Motivating use case:** local model
-inference (e.g. vLLM) inside the airgapped sandbox.
+docker-airgapped runner, #130) · **Motivating use case:** data- and
+compute-heavy workloads inside the airgapped sandbox.
 
 ## Motivation
 
 The `docker-airgapped` runner exists so untrusted (often model-authored)
 workflows can run with the stdio protocol as their *only* capability
-channel. Local inference is a natural workload for it — the whole point of
-running a model locally is that prompts and outputs never leave the box —
-but today the profile can't express what inference needs:
+channel. Sealed processing of sensitive data is a natural workload for
+it — the whole point is that inputs and intermediate state never leave the
+box — but today the profile can't express what heavier workloads need:
 
 - **GPUs** work only by accident: `--gpus` is absent from
   `_AIRGAPPED_VETOED_FLAGS`, so it slips through `airgapped_extra_args`.
   Granting a capability by denylist omission is the wrong mechanism — it is
   invisible, unaudited, and would be silently revoked if the flag were ever
   added to the veto list.
-- **Model weights** must be baked into the image: `--network=none` rules
-  out runtime downloads and `--volume`/`--mount` are vetoed. Weights are
-  tens of GB and change more often than code; forcing an image rebuild per
-  revision pushes operators toward the unprotected `docker` runner — the
+- **Reference data** must be baked into the image: `--network=none` rules
+  out runtime downloads and `--volume`/`--mount` are vetoed. Large
+  datasets change more often than code; forcing an image rebuild per
+  refresh pushes operators toward the unprotected `docker` runner — the
   opposite of what the profile is for.
-- **Shared memory**: PyTorch/vLLM move tensors between processes through
-  `/dev/shm`, and Docker's default is 64 MB. `--shm-size` also slips
-  through `extra_args` today — RAM allocation in disguise, unaccounted
-  next to `airgapped_memory`.
+- **Shared memory**: workloads that pass large buffers between processes
+  go through `/dev/shm`, and Docker's default is 64 MB. `--shm-size` also
+  slips through `extra_args` today — RAM allocation in disguise,
+  unaccounted next to `airgapped_memory`.
 
 ## Design principle: named knobs, not veto opt-outs
 
@@ -75,7 +75,7 @@ docker's last-wins parsing keeps the profile authoritative.
   probe): absolute paths, host path exists, no duplicate targets, target
   is not `/`.
 - Security note (documented): mounted content is readable by **every**
-  airgapped workflow on that worker. Mount model weights and static
+  airgapped workflow on that worker. Mount reference data and static
   assets; never mount directories containing secrets.
 
 ### `airgapped_gpus` semantics
@@ -83,10 +83,10 @@ docker's last-wins parsing keeps the profile authoritative.
 - String passed through to `--gpus`. Empty = no GPU (today's effective
   default, now explicit).
 - A GPU is a compute device, not an exfiltration path; it is the knob that
-  makes local inference possible at all. Documented caveat: GPUs are a
-  shared-hardware side channel in the strictest threat models — operators
-  who care isolate at the worker level (one airgapped worker per GPU
-  tenant).
+  makes GPU-accelerated sealed compute possible at all. Documented caveat:
+  GPUs are a shared-hardware side channel in the strictest threat models —
+  operators who care isolate at the worker level (one airgapped worker per
+  GPU tenant).
 
 ### Veto list additions
 
@@ -106,23 +106,24 @@ accident this spec removes.)
 No server, dispatch, or protocol changes: the runner name and its
 guarantee semantics are unchanged.
 
-## DOCKER.md: inference profile guidance
+## DOCKER.md: heavy-workload profile guidance
 
-New section covering the vLLM-shaped setup end to end:
+New section covering the sized-up setup end to end:
 
-- Image recipe: `FROM flux:<version>` + `pip install vllm`; weights come
-  from `airgapped_mounts`, not the image.
+- Image recipe: `FROM flux:<version>` + the workload's libraries;
+  reference data comes from `airgapped_mounts`, not the image.
 - Sizing: raise `airgapped_memory` / `airgapped_cpus` /
   `airgapped_tmp_size` / `airgapped_execution_timeout`; set
-  `airgapped_shm_size` (vLLM recommends ≥ a few GB for tensor-parallel).
-  **tmpfs pages (`/tmp`, `/dev/shm`) count against the container's memory
-  cgroup** — `airgapped_memory` must cover process + caches + shm.
-- Read-only rootfs: point `HF_HOME` / `XDG_CACHE_HOME` at `/tmp` (compile
-  and tokenizer caches), via `airgapped_extra_args = ["--env", ...]`.
-- Serving pattern: `--network=none` keeps the container's own loopback, so
-  a workflow may run the vLLM engine in-process or spawn `vllm serve` on
-  `127.0.0.1` *inside* the container — nothing is reachable from outside,
-  and results still flow only through the stdio protocol.
+  `airgapped_shm_size` for workloads that pass large buffers between
+  processes. **tmpfs pages (`/tmp`, `/dev/shm`) count against the
+  container's memory cgroup** — `airgapped_memory` must cover process +
+  caches + shm.
+- Read-only rootfs: point cache locations (`XDG_CACHE_HOME`, ...) at
+  `/tmp` via `airgapped_extra_args = ["--env", ...]`.
+- Helper processes: `--network=none` keeps the container's own loopback,
+  so a workflow may spawn a helper server on `127.0.0.1` *inside* the
+  container — nothing is reachable from outside, and results still flow
+  only through the stdio protocol.
 
 ## Testing
 

--- a/docs/specs/2026-07-16-airgapped-capability-knobs.md
+++ b/docs/specs/2026-07-16-airgapped-capability-knobs.md
@@ -1,0 +1,145 @@
+# Spec: airgapped capability knobs — GPUs, read-only mounts, shared memory
+
+**Date:** 2026-07-16 · **Status:** draft for review (follow-up to the
+docker-airgapped runner, #130) · **Motivating use case:** local model
+inference (e.g. vLLM) inside the airgapped sandbox.
+
+## Motivation
+
+The `docker-airgapped` runner exists so untrusted (often model-authored)
+workflows can run with the stdio protocol as their *only* capability
+channel. Local inference is a natural workload for it — the whole point of
+running a model locally is that prompts and outputs never leave the box —
+but today the profile can't express what inference needs:
+
+- **GPUs** work only by accident: `--gpus` is absent from
+  `_AIRGAPPED_VETOED_FLAGS`, so it slips through `airgapped_extra_args`.
+  Granting a capability by denylist omission is the wrong mechanism — it is
+  invisible, unaudited, and would be silently revoked if the flag were ever
+  added to the veto list.
+- **Model weights** must be baked into the image: `--network=none` rules
+  out runtime downloads and `--volume`/`--mount` are vetoed. Weights are
+  tens of GB and change more often than code; forcing an image rebuild per
+  revision pushes operators toward the unprotected `docker` runner — the
+  opposite of what the profile is for.
+- **Shared memory**: PyTorch/vLLM move tensors between processes through
+  `/dev/shm`, and Docker's default is 64 MB. `--shm-size` also slips
+  through `extra_args` today — RAM allocation in disguise, unaccounted
+  next to `airgapped_memory`.
+
+## Design principle: named knobs, not veto opt-outs
+
+The runner name is a dispatch contract — the dynamic-workflows server
+stamps `require_runner="docker-airgapped"` and trusts any worker
+advertising it. Two rules keep the name meaningful:
+
+1. **The knob set is enumerated in code, not generic.** Each knob is a
+   deliberate judgment that the isolation *output* guarantee survives it.
+   Capability channels (network, DNS, publish, privileged, caps, host
+   namespaces, writable mounts) are never knobs — operators who need those
+   switch to the plain `docker` runner, changing the *name* and therefore
+   the dispatched guarantee.
+2. **Each capability is grantable only through its named config key.** The
+   raw flags (`--gpus`, `--shm-size`, and the already-vetoed mount flags)
+   are rejected in `airgapped_extra_args`, so a grep of `flux.toml` for
+   `airgapped_` shows exactly which surfaces were opened. Config choice,
+   not runtime surface: workflow authors (the adversary in this model)
+   never touch worker config.
+
+CPU/RAM/pids/tmpfs/timeout already follow this pattern
+(`airgapped_memory`, `airgapped_cpus`, `airgapped_pids_limit`,
+`airgapped_tmp_size`, `airgapped_execution_timeout`) — resizable, never
+unset. This PR adds the three missing knobs.
+
+## New config keys (`[flux.workers]`)
+
+| Key | Type / default | Emitted as |
+|---|---|---|
+| `airgapped_gpus` | `str`, `""` (off) | `--gpus <value>` (e.g. `all`, `"device=0"`) |
+| `airgapped_mounts` | `list[str]`, `[]` | `--mount type=bind,source=<src>,target=<dst>,readonly` per entry |
+| `airgapped_shm_size` | `str`, `""` (docker default, 64m) | `--shm-size <value>` |
+
+All three are emitted from `_locked_args()` — after `extra_args`, so
+docker's last-wins parsing keeps the profile authoritative.
+
+### `airgapped_mounts` semantics
+
+- Entry format `"/host/path:/container/path"`. Both paths must be
+  absolute. A trailing `:ro` is accepted (and redundant); any other
+  option — `rw` above all — is rejected at worker startup.
+- **Read-only is forced by the runner**, not trusted from config: the
+  emitted `--mount` always carries `readonly`. A read-only bind is an
+  *input* channel — data can enter the sandbox but still cannot leave
+  except through the worker-mediated stdio protocol.
+- Validation at worker startup (fail fast, same philosophy as the docker
+  probe): absolute paths, host path exists, no duplicate targets, target
+  is not `/`.
+- Security note (documented): mounted content is readable by **every**
+  airgapped workflow on that worker. Mount model weights and static
+  assets; never mount directories containing secrets.
+
+### `airgapped_gpus` semantics
+
+- String passed through to `--gpus`. Empty = no GPU (today's effective
+  default, now explicit).
+- A GPU is a compute device, not an exfiltration path; it is the knob that
+  makes local inference possible at all. Documented caveat: GPUs are a
+  shared-hardware side channel in the strictest threat models — operators
+  who care isolate at the worker level (one airgapped worker per GPU
+  tenant).
+
+### Veto list additions
+
+`--gpus` and `--shm-size` join `_AIRGAPPED_VETOED_FLAGS`. This is the
+counterpart of making them knobs: the named key becomes the *only* grant
+path. (Both currently pass the veto — for `--gpus` that is exactly the
+accident this spec removes.)
+
+## Wiring
+
+- `flux/config.py` — three new fields on the workers config.
+- `flux/runners/docker.py` — constructor params + validation +
+  `_locked_args()` emission; veto list additions.
+- `flux/runners/__init__.py` — pass the new config through (same shape as
+  the existing airgapped params).
+
+No server, dispatch, or protocol changes: the runner name and its
+guarantee semantics are unchanged.
+
+## DOCKER.md: inference profile guidance
+
+New section covering the vLLM-shaped setup end to end:
+
+- Image recipe: `FROM flux:<version>` + `pip install vllm`; weights come
+  from `airgapped_mounts`, not the image.
+- Sizing: raise `airgapped_memory` / `airgapped_cpus` /
+  `airgapped_tmp_size` / `airgapped_execution_timeout`; set
+  `airgapped_shm_size` (vLLM recommends ≥ a few GB for tensor-parallel).
+  **tmpfs pages (`/tmp`, `/dev/shm`) count against the container's memory
+  cgroup** — `airgapped_memory` must cover process + caches + shm.
+- Read-only rootfs: point `HF_HOME` / `XDG_CACHE_HOME` at `/tmp` (compile
+  and tokenizer caches), via `airgapped_extra_args = ["--env", ...]`.
+- Serving pattern: `--network=none` keeps the container's own loopback, so
+  a workflow may run the vLLM engine in-process or spawn `vllm serve` on
+  `127.0.0.1` *inside* the container — nothing is reachable from outside,
+  and results still flow only through the stdio protocol.
+
+## Testing
+
+- Veto: `airgapped_extra_args` containing `--gpus` / `--shm-size` /
+  `--mount` (and `=`-joined forms) rejected at construction.
+- Mounts: relative host or container path rejected; `rw` option rejected;
+  trailing `:ro` accepted; duplicate targets rejected; missing host path
+  rejected; emitted `--mount` string always contains `readonly`.
+- `_locked_args()` contains `--gpus`/`--shm-size`/`--mount` exactly when
+  configured, in the locked section (after extra_args in the assembled
+  command).
+- Config plumbing: runner built from `[flux.workers]` keys carries the
+  values (mirrors existing airgapped construction tests).
+
+## Rollout / compatibility
+
+Additive config; default behavior identical except that `--gpus` /
+`--shm-size` in `airgapped_extra_args` now fail worker startup with a
+pointer to the named key (previously they silently worked — any operator
+relying on that moves the value to the new key). Version: 0.60.0.

--- a/examples/airgapped.py
+++ b/examples/airgapped.py
@@ -1,0 +1,133 @@
+"""Workflows sealed in the docker-airgapped runner.
+
+``docker-airgapped`` is the runner for code you do not trust — model-authored
+(dynamic) workflows above all. Each execution runs in a container whose only
+capability channel is the stdio protocol to the parent worker: no network
+(``--network=none``), read-only rootfs with a size-capped tmpfs ``/tmp``,
+no capabilities, no privilege escalation, pids/memory/cpu limits, and a
+wall-clock ceiling. Checkpoints, secrets, configs, and approvals all flow
+through the worker, where every request is permission-checked.
+
+Workers opt in explicitly:
+
+    [flux.workers]
+    runners = ["docker-airgapped"]
+    airgapped_image = "<registry>/flux:<version-matching-the-worker>"
+
+Three capabilities can be granted — each only through its named config key,
+so ``flux.toml`` is the audit trail of opened surfaces:
+
+    airgapped_gpus = "all"                      # compute, no data path out
+    airgapped_mounts = ["/srv/assets:/assets"]  # read-only, forced
+    airgapped_shm_size = "8g"                   # /dev/shm for tensor passing
+
+Pinning ``runner="docker-airgapped"`` also constrains dispatch: the workflow
+only goes to workers advertising the sealed runner. (Dynamically registered
+workflows get this pin stamped server-side via
+``[flux.dynamic_workflows] require_runner`` — authors can't opt out.)
+
+Runner selection is a dispatch concern; running these inline
+(``workflow.run()``, as in the tests) executes in the current process, so
+each example degrades gracefully outside the container.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from flux import ExecutionContext
+from flux.task import task
+from flux.workflow import workflow
+
+# Inside the sealed container this path exists only if the operator granted
+# it via airgapped_mounts; read-only is forced by the runner.
+ASSETS_DIR = Path("/assets")
+
+_BUILTIN_STOPWORDS = frozenset({"a", "an", "and", "in", "is", "of", "or", "the", "to"})
+
+
+@task
+async def tokenize(text: str) -> list[str]:
+    return [word.strip(".,;:!?\"'()").lower() for word in text.split()]
+
+
+@task
+async def load_stopwords() -> list[str]:
+    """Read reference data from a mounted read-only asset, if granted.
+
+    The mount is an *input* channel: data can enter the sandbox, results
+    still leave only through the worker-mediated stdio protocol. Without the
+    grant (or when running inline) the built-in fallback keeps the workflow
+    functional.
+    """
+    stopwords_file = ASSETS_DIR / "stopwords.txt"
+    if stopwords_file.is_file():
+        return [line.strip() for line in stopwords_file.read_text().splitlines() if line.strip()]
+    return sorted(_BUILTIN_STOPWORDS)
+
+
+@task
+async def count_keywords(words: list[str], stopwords: list[str]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    excluded = set(stopwords)
+    for word in words:
+        if word and word not in excluded:
+            counts[word] = counts.get(word, 0) + 1
+    return dict(sorted(counts.items(), key=lambda item: (-item[1], item[0])))
+
+
+@workflow.with_options(runner="docker-airgapped")
+async def sealed_keyword_count(ctx: ExecutionContext[str]):
+    """The untrusted-code shape: arbitrary text processing, fully sealed.
+
+    Even if this code were adversarial it could not phone home (no network),
+    tamper with the host (read-only rootfs, no mounts unless granted
+    read-only), or exhaust the worker (memory/cpu/pids/wall-clock limits).
+    """
+    if not ctx.input:
+        raise TypeError("Input not provided")
+    words = await tokenize(ctx.input)
+    stopwords = await load_stopwords()
+    return await count_keywords(words, stopwords)
+
+
+@task
+async def summarize_locally(text: str, max_words: int = 12) -> dict[str, str | int]:
+    """Local inference stays local: prompt and output never leave the box.
+
+    In a real deployment the airgapped image bundles an inference engine
+    (e.g. ``pip install vllm``), weights arrive through a read-only
+    ``airgapped_mounts`` grant, and ``airgapped_gpus`` exposes the device —
+    see DOCKER.md ("Local model inference in the airgapped runner"). The
+    engine can run in-process, or as a server on the container's own
+    loopback: ``--network=none`` removes external connectivity but keeps
+    ``127.0.0.1`` inside the sandbox.
+
+    This example uses a deterministic extractive stand-in so it runs
+    anywhere; swap the body for a model call in your image.
+    """
+    words = text.split()
+    summary = " ".join(words[:max_words]) + ("…" if len(words) > max_words else "")
+    return {"summary": summary, "input_words": len(words)}
+
+
+@workflow.with_options(runner="docker-airgapped")
+async def sealed_summarize(ctx: ExecutionContext[str]):
+    """Privacy-preserving inference: sealed compute over sensitive text.
+
+    The only thing that leaves the container is this return value, as a
+    checkpoint through the parent worker.
+    """
+    if not ctx.input:
+        raise TypeError("Input not provided")
+    return await summarize_locally(ctx.input)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    ctx = sealed_keyword_count.run("the quick brown fox jumps over the lazy dog")
+    print(ctx.to_json())
+    ctx = sealed_summarize.run(
+        "Flux executes untrusted workflows inside a sealed container whose "
+        "only capability channel is the stdio protocol to the parent worker.",
+    )
+    print(ctx.to_json())

--- a/examples/airgapped.py
+++ b/examples/airgapped.py
@@ -19,7 +19,7 @@ so ``flux.toml`` is the audit trail of opened surfaces:
 
     airgapped_gpus = "all"                      # compute, no data path out
     airgapped_mounts = ["/srv/assets:/assets"]  # read-only, forced
-    airgapped_shm_size = "8g"                   # /dev/shm for tensor passing
+    airgapped_shm_size = "8g"                   # /dev/shm for large buffers
 
 Pinning ``runner="docker-airgapped"`` also constrains dispatch: the workflow
 only goes to workers advertising the sealed runner. (Dynamically registered
@@ -33,6 +33,7 @@ each example degrades gracefully outside the container.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from flux import ExecutionContext
@@ -44,6 +45,9 @@ from flux.workflow import workflow
 ASSETS_DIR = Path("/assets")
 
 _BUILTIN_STOPWORDS = frozenset({"a", "an", "and", "in", "is", "of", "or", "the", "to"})
+
+_EMAIL = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+_PHONE = re.compile(r"\+?\d[\d\s().-]{7,}\d")
 
 
 @task
@@ -92,42 +96,36 @@ async def sealed_keyword_count(ctx: ExecutionContext[str]):
 
 
 @task
-async def summarize_locally(text: str, max_words: int = 12) -> dict[str, str | int]:
-    """Local inference stays local: prompt and output never leave the box.
+async def redact(text: str) -> dict[str, str | int]:
+    """Mask emails and phone numbers before anything leaves the sandbox."""
+    redactions = 0
 
-    In a real deployment the airgapped image bundles an inference engine
-    (e.g. ``pip install vllm``), weights arrive through a read-only
-    ``airgapped_mounts`` grant, and ``airgapped_gpus`` exposes the device —
-    see DOCKER.md ("Local model inference in the airgapped runner"). The
-    engine can run in-process, or as a server on the container's own
-    loopback: ``--network=none`` removes external connectivity but keeps
-    ``127.0.0.1`` inside the sandbox.
+    def _mask(match: re.Match[str]) -> str:
+        nonlocal redactions
+        redactions += 1
+        return "[REDACTED]"
 
-    This example uses a deterministic extractive stand-in so it runs
-    anywhere; swap the body for a model call in your image.
-    """
-    words = text.split()
-    summary = " ".join(words[:max_words]) + ("…" if len(words) > max_words else "")
-    return {"summary": summary, "input_words": len(words)}
+    masked = _EMAIL.sub(_mask, text)
+    masked = _PHONE.sub(_mask, masked)
+    return {"text": masked, "redactions": redactions}
 
 
 @workflow.with_options(runner="docker-airgapped")
-async def sealed_summarize(ctx: ExecutionContext[str]):
-    """Privacy-preserving inference: sealed compute over sensitive text.
+async def sealed_redact(ctx: ExecutionContext[str]):
+    """Privacy-preserving processing of sensitive text.
 
-    The only thing that leaves the container is this return value, as a
-    checkpoint through the parent worker.
+    The raw input reaches the container through the worker's stdio channel
+    and is processed with no network to leak it through; the only thing
+    that leaves is this return value, checkpointed through the parent
+    worker — already masked.
     """
     if not ctx.input:
         raise TypeError("Input not provided")
-    return await summarize_locally(ctx.input)
+    return await redact(ctx.input)
 
 
 if __name__ == "__main__":  # pragma: no cover
     ctx = sealed_keyword_count.run("the quick brown fox jumps over the lazy dog")
     print(ctx.to_json())
-    ctx = sealed_summarize.run(
-        "Flux executes untrusted workflows inside a sealed container whose "
-        "only capability channel is the stdio protocol to the parent worker.",
-    )
+    ctx = sealed_redact.run("Contact Ada at ada@example.com or +1 (555) 010-9999 for access.")
     print(ctx.to_json())

--- a/examples/runners.py
+++ b/examples/runners.py
@@ -15,6 +15,9 @@ workflow only goes to workers that advertise that runner.
 - ``docker``: one container per execution (workers must enable it and set
   ``docker_image``). Full filesystem/dependency isolation for untrusted
   code.
+- ``docker-airgapped``: the docker runner with a locked isolation profile
+  (no network, read-only rootfs, capability drops, resource + wall-clock
+  limits). For code you do not trust at all — see ``examples/airgapped.py``.
 
 The runner option matters when executions are dispatched to workers;
 running a workflow inline (``workflow.run()``, as below) executes in the

--- a/flux/config.py
+++ b/flux/config.py
@@ -197,13 +197,40 @@ class WorkersConfig(BaseConfig):
             "both durabilities (0 disables — discouraged)"
         ),
     )
+    airgapped_gpus: str = Field(
+        default="",
+        description=(
+            "GPUs exposed to airgapped containers ('all', 'device=0', ...); "
+            "empty (default) grants none. The only way to grant GPUs — "
+            "--gpus in airgapped_extra_args is rejected"
+        ),
+    )
+    airgapped_mounts: list[str] = Field(
+        default=[],
+        description=(
+            "Read-only bind mounts for airgapped containers, entries "
+            "'/host/path:/container/path'. Read-only is forced by the "
+            "runner; an input channel for model weights and static assets. "
+            "Mounted content is readable by every airgapped workflow on "
+            "this worker — never mount directories containing secrets"
+        ),
+    )
+    airgapped_shm_size: str = Field(
+        default="",
+        description=(
+            "Size of /dev/shm in airgapped containers (docker syntax, e.g. "
+            "'4g'); empty keeps docker's 64m default. tmpfs pages count "
+            "against airgapped_memory"
+        ),
+    )
     airgapped_extra_args: list[str] = Field(
         default=[],
         description=(
             "Extra 'docker run' arguments for the airgapped runner. Flags "
             "that would weaken the isolation profile (--network, --volume, "
             "--privileged, --cap-add, host namespaces, DNS, ...) are rejected "
-            "at worker startup"
+            "at worker startup, as are flags with a named airgapped_* key "
+            "(--gpus, --shm-size, mounts)"
         ),
     )
     loop_lag_threshold: float = Field(

--- a/flux/config.py
+++ b/flux/config.py
@@ -210,7 +210,7 @@ class WorkersConfig(BaseConfig):
         description=(
             "Read-only bind mounts for airgapped containers, entries "
             "'/host/path:/container/path'. Read-only is forced by the "
-            "runner; an input channel for model weights and static assets. "
+            "runner; an input channel for reference data and static assets. "
             "Mounted content is readable by every airgapped workflow on "
             "this worker — never mount directories containing secrets"
         ),

--- a/flux/runners/__init__.py
+++ b/flux/runners/__init__.py
@@ -71,6 +71,9 @@ def create_runners(names: list[str], config) -> dict[str, Runner]:
                 tmp_size=config.airgapped_tmp_size,
                 execution_timeout=config.airgapped_execution_timeout,
                 extra_args=list(config.airgapped_extra_args),
+                gpus=config.airgapped_gpus,
+                mounts=list(config.airgapped_mounts),
+                shm_size=config.airgapped_shm_size,
             )
         else:
             raise ValueError(

--- a/flux/runners/docker.py
+++ b/flux/runners/docker.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import os
 import shutil
 import subprocess
 from typing import TYPE_CHECKING
@@ -151,7 +152,10 @@ class DockerRunner(SubprocessRunner):
 # extra_args must not be able to re-open what the airgapped profile closed:
 # network, host namespaces, devices, mounts, privileges, DNS. A denylist (not
 # an allowlist) on purpose — benign operator knobs (--env, --user, --tmpfs)
-# can't be enumerated, while the guarantees to protect can.
+# can't be enumerated, while the guarantees to protect can. Capabilities that
+# ARE grantable (GPUs, read-only mounts, shared memory) are vetoed here too:
+# each one is grantable only through its named airgapped_* config key, so the
+# config file is the complete audit trail of opened surfaces.
 _AIRGAPPED_VETOED_FLAGS = frozenset(
     {
         "--network",
@@ -184,8 +188,61 @@ _AIRGAPPED_VETOED_FLAGS = frozenset(
         "--cgroupns",
         "--device-cgroup-rule",
         "--oom-kill-disable",
+        "--gpus",
+        "--shm-size",
     },
 )
+
+
+def _parse_airgapped_mounts(mounts: list[str]) -> list[tuple[str, str]]:
+    """Validate ``airgapped_mounts`` entries into (source, target) pairs.
+
+    Entry format is ``/host/path:/container/path`` with an optional,
+    redundant ``:ro`` suffix. Read-only is forced by the runner regardless;
+    anything else after the target (``rw`` above all) is rejected.
+    """
+    parsed: list[tuple[str, str]] = []
+    seen_targets: set[str] = set()
+    for entry in mounts:
+        parts = entry.split(":")
+        if len(parts) == 3 and parts[2] == "ro":
+            parts = parts[:2]
+        if len(parts) != 2:
+            raise ValueError(
+                f"[flux.workers] airgapped_mounts entry '{entry}' is invalid: "
+                "expected '/host/path:/container/path' (optionally ':ro'; "
+                "mounts are always read-only)",
+            )
+        source, target = parts
+        if not (os.path.isabs(source) and os.path.isabs(target)):
+            raise ValueError(
+                f"[flux.workers] airgapped_mounts entry '{entry}': both the "
+                "host and container paths must be absolute",
+            )
+        if "," in source or "," in target:
+            # --mount options are comma-separated; a comma in a path would
+            # silently change the mount spec.
+            raise ValueError(
+                f"[flux.workers] airgapped_mounts entry '{entry}': paths must not contain commas",
+            )
+        if target == "/":
+            raise ValueError(
+                f"[flux.workers] airgapped_mounts entry '{entry}': mounting "
+                "over '/' is not allowed",
+            )
+        if target in seen_targets:
+            raise ValueError(
+                f"[flux.workers] airgapped_mounts entry '{entry}': duplicate "
+                f"container target '{target}'",
+            )
+        if not os.path.exists(source):
+            raise ValueError(
+                f"[flux.workers] airgapped_mounts entry '{entry}': host path "
+                f"'{source}' does not exist",
+            )
+        seen_targets.add(target)
+        parsed.append((source, target))
+    return parsed
 
 
 class AirgappedDockerRunner(DockerRunner):
@@ -203,6 +260,15 @@ class AirgappedDockerRunner(DockerRunner):
     The profile is emitted from code (``_locked_args``), after operator
     ``extra_args``, so configuration cannot weaken it; ``extra_args`` that
     would re-open a closed surface are rejected at worker startup.
+
+    Three capabilities are grantable — each only through its named config
+    key, never through ``extra_args``, so the config file is the audit
+    trail: ``airgapped_gpus`` (compute device, no data path out),
+    ``airgapped_mounts`` (bind mounts with read-only forced by the runner —
+    an input channel for model weights and static assets), and
+    ``airgapped_shm_size`` (``/dev/shm`` sizing for tensor-passing
+    workloads). None of them opens an output channel: results still leave
+    only through the worker-mediated stdio protocol.
     """
 
     name = "docker-airgapped"
@@ -217,6 +283,9 @@ class AirgappedDockerRunner(DockerRunner):
         tmp_size: str = "64m",
         execution_timeout: float = 900,
         extra_args: list[str] | None = None,
+        gpus: str = "",
+        mounts: list[str] | None = None,
+        shm_size: str = "",
     ):
         if not memory:
             raise ValueError(
@@ -230,11 +299,21 @@ class AirgappedDockerRunner(DockerRunner):
         for token in extra_args or []:
             flag = token.split("=", 1)[0]
             if flag in _AIRGAPPED_VETOED_FLAGS:
+                hint = ""
+                if flag == "--gpus":
+                    hint = " (grant GPUs via [flux.workers] airgapped_gpus)"
+                elif flag == "--shm-size":
+                    hint = " (size /dev/shm via [flux.workers] airgapped_shm_size)"
+                elif flag in ("--volume", "-v", "--mount"):
+                    hint = " (read-only mounts go through [flux.workers] airgapped_mounts)"
                 raise ValueError(
                     f"[flux.workers] airgapped_extra_args contains '{token}': "
                     f"'{flag}' would weaken the airgapped isolation profile "
-                    "and is not allowed",
+                    f"and is not allowed{hint}",
                 )
+        self._mounts = _parse_airgapped_mounts(list(mounts or []))
+        self._gpus = gpus
+        self._shm_size = shm_size
         super().__init__(
             image=image,
             term_grace=term_grace,
@@ -252,7 +331,7 @@ class AirgappedDockerRunner(DockerRunner):
         self._tmp_size = tmp_size
 
     def _locked_args(self) -> list[str]:
-        return [
+        args = [
             "--network=none",
             "--read-only",
             "--tmpfs",
@@ -266,3 +345,13 @@ class AirgappedDockerRunner(DockerRunner):
             "--cpus",
             str(self._airgapped_cpus),
         ]
+        # Named capability knobs. Emitted here — not accepted in extra_args —
+        # so each grant is explicit config; read-only is forced on mounts no
+        # matter what the entry said.
+        for source, target in self._mounts:
+            args += ["--mount", f"type=bind,source={source},target={target},readonly"]
+        if self._gpus:
+            args += ["--gpus", self._gpus]
+        if self._shm_size:
+            args += ["--shm-size", self._shm_size]
+        return args

--- a/flux/runners/docker.py
+++ b/flux/runners/docker.py
@@ -271,10 +271,10 @@ class AirgappedDockerRunner(DockerRunner):
     key, never through ``extra_args``, so the config file is the audit
     trail: ``airgapped_gpus`` (compute device, no data path out),
     ``airgapped_mounts`` (bind mounts with read-only forced by the runner —
-    an input channel for model weights and static assets), and
-    ``airgapped_shm_size`` (``/dev/shm`` sizing for tensor-passing
-    workloads). None of them opens an output channel: results still leave
-    only through the worker-mediated stdio protocol.
+    an input channel for reference data and static assets), and
+    ``airgapped_shm_size`` (``/dev/shm`` sizing for workloads that pass
+    large buffers between processes). None of them opens an output channel:
+    results still leave only through the worker-mediated stdio protocol.
     """
 
     name = "docker-airgapped"

--- a/flux/runners/docker.py
+++ b/flux/runners/docker.py
@@ -225,7 +225,13 @@ def _parse_airgapped_mounts(mounts: list[str]) -> list[tuple[str, str]]:
             raise ValueError(
                 f"[flux.workers] airgapped_mounts entry '{entry}': paths must not contain commas",
             )
-        if target == "/":
+        # Normalize before the guards below: '/.', '/models/..' and trailing
+        # slashes would otherwise slip past the root-target and duplicate
+        # checks while resolving to the same location in the container.
+        source = os.path.normpath(source)
+        target = os.path.normpath(target)
+        # POSIX normpath preserves '//', so test all-slash rather than '/'.
+        if target.rstrip("/") == "":
             raise ValueError(
                 f"[flux.workers] airgapped_mounts entry '{entry}': mounting "
                 "over '/' is not allowed",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
       - Workflow Controls: advanced-features/workflow-controls.md
       - Worker Affinity: advanced-features/worker-affinity.md
       - Dynamic Routing: advanced-features/dynamic-routing.md
+      - Airgapped Execution: advanced-features/airgapped-execution.md
       - Observability: advanced-features/observability.md
       - Task Progress Streaming: advanced-features/task-progress.md
       - Agent Skills: advanced-features/agent-skills.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.59.0"
+version = "0.60.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/examples/test_airgapped.py
+++ b/tests/examples/test_airgapped.py
@@ -1,0 +1,37 @@
+"""Tests for the docker-airgapped examples.
+
+Runner selection is a dispatch concern; inline execution runs the workflow
+in the current process, so these verify the workflows themselves (including
+the graceful fallback when no read-only asset mount is granted) and that
+each carries the sealed-runner requirement.
+"""
+
+from __future__ import annotations
+
+from examples.airgapped import sealed_keyword_count, sealed_summarize
+
+
+def test_sealed_keyword_count_runs_inline():
+    ctx = sealed_keyword_count.run("the quick brown fox jumps over the lazy dog")
+    assert ctx.has_finished and ctx.has_succeeded
+    assert ctx.output["quick"] == 1
+    assert "the" not in ctx.output  # stopwords excluded via the fallback list
+
+
+def test_sealed_keyword_count_orders_by_frequency():
+    ctx = sealed_keyword_count.run("data data data pipeline pipeline sealed")
+    assert ctx.has_succeeded, ctx.output
+    assert list(ctx.output) == ["data", "pipeline", "sealed"]
+
+
+def test_sealed_summarize_runs_inline():
+    text = "Flux executes untrusted workflows inside a sealed container whose only capability channel is the stdio protocol to the parent worker."
+    ctx = sealed_summarize.run(text)
+    assert ctx.has_finished and ctx.has_succeeded
+    assert ctx.output["summary"].endswith("…")
+    assert ctx.output["input_words"] == len(text.split())
+
+
+def test_examples_declare_the_sealed_runner():
+    assert sealed_keyword_count.runner == "docker-airgapped"
+    assert sealed_summarize.runner == "docker-airgapped"

--- a/tests/examples/test_airgapped.py
+++ b/tests/examples/test_airgapped.py
@@ -8,7 +8,7 @@ each carries the sealed-runner requirement.
 
 from __future__ import annotations
 
-from examples.airgapped import sealed_keyword_count, sealed_summarize
+from examples.airgapped import sealed_keyword_count, sealed_redact
 
 
 def test_sealed_keyword_count_runs_inline():
@@ -24,14 +24,20 @@ def test_sealed_keyword_count_orders_by_frequency():
     assert list(ctx.output) == ["data", "pipeline", "sealed"]
 
 
-def test_sealed_summarize_runs_inline():
-    text = "Flux executes untrusted workflows inside a sealed container whose only capability channel is the stdio protocol to the parent worker."
-    ctx = sealed_summarize.run(text)
+def test_sealed_redact_masks_pii():
+    ctx = sealed_redact.run("Contact Ada at ada@example.com or +1 (555) 010-9999 for access.")
     assert ctx.has_finished and ctx.has_succeeded
-    assert ctx.output["summary"].endswith("…")
-    assert ctx.output["input_words"] == len(text.split())
+    assert "ada@example.com" not in ctx.output["text"]
+    assert "555" not in ctx.output["text"]
+    assert ctx.output["redactions"] == 2
+
+
+def test_sealed_redact_clean_text_untouched():
+    ctx = sealed_redact.run("Nothing sensitive here.")
+    assert ctx.has_succeeded, ctx.output
+    assert ctx.output == {"text": "Nothing sensitive here.", "redactions": 0}
 
 
 def test_examples_declare_the_sealed_runner():
     assert sealed_keyword_count.runner == "docker-airgapped"
-    assert sealed_summarize.runner == "docker-airgapped"
+    assert sealed_redact.runner == "docker-airgapped"

--- a/tests/flux/test_airgapped_runner.py
+++ b/tests/flux/test_airgapped_runner.py
@@ -92,10 +92,26 @@ class TestVetoList:
             ["--add-host=evil:1.2.3.4"],
             ["--sysctl", "net.ipv4.ip_forward=1"],
             ["--oom-kill-disable"],
+            ["--gpus=all"],
+            ["--gpus", "all"],
+            ["--shm-size=4g"],
+            ["--shm-size", "4g"],
         ],
     )
     def test_profile_weakening_args_rejected(self, args):
         with pytest.raises(ValueError, match="airgapped isolation profile"):
+            make_runner(extra_args=args)
+
+    @pytest.mark.parametrize(
+        ("args", "hint"),
+        [
+            (["--gpus=all"], "airgapped_gpus"),
+            (["--shm-size=4g"], "airgapped_shm_size"),
+            (["--mount", "type=bind,src=/,dst=/host"], "airgapped_mounts"),
+        ],
+    )
+    def test_rejection_points_at_the_named_knob(self, args, hint):
+        with pytest.raises(ValueError, match=hint):
             make_runner(extra_args=args)
 
     @pytest.mark.parametrize(
@@ -111,6 +127,84 @@ class TestVetoList:
         runner = make_runner(extra_args=args)
         command = runner._build_command("c")
         assert args[0] in command
+
+
+class TestCapabilityKnobs:
+    """GPUs, read-only mounts, and shm sizing are grantable only through
+    their named config keys and always land in the locked section."""
+
+    def test_off_by_default(self):
+        command = make_runner()._build_command("c")
+        assert "--gpus" not in command
+        assert "--shm-size" not in command
+        assert "--mount" not in command
+
+    def test_gpus_emitted_when_configured(self):
+        command = make_runner(gpus="all")._build_command("c")
+        assert "--gpus all" in " ".join(command)
+
+    def test_shm_size_emitted_when_configured(self):
+        command = make_runner(shm_size="4g")._build_command("c")
+        assert "--shm-size 4g" in " ".join(command)
+
+    def test_mount_emitted_read_only(self, tmp_path):
+        runner = make_runner(mounts=[f"{tmp_path}:/models"])
+        joined = " ".join(runner._build_command("c"))
+        assert f"--mount type=bind,source={tmp_path},target=/models,readonly" in joined
+
+    def test_redundant_ro_suffix_accepted(self, tmp_path):
+        runner = make_runner(mounts=[f"{tmp_path}:/models:ro"])
+        joined = " ".join(runner._build_command("c"))
+        assert "target=/models,readonly" in joined
+
+    def test_rw_suffix_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="always read-only"):
+            make_runner(mounts=[f"{tmp_path}:/models:rw"])
+
+    def test_relative_paths_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="absolute"):
+            make_runner(mounts=["models:/models"])
+        with pytest.raises(ValueError, match="absolute"):
+            make_runner(mounts=[f"{tmp_path}:models"])
+
+    def test_missing_host_path_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="does not exist"):
+            make_runner(mounts=[f"{tmp_path / 'nope'}:/models"])
+
+    def test_duplicate_targets_rejected(self, tmp_path):
+        a, b = tmp_path / "a", tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        with pytest.raises(ValueError, match="duplicate"):
+            make_runner(mounts=[f"{a}:/models", f"{b}:/models"])
+
+    def test_root_target_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="mounting"):
+            make_runner(mounts=[f"{tmp_path}:/"])
+
+    def test_comma_in_path_rejected(self, tmp_path):
+        weird = tmp_path / "a,b"
+        weird.mkdir()
+        with pytest.raises(ValueError, match="commas"):
+            make_runner(mounts=[f"{weird}:/models"])
+
+    def test_malformed_entry_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="expected"):
+            make_runner(mounts=[str(tmp_path)])
+
+    def test_knobs_land_in_locked_section(self, tmp_path):
+        """Capability grants sit with the profile, after operator extra_args."""
+        runner = make_runner(
+            extra_args=["--env", "TZ=UTC"],
+            gpus="all",
+            shm_size="2g",
+            mounts=[f"{tmp_path}:/models"],
+        )
+        command = runner._build_command("c")
+        env_at = command.index("--env")
+        assert env_at < command.index("--gpus")
+        assert env_at < command.index("--shm-size")
+        assert env_at < command.index("--mount")
 
 
 class TestLimitValidation:
@@ -142,6 +236,9 @@ class TestFactoryWiring:
         cfg.airgapped_tmp_size = "64m"
         cfg.airgapped_execution_timeout = 900
         cfg.airgapped_extra_args = []
+        cfg.airgapped_gpus = ""
+        cfg.airgapped_mounts = []
+        cfg.airgapped_shm_size = ""
         for key, value in overrides.items():
             setattr(cfg, key, value)
         return cfg
@@ -169,6 +266,22 @@ class TestFactoryWiring:
         with patch.object(DockerRunner, "_verify_docker_available"):
             with pytest.raises(ValueError, match="airgapped_image"):
                 create_runners(["docker-airgapped"], self._config())
+
+    def test_capability_knobs_flow_from_config(self, tmp_path):
+        with patch.object(DockerRunner, "_verify_docker_available"):
+            runners = create_runners(
+                ["docker-airgapped"],
+                self._config(
+                    docker_image="flux:base",
+                    airgapped_gpus="device=0",
+                    airgapped_mounts=[f"{tmp_path}:/models"],
+                    airgapped_shm_size="4g",
+                ),
+            )
+        joined = " ".join(runners["docker-airgapped"]._build_command("c"))
+        assert "--gpus device=0" in joined
+        assert f"type=bind,source={tmp_path},target=/models,readonly" in joined
+        assert "--shm-size 4g" in joined
 
 
 class TestExecutionTimeout:

--- a/tests/flux/test_airgapped_runner.py
+++ b/tests/flux/test_airgapped_runner.py
@@ -178,9 +178,17 @@ class TestCapabilityKnobs:
         with pytest.raises(ValueError, match="duplicate"):
             make_runner(mounts=[f"{a}:/models", f"{b}:/models"])
 
-    def test_root_target_rejected(self, tmp_path):
+    @pytest.mark.parametrize("target", ["/", "/.", "/models/..", "//"])
+    def test_root_target_rejected_even_unnormalized(self, target, tmp_path):
         with pytest.raises(ValueError, match="mounting"):
-            make_runner(mounts=[f"{tmp_path}:/"])
+            make_runner(mounts=[f"{tmp_path}:{target}"])
+
+    def test_duplicate_detection_survives_trailing_slash(self, tmp_path):
+        a, b = tmp_path / "a", tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        with pytest.raises(ValueError, match="duplicate"):
+            make_runner(mounts=[f"{a}:/models", f"{b}:/models/"])
 
     def test_comma_in_path_rejected(self, tmp_path):
         weird = tmp_path / "a,b"


### PR DESCRIPTION
Follow-up to the docker-airgapped runner (#130): named capability knobs for data- and compute-heavy sealed workloads. Spec: `docs/specs/2026-07-16-airgapped-capability-knobs.md`.

## Design principle: named knobs, not veto opt-outs

The runner name is a dispatch contract — the dynamic-workflows server stamps `require_runner="docker-airgapped"` and trusts any worker advertising it. So capability channels (network, DNS, publish, privileged, caps, host namespaces, writable mounts) are never grantable here; operators who need those switch to the plain `docker` runner, changing the name and therefore the dispatched guarantee. What IS grantable is an enumerated set of resource/input capabilities that the isolation *output* guarantee survives — and each is grantable **only** through its named config key, never through `extra_args`, so `flux.toml` is the complete audit trail of opened surfaces.

## New `[flux.workers]` keys

| Key | Default | Emitted as |
|---|---|---|
| `airgapped_gpus` | `""` (off) | `--gpus <value>` |
| `airgapped_mounts` | `[]` | `--mount type=bind,source=…,target=…,readonly` per entry |
| `airgapped_shm_size` | `""` (docker's 64m) | `--shm-size <value>` |

- **`airgapped_gpus`** — previously `--gpus` slipped through `airgapped_extra_args` by denylist omission; a capability granted by accident, invisible and unaudited. Now it's an explicit key and the raw flag is vetoed.
- **`airgapped_mounts`** — general-purpose read-only binds (`"/host/path:/container/path"`, optional redundant `:ro`). Read-only is **forced by the runner** in the emitted `--mount` regardless of config; `rw`, relative paths, missing host paths, duplicate targets, root targets, and comma-bearing paths are all rejected at worker startup, with targets normalized first so `/.`, `/models/..`, and trailing slashes can't slip past the guards. A read-only bind is an input channel — reference data and static assets can enter, results still leave only through the worker-mediated stdio protocol. Large datasets no longer need to be baked into the image, so a data refresh doesn't mean an image rebuild.
- **`airgapped_shm_size`** — workloads that pass large buffers between processes go through `/dev/shm`, and docker's 64 MB default is far too small; this is RAM allocation in disguise, so it lives next to `airgapped_memory` instead of hiding in an args list.

All three emit from `_locked_args()` (after `extra_args`, docker last-wins), keeping the profile authoritative. `--gpus` and `--shm-size` join `_AIRGAPPED_VETOED_FLAGS`; rejections now point at the named key to use instead.

## Examples & docs

- `examples/airgapped.py` (+ `tests/examples/test_airgapped.py`) — showcase workflows pinned to the sealed runner: untrusted-shape keyword extraction with read-only reference-data mounts (graceful fallback when the grant or container is absent), and privacy-preserving PII redaction where the only thing leaving the sandbox is the already-masked result. All runnable inline, all dispatch-pinned via `runner="docker-airgapped"`.
- `docs/advanced-features/airgapped-execution.md` (in the mkdocs nav) — the locked profile, worker config, the capability-knob table with the never-grantable list, sizing for heavy workloads, dynamic-workflow stamping, and failure semantics (crash vs timeout vs cancellation).
- `DOCKER.md` gains a "Sizing the airgapped runner for heavy workloads" section: full config example, image recipe (reference data from the mount, not the image), sizing guidance (tmpfs pages count against the memory cgroup; caches to `/tmp` since the rootfs is read-only), and the in-container loopback helper-process pattern.
- `examples/runners.py` docstring now lists the sealed runner alongside the other three.

## Compatibility

Additive config; default behavior identical, with one deliberate exception: `--gpus` / `--shm-size` in `airgapped_extra_args` now fail worker startup with a pointer to the named key (previously they silently worked).

## Tests

`tests/flux/test_airgapped_runner.py`: veto coverage for the new flags (both `=`-joined and split forms) with named-knob hints; mount validation matrix (ro forced, rw/relative/missing/duplicate/root/comma rejected, unnormalized root and trailing-slash duplicate bypasses closed, malformed entries); knobs land in the locked section after `extra_args`; factory wiring from config. Plus the inline example tests above.

Local validation: pre-commit clean; unit suite 2751 passed / 9 skipped; e2e 124 passed (the two `github_stars` failures are the sandbox proxy blocking direct `api.github.com`, unrelated).

Version: 0.60.0.