### PR TITLE
Airgapped service sockets: warm local runtimes for sealed executions

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -122,6 +122,52 @@ Notes:
   isolate at the worker level (one airgapped worker per GPU tenant) if
   that matters to you.
 
+## Service sidecars for the airgapped runner
+
+Long-lived runtimes with expensive startup live *outside* the sandbox as
+operator-managed sidecars, reached over a Unix domain socket
+(`[flux.workers] airgapped_service_sockets` — see the Airgapped Execution
+docs for semantics). The sidecar is trusted infrastructure, like a
+database: run it as its own hardened unit — dedicated user, no egress,
+GPU pinned — serving only its socket.
+
+Directory contract (validated at worker startup): the configured host
+directory carries no write bits (`chmod 0555`) and the socket inside is
+world-connectable (`0666`). Host-side root keeps `CAP_DAC_OVERRIDE`, so a
+root-managed sidecar can create and replace its socket across restarts
+even in the write-less directory; sealed containers cannot, because the
+profile drops all capabilities.
+
+llama.cpp (binds a UDS when the host ends in `.sock`):
+
+```bash
+llama-server -m /srv/models/model.gguf \
+  --host /run/flux-services/inference/service.sock
+```
+
+vLLM (uvicorn UDS):
+
+```bash
+vllm serve <model> --uds /run/flux-services/inference/service.sock
+```
+
+Example systemd shape — create the directory, bind the socket, lock the
+directory down:
+
+```ini
+[Service]
+ExecStartPre=/usr/bin/install -d -m 0755 /run/flux-services/inference
+ExecStart=/usr/local/bin/llama-server -m /srv/models/model.gguf \
+  --host /run/flux-services/inference/service.sock
+ExecStartPost=/bin/sh -c 'chmod 0666 /run/flux-services/inference/service.sock; \
+  chmod 0555 /run/flux-services/inference'
+Restart=always
+```
+
+(`0755` during bind so a non-root `User=` can create the socket; locked
+to `0555` once it exists. A root-run sidecar can keep the directory at
+`0555` permanently.)
+
 ## Running the Server
 
 ```bash

--- a/docs/advanced-features/airgapped-execution.md
+++ b/docs/advanced-features/airgapped-execution.md
@@ -58,16 +58,17 @@ redaction of sensitive data).
 
 ## Capability knobs
 
-Three capabilities can be granted. Each is grantable **only through its
-named config key** — the raw flags (`--gpus`, `--shm-size`, and all mount
-flags) are rejected in `airgapped_extra_args` — so a grep of `flux.toml`
-for `airgapped_` is the complete audit trail of opened surfaces:
+Capabilities are granted **only through named config keys** — the raw
+flags (`--gpus`, `--shm-size`, and all mount flags) are rejected in
+`airgapped_extra_args` — so a grep of `flux.toml` for `airgapped_` is the
+complete audit trail of opened surfaces:
 
 | Key | Grants | Why it's safe to grant |
 |---|---|---|
 | `airgapped_gpus` | `--gpus all` / `"device=0"` | a compute device; no data path out |
 | `airgapped_mounts` | read-only bind mounts | an *input* channel — data can enter, results still leave only via the stdio protocol |
 | `airgapped_shm_size` | `/dev/shm` sizing | RAM allocation (large inter-process buffers); accounted next to `airgapped_memory` |
+| `airgapped_service_sockets` | UDS access to local sidecars | point-to-point to loopback-bound trusted infrastructure; no network stack, no lateral channel, no egress |
 
 `airgapped_mounts` entries are `"/host/path:/container/path"`. Read-only
 is **forced by the runner** regardless of what the entry says; `rw`,
@@ -81,6 +82,66 @@ privileges, host namespaces, and writable mounts cannot be enabled on this
 runner. Operators who need them switch to the plain `docker` runner —
 changing the runner *name*, and therefore the guarantee that dispatch and
 the dynamic-workflows server rely on.
+
+## Service sockets — warm runtimes for sealed executions
+
+A runtime whose startup is expensive (state loaded into memory over
+minutes) cannot live inside a single-use container. `airgapped_service_sockets`
+lets it live *outside* as a long-lived, operator-managed sidecar on the
+worker host, reached over a Unix domain socket — no network stack
+anywhere, point-to-point by construction:
+
+```toml
+[flux.workers]
+runners = ["docker-airgapped"]
+airgapped_service_sockets = { inference = "/run/flux-services/inference" }
+```
+
+Each value is a host directory containing the service's socket at
+`<dir>/service.sock`; it is bind-mounted into containers at
+`/run/flux/services/<name>`. The directory contract keeps the mount
+write-proof: mode `0555` (validated at worker startup; created if
+absent), sockets `0666`. The mount is `rw` — connecting to a UDS requires
+write permission on the socket inode — but `--cap-drop=ALL` strips
+`CAP_DAC_OVERRIDE`, so the write-less directory binds every container
+uid, root included: executions can connect, never create files. A
+missing socket at startup is only a warning (the sidecar may start
+later); a down sidecar surfaces to workflows as a normal connect error.
+
+Granted services are advertised as `flux.service.<name>` worker labels
+(the `flux.` label prefix is reserved — user labels can't spoof grants),
+so workflows target service-bearing workers with the existing affinity
+mechanism. In workflow code:
+
+```python
+from flux.tasks import service_client
+
+@task
+async def generate(prompt: str) -> dict:
+    async with service_client("inference") as client:   # httpx over UDS
+        response = await client.post("/v1/completions", json={"prompt": prompt})
+        return response.json()
+
+@workflow.with_options(
+    runner="docker-airgapped",
+    affinity={"flux.service.inference": "true"},
+)
+async def sealed_generate(ctx: ExecutionContext[str]):
+    return await generate(ctx.input)
+```
+
+Streaming is native HTTP over the socket (SSE/chunked responses work
+as-is; tee tokens into `progress()` for live visibility), and because
+service calls live inside ordinary tasks, replay short-circuits from the
+event log without re-contacting the sidecar.
+
+The honest tradeoff, documented deliberately: socket traffic is the one
+channel the worker does **not** mediate — no per-call allowlist, audit,
+or rate limit (the grant granularity is the service, and the sidecar
+enforces its own limits). The sidecar receives data, not code, from
+processes with no other capabilities; run it as its own hardened unit
+(dedicated user, no egress, GPU pinned) — it is trusted infrastructure,
+like a database. Sidecar recipes (llama-server, vLLM) are in DOCKER.md.
 
 ## Sizing for data- and compute-heavy workloads
 

--- a/docs/specs/2026-07-16-airgapped-service-sockets.md
+++ b/docs/specs/2026-07-16-airgapped-service-sockets.md
@@ -68,25 +68,31 @@ the *directory* is restart-safe — but a shared writable directory would
 be a dead-drop channel between untrusted executions. The contract closes
 that:
 
-- Host directory: `root:root`, mode `0555`. Socket: mode `0666`
-  (`service.sock`, and any additional sockets the operator places there).
+- Host directory: **no write bits** (`0555` or stricter). Socket: mode
+  `0666` (`service.sock`). Ownership is deliberately *not* part of the
+  enforced contract — the guarantee rests on mode bits alone, which is
+  what keeps non-root worker deployments and non-root sidecar recipes
+  viable.
 - The mount is emitted **rw** — connecting to a UDS requires write
   permission on the socket inode, and a read-only mount fails the
   connect with `EROFS`. This is a deliberate, structural exception to
   the "mounts are always read-only" rule (#133), confined to the
   service directories.
-- The `0555` directory is binding **even for container root**: the
+- The write-less directory is binding **even for container root**: the
   profile's `--cap-drop=ALL` removes `CAP_DAC_OVERRIDE`, which is what
   lets uid 0 ignore mode bits. Executions can connect to sockets; they
   cannot create, replace, or delete files in the directory. (Running
-  `--user` non-root remains recommended defense in depth.)
+  `--user` non-root remains recommended defense in depth. Host-side
+  root keeps the capability, so a root-managed sidecar can still
+  create/replace its socket across restarts.)
 
-The worker validates the contract at startup (fail fast, same
-philosophy as the docker probe): directory exists (created with the
-right owner/mode if absent and the worker has the privilege; otherwise
-error), owner is root, mode is `0555`, service-name validity, no
-duplicate directories. A missing *socket* is a warning, not an error —
-the sidecar may start after the worker.
+The worker validates at startup (fail fast, same philosophy as the
+docker probe): service-name validity, no duplicate directories, and the
+directory exists with no write bits — created if absent, with creation
+failures re-raised against the specific config entry. Socket problems
+are *warnings*, not errors, because the sidecar may start after the
+worker: missing socket, path that is not a unix socket, or a socket
+that is not world-connectable each log a pointed warning.
 
 ### Mount emission
 

--- a/docs/specs/2026-07-16-airgapped-service-sockets.md
+++ b/docs/specs/2026-07-16-airgapped-service-sockets.md
@@ -1,0 +1,245 @@
+# Spec: airgapped service sockets — warm runtimes for sealed executions
+
+**Date:** 2026-07-16 · **Status:** draft for review (follow-up to #130/#133)
+· **Motivating use case:** long-lived local runtimes whose state takes
+minutes to load, consumed from sealed, single-use executions.
+
+## Motivation
+
+A `docker-airgapped` execution container lives exactly as long as one
+execution. Any runtime whose startup is expensive — state loaded into
+(GPU) memory measured in minutes — pays that cost *per execution* if it
+runs inside the container. The state must outlive executions, so it must
+live outside the sandbox.
+
+The design that preserves every current guarantee: the runtime runs as a
+**long-lived, operator-managed sidecar** on the worker host, and sealed
+executions reach it over a **Unix domain socket** mounted into the
+container. No network stack is involved anywhere — `--network=none`
+stays literally true — and the wire is point-to-point by construction:
+no lateral channel between executions, no egress, nothing reachable
+from outside the host.
+
+With the heavy state out of the container, the sealed image goes back to
+being slim and the measured cold start is ~1–1.5 s per execution
+(container create ~0.2–0.5 s + `flux.runners.child` import ~0.6 s,
+measured; no GPU hook — the sidecar owns the device).
+
+### Alternatives considered
+
+- **Warm container pools** — rejected: at ~1 s cold start they buy back
+  sub-second docker overhead at the cost of pool lifecycle, idle-health,
+  and refill machinery. If a future latency-sensitive path cares, the
+  cheaper lever is trimming the child's import graph.
+- **Worker-brokered `service_call` frames** — deferred, complementary:
+  per-call allowlisting/audit/rate-limiting through the stdio protocol,
+  at the cost of a new frame family and double serialization. Sockets
+  win on protocol fidelity and latency; the broker can be layered on
+  later where auditability matters more.
+- **Internal docker networks** (shared or per-execution) — parked: a
+  shared net creates lateral channels between untrusted executions; a
+  per-execution net avoids that but reintroduces a network stack and
+  churn. Only needed for TCP-only runtimes; both major local runtimes
+  serve UDS natively (`llama-server --host <path>.sock`, vLLM `--uds`).
+- **Long-lived pod containers** (state inside a reused container) —
+  parked: executions sharing a container share its filesystem and
+  process state, which is a different guarantee and therefore a
+  different runner name, and a much larger protocol change
+  (exec-based dispatch).
+
+## Config
+
+```toml
+[flux.workers]
+runners = ["docker-airgapped"]
+airgapped_service_sockets = { inference = "/run/flux-services/inference" }
+```
+
+- Key = service name: `[a-z0-9]([a-z0-9-]*[a-z0-9])?`, ≤ 32 chars (it
+  becomes a worker label; see Dispatch).
+- Value = **host directory** that contains (or will contain) the
+  service's socket at `<dir>/service.sock`.
+
+### Why a directory, and the permission contract
+
+Mounting the socket *file* pins its inode: a sidecar restart re-creates
+the socket and running mounts silently point at the dead one. Mounting
+the *directory* is restart-safe — but a shared writable directory would
+be a dead-drop channel between untrusted executions. The contract closes
+that:
+
+- Host directory: `root:root`, mode `0555`. Socket: mode `0666`
+  (`service.sock`, and any additional sockets the operator places there).
+- The mount is emitted **rw** — connecting to a UDS requires write
+  permission on the socket inode, and a read-only mount fails the
+  connect with `EROFS`. This is a deliberate, structural exception to
+  the "mounts are always read-only" rule (#133), confined to the
+  service directories.
+- The `0555` directory is binding **even for container root**: the
+  profile's `--cap-drop=ALL` removes `CAP_DAC_OVERRIDE`, which is what
+  lets uid 0 ignore mode bits. Executions can connect to sockets; they
+  cannot create, replace, or delete files in the directory. (Running
+  `--user` non-root remains recommended defense in depth.)
+
+The worker validates the contract at startup (fail fast, same
+philosophy as the docker probe): directory exists (created with the
+right owner/mode if absent and the worker has the privilege; otherwise
+error), owner is root, mode is `0555`, service-name validity, no
+duplicate directories. A missing *socket* is a warning, not an error —
+the sidecar may start after the worker.
+
+### Mount emission
+
+`AirgappedDockerRunner._locked_args()` emits, per service:
+
+```
+--mount type=bind,source=/run/flux-services/inference,target=/run/flux/services/inference
+```
+
+Fixed in-container prefix `/run/flux/services/<name>`. The raw mount
+flags stay vetoed in `airgapped_extra_args` — the named key is the only
+grant path, so `flux.toml` remains the complete audit trail.
+
+### Knob vs. new runner name — decision for review
+
+"No network" stays literally true and the grant is enumerable config —
+knob-shaped. But "every effect passes through the permission-checked
+worker" stops being strictly true — name-shaped. **Recommendation:**
+ship as a knob on `docker-airgapped`, advertise granted services in the
+worker registration (labels below), and revisit a distinct
+`docker-enclave` name only if a mediated/unmediated distinction ever
+needs to be dispatch-visible on its own. Flagged here because it is a
+judgment call about what the runner name promises.
+
+## Dispatch
+
+Workers derive one label per granted service at registration:
+`flux.service.<name> = "true"`. Workflows that need a service target it
+with the existing affinity mechanism — no new matching machinery:
+
+```python
+@workflow.with_options(
+    runner="docker-airgapped",
+    affinity={"flux.service.inference": "true"},
+)
+async def sealed_generate(ctx: ExecutionContext[str]): ...
+```
+
+The `flux.` label prefix is already reserved (worker metrics, #120), so
+user labels cannot spoof service grants. Dynamic workflows can have
+service affinities stamped from declared needs later; v1 leaves that to
+the author's `with_options`.
+
+## Child-side surface
+
+The runner passes the mounted map to the child through its sanitized
+env (parent-set): `FLUX_SERVICE_SOCKETS={"inference":
+"/run/flux/services/inference/service.sock"}`.
+
+New helpers in `flux/tasks` (usable in any runner — inline and
+subprocess executions simply see no services unless the env is set):
+
+```python
+from flux.tasks import service_client, service_socket
+
+@task
+async def generate(prompt: str) -> str:
+    async with service_client("inference") as client:      # httpx over UDS
+        r = await client.post("/v1/completions", json={"prompt": prompt, ...})
+        return r.json()["choices"][0]["text"]
+```
+
+- `service_socket(name) -> str` — the socket path; raises a clear
+  `ExecutionError` naming the service and the affinity hint when absent.
+- `service_client(name, **httpx_kwargs) -> httpx.AsyncClient` —
+  preconfigured UDS transport, base_url `http://flux-service` (host is
+  ignored over UDS). OpenAI-compatible SDKs work by passing this client
+  as their http client.
+
+Semantics that come free from existing machinery:
+
+- **Replay:** service calls happen inside ordinary tasks; outputs are
+  checkpointed, resume short-circuits, the sidecar is never
+  re-contacted for completed calls.
+- **Failures:** a down sidecar is `ECONNREFUSED` → a normal task error →
+  retry/fallback/rollback chain.
+- **Streaming:** native HTTP/SSE over the socket (no frames, kernel
+  flow control); workflow code tees tokens into `progress()` for live
+  visibility, exactly as the agent loop does.
+- **Cancellation/timeouts:** SIGTERM into the container ends client
+  connections; the execution ceiling bounds total time.
+
+## Security analysis (delta from today)
+
+| Property | Today | With service sockets |
+|---|---|---|
+| Network stack | none | none |
+| Lateral channel between executions | none | none direct; the sidecar is the only shared point |
+| Egress | impossible | impossible (sidecar is UDS-bound, no egress of its own) |
+| Worker mediates every effect | yes | **no** — socket traffic bypasses the broker |
+
+Documented operator caveats:
+
+- **Unmediated channel:** no per-call allowlist/audit/rate-limit; the
+  worker never sees payloads (an observability loss and a privacy
+  gain). The grant granularity is the service, not the request.
+- **Sidecar-side DoS:** nothing throttles an execution hammering the
+  socket except the sidecar's own limits and the container's cpu/pids
+  caps.
+- **Shared-runtime state:** all executions multiplex into one runtime;
+  cross-request state (caches) is a potential side channel — identical
+  exposure to a brokered design, noted for completeness.
+- The sidecar receives **data, not code**, from processes with no other
+  capabilities.
+
+## Sidecar recipes (docs)
+
+DOCKER.md gains a section with systemd/compose examples:
+
+```bash
+llama-server -m model.gguf --host /run/flux-services/inference/service.sock
+# or
+vllm serve <model> --uds /run/flux-services/inference/service.sock
+```
+
+plus the permission contract, and the note that the sidecar should be
+its own hardened unit (no egress, dedicated user, GPU pinned) — it is
+trusted infrastructure, like a database.
+
+## Wiring
+
+- `flux/config.py` — `airgapped_service_sockets: dict[str, str]`.
+- `flux/runners/docker.py` — validation (names, directory contract) +
+  `_locked_args()` emission + child-env injection.
+- `flux/worker.py` / registration — derive `flux.service.*` labels.
+- `flux/tasks/service_socket.py` — `service_socket` / `service_client`;
+  exported from `flux.tasks`.
+- Docs: `docs/advanced-features/airgapped-execution.md` section +
+  DOCKER.md recipes; example in `examples/airgapped.py` with graceful
+  inline fallback.
+
+No server or protocol changes.
+
+## Testing
+
+- Name validation (shape, length, duplicates) and directory-contract
+  validation (missing dir, wrong owner/mode) fail worker startup with
+  pointed messages; missing socket only warns.
+- `_locked_args()` emits one rw `--mount` per service at the fixed
+  in-container prefix; nothing emitted when the map is empty; raw mount
+  flags in `extra_args` still rejected.
+- Registration carries `flux.service.<name>` labels; user labels under
+  `flux.` are still rejected/stripped.
+- `service_socket`/`service_client`: env parsing; absent-service error
+  names the affinity hint; round-trip against a real UDS server
+  (asyncio `start_unix_server` / uvicorn UDS fixture), including a
+  streamed response.
+- Example test: inline run with graceful fallback when no service env.
+
+## Rollout / compatibility
+
+Additive: empty map (default) changes nothing. Version: 0.61.0.
+Future work, explicitly out of scope: worker-managed sidecar lifecycle
+(command/restart/health in `flux.toml`), brokered `service_call` frames
+for audited access, per-execution internal networks for TCP-only
+runtimes.

--- a/examples/airgapped.py
+++ b/examples/airgapped.py
@@ -124,6 +124,43 @@ async def sealed_redact(ctx: ExecutionContext[str]):
     return await redact(ctx.input)
 
 
+@task
+async def classify(text: str) -> dict:
+    """Call a warm local service over its Unix socket, if granted.
+
+    Workers grant long-lived sidecars to sealed executions via
+    ``[flux.workers] airgapped_service_sockets`` — the runtime loads its
+    state once at startup and every execution reaches it point-to-point,
+    with no network stack anywhere. When the grant is absent (or running
+    inline), fall back to a local heuristic so the workflow stays
+    functional everywhere.
+    """
+    from flux.errors import ExecutionError
+    from flux.tasks import service_client
+
+    try:
+        async with service_client("classifier") as client:
+            response = await client.post("/classify", json={"text": text})
+            response.raise_for_status()
+            return {"label": response.json()["label"], "via": "service"}
+    except ExecutionError:
+        # Service not granted here — degrade to the built-in heuristic.
+        label = "question" if text.rstrip().endswith("?") else "statement"
+        return {"label": label, "via": "fallback"}
+
+
+@workflow.with_options(
+    runner="docker-airgapped",
+    affinity={"flux.service.classifier": "true"},
+)
+async def sealed_classify(ctx: ExecutionContext[str]):
+    """Warm-sidecar consumption: the affinity routes this workflow to
+    workers that advertise the ``classifier`` service socket."""
+    if not ctx.input:
+        raise TypeError("Input not provided")
+    return await classify(ctx.input)
+
+
 if __name__ == "__main__":  # pragma: no cover
     ctx = sealed_keyword_count.run("the quick brown fox jumps over the lazy dog")
     print(ctx.to_json())

--- a/flux/config.py
+++ b/flux/config.py
@@ -223,6 +223,18 @@ class WorkersConfig(BaseConfig):
             "against airgapped_memory"
         ),
     )
+    airgapped_service_sockets: dict[str, str] = Field(
+        default={},
+        description=(
+            "Service name -> host directory containing that service's Unix "
+            "socket at <dir>/service.sock. Each directory is bind-mounted "
+            "into airgapped containers at /run/flux/services/<name> so "
+            "sealed executions can reach long-lived local sidecars (warm "
+            "runtimes) with no network stack. Directory must carry no "
+            "write bits (0555); granted services are advertised as "
+            "flux.service.<name> worker labels"
+        ),
+    )
     airgapped_extra_args: list[str] = Field(
         default=[],
         description=(

--- a/flux/runners/__init__.py
+++ b/flux/runners/__init__.py
@@ -74,6 +74,7 @@ def create_runners(names: list[str], config) -> dict[str, Runner]:
                 gpus=config.airgapped_gpus,
                 mounts=list(config.airgapped_mounts),
                 shm_size=config.airgapped_shm_size,
+                service_sockets=dict(config.airgapped_service_sockets),
             )
         else:
             raise ValueError(

--- a/flux/runners/docker.py
+++ b/flux/runners/docker.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import os
+import re
 import shutil
 import subprocess
 from typing import TYPE_CHECKING
@@ -194,6 +196,81 @@ _AIRGAPPED_VETOED_FLAGS = frozenset(
 )
 
 
+_SERVICE_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
+SERVICE_SOCKET_FILENAME = "service.sock"
+SERVICE_MOUNT_PREFIX = "/run/flux/services"
+
+
+def _validate_service_sockets(services: dict[str, str]) -> dict[str, str]:
+    """Validate the ``airgapped_service_sockets`` map (name -> host dir).
+
+    The directory contract: mode ``0555`` (no write bits at all), socket
+    ``service.sock`` inside at ``0666``. The mount must be rw — connecting
+    to a UDS requires write permission on the socket inode — but the
+    profile's ``--cap-drop=ALL`` strips ``CAP_DAC_OVERRIDE``, so the
+    write-less directory mode binds every container uid, root included:
+    executions can connect to the sockets, never create files (no
+    dead-drop between executions). Host-side root (the sidecar or its unit
+    manager) keeps ``CAP_DAC_OVERRIDE`` and can still create or replace
+    the socket across restarts.
+    """
+    validated: dict[str, str] = {}
+    seen_dirs: set[str] = set()
+    for name, host_dir in services.items():
+        if len(name) > 32 or not _SERVICE_NAME_RE.match(name):
+            raise ValueError(
+                f"[flux.workers] airgapped_service_sockets name '{name}' is "
+                "invalid: use lowercase letters, digits, and single hyphens "
+                "(max 32 chars) — it becomes the worker label "
+                f"'flux.service.{name}'",
+            )
+        if not os.path.isabs(host_dir):
+            raise ValueError(
+                f"[flux.workers] airgapped_service_sockets['{name}']: host "
+                f"directory '{host_dir}' must be an absolute path",
+            )
+        if "," in host_dir:
+            # --mount options are comma-separated; a comma in the path
+            # would silently change the mount spec.
+            raise ValueError(
+                f"[flux.workers] airgapped_service_sockets['{name}']: host "
+                "directory must not contain commas",
+            )
+        host_dir = os.path.normpath(host_dir)
+        if host_dir in seen_dirs:
+            raise ValueError(
+                f"[flux.workers] airgapped_service_sockets['{name}']: host "
+                f"directory '{host_dir}' is already used by another service",
+            )
+        if not os.path.exists(host_dir):
+            os.makedirs(host_dir)
+            os.chmod(host_dir, 0o555)
+        elif not os.path.isdir(host_dir):
+            raise ValueError(
+                f"[flux.workers] airgapped_service_sockets['{name}']: "
+                f"'{host_dir}' exists but is not a directory",
+            )
+        else:
+            mode = os.stat(host_dir).st_mode & 0o777
+            if mode & 0o222:
+                raise ValueError(
+                    f"[flux.workers] airgapped_service_sockets['{name}']: "
+                    f"'{host_dir}' has mode {mode:o}; the directory must "
+                    "carry no write bits (chmod 0555) so sealed executions "
+                    "cannot use it as a shared writable surface",
+                )
+        socket_path = os.path.join(host_dir, SERVICE_SOCKET_FILENAME)
+        if not os.path.exists(socket_path):
+            logger.warning(
+                f"Service '{name}': no socket at {socket_path} yet — the "
+                "sidecar may not be running; executions using this service "
+                "will fail to connect until it is",
+            )
+        seen_dirs.add(host_dir)
+        validated[name] = host_dir
+    return validated
+
+
 def _parse_airgapped_mounts(mounts: list[str]) -> list[tuple[str, str]]:
     """Validate ``airgapped_mounts`` entries into (source, target) pairs.
 
@@ -267,14 +344,18 @@ class AirgappedDockerRunner(DockerRunner):
     ``extra_args``, so configuration cannot weaken it; ``extra_args`` that
     would re-open a closed surface are rejected at worker startup.
 
-    Three capabilities are grantable — each only through its named config
-    key, never through ``extra_args``, so the config file is the audit
-    trail: ``airgapped_gpus`` (compute device, no data path out),
+    Capabilities are grantable — each only through its named config key,
+    never through ``extra_args``, so the config file is the audit trail:
+    ``airgapped_gpus`` (compute device, no data path out),
     ``airgapped_mounts`` (bind mounts with read-only forced by the runner —
-    an input channel for reference data and static assets), and
+    an input channel for reference data and static assets),
     ``airgapped_shm_size`` (``/dev/shm`` sizing for workloads that pass
-    large buffers between processes). None of them opens an output channel:
-    results still leave only through the worker-mediated stdio protocol.
+    large buffers between processes), and ``airgapped_service_sockets``
+    (Unix-socket access to long-lived, operator-managed sidecars on the
+    worker host — warm runtimes consumed point-to-point, with no network
+    stack anywhere; see ``_validate_service_sockets`` for the directory
+    contract). Socket traffic is the one channel the worker does not
+    mediate; everything else still leaves only through the stdio protocol.
     """
 
     name = "docker-airgapped"
@@ -292,6 +373,7 @@ class AirgappedDockerRunner(DockerRunner):
         gpus: str = "",
         mounts: list[str] | None = None,
         shm_size: str = "",
+        service_sockets: dict[str, str] | None = None,
     ):
         if not memory:
             raise ValueError(
@@ -320,6 +402,7 @@ class AirgappedDockerRunner(DockerRunner):
         self._mounts = _parse_airgapped_mounts(list(mounts or []))
         self._gpus = gpus
         self._shm_size = shm_size
+        self._service_sockets = _validate_service_sockets(dict(service_sockets or {}))
         super().__init__(
             image=image,
             term_grace=term_grace,
@@ -335,6 +418,11 @@ class AirgappedDockerRunner(DockerRunner):
         self._airgapped_cpus = cpus
         self._pids_limit = pids_limit
         self._tmp_size = tmp_size
+
+    @property
+    def service_names(self) -> list[str]:
+        """Granted service-socket names; advertised as worker labels."""
+        return sorted(self._service_sockets)
 
     def _locked_args(self) -> list[str]:
         args = [
@@ -360,4 +448,24 @@ class AirgappedDockerRunner(DockerRunner):
             args += ["--gpus", self._gpus]
         if self._shm_size:
             args += ["--shm-size", self._shm_size]
+        # Service sockets: the one deliberately-rw mount family (UDS connect
+        # needs write on the socket inode); the 0555 directory contract plus
+        # --cap-drop=ALL keeps it write-proof for every container uid. The
+        # env var is emitted here, after extra_args, so docker's last-wins
+        # parsing keeps the advertised map authoritative.
+        for name in sorted(self._service_sockets):
+            args += [
+                "--mount",
+                f"type=bind,source={self._service_sockets[name]},"
+                f"target={SERVICE_MOUNT_PREFIX}/{name}",
+            ]
+        if self._service_sockets:
+            socket_map = {
+                name: f"{SERVICE_MOUNT_PREFIX}/{name}/{SERVICE_SOCKET_FILENAME}"
+                for name in self._service_sockets
+            }
+            args += [
+                "--env",
+                f"FLUX_SERVICE_SOCKETS={json.dumps(socket_map, sort_keys=True, separators=(',', ':'))}",
+            ]
         return args

--- a/flux/runners/docker.py
+++ b/flux/runners/docker.py
@@ -24,6 +24,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import subprocess
 from typing import TYPE_CHECKING
 from uuid import uuid4
@@ -217,7 +218,7 @@ def _validate_service_sockets(services: dict[str, str]) -> dict[str, str]:
     validated: dict[str, str] = {}
     seen_dirs: set[str] = set()
     for name, host_dir in services.items():
-        if len(name) > 32 or not _SERVICE_NAME_RE.match(name):
+        if len(name) > 32 or "--" in name or not _SERVICE_NAME_RE.match(name):
             raise ValueError(
                 f"[flux.workers] airgapped_service_sockets name '{name}' is "
                 "invalid: use lowercase letters, digits, and single hyphens "
@@ -243,8 +244,15 @@ def _validate_service_sockets(services: dict[str, str]) -> dict[str, str]:
                 f"directory '{host_dir}' is already used by another service",
             )
         if not os.path.exists(host_dir):
-            os.makedirs(host_dir)
-            os.chmod(host_dir, 0o555)
+            try:
+                os.makedirs(host_dir)
+                os.chmod(host_dir, 0o555)
+            except OSError as e:
+                raise ValueError(
+                    f"[flux.workers] airgapped_service_sockets['{name}']: "
+                    f"could not create '{host_dir}' ({e}); create it "
+                    "manually with mode 0555",
+                ) from e
         elif not os.path.isdir(host_dir):
             raise ValueError(
                 f"[flux.workers] airgapped_service_sockets['{name}']: "
@@ -266,6 +274,21 @@ def _validate_service_sockets(services: dict[str, str]) -> dict[str, str]:
                 "sidecar may not be running; executions using this service "
                 "will fail to connect until it is",
             )
+        else:
+            socket_stat = os.stat(socket_path)
+            if not stat.S_ISSOCK(socket_stat.st_mode):
+                logger.warning(
+                    f"Service '{name}': {socket_path} exists but is not a "
+                    "unix socket; executions will fail to connect to it",
+                )
+            elif socket_stat.st_mode & 0o002 == 0:
+                logger.warning(
+                    f"Service '{name}': {socket_path} is not "
+                    "world-connectable (mode "
+                    f"{socket_stat.st_mode & 0o777:o}, expected 0666); "
+                    "container uids without write permission on the socket "
+                    "will fail to connect",
+                )
         seen_dirs.add(host_dir)
         validated[name] = host_dir
     return validated

--- a/flux/tasks/__init__.py
+++ b/flux/tasks/__init__.py
@@ -5,3 +5,4 @@ from flux.tasks.call import call
 from flux.tasks.graph import Graph
 from flux.tasks.progress import progress
 from flux.tasks.dynamic import create_workflow, run_workflow
+from flux.tasks.service_socket import service_client, service_socket

--- a/flux/tasks/service_socket.py
+++ b/flux/tasks/service_socket.py
@@ -1,0 +1,76 @@
+"""Client-side access to worker-granted service sockets.
+
+Airgapped workers can grant sealed executions access to long-lived local
+sidecars (warm runtimes) over Unix domain sockets — see
+``[flux.workers] airgapped_service_sockets``. The runner mounts each
+service's socket directory into the container and publishes the map in
+the ``FLUX_SERVICE_SOCKETS`` environment variable; these helpers are the
+workflow-facing surface.
+
+Calls made through :func:`service_client` should live inside ordinary
+``@task`` functions: outputs are then checkpointed, replay short-circuits
+without re-contacting the sidecar, and a down sidecar surfaces as a
+normal task error (retry/fallback/rollback apply).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import httpx
+
+from flux.errors import ExecutionError
+
+SERVICE_SOCKETS_ENV = "FLUX_SERVICE_SOCKETS"
+
+
+def _available_services() -> dict[str, str]:
+    raw = os.environ.get(SERVICE_SOCKETS_ENV, "")
+    if not raw:
+        return {}
+    try:
+        services = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(services, dict):
+        return {}
+    return {str(name): str(path) for name, path in services.items()}
+
+
+def service_socket(name: str) -> str:
+    """Return the Unix-socket path for a granted service.
+
+    Raises ExecutionError when the service is not available in this
+    execution — either the worker does not grant it, or the workflow was
+    not routed to a worker that does (target them with
+    ``affinity={"flux.service.<name>": "true"}``).
+    """
+    services = _available_services()
+    if name not in services:
+        available = ", ".join(sorted(services)) or "none"
+        raise ExecutionError(
+            message=(
+                f"Service '{name}' is not available in this execution "
+                f"(available: {available}). Grant it on the worker via "
+                f"[flux.workers] airgapped_service_sockets and route to "
+                f"service-bearing workers with "
+                f"affinity={{'flux.service.{name}': 'true'}}."
+            ),
+        )
+    return services[name]
+
+
+def service_client(name: str, **client_kwargs: Any) -> httpx.AsyncClient:
+    """An ``httpx.AsyncClient`` speaking HTTP over the service's socket.
+
+    The host in request URLs is ignored over a UDS transport; a stable
+    placeholder base_url is set so plain paths work. Extra keyword
+    arguments (timeout, headers, ...) pass through to the client. Works
+    with OpenAI-compatible SDKs by handing them this client as their
+    http client.
+    """
+    transport = httpx.AsyncHTTPTransport(uds=service_socket(name))
+    client_kwargs.setdefault("base_url", "http://flux-service")
+    return httpx.AsyncClient(transport=transport, **client_kwargs)

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -129,7 +129,21 @@ class Worker:
         self._progress_queues: dict[str, asyncio.Queue] = {}
         self._progress_flushers: dict[str, asyncio.Task | None] = {}
         self._reconnect_max_delay = config.reconnect_max_delay
+        # The flux. label prefix is reserved for platform-derived labels so
+        # user labels cannot spoof capability grants (service sockets below).
+        reserved = sorted(k for k in self.labels if k.startswith("flux."))
+        if reserved:
+            raise ValueError(
+                f"Worker labels {reserved} use the reserved 'flux.' prefix; "
+                "these labels are derived from worker configuration and "
+                "cannot be set directly",
+            )
         self._runners = create_runners(list(config.runners), config)
+        airgapped = self._runners.get("docker-airgapped")
+        for service_name in getattr(airgapped, "service_names", []):
+            # Advertised so workflows can target service-bearing workers via
+            # the existing affinity mechanism.
+            self.labels[f"flux.service.{service_name}"] = "true"
         self._default_runner = config.default_runner
         if self._default_runner not in self._runners:
             raise ValueError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.60.0"
+version = "0.61.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/e2e/fixtures/service_socket_workflow.py
+++ b/tests/e2e/fixtures/service_socket_workflow.py
@@ -1,0 +1,38 @@
+"""Fixture workflows for the service-socket e2e tests.
+
+``service_roundtrip`` is affinity-pinned to workers advertising the plain
+``svc=echo`` label (the e2e harness injects ``FLUX_SERVICE_SOCKETS`` into
+that worker's environment; the subprocess child inherits it through the
+sanitized-env passthrough, exactly as an airgapped child receives it from
+the runner's ``--env``).
+"""
+
+from __future__ import annotations
+
+from flux import ExecutionContext
+from flux.task import task
+from flux.tasks import service_client, service_socket
+from flux.workflow import workflow
+
+
+@task
+async def call_echo_service() -> dict:
+    async with service_client("echo") as client:
+        response = await client.get("/classify")
+        response.raise_for_status()
+        return response.json()
+
+
+@workflow.with_options(affinity={"svc": "echo"})
+async def service_roundtrip(ctx: ExecutionContext):
+    return await call_echo_service()
+
+
+@task
+async def resolve_missing_service() -> str:
+    return service_socket("not-granted-anywhere")
+
+
+@workflow
+async def service_missing(ctx: ExecutionContext):
+    return await resolve_missing_service()

--- a/tests/e2e/test_service_sockets.py
+++ b/tests/e2e/test_service_sockets.py
@@ -1,0 +1,141 @@
+"""E2E tests for service sockets: the full server -> dispatch -> worker ->
+subprocess child -> UDS sidecar path.
+
+A real HTTP-over-UDS sidecar runs in a background thread; the worker
+process carries ``FLUX_SERVICE_SOCKETS`` in its environment, the
+subprocess child inherits it through the sanitized-env passthrough (the
+same variable an airgapped container receives via the runner's ``--env``),
+and the workflow's ``service_client`` call crosses the socket for real.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+FIXTURES = Path(__file__).parent / "fixtures"
+PROJECT_ROOT = Path(__file__).parents[2]
+
+pytestmark = pytest.mark.e2e
+
+
+class _UdsSidecar:
+    """Minimal HTTP/1.1 sidecar on a Unix socket, run in its own thread."""
+
+    def __init__(self, body: bytes):
+        # Keep the socket path short: UDS paths are capped near 108 chars
+        # and pytest tmp factories produce long ones.
+        self._dir = tempfile.mkdtemp(prefix="flux-svc-")
+        self.socket_path = str(Path(self._dir) / "service.sock")
+        self._body = body
+        self._ready = threading.Event()
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self.requests_served = 0
+
+    def _run(self):
+        async def main():
+            async def handle(reader, writer):
+                while True:
+                    line = await reader.readline()
+                    if not line or line == b"\r\n":
+                        break
+                self.requests_served += 1
+                writer.write(
+                    b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n"
+                    b"content-length: " + str(len(self._body)).encode() + b"\r\n\r\n" + self._body,
+                )
+                await writer.drain()
+                writer.close()
+
+            server = await asyncio.start_unix_server(handle, path=self.socket_path)
+            self._ready.set()
+            while not self._stop.is_set():
+                await asyncio.sleep(0.1)
+            server.close()
+            await server.wait_closed()
+
+        asyncio.run(main())
+
+    def __enter__(self):
+        self._thread.start()
+        assert self._ready.wait(timeout=10), "UDS sidecar failed to start"
+        return self
+
+    def __exit__(self, *exc):
+        self._stop.set()
+        self._thread.join(timeout=10)
+
+
+def test_service_call_roundtrip_through_dispatch(cli):
+    """A dispatched execution reaches a warm sidecar over its socket and
+    the response comes back through the normal checkpoint path."""
+    with _UdsSidecar(b'{"label": "sealed-ok"}') as sidecar:
+        worker = cli.start_worker(
+            "svc-echo-worker",
+            labels={"svc": "echo"},
+            env={"FLUX_SERVICE_SOCKETS": json.dumps({"echo": sidecar.socket_path})},
+        )
+        try:
+            cli.register(str(FIXTURES / "service_socket_workflow.py"))
+            r = cli.run("service_roundtrip", "null", timeout=60)
+            assert r["state"] == "COMPLETED"
+            assert r.get("current_worker") == "svc-echo-worker"
+            assert r["output"] == {"label": "sealed-ok"}
+            assert sidecar.requests_served >= 1
+        finally:
+            cli.stop_worker(worker)
+
+
+def test_missing_service_fails_with_a_pointer(cli):
+    """An ungranted service is a normal task failure whose message names
+    the config key and the affinity hint."""
+    cli.register(str(FIXTURES / "service_socket_workflow.py"))
+    r = cli.run("service_missing", "null", timeout=60)
+    assert r["state"] == "FAILED"
+    output = str(r.get("output"))
+    assert "airgapped_service_sockets" in output
+    assert "flux.service.not-granted-anywhere" in output
+
+
+def test_reserved_flux_label_rejected_at_worker_startup(cli):
+    """User labels under the reserved flux. prefix must fail worker
+    startup — they would spoof service-capability grants."""
+    proc = subprocess.Popen(
+        [
+            "poetry",
+            "run",
+            "flux",
+            "start",
+            "worker",
+            "spoofing-worker",
+            "--server-url",
+            cli.server_url,
+            "--label",
+            "flux.service.fake=true",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        cwd=PROJECT_ROOT,
+        env=dict(cli._env),
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + 45
+        while proc.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.5)
+        assert proc.poll() is not None, "worker with reserved label should exit"
+        assert proc.returncode != 0
+        stderr = proc.stderr.read() if proc.stderr else ""
+        assert "reserved 'flux.' prefix" in stderr
+        assert all(w["name"] != "spoofing-worker" for w in cli.worker_list())
+    finally:
+        if proc.poll() is None:
+            proc.kill()

--- a/tests/examples/test_airgapped.py
+++ b/tests/examples/test_airgapped.py
@@ -38,6 +38,18 @@ def test_sealed_redact_clean_text_untouched():
     assert ctx.output == {"text": "Nothing sensitive here.", "redactions": 0}
 
 
+def test_sealed_classify_falls_back_without_the_service():
+    from examples.airgapped import sealed_classify
+
+    ctx = sealed_classify.run("Is this sealed?")
+    assert ctx.has_finished and ctx.has_succeeded
+    assert ctx.output == {"label": "question", "via": "fallback"}
+
+
 def test_examples_declare_the_sealed_runner():
+    from examples.airgapped import sealed_classify
+
     assert sealed_keyword_count.runner == "docker-airgapped"
     assert sealed_redact.runner == "docker-airgapped"
+    assert sealed_classify.runner == "docker-airgapped"
+    assert sealed_classify.affinity == {"flux.service.classifier": "true"}

--- a/tests/flux/tasks/test_service_socket.py
+++ b/tests/flux/tasks/test_service_socket.py
@@ -1,0 +1,119 @@
+"""Tests for the service-socket client helpers.
+
+The round-trip tests run a real HTTP server on a Unix domain socket
+(asyncio.start_unix_server with hand-rolled responses) — the same wire a
+sealed execution sees, minus the container.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from flux.errors import ExecutionError
+from flux.tasks import service_client, service_socket
+from flux.tasks.service_socket import SERVICE_SOCKETS_ENV
+
+
+def _set_services(monkeypatch, services: dict[str, str]) -> None:
+    monkeypatch.setenv(SERVICE_SOCKETS_ENV, json.dumps(services))
+
+
+class TestServiceSocket:
+    def test_returns_granted_path(self, monkeypatch):
+        _set_services(monkeypatch, {"inference": "/run/flux/services/inference/service.sock"})
+        assert service_socket("inference") == "/run/flux/services/inference/service.sock"
+
+    def test_missing_service_names_the_fix(self, monkeypatch):
+        _set_services(monkeypatch, {"other": "/run/flux/services/other/service.sock"})
+        with pytest.raises(ExecutionError) as excinfo:
+            service_socket("inference")
+        message = str(excinfo.value)
+        assert "available: other" in message
+        assert "airgapped_service_sockets" in message
+        assert "flux.service.inference" in message
+
+    def test_no_env_means_no_services(self, monkeypatch):
+        monkeypatch.delenv(SERVICE_SOCKETS_ENV, raising=False)
+        with pytest.raises(ExecutionError, match="available: none"):
+            service_socket("inference")
+
+    def test_malformed_env_treated_as_empty(self, monkeypatch):
+        monkeypatch.setenv(SERVICE_SOCKETS_ENV, "not-json")
+        with pytest.raises(ExecutionError, match="available: none"):
+            service_socket("inference")
+
+
+async def _serve_http_over_uds(socket_path: str, body: bytes, *, chunked: bool = False):
+    """Minimal HTTP/1.1 server on a UDS; enough for httpx round-trips."""
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        while True:
+            line = await reader.readline()
+            if not line or line == b"\r\n":
+                break
+        if chunked:
+            writer.write(
+                b"HTTP/1.1 200 OK\r\ncontent-type: text/plain\r\n"
+                b"transfer-encoding: chunked\r\n\r\n",
+            )
+            for piece in (body[: len(body) // 2], body[len(body) // 2 :]):
+                writer.write(f"{len(piece):x}\r\n".encode() + piece + b"\r\n")
+                await writer.drain()
+            writer.write(b"0\r\n\r\n")
+        else:
+            writer.write(
+                b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n"
+                b"content-length: " + str(len(body)).encode() + b"\r\n\r\n" + body,
+            )
+        await writer.drain()
+        writer.close()
+
+    return await asyncio.start_unix_server(handle, path=socket_path)
+
+
+class TestServiceClient:
+    async def test_round_trip_over_uds(self, monkeypatch, tmp_path):
+        socket_path = str(tmp_path / "service.sock")
+        server = await _serve_http_over_uds(socket_path, b'{"ok": true}')
+        _set_services(monkeypatch, {"echo": socket_path})
+        try:
+            async with service_client("echo") as client:
+                response = await client.get("/health")
+            assert response.status_code == 200
+            assert response.json() == {"ok": True}
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    async def test_streamed_response_over_uds(self, monkeypatch, tmp_path):
+        socket_path = str(tmp_path / "service.sock")
+        server = await _serve_http_over_uds(socket_path, b"hello sealed world", chunked=True)
+        _set_services(monkeypatch, {"echo": socket_path})
+        try:
+            chunks: list[bytes] = []
+            async with service_client("echo") as client:
+                async with client.stream("GET", "/generate") as response:
+                    async for chunk in response.aiter_bytes():
+                        chunks.append(chunk)
+            assert b"".join(chunks) == b"hello sealed world"
+            assert len(chunks) >= 2  # arrived as a stream, not one buffer
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    async def test_down_sidecar_is_a_connect_error(self, monkeypatch, tmp_path):
+        import httpx
+
+        _set_services(monkeypatch, {"echo": str(tmp_path / "absent.sock")})
+        async with service_client("echo") as client:
+            with pytest.raises(httpx.ConnectError):
+                await client.get("/health")
+
+    def test_client_kwargs_pass_through(self, monkeypatch, tmp_path):
+        _set_services(monkeypatch, {"echo": str(tmp_path / "service.sock")})
+        client = service_client("echo", timeout=42.0, base_url="http://custom")
+        assert client.timeout.read == 42.0
+        assert str(client.base_url) == "http://custom"

--- a/tests/flux/tasks/test_service_socket.py
+++ b/tests/flux/tasks/test_service_socket.py
@@ -112,8 +112,8 @@ class TestServiceClient:
             with pytest.raises(httpx.ConnectError):
                 await client.get("/health")
 
-    def test_client_kwargs_pass_through(self, monkeypatch, tmp_path):
+    async def test_client_kwargs_pass_through(self, monkeypatch, tmp_path):
         _set_services(monkeypatch, {"echo": str(tmp_path / "service.sock")})
-        client = service_client("echo", timeout=42.0, base_url="http://custom")
-        assert client.timeout.read == 42.0
-        assert str(client.base_url) == "http://custom"
+        async with service_client("echo", timeout=42.0, base_url="http://custom") as client:
+            assert client.timeout.read == 42.0
+            assert str(client.base_url) == "http://custom"

--- a/tests/flux/test_airgapped_runner.py
+++ b/tests/flux/test_airgapped_runner.py
@@ -215,6 +215,107 @@ class TestCapabilityKnobs:
         assert env_at < command.index("--mount")
 
 
+class TestServiceSockets:
+    """Named UDS grants: directory contract, mount + env emission, labels."""
+
+    @staticmethod
+    def _service_dir(tmp_path, name="inference", with_socket=False, mode=0o555):
+        service_dir = tmp_path / name
+        service_dir.mkdir()
+        if with_socket:
+            import socket as socket_mod
+
+            sock = socket_mod.socket(socket_mod.AF_UNIX, socket_mod.SOCK_STREAM)
+            sock.bind(str(service_dir / "service.sock"))
+            sock.close()
+        service_dir.chmod(mode)
+        return service_dir
+
+    def test_mount_and_env_emitted(self, tmp_path):
+        service_dir = self._service_dir(tmp_path)
+        runner = make_runner(service_sockets={"inference": str(service_dir)})
+        joined = " ".join(runner._build_command("c"))
+        assert (
+            f"--mount type=bind,source={service_dir},target=/run/flux/services/inference" in joined
+        )
+        assert (
+            '--env FLUX_SERVICE_SOCKETS={"inference":"/run/flux/services/inference/service.sock"}'
+            in joined
+        )
+
+    def test_service_mount_is_rw_not_readonly(self, tmp_path):
+        """UDS connect requires write on the socket inode; the 0555 dir plus
+        cap-drop ALL is what keeps the mount write-proof, not the ro flag."""
+        service_dir = self._service_dir(tmp_path)
+        runner = make_runner(service_sockets={"inference": str(service_dir)})
+        command = runner._build_command("c")
+        service_mounts = [a for a in command if "flux/services" in a]
+        assert service_mounts and all("readonly" not in a for a in service_mounts)
+
+    def test_nothing_emitted_without_grants(self):
+        command = make_runner()._build_command("c")
+        assert "FLUX_SERVICE_SOCKETS" not in " ".join(command)
+
+    def test_missing_directory_created_write_less(self, tmp_path):
+        target = tmp_path / "fresh"
+        make_runner(service_sockets={"svc": str(target)})
+        assert target.is_dir()
+        assert (target.stat().st_mode & 0o777) == 0o555
+
+    def test_writable_directory_rejected(self, tmp_path):
+        service_dir = self._service_dir(tmp_path, mode=0o755)
+        with pytest.raises(ValueError, match="no write bits"):
+            make_runner(service_sockets={"inference": str(service_dir)})
+
+    def test_missing_socket_warns_but_starts(self, tmp_path, caplog):
+        service_dir = self._service_dir(tmp_path)
+        with caplog.at_level("WARNING"):
+            make_runner(service_sockets={"inference": str(service_dir)})
+        assert any("no socket" in r.message for r in caplog.records)
+
+    def test_present_socket_no_warning(self, tmp_path, caplog):
+        service_dir = self._service_dir(tmp_path, with_socket=True)
+        with caplog.at_level("WARNING"):
+            make_runner(service_sockets={"inference": str(service_dir)})
+        assert not any("no socket" in r.message for r in caplog.records)
+
+    @pytest.mark.parametrize("name", ["", "Bad", "with_underscore", "-lead", "trail-", "a" * 33])
+    def test_invalid_names_rejected(self, name, tmp_path):
+        with pytest.raises(ValueError, match="airgapped_service_sockets"):
+            make_runner(service_sockets={name: str(tmp_path)})
+
+    def test_relative_and_comma_paths_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="absolute"):
+            make_runner(service_sockets={"svc": "relative/dir"})
+        weird = tmp_path / "a,b"
+        with pytest.raises(ValueError, match="commas"):
+            make_runner(service_sockets={"svc": str(weird)})
+
+    def test_duplicate_directories_rejected(self, tmp_path):
+        service_dir = self._service_dir(tmp_path)
+        with pytest.raises(ValueError, match="already used"):
+            make_runner(
+                service_sockets={"one": str(service_dir), "two": str(service_dir) + "/"},
+            )
+
+    def test_grants_land_in_locked_section(self, tmp_path):
+        service_dir = self._service_dir(tmp_path)
+        runner = make_runner(
+            extra_args=["--env", "TZ=UTC"],
+            service_sockets={"inference": str(service_dir)},
+        )
+        command = runner._build_command("c")
+        env_at = command.index("--env")  # operator's, first
+        mount_at = next(i for i, a in enumerate(command) if "flux/services" in a)
+        assert env_at < mount_at
+
+    def test_service_names_property(self, tmp_path):
+        a = self._service_dir(tmp_path, "svc-a")
+        b = self._service_dir(tmp_path, "svc-b")
+        runner = make_runner(service_sockets={"svc-b": str(b), "svc-a": str(a)})
+        assert runner.service_names == ["svc-a", "svc-b"]
+
+
 class TestLimitValidation:
     def test_empty_memory_rejected(self):
         with pytest.raises(ValueError, match="airgapped_memory"):
@@ -247,6 +348,7 @@ class TestFactoryWiring:
         cfg.airgapped_gpus = ""
         cfg.airgapped_mounts = []
         cfg.airgapped_shm_size = ""
+        cfg.airgapped_service_sockets = {}
         for key, value in overrides.items():
             setattr(cfg, key, value)
         return cfg
@@ -290,6 +392,22 @@ class TestFactoryWiring:
         assert "--gpus device=0" in joined
         assert f"type=bind,source={tmp_path},target=/models,readonly" in joined
         assert "--shm-size 4g" in joined
+
+    def test_service_sockets_flow_from_config(self, tmp_path):
+        service_dir = tmp_path / "inference"
+        service_dir.mkdir()
+        service_dir.chmod(0o555)
+        with patch.object(DockerRunner, "_verify_docker_available"):
+            runners = create_runners(
+                ["docker-airgapped"],
+                self._config(
+                    docker_image="flux:base",
+                    airgapped_service_sockets={"inference": str(service_dir)},
+                ),
+            )
+        runner = runners["docker-airgapped"]
+        assert runner.service_names == ["inference"]
+        assert "FLUX_SERVICE_SOCKETS" in " ".join(runner._build_command("c"))
 
 
 class TestExecutionTimeout:

--- a/tests/flux/test_airgapped_runner.py
+++ b/tests/flux/test_airgapped_runner.py
@@ -228,6 +228,9 @@ class TestServiceSockets:
             sock = socket_mod.socket(socket_mod.AF_UNIX, socket_mod.SOCK_STREAM)
             sock.bind(str(service_dir / "service.sock"))
             sock.close()
+            # Sockets honor the process umask at bind; pin the contract mode
+            # so tests don't depend on the environment's umask.
+            (service_dir / "service.sock").chmod(0o666)
         service_dir.chmod(mode)
         return service_dir
 
@@ -273,11 +276,12 @@ class TestServiceSockets:
             make_runner(service_sockets={"inference": str(service_dir)})
         assert any("no socket" in r.message for r in caplog.records)
 
-    def test_present_socket_no_warning(self, tmp_path, caplog):
+    def test_healthy_socket_emits_no_warnings(self, tmp_path, caplog):
         service_dir = self._service_dir(tmp_path, with_socket=True)
         with caplog.at_level("WARNING"):
             make_runner(service_sockets={"inference": str(service_dir)})
-        assert not any("no socket" in r.message for r in caplog.records)
+        runner_warnings = [r for r in caplog.records if r.name == "flux.runners.docker"]
+        assert runner_warnings == []
 
     @pytest.mark.parametrize(
         "name",

--- a/tests/flux/test_airgapped_runner.py
+++ b/tests/flux/test_airgapped_runner.py
@@ -279,10 +279,42 @@ class TestServiceSockets:
             make_runner(service_sockets={"inference": str(service_dir)})
         assert not any("no socket" in r.message for r in caplog.records)
 
-    @pytest.mark.parametrize("name", ["", "Bad", "with_underscore", "-lead", "trail-", "a" * 33])
+    @pytest.mark.parametrize(
+        "name",
+        ["", "Bad", "with_underscore", "-lead", "trail-", "a--b", "a" * 33],
+    )
     def test_invalid_names_rejected(self, name, tmp_path):
         with pytest.raises(ValueError, match="airgapped_service_sockets"):
             make_runner(service_sockets={name: str(tmp_path)})
+
+    def test_uncreatable_directory_names_the_config_entry(self, tmp_path):
+        blocker = tmp_path / "blocker"
+        blocker.write_text("a file, not a directory")
+        with pytest.raises(ValueError, match=r"airgapped_service_sockets\['svc'\].*create"):
+            make_runner(service_sockets={"svc": str(blocker / "nested")})
+
+    def test_non_socket_file_warns(self, tmp_path, caplog):
+        service_dir = tmp_path / "svc"
+        service_dir.mkdir()
+        (service_dir / "service.sock").write_text("plain file")
+        service_dir.chmod(0o555)
+        with caplog.at_level("WARNING"):
+            make_runner(service_sockets={"svc": str(service_dir)})
+        assert any("not a unix socket" in r.message for r in caplog.records)
+
+    def test_restricted_socket_warns(self, tmp_path, caplog):
+        import socket as socket_mod
+
+        service_dir = tmp_path / "svc"
+        service_dir.mkdir()
+        sock = socket_mod.socket(socket_mod.AF_UNIX, socket_mod.SOCK_STREAM)
+        sock.bind(str(service_dir / "service.sock"))
+        sock.close()
+        (service_dir / "service.sock").chmod(0o600)
+        service_dir.chmod(0o555)
+        with caplog.at_level("WARNING"):
+            make_runner(service_sockets={"svc": str(service_dir)})
+        assert any("world-connectable" in r.message for r in caplog.records)
 
     def test_relative_and_comma_paths_rejected(self, tmp_path):
         with pytest.raises(ValueError, match="absolute"):

--- a/tests/flux/test_worker.py
+++ b/tests/flux/test_worker.py
@@ -49,6 +49,45 @@ def worker(mock_config):
     return Worker(name="test-worker", server_url="http://localhost:8000")
 
 
+def test_reserved_flux_labels_rejected(mock_config):
+    with pytest.raises(ValueError, match="reserved 'flux.' prefix"):
+        Worker(
+            name="test-worker",
+            server_url="http://localhost:8000",
+            labels={"flux.service.inference": "true"},
+        )
+
+
+def test_service_socket_labels_derived_from_runner(mock_config, tmp_path):
+    service_dir = tmp_path / "inference"
+    service_dir.mkdir()
+    service_dir.chmod(0o555)
+    mock_config.settings.workers.runners = ["subprocess", "docker-airgapped"]
+    mock_config.settings.workers.docker_image = "flux:test"
+    mock_config.settings.workers.airgapped_image = ""
+    mock_config.settings.workers.airgapped_memory = "512m"
+    mock_config.settings.workers.airgapped_cpus = 1.0
+    mock_config.settings.workers.airgapped_pids_limit = 256
+    mock_config.settings.workers.airgapped_tmp_size = "64m"
+    mock_config.settings.workers.airgapped_execution_timeout = 900
+    mock_config.settings.workers.airgapped_extra_args = []
+    mock_config.settings.workers.airgapped_gpus = ""
+    mock_config.settings.workers.airgapped_mounts = []
+    mock_config.settings.workers.airgapped_shm_size = ""
+    mock_config.settings.workers.airgapped_service_sockets = {"inference": str(service_dir)}
+
+    from flux.runners.docker import DockerRunner
+
+    with patch.object(DockerRunner, "_verify_docker_available"):
+        worker = Worker(
+            name="test-worker",
+            server_url="http://localhost:8000",
+            labels={"gpu": "true"},
+        )
+    assert worker.labels["flux.service.inference"] == "true"
+    assert worker.labels["gpu"] == "true"
+
+
 def test_worker_init_fails_fast_when_bootstrap_token_missing():
     """A worker started without a configured bootstrap_token must fail at __init__,
     not silently send 'Bearer None' to the server.


### PR DESCRIPTION
Follow-up to #130/#133. A runtime whose startup is expensive (state loaded over minutes) cannot live inside a single-use sealed container — it pays the load per execution. This PR lets it live *outside* as a long-lived, operator-managed sidecar on the worker host, reached over a Unix domain socket: no network stack anywhere (`--network=none` stays literally true), point-to-point by construction, no lateral channel between executions, no egress. Spec: `docs/specs/2026-07-16-airgapped-service-sockets.md`.

With the heavy state out of the container, the sealed image goes back to being slim and per-execution cold start collapses to ~1–1.5 s (container create + `flux.runners.child` import, measured) — which is also why warm container pools were considered and rejected (noted in the spec's alternatives).

## Config

```toml
[flux.workers]
runners = ["docker-airgapped"]
airgapped_service_sockets = { inference = "/run/flux-services/inference" }
```

Each value is a host directory whose `service.sock` is bind-mounted into containers at `/run/flux/services/<name>`; the socket map reaches the child via `FLUX_SERVICE_SOCKETS`.

## The directory contract

- Host directory: **no write bits** (`0555`), validated at worker startup (created if absent; pointed error otherwise). Socket inside: `0666`.
- The mount is `rw` — connecting to a UDS requires write permission on the socket inode, so this is the one deliberate exception to #133's read-only-mounts rule. It stays write-proof anyway: the profile's `--cap-drop=ALL` strips `CAP_DAC_OVERRIDE`, which is what lets uid 0 ignore mode bits — so **every** container uid, root included, can connect to sockets but cannot create files. No dead-drop between executions.
- Host-side root keeps `CAP_DAC_OVERRIDE`, so a root-managed sidecar creates/replaces its socket across restarts even in the write-less directory; mounting the directory (not the socket file) makes restarts transparent to running containers.
- A missing socket at startup is a warning (the sidecar may start later); a down sidecar surfaces as a normal connect error → the retry/fallback/rollback chain.
- Service names are validated (`[a-z0-9-]`, ≤32) because they become labels; raw mount flags remain vetoed in `airgapped_extra_args`.

## Dispatch

Workers advertise granted services as `flux.service.<name>` labels at registration, and the `flux.` label prefix is now **reserved** — user-supplied labels under it fail worker startup, so labels cannot spoof capability grants. Workflows target service-bearing workers with the existing affinity mechanism: `affinity={"flux.service.inference": "true"}`. No new matching machinery.

## Workflow surface

```python
from flux.tasks import service_client

@task
async def generate(prompt: str) -> dict:
    async with service_client("inference") as client:   # httpx over UDS
        r = await client.post("/v1/completions", json={"prompt": prompt})
        return r.json()
```

`service_socket(name)` returns the path (with an error that names the config key and affinity hint when absent); `service_client(name)` returns a preconfigured `httpx.AsyncClient` (OpenAI-compatible SDKs accept it as their http client). Calls live inside ordinary tasks, so replay short-circuits from the event log without re-contacting the sidecar; streaming is native HTTP/SSE over the socket.

## The honest tradeoff (documented)

Socket traffic is the one channel the worker does not mediate — no per-call allowlist/audit/rate-limit; the grant granularity is the service and the config key is the audit trail. The sidecar receives data, not code, from processes with no other capabilities; docs tell operators to run it as its own hardened unit. The knob-vs-new-runner-name question is discussed in the spec; this ships as a knob with services advertised in registration.

## Docs & example

- `docs/advanced-features/airgapped-execution.md` — new "Service sockets" section + knob table row.
- `DOCKER.md` — sidecar recipes: `llama-server --host <path>.sock`, `vllm serve --uds`, and a systemd unit shape handling the bind-then-lock permission dance for non-root sidecars.
- `examples/airgapped.py` — `sealed_classify`: calls a warm service with a graceful local fallback when the grant is absent, affinity-pinned to service-bearing workers.

## Tests

- **E2E** (`tests/e2e/test_service_sockets.py`): a real HTTP-over-UDS sidecar in a background thread and a dedicated worker carrying `FLUX_SERVICE_SOCKETS` — the round-trip test drives server dispatch, affinity routing, the subprocess child's sanitized-env passthrough (the same variable an airgapped container gets from the runner's `--env`), `service_client` over the socket, and the checkpointed result; plus the ungranted-service failure message and the reserved `flux.` label rejection at worker startup.
- Runner: mount + env emission (rw, locked section, nothing without grants), directory contract (writable dir rejected, missing dir created `0555`, socket warning), name/path/duplicate validation, config wiring.
- Worker: `flux.`-prefixed user labels rejected; service labels derived from the runner.
- Helpers: env parsing, absent-service error message, and real HTTP-over-UDS round trips (plain + chunked/streamed + down-sidecar connect error) against an asyncio unix server.
- Example: inline run exercises the fallback path.

Local validation: pre-commit clean; unit suite 2789 passed / 9 skipped; e2e 124 passed + the 3 new service-socket tests (the two `github_stars` failures are the sandbox proxy blocking direct `api.github.com`, unrelated).

Version: 0.61.0.