### PR TITLE
Add dynamic dispatch expressions: require() affinity filtering + input-resolved scoring

### DIFF
--- a/docs/advanced-features/dynamic-routing.md
+++ b/docs/advanced-features/dynamic-routing.md
@@ -60,6 +60,42 @@ dotted paths (`input("customer.region")`) descend nested dictionaries. This
 is how payload-driven locality works: the same workflow routes each
 execution by its own data.
 
+## Dynamic keys and conditional terms
+
+The [affinity expression](worker-affinity.md) vocabulary works in the score
+stage too — the same comparison is a hard wall under `require(...)` and a
+soft preference under `prefer(...)`:
+
+- `prefer(label_for("cache.", input("dataset")) == "true", weight=5)` —
+  dynamic label key: prefer workers holding a warm copy of *this*
+  execution's dataset without excluding cold ones. Unresolved input (or an
+  invalid resolved key) just means the term cannot discriminate — everyone
+  scores 0 for it; the policy does not degrade. (`least`/`most` reject
+  `label_for` — label strings have no ordering.)
+- `prefer(service(input("model")), weight=2)` — prefer a worker with the
+  granted service socket, fall back to the rest.
+- `when(input("latency_sensitive") == "true", least(load(), weight=10))` —
+  apply a term only when the request says it matters. The condition reads
+  execution input only, never worker attributes; unresolved leaves the term
+  inactive.
+
+Pair the stages for floor-plus-preference routing:
+
+```python
+@workflow.with_options(
+    affinity=require(label("datacenter") == input("dc")),          # must
+    routing=score(
+        prefer(label_for("cache.", input("dataset")) == "true",    # prefer
+               weight=10),
+        least(load()),
+    ),
+)
+```
+
+Note the distinction with `optional(...)` in `require`: an optional term is
+*hard when its input is present* (a pin), while a `prefer` term is *soft
+always* (a nudge).
+
 ## How scoring works
 
 1. Hard constraints filter first — a policy can never route to a worker

--- a/docs/advanced-features/worker-affinity.md
+++ b/docs/advanced-features/worker-affinity.md
@@ -114,8 +114,108 @@ ctx = ai_researcher.run("https://example.com")
 
 Without the affinity constraint, the workflow might run on a generic worker without browser tools and fail.
 
+## Affinity Expressions: `require(...)`
+
+The static dict pins a workflow to one fixed label set. An **affinity
+expression** built with `flux.routing.require(...)` keeps the same
+hard-filter role but resolves its terms **per execution** against the
+execution input — one registration can serve many differently-routed
+requests. Unlike scoring policies, expressions work in **both** poll and
+event dispatch modes (filtering is a per-worker predicate).
+
+```python
+from flux import workflow
+from flux.routing import require, optional, when, label, label_for, input
+
+@workflow.with_options(
+    affinity=require(
+        label("datacenter") == input("dc"),                 # data locality
+        label_for("dataset.", input("dataset")) == "true",  # worker holds a local copy
+        optional(label("node") == input("node")),           # hard pin only when requested
+        when(input("classification") == "restricted",
+             label("compliance.hipaa") == "true"),          # gate on requester intent
+    ),
+)
+async def locality_query(ctx): ...
+```
+
+An execution with input `{"dc": "eu-central", "dataset": "orders-2026"}`
+matches only workers in that datacenter labeled `dataset.orders-2026=true`;
+add `"node": "node-a"` to pin it to one machine; add
+`"classification": "restricted"` to gate it to compliance-certified workers.
+Same workflow, different eligible sets, zero catalog churn.
+
+Other common patterns:
+
+```python
+# Tenant isolation on a shared fleet
+affinity=require(label("tenant") == input("tenant_id"))
+
+# Maintenance windows without redeploying workflows
+affinity=require(label("maintenance") != "true")
+```
+
+### Vocabulary
+
+- `label(key) == value` / `label(key) != value` — compare a worker label
+  against a constant or `input("path")` (dotted paths descend nested dicts).
+  Only `==` and `!=`; ordered comparisons belong to
+  [Dynamic Routing](dynamic-routing.md).
+- `label_for(prefix, input("path"))` — dynamic label key: the author
+  declares the namespace (`prefix` is mandatory), input only completes it.
+  The resolved key must be a valid label key; inputs never create labels,
+  only test them.
+- `service(name_or_input)` — targets workers holding a granted service
+  socket; sugar for `label_for("flux.service.", ...) == "true"`. Because the
+  `flux.` label prefix is reserved (workers reject user labels under it),
+  this is a capability grant a worker cannot fabricate. See
+  [Airgapped Execution](airgapped-execution.md).
+- `optional(term)` — skipped when its input is absent; a resolved
+  comparison that is false still fails the match, and input that resolves
+  to something invalid (bad label key, non-scalar, invalid service name)
+  fails and diagnoses exactly like a bare term.
+- `when(input(...) == const, term)` — the term applies only when the input
+  condition holds. Conditions read execution input only, never worker
+  attributes; an unresolved condition leaves the term inactive.
+
+### Evaluation semantics
+
+Terms are AND-ed and evaluation is **fail-closed**: a bare term whose input
+cannot be resolved matches no worker — and because that is a property of the
+execution alone, dispatch **fails the execution** with an error naming the
+unresolved input instead of queueing it forever. A resolvable-but-unmatched
+expression parks the execution exactly like the dict form (a matching worker
+may join later).
+
+| Term | Input resolved? | Label present? | Result |
+|---|---|---|---|
+| `label(k) == input(p)` | no | — | no match; execution **fails** with a named diagnostic |
+| `label(k) == input(p)` | yes | no | no match (parks) |
+| `label(k) == input(p)` | yes | yes, equal | match |
+| `label(k) != v` | — | no | **match** (absent ≠ v — the one documented inversion) |
+| `optional(term)` | no | — | term skipped |
+| `optional(term)` | yes, false | — | no match (optional ≠ decorative) |
+| `optional(term)` | yes, invalid key | — | no match; execution **fails** (optional forgives absence only) |
+| `when(if, then)`, `if` unresolved | — | — | term inactive |
+| `label_for(...)`, resolved key invalid | yes | — | no match; execution **fails** with a named diagnostic |
+
+Input values compare against labels as strings (booleans as
+`"true"`/`"false"`). The dict form remains valid forever and its semantics
+are unchanged.
+
+Expressions are extracted statically at registration (AST, like `routing=`);
+an expression that cannot be statically extracted fails registration loudly
+rather than silently dropping a hard constraint.
+
+See `examples/affinity_expressions.py` for runnable data-locality, tenant
+isolation, and maintenance-window patterns.
+
 ## Beyond Hard Constraints
 
 Affinity decides which workers *can* run a workflow. To rank the eligible
 workers — by latency, load, locality, or custom metrics — add a scoring
-policy on top: see [Dynamic Routing](dynamic-routing.md).
+policy on top: see [Dynamic Routing](dynamic-routing.md). The dynamic
+vocabulary spans both stages — `input(...)` values, `label_for(...)` keys,
+`service(...)`, and `when(...)` work in `prefer()` too, so the same
+comparison can be a hard wall in `require()` and a soft preference in
+`score()`.

--- a/examples/affinity_expressions.py
+++ b/examples/affinity_expressions.py
@@ -1,0 +1,93 @@
+"""Affinity expressions: per-execution worker targeting with require(...).
+
+A static ``affinity={"gpu": "a100"}`` dict pins a workflow to one fixed
+label set. An expression built with ``flux.routing.require(...)`` keeps the
+same hard-filter role but resolves its terms against each execution's input
+at dispatch — so one registered workflow serves many differently-routed
+requests:
+
+    {"dc": "eu-central", "dataset": "orders-2026"}   -> workers in that
+        datacenter holding a local copy of the dataset
+    {..., "node": "node-a"}                          -> pinned to one machine
+    {..., "classification": "restricted"}            -> gated to
+        compliance-certified workers
+
+Affinity only takes effect on the distributed path (``flux start server`` +
+labeled workers); inline runs execute in-process. Running this file inline
+still exercises the full registration path — the catalog statically
+extracts the expression from source, and an unparseable one fails loudly.
+"""
+
+from __future__ import annotations
+
+from flux import ExecutionContext, task, workflow
+from flux.routing import (
+    input,
+    label,
+    label_for,
+    least,
+    load,
+    optional,
+    prefer,
+    require,
+    score,
+    when,
+)
+
+
+@task
+async def run_query(dataset: str, query: str) -> dict:
+    # A real deployment would query the worker-local dataset copy here.
+    return {"dataset": dataset, "rows": [f"result({query})"]}
+
+
+@workflow.with_options(
+    affinity=require(
+        label("datacenter") == input("dc"),  # data locality
+        label_for("dataset.", input("dataset")) == "true",  # worker holds a local copy
+        optional(label("node") == input("node")),  # hard pin only when requested
+        when(  # compliance gate on requester intent
+            input("classification") == "restricted",
+            label("compliance.hipaa") == "true",
+        ),
+    ),
+    # The same vocabulary ranks the eligible workers: require() is the hard
+    # floor, prefer() the soft preference — here, favor a warm cache copy
+    # without excluding cold workers, then break ties by load.
+    routing=score(
+        prefer(label_for("cache.", input("dataset")) == "true", weight=5),
+        least(load()),
+    ),
+)
+async def locality_query(ctx: ExecutionContext[dict]):
+    """Run a query on a worker co-located with the requested dataset."""
+    request = ctx.input or {}
+    return await run_query(request.get("dataset", ""), request.get("query", ""))
+
+
+@workflow.with_options(affinity=require(label("tenant") == input("tenant_id")))
+async def tenant_report(ctx: ExecutionContext[dict]):
+    """Tenant isolation on a shared fleet: each tenant's executions only
+    reach workers labeled for that tenant."""
+    tenant = (ctx.input or {}).get("tenant_id")
+    return {"tenant": tenant, "report": "ok"}
+
+
+@workflow.with_options(affinity=require(label("maintenance") != "true"))
+async def nightly_cleanup(ctx: ExecutionContext):
+    """Maintenance windows without redeploying: label a worker
+    maintenance=true to drain it; unlabeled workers keep matching."""
+    return {"cleaned": True}
+
+
+if __name__ == "__main__":  # pragma: no cover
+    ctx = locality_query.run(
+        {"dc": "eu-central", "dataset": "orders-2026", "query": "count(*)"},
+    )
+    print(ctx.to_json())
+
+    ctx = tenant_report.run({"tenant_id": "acme"})
+    print(ctx.to_json())
+
+    ctx = nightly_cleanup.run()
+    print(ctx.to_json())

--- a/flux/catalogs.py
+++ b/flux/catalogs.py
@@ -199,7 +199,7 @@ class WorkflowInfo:
         namespace: str = "default",
         version: int = 1,
         requests: ResourceRequest | None = None,
-        affinity: dict[str, str] | None = None,
+        affinity: dict[str, str] | list[dict] | None = None,
         schedule: Any | None = None,
         metadata: dict | None = None,
     ):
@@ -564,14 +564,188 @@ class WorkflowCatalog(ABC):
                 return bool(kw.value.value)
         return False
 
-    def _extract_affinity(self, node: ast.AST) -> dict[str, str] | None:
+    def _extract_affinity(self, node: ast.AST) -> dict[str, str] | list | None:
         if isinstance(node, ast.Dict):
             result = {}
             for key, value in zip(node.keys, node.values):
                 if isinstance(key, ast.Constant) and isinstance(value, ast.Constant):
                     result[str(key.value)] = str(value.value)
             return result if result else None
+        if isinstance(node, ast.Call) and (
+            (isinstance(node.func, ast.Name) and node.func.id == "require")
+            or (isinstance(node.func, ast.Attribute) and node.func.attr == "require")
+        ):
+            return self._extract_require(node)
         return None
+
+    def _extract_require(self, node: ast.Call) -> list[dict]:
+        """Extract an ``affinity=require(...)`` expression into its term specs.
+
+        Like ``routing``, an unparseable expression raises instead of
+        returning None: silently dropping a hard constraint would dispatch
+        the workflow somewhere the author excluded. Building through the real
+        ``flux.routing`` factories reuses their validation.
+        """
+        from typing import NoReturn
+
+        from flux import routing as routing_dsl
+
+        def fail(reason: str) -> NoReturn:
+            raise SyntaxError(
+                f"affinity expression must be statically declarable ({reason}); build "
+                "it with flux.routing.require(...) using literal values or input(...)",
+            )
+
+        def call_name(call: ast.AST) -> str | None:
+            if not isinstance(call, ast.Call):
+                return None
+            if isinstance(call.func, ast.Name):
+                return call.func.id
+            if isinstance(call.func, ast.Attribute):
+                return call.func.attr
+            return None
+
+        def extract_input_ref(ref_node: ast.AST) -> Any:
+            assert isinstance(ref_node, ast.Call)
+            if len(ref_node.args) == 1 and isinstance(ref_node.args[0], ast.Constant):
+                try:
+                    return routing_dsl.input(ref_node.args[0].value)
+                except (TypeError, ValueError) as e:
+                    raise SyntaxError(f"Invalid input() reference: {e}") from e
+            fail("input() takes a single literal path")
+
+        def extract_selector(sel_node: ast.AST) -> Any:
+            name = call_name(sel_node)
+            assert isinstance(sel_node, ast.Call)
+            if name == "label":
+                if len(sel_node.args) == 1 and isinstance(sel_node.args[0], ast.Constant):
+                    try:
+                        return routing_dsl.label(sel_node.args[0].value)
+                    except (TypeError, ValueError) as e:
+                        raise SyntaxError(f"Invalid affinity selector 'label': {e}") from e
+                fail("label() takes a literal key")
+            if name == "label_for":
+                if (
+                    len(sel_node.args) == 2
+                    and isinstance(sel_node.args[0], ast.Constant)
+                    and call_name(sel_node.args[1]) == "input"
+                ):
+                    try:
+                        return routing_dsl.label_for(
+                            sel_node.args[0].value,
+                            extract_input_ref(sel_node.args[1]),
+                        )
+                    except (TypeError, ValueError) as e:
+                        raise SyntaxError(f"Invalid affinity selector 'label_for': {e}") from e
+                fail("label_for() takes a literal prefix and input(...)")
+            fail(f"expected label()/label_for(), got '{name}'")
+
+        def extract_value(value_node: ast.AST) -> Any:
+            if isinstance(value_node, ast.Constant):
+                return value_node.value
+            if call_name(value_node) == "input":
+                return extract_input_ref(value_node)
+            fail(f"unsupported value expression at line {getattr(value_node, 'lineno', '?')}")
+
+        _AST_OPS = {ast.Eq: "==", ast.NotEq: "!="}
+
+        def extract_condition(cond_node: ast.AST) -> Any:
+            """A label comparison: label(...)/label_for(...) vs constant/input."""
+            if not isinstance(cond_node, ast.Compare) or len(cond_node.ops) != 1:
+                fail(
+                    "require() terms are single label comparisons, "
+                    'e.g. label("region") == input("region")',
+                )
+            op = _AST_OPS.get(type(cond_node.ops[0]))
+            if op is None:
+                fail(
+                    f"require() supports only == and != (line {cond_node.lineno}); "
+                    "ordered comparisons belong to routing=",
+                )
+            left, right = cond_node.left, cond_node.comparators[0]
+            if call_name(left) in ("label", "label_for"):
+                selector, value = extract_selector(left), extract_value(right)
+            elif call_name(right) in ("label", "label_for"):
+                # == and != are symmetric, so no operator flip is needed.
+                selector, value = extract_selector(right), extract_value(left)
+            else:
+                fail("one side of a require() comparison must be label()/label_for()")
+            try:
+                return routing_dsl.Condition(selector, op, value)
+            except ValueError as e:
+                raise SyntaxError(f"Invalid affinity condition: {e}") from e
+
+        def extract_input_condition(cond_node: ast.AST) -> Any:
+            """A when() condition: input(...) vs constant, either order."""
+            if not isinstance(cond_node, ast.Compare) or len(cond_node.ops) != 1:
+                fail('when() takes an input comparison, e.g. input("tier") == "dedicated"')
+            op = _AST_OPS.get(type(cond_node.ops[0]))
+            if op is None:
+                fail(f"when() conditions support only == and != (line {cond_node.lineno})")
+            left, right = cond_node.left, cond_node.comparators[0]
+            if call_name(left) == "input":
+                ref, const = extract_input_ref(left), right
+            elif call_name(right) == "input":
+                ref, const = extract_input_ref(right), left
+            else:
+                fail("one side of a when() condition must be input(...)")
+            if not isinstance(const, ast.Constant):
+                fail("when() conditions compare input(...) against a literal")
+            try:
+                return routing_dsl.InputCondition(ref, op, const.value)
+            except ValueError as e:
+                raise SyntaxError(f"Invalid affinity when() condition: {e}") from e
+
+        def extract_service(svc_node: ast.AST) -> Any:
+            assert isinstance(svc_node, ast.Call)
+            if len(svc_node.args) != 1:
+                fail("service() takes exactly one argument")
+            arg = svc_node.args[0]
+            if isinstance(arg, ast.Constant):
+                value: Any = arg.value
+            elif call_name(arg) == "input":
+                value = extract_input_ref(arg)
+            else:
+                fail("service() takes a literal name or input(...)")
+            try:
+                return routing_dsl.service(value)
+            except (TypeError, ValueError) as e:
+                raise SyntaxError(f"Invalid affinity term 'service': {e}") from e
+
+        def extract_match_term(term_node: ast.AST) -> Any:
+            if call_name(term_node) == "service":
+                return extract_service(term_node)
+            return extract_condition(term_node)
+
+        terms = []
+        for term_node in node.args:
+            name = call_name(term_node)
+            try:
+                if name == "optional":
+                    assert isinstance(term_node, ast.Call)
+                    if len(term_node.args) != 1:
+                        fail("optional() takes exactly one term")
+                    terms.append(routing_dsl.optional(extract_match_term(term_node.args[0])))
+                elif name == "when":
+                    assert isinstance(term_node, ast.Call)
+                    if len(term_node.args) != 2:
+                        fail("when() takes a condition and a term")
+                    terms.append(
+                        routing_dsl.when(
+                            extract_input_condition(term_node.args[0]),
+                            extract_match_term(term_node.args[1]),
+                        ),
+                    )
+                else:
+                    terms.append(extract_match_term(term_node))
+            except (TypeError, ValueError) as e:
+                raise SyntaxError(f"Invalid affinity term '{name}': {e}") from e
+        for kw in node.keywords:
+            fail(f"require() takes no keyword arguments, got '{kw.arg}'")
+        try:
+            return routing_dsl.require(*terms)
+        except ValueError as e:
+            raise SyntaxError(f"Invalid affinity expression: {e}") from e
 
     def _extract_routing(self, node: ast.AST) -> dict | None:
         """Extract a ``routing=score(...)`` policy into its JSON spec.
@@ -609,12 +783,37 @@ class WorkflowCatalog(ABC):
             "load": routing_dsl.load,
         }
 
+        def extract_input_ref(ref_node: ast.AST) -> Any:
+            assert isinstance(ref_node, ast.Call)
+            if len(ref_node.args) == 1 and isinstance(ref_node.args[0], ast.Constant):
+                try:
+                    return routing_dsl.input(ref_node.args[0].value)
+                except (TypeError, ValueError) as e:
+                    raise SyntaxError(f"Invalid input() reference: {e}") from e
+            fail("input() takes a single literal path")
+
         def extract_selector(sel_node: ast.AST) -> Any:
             name = call_name(sel_node)
+            if name is None:
+                fail(f"expected label()/label_for()/metric()/resource()/load(), got '{name}'")
+            assert isinstance(sel_node, ast.Call)
+            if name == "label_for":
+                if (
+                    len(sel_node.args) == 2
+                    and isinstance(sel_node.args[0], ast.Constant)
+                    and call_name(sel_node.args[1]) == "input"
+                ):
+                    try:
+                        return routing_dsl.label_for(
+                            sel_node.args[0].value,
+                            extract_input_ref(sel_node.args[1]),
+                        )
+                    except (TypeError, ValueError) as e:
+                        raise SyntaxError(f"Invalid routing selector 'label_for': {e}") from e
+                fail("label_for() takes a literal prefix and input(...)")
             factory = _SELECTOR_FACTORIES.get(name or "")
             if factory is None:
-                fail(f"expected label()/metric()/resource()/load(), got '{name}'")
-            assert isinstance(sel_node, ast.Call)
+                fail(f"expected label()/label_for()/metric()/resource()/load(), got '{name}'")
             args = []
             for arg in sel_node.args:
                 if not isinstance(arg, ast.Constant):
@@ -629,11 +828,7 @@ class WorkflowCatalog(ABC):
             if isinstance(value_node, ast.Constant):
                 return value_node.value
             if call_name(value_node) == "input":
-                call = value_node
-                assert isinstance(call, ast.Call)
-                if len(call.args) == 1 and isinstance(call.args[0], ast.Constant):
-                    return routing_dsl.input(call.args[0].value)
-                fail("input() takes a single literal path")
+                return extract_input_ref(value_node)
             fail(f"unsupported value expression at line {getattr(value_node, 'lineno', '?')}")
 
         _AST_OPS = {
@@ -657,9 +852,10 @@ class WorkflowCatalog(ABC):
             if op is None:
                 fail(f"unsupported comparison operator at line {cond_node.lineno}")
             left, right = cond_node.left, cond_node.comparators[0]
-            if call_name(left) in _SELECTOR_FACTORIES:
+            selector_names = (*_SELECTOR_FACTORIES, "label_for")
+            if call_name(left) in selector_names:
                 selector, value = extract_selector(left), extract_value(right)
-            elif call_name(right) in _SELECTOR_FACTORIES:
+            elif call_name(right) in selector_names:
                 selector, value, op = extract_selector(right), extract_value(left), _FLIPPED[op]
             else:
                 fail("one side of a prefer() comparison must be a selector")
@@ -668,15 +864,47 @@ class WorkflowCatalog(ABC):
             except ValueError as e:
                 raise SyntaxError(f"Invalid routing condition: {e}") from e
 
-        if call_name(node) != "score":
-            fail("expected a score(...) call")
-        assert isinstance(node, ast.Call)
+        def extract_input_condition(cond_node: ast.AST) -> Any:
+            """A when() condition: input(...) vs constant, either order."""
+            if not isinstance(cond_node, ast.Compare) or len(cond_node.ops) != 1:
+                fail('when() takes an input comparison, e.g. input("tier") == "dedicated"')
+            op = _AST_OPS.get(type(cond_node.ops[0]))
+            if op not in ("==", "!="):
+                fail(f"when() conditions support only == and != (line {cond_node.lineno})")
+            left, right = cond_node.left, cond_node.comparators[0]
+            if call_name(left) == "input":
+                ref, const = extract_input_ref(left), right
+            elif call_name(right) == "input":
+                ref, const = extract_input_ref(right), left
+            else:
+                fail("one side of a when() condition must be input(...)")
+            if not isinstance(const, ast.Constant):
+                fail("when() conditions compare input(...) against a literal")
+            try:
+                return routing_dsl.InputCondition(ref, op, const.value)
+            except ValueError as e:
+                raise SyntaxError(f"Invalid routing when() condition: {e}") from e
 
-        terms = []
-        for term_node in node.args:
+        def extract_service(svc_node: ast.AST) -> Any:
+            assert isinstance(svc_node, ast.Call)
+            if len(svc_node.args) != 1:
+                fail("service() takes exactly one argument")
+            arg = svc_node.args[0]
+            if isinstance(arg, ast.Constant):
+                value: Any = arg.value
+            elif call_name(arg) == "input":
+                value = extract_input_ref(arg)
+            else:
+                fail("service() takes a literal name or input(...)")
+            try:
+                return routing_dsl.service(value)
+            except (TypeError, ValueError) as e:
+                raise SyntaxError(f"Invalid routing term 'service': {e}") from e
+
+        def extract_term(term_node: ast.AST) -> Any:
             name = call_name(term_node)
-            if name not in ("prefer", "least", "most", "sticky"):
-                fail(f"expected prefer()/least()/most()/sticky() terms, got '{name}'")
+            if name not in ("prefer", "least", "most", "sticky", "when"):
+                fail(f"expected prefer()/least()/most()/sticky()/when() terms, got '{name}'")
             assert isinstance(term_node, ast.Call)
             kwargs = {}
             for kw in term_node.keywords:
@@ -687,24 +915,32 @@ class WorkflowCatalog(ABC):
                 if name == "sticky":
                     if term_node.args:
                         fail("sticky() takes no positional arguments")
-                    terms.append(routing_dsl.sticky(**kwargs))
-                    continue
+                    return routing_dsl.sticky(**kwargs)
+                if name == "when":
+                    if len(term_node.args) != 2 or kwargs:
+                        fail("when() takes a condition and a term, and no keyword arguments")
+                    return routing_dsl.when(
+                        extract_input_condition(term_node.args[0]),
+                        extract_term(term_node.args[1]),
+                    )
                 if len(term_node.args) != 1:
                     fail(f"{name}() takes exactly one positional argument")
                 if name == "prefer":
-                    terms.append(
-                        routing_dsl.prefer(extract_condition(term_node.args[0]), **kwargs),
-                    )
-                elif name == "least":
-                    terms.append(
-                        routing_dsl.least(extract_selector(term_node.args[0]), **kwargs),
-                    )
-                else:
-                    terms.append(
-                        routing_dsl.most(extract_selector(term_node.args[0]), **kwargs),
-                    )
+                    arg = term_node.args[0]
+                    if call_name(arg) == "service":
+                        return routing_dsl.prefer(extract_service(arg), **kwargs)
+                    return routing_dsl.prefer(extract_condition(arg), **kwargs)
+                if name == "least":
+                    return routing_dsl.least(extract_selector(term_node.args[0]), **kwargs)
+                return routing_dsl.most(extract_selector(term_node.args[0]), **kwargs)
             except (TypeError, ValueError) as e:
                 raise SyntaxError(f"Invalid routing term '{name}': {e}") from e
+
+        if call_name(node) != "score":
+            fail("expected a score(...) call")
+        assert isinstance(node, ast.Call)
+
+        terms = [extract_term(term_node) for term_node in node.args]
         try:
             return routing_dsl.score(*terms)
         except ValueError as e:

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC
 from abc import abstractmethod
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import func
 from sqlalchemy import or_
@@ -17,10 +17,13 @@ from flux.models import ExecutionEventModel
 from flux.models import ExecutionContextModel
 from flux.models import RepositoryFactory
 from flux.models import WorkflowModel
+from flux.utils import get_logger
 from flux.worker_registry import WorkerInfo
 
 if TYPE_CHECKING:
     from flux.unit_of_work import UnitOfWork
+
+logger = get_logger(__name__)
 
 
 _NO_DEMOTE_TO_PAUSED_FROM = frozenset(
@@ -441,7 +444,12 @@ class DatabaseContextManager(ContextManager):
         )
         return session.execute(stmt).scalar_one_or_none()
 
-    def _worker_matches_workflow(self, worker: WorkerInfo, workflow: WorkflowModel) -> bool:
+    def _worker_matches_workflow(
+        self,
+        worker: WorkerInfo,
+        workflow: WorkflowModel,
+        input_value: Any = None,
+    ) -> bool:
         from flux.domain.resource_request import worker_matches
 
         return worker_matches(
@@ -449,7 +457,33 @@ class DatabaseContextManager(ContextManager):
             workflow.requests,
             workflow.affinity,
             runner=(workflow.wf_metadata or {}).get("runner"),
+            input_value=input_value,
         )
+
+    def _affinity_diagnostic(self, workflow: WorkflowModel, model) -> str | None:
+        """Execution-level reason a require(...) affinity can never match.
+
+        Non-None only for worker-independent problems (unresolved input on a
+        non-optional term, invalid resolved key, malformed spec) — those fail
+        the execution instead of parking it forever. Static dict affinity
+        never diagnoses: an unmatched label is fleet-dependent and waits for
+        a matching worker, as it always has.
+        """
+        if not isinstance(workflow.affinity, (list, tuple)):
+            return None
+        from flux.routing import require_diagnostic
+
+        return require_diagnostic(workflow.affinity, model.input)
+
+    def _fail_undispatchable(self, model, session: Session, diagnostic: str) -> None:
+        ctx = model.to_plain()
+        ctx.fail(
+            ctx.execution_id,
+            {"type": "AffinityResolutionError", "message": diagnostic},
+        )
+        model.state = ctx.state
+        session.add_all(self._get_additional_events(ctx, session))
+        logger.warning(f"Execution {ctx.execution_id} failed at dispatch: {diagnostic}")
 
     def _next_matching_execution(
         self,
@@ -488,7 +522,14 @@ class DatabaseContextManager(ContextManager):
             return result if result else (None, None)
 
         for model, workflow in query:
-            if not self._worker_matches_workflow(worker, workflow):
+            diagnostic = self._affinity_diagnostic(workflow, model)
+            if diagnostic:
+                self._fail_undispatchable(model, session, diagnostic)
+                # Flag the staged failure so the caller commits it even when
+                # nothing ends up claimed on this poll tick.
+                session.info["affinity_failed"] = True
+                continue
+            if not self._worker_matches_workflow(worker, workflow, model.input):
                 continue
             return model, workflow
         return None, None
@@ -521,6 +562,8 @@ class DatabaseContextManager(ContextManager):
                 session.commit()
                 return ctx
 
+            if session.info.pop("affinity_failed", False):
+                session.commit()
             return None
 
     def _is_least_loaded_worker(self, worker: WorkerInfo, session: Session) -> bool:
@@ -602,7 +645,7 @@ class DatabaseContextManager(ContextManager):
                     .with_for_update(skip_locked=True)
                 )
                 for model, workflow in fallback_query:
-                    if self._worker_matches_workflow(worker, workflow):
+                    if self._worker_matches_workflow(worker, workflow, model.input):
                         result = (model, workflow)
                         break
 
@@ -724,10 +767,15 @@ class DatabaseContextManager(ContextManager):
                 .limit(limit)
             )
             for model, workflow in query:
+                diagnostic = self._affinity_diagnostic(workflow, model)
+                if diagnostic:
+                    self._fail_undispatchable(model, session, diagnostic)
+                    continue
                 eligible = [
                     w
                     for w in workers
-                    if self._has_free_slot(w, loads) and self._worker_matches_workflow(w, workflow)
+                    if self._has_free_slot(w, loads)
+                    and self._worker_matches_workflow(w, workflow, model.input)
                 ]
                 if not eligible:
                     continue
@@ -847,7 +895,7 @@ class DatabaseContextManager(ContextManager):
                         w
                         for w in workers
                         if self._has_free_slot(w, loads)
-                        and self._worker_matches_workflow(w, workflow)
+                        and self._worker_matches_workflow(w, workflow, model.input)
                     ]
                     if not eligible:
                         continue

--- a/flux/domain/resource_request.py
+++ b/flux/domain/resource_request.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from flux.worker_registry import WorkerResourcesInfo
 
 
@@ -307,12 +309,17 @@ class ResourceRequest:
 def worker_matches(
     worker,
     requests: dict | None,
-    affinity: dict | None,
+    affinity: dict | list | None,
     runner: str | None = None,
+    input_value: Any = None,
 ) -> bool:
     """Whether a worker satisfies a workflow's affinity labels, resource
     requests, and required runner. Shared by the SQL dispatch paths and the
-    transient (no-row) dispatch, which has no session to hang the check on."""
+    transient (no-row) dispatch, which has no session to hang the check on.
+
+    ``affinity`` is either the static label dict or a ``require(...)``
+    expression (a list of term specs) whose terms resolve against the
+    execution input (``input_value``) — see :mod:`flux.routing`."""
     if runner is not None:
         # A worker that never advertised runners (None) is a legacy
         # in-process-only worker: it can honor runner="inprocess" and nothing
@@ -323,7 +330,12 @@ def worker_matches(
         if runner not in advertised:
             return False
     if affinity is not None:
-        if not ResourceRequest.matches_labels(worker.labels, affinity):
+        if isinstance(affinity, (list, tuple)):
+            from flux.routing import require_matches
+
+            if not require_matches(affinity, worker.labels, input_value):
+                return False
+        elif not ResourceRequest.matches_labels(worker.labels, affinity):
             return False
     if requests is not None:
         resource_request = ResourceRequest(**(requests or {}))

--- a/flux/models.py
+++ b/flux/models.py
@@ -583,7 +583,7 @@ class WorkflowModel(Base):
         source: bytes,
         namespace: str = "default",
         requests: dict | ResourceRequest | None = None,
-        affinity: dict[str, str] | None = None,
+        affinity: dict[str, str] | list[dict] | None = None,
         metadata: dict | None = None,
     ):
         self.id = id

--- a/flux/routing.py
+++ b/flux/routing.py
@@ -1,4 +1,4 @@
-"""Declarative routing policies: the score stage of workflow dispatch.
+"""Declarative routing policies: the filter and score stages of dispatch.
 
 Hard constraints (``requests``, ``affinity``, ``runner``, health, capacity)
 filter the candidate workers; a routing policy ranks the survivors. Policies
@@ -6,6 +6,21 @@ are data, not code — the decorator factories below compile to a JSON spec
 that the catalog extracts statically (AST, like ``requests``) and the server
 evaluates natively inside the dispatch batch. No user code ever runs on the
 server.
+
+Two families of factories live here:
+
+- ``score(...)`` builds the *scoring* policy for ``routing=`` (ranks eligible
+  workers; event dispatch mode only).
+- ``require(...)`` builds an *affinity expression* for ``affinity=`` (a hard
+  per-worker filter whose terms resolve against the execution input at
+  dispatch; works in both poll and event dispatch modes). See ``require``.
+
+The dynamic constructs span both stages: ``input(...)`` values,
+``label_for(...)`` dynamic keys, and ``service(...)`` work in ``require``
+terms and in ``prefer()``; ``when(input(...) == const, term)`` gates a term
+in either stage. The same comparison is a hard wall under ``require`` and a
+soft preference under ``prefer`` — pair them for floor-plus-preference
+routing.
 
     @workflow.with_options(
         routing=score(
@@ -34,7 +49,8 @@ same as the sticky hint.
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING, Any
+import re
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from flux.utils import get_logger
 
@@ -69,6 +85,10 @@ class InputRef:
 
     ``input("region")`` compares against ``ctx.input["region"]``;
     dotted paths (``input("customer.region")``) descend nested dicts.
+
+    Comparing an ``input(...)`` against a constant builds an
+    :class:`InputCondition` for ``when(...)`` in a ``require`` expression:
+    ``when(input("tier") == "dedicated", ...)``.
     """
 
     def __init__(self, path: str):
@@ -78,6 +98,37 @@ class InputRef:
 
     def to_spec(self) -> dict[str, str]:
         return {"$input": self.path}
+
+    def __eq__(self, other: Any) -> InputCondition:  # type: ignore[override]
+        return InputCondition(self, "==", other)
+
+    def __ne__(self, other: Any) -> InputCondition:  # type: ignore[override]
+        return InputCondition(self, "!=", other)
+
+    # Comparisons build InputConditions, so instances are deliberately
+    # unhashable (same contract as Selector).
+    __hash__ = None  # type: ignore[assignment]
+
+
+class InputCondition:
+    """A comparison of an execution-input value against a constant.
+
+    Only usable as the ``when(...)`` condition of a ``require`` expression:
+    it conditions on the requester's intent, never on worker attributes.
+    """
+
+    def __init__(self, ref: InputRef, op: str, value: Any):
+        if op not in ("==", "!="):
+            raise ValueError(f"input() conditions support only == and !=, got: '{op}'")
+        if isinstance(value, (InputRef, Selector)):
+            raise ValueError("input() can only be compared against constants")
+        if not isinstance(value, (str, int, float, bool)) and value is not None:
+            raise ValueError(
+                f"input() comparison value must be a constant, got: {type(value).__name__}",
+            )
+        self.ref = ref
+        self.op = op
+        self.value = value
 
 
 def input(path: str) -> InputRef:  # noqa: A001 - deliberate DSL name
@@ -111,6 +162,9 @@ class Selector:
     comparisons (``60 > metric("temp")``) work through Python's reflected
     operator protocol.
     """
+
+    # str for static selectors ("label:gpu"); DynamicLabel stores a dict spec.
+    spec: str | dict[str, Any]
 
     def __init__(self, kind: str, key: str | None = None):
         if kind == "load":
@@ -166,6 +220,60 @@ def load() -> Selector:
     return Selector("load")
 
 
+# Resolved dynamic label keys must look like ordinary label keys: alphanumeric
+# with interior ``.``/``_``/``-``, bounded length. Static keys authored in a
+# dict or ``label(...)`` are not retro-validated; only keys completed from
+# execution input are held to this.
+MAX_LABEL_KEY_LENGTH = 128
+_LABEL_KEY_RE = re.compile(r"^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$")
+
+# Granted service sockets are advertised as ``flux.service.<name>`` labels;
+# the worker rejects user labels under ``flux.``, so these cannot be spoofed.
+SERVICE_LABEL_PREFIX = "flux.service."
+
+# Service names follow the worker-side socket-name rule (enforced at worker
+# startup on [flux.workers] airgapped_service_sockets, see
+# flux/runners/docker.py) — validating service() terms against the same rule
+# keeps a workflow from compiling an expression no real worker can satisfy.
+MAX_SERVICE_NAME_LENGTH = 32
+SERVICE_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
+
+
+def is_valid_service_name(name: str) -> bool:
+    """Whether a service-socket name is one worker registration could grant:
+    lowercase letters, digits, and single hyphens, max 32 chars."""
+    return (
+        isinstance(name, str)
+        and len(name) <= MAX_SERVICE_NAME_LENGTH
+        and "--" not in name
+        and bool(SERVICE_NAME_RE.match(name))
+    )
+
+
+class DynamicLabel(Selector):
+    """A label selector whose key is completed from execution input.
+
+    ``label_for("sku.", input("model"))`` inspects label ``sku.<model>`` on
+    each candidate worker. The prefix is mandatory — the workflow author
+    declares the namespace, input only completes it. Valid in ``require(...)``
+    terms and in ``prefer()``; not in ``least()``/``most()``, where label
+    strings have no ordering.
+    """
+
+    def __init__(self, prefix: str, ref: InputRef):
+        if not prefix or not isinstance(prefix, str):
+            raise ValueError("label_for() requires a non-empty string prefix")
+        if not isinstance(ref, InputRef):
+            raise ValueError(
+                f"label_for() key must be completed from input(...), got: {type(ref).__name__}",
+            )
+        # The prefix must be a valid label-key head so no input value can
+        # produce a valid key from an invalid namespace.
+        if not _LABEL_KEY_RE.match(prefix.rstrip("._-") or ""):
+            raise ValueError(f"label_for() prefix is not a valid label key prefix: '{prefix}'")
+        self.spec = {"kind": "label", "prefix": prefix, "input": ref.path}
+
+
 def _validate_weight(weight: Any) -> float:
     try:
         weight = float(weight)
@@ -181,14 +289,33 @@ def _require_selector(value: Any, term: str) -> Selector:
         raise ValueError(
             f"{term}() takes a selector (label/metric/resource/load), got: {type(value).__name__}",
         )
+    if not isinstance(value.spec, str):
+        raise ValueError(
+            f"label_for() keys resolve to label strings, which have no ordering — "
+            f"use it in prefer() or require(), not in {term}()",
+        )
     return value
 
 
-def prefer(condition: Condition, *, weight: float = 1.0) -> dict:
+def prefer(condition: Condition | dict, *, weight: float = 1.0) -> dict:
     """Boolean preference: 1.0 when the condition holds, else 0.
 
     ``prefer(label("region") == input("region"), weight=10)``
+
+    Also accepts dynamic-key comparisons and ``service(...)`` — the soft
+    counterparts of their ``require(...)`` forms:
+    ``prefer(label_for("cache.", input("dataset")) == "true", weight=5)``
+    prefers workers with a warm copy without excluding the rest.
     """
+    if isinstance(condition, dict) and condition.get("kind") == "match":
+        # service(...) compiles to a match term; re-shape it as a preference.
+        return {
+            "kind": "prefer",
+            "selector": condition.get("selector"),
+            "op": condition.get("op"),
+            "value": condition.get("value"),
+            "weight": _validate_weight(weight),
+        }
     if not isinstance(condition, Condition):
         raise ValueError(
             "prefer() takes a selector comparison, e.g. "
@@ -230,21 +357,180 @@ def sticky(*, weight: float = 1.0) -> dict:
     return {"kind": "sticky", "weight": _validate_weight(weight)}
 
 
+_SCORE_TERM_KINDS = ("prefer", "least", "most", "sticky")
+
+
 def score(*terms: dict) -> dict:
     """Compose terms into a routing policy spec (stored in workflow metadata)."""
     if not terms:
         raise ValueError("score() requires at least one term")
     for term in terms:
-        if not isinstance(term, dict) or term.get("kind") not in (
-            "prefer",
-            "least",
-            "most",
-            "sticky",
-        ):
+        if not isinstance(term, dict):
             raise ValueError(
-                f"score() accepts only prefer()/least()/most()/sticky() terms, got: {term!r}",
+                f"score() accepts only prefer()/least()/most()/sticky()/when() terms, "
+                f"got: {term!r}",
+            )
+        if term.get("kind") == "when":
+            then = term.get("then")
+            if not isinstance(then, dict) or then.get("kind") not in _SCORE_TERM_KINDS:
+                raise ValueError(
+                    "when(...) in score() must wrap a prefer()/least()/most()/sticky() "
+                    "term; label comparisons belong in require()",
+                )
+        elif term.get("kind") not in _SCORE_TERM_KINDS:
+            raise ValueError(
+                f"score() accepts only prefer()/least()/most()/sticky()/when() terms, "
+                f"got: {term!r}",
             )
     return {"terms": list(terms)}
+
+
+# ---------------------------------------------------------------------------
+# require(...): affinity expressions (the filter stage)
+# ---------------------------------------------------------------------------
+#
+#     @workflow.with_options(
+#         affinity=require(
+#             service(input("model")),
+#             label_for("sku.", input("model")) == "true",
+#             optional(label("node") == input("node")),
+#             when(input("tier") == "dedicated", label("cap.dedicated") == "true"),
+#         ),
+#     )
+#
+# Terms are AND-ed, ops are == and != only, and evaluation is fail-closed: a
+# term whose input cannot be resolved fails the match, except under
+# optional(...) (skip on unresolved input) and when(...) (inactive on an
+# unresolved condition). ``!=`` treats an absent label as passing (absent ≠
+# value) — the one deliberate inversion, so maintenance-window style terms
+# work without every worker carrying the label. Resolved input values are
+# compared against labels as strings (bools as "true"/"false").
+
+_REQUIRE_OPS = ("==", "!=")
+
+
+def label_for(prefix: str, ref: InputRef) -> DynamicLabel:
+    """Label selector whose key is ``prefix`` completed from execution input.
+
+    ``label_for("sku.", input("model")) == "true"`` checks label
+    ``sku.<model> == "true"`` on each candidate. Inputs never create labels,
+    only test them; the resolved key must be a valid label key.
+    """
+    return DynamicLabel(prefix, ref)
+
+
+def service(name: str | InputRef) -> dict:
+    """Target workers holding a granted, runner-verified service socket.
+
+    A hard wall as a ``require(...)`` term, a soft preference inside
+    ``prefer(...)``. Sugar for
+    ``label_for("flux.service.", name) == "true"``. Because the
+    ``flux.`` label prefix is reserved (workers reject user labels under it),
+    this is a capability grant a worker cannot fabricate.
+    """
+    if isinstance(name, InputRef):
+        selector: Any = DynamicLabel(SERVICE_LABEL_PREFIX, name).spec
+    elif isinstance(name, str) and name:
+        if not is_valid_service_name(name):
+            raise ValueError(
+                f"service() name '{name}' is invalid: use lowercase letters, digits, "
+                f"and single hyphens (max {MAX_SERVICE_NAME_LENGTH} chars) — it must "
+                f"match a worker's granted socket name",
+            )
+        selector = f"label:{SERVICE_LABEL_PREFIX}{name}"
+    else:
+        raise ValueError(
+            f"service() takes a service name or input(...), got: {type(name).__name__}",
+        )
+    return {"kind": "match", "selector": selector, "op": "==", "value": "true"}
+
+
+def _compile_match(term: Any, context: str) -> dict:
+    """Normalize a require term (a label Condition or a compiled dict) into
+    its ``{"kind": "match", ...}`` spec."""
+    if isinstance(term, dict):
+        if term.get("kind") == "match":
+            return dict(term)
+        raise ValueError(f"{context} takes a label comparison or service(...), got: {term!r}")
+    if not isinstance(term, Condition):
+        raise ValueError(
+            f"{context} takes a label comparison, e.g. "
+            f'label("region") == input("region"), got: {type(term).__name__}',
+        )
+    spec = term.selector.spec
+    is_label = (isinstance(spec, str) and spec.startswith("label:")) or (
+        isinstance(spec, dict) and spec.get("kind") == "label"
+    )
+    if not is_label:
+        raise ValueError(
+            f"require() terms compare labels only (label()/label_for()); metric()/"
+            f"resource()/load() belong to requests= and routing=, got: '{spec}'",
+        )
+    if term.op not in _REQUIRE_OPS:
+        raise ValueError(
+            f"require() supports only == and != (ordered comparisons on labels are "
+            f"stringly-typed traps; use routing= for metrics), got: '{term.op}'",
+        )
+    return {"kind": "match", "selector": spec, "op": term.op, "value": term.value}
+
+
+def optional(term: Condition | dict) -> dict:
+    """Present-or-skip: the term is skipped when its input is absent, but a
+    resolved comparison that is false still fails the match — and input that
+    resolves to something invalid (bad label key, non-scalar, invalid service
+    name) fails and diagnoses like a bare term."""
+    compiled = _compile_match(term, "optional()")
+    compiled["optional"] = True
+    return compiled
+
+
+def when(condition: InputCondition, term: Condition | dict) -> dict:
+    """Apply ``term`` only when an input condition holds.
+
+    The condition resolves from execution input only — it gates on the
+    requester's intent, never on worker attributes. An unresolved condition
+    leaves the term inactive (a widening construct by design, unlike bare
+    require terms, which fail closed).
+
+    Valid in both stages: wrapping a label comparison (or ``service(...)``)
+    it gates a ``require(...)`` term; wrapping a ``prefer()``/``least()``/
+    ``most()``/``sticky()`` term it gates a ``score(...)`` term.
+    """
+    if not isinstance(condition, InputCondition):
+        raise ValueError(
+            "when() condition must compare input(...) against a constant, e.g. "
+            f'when(input("tier") == "dedicated", ...), got: {type(condition).__name__}',
+        )
+    if isinstance(term, dict) and term.get("kind") in _SCORE_TERM_KINDS:
+        then = dict(term)
+    else:
+        then = _compile_match(term, "when()")
+    return {
+        "kind": "when",
+        "if": {"input": condition.ref.path, "op": condition.op, "value": condition.value},
+        "then": then,
+    }
+
+
+def require(*terms: Condition | dict) -> list[dict]:
+    """Compose terms into an affinity expression (stored as the workflow's
+    ``affinity``). All terms must hold (AND); see the module docs for the
+    fail-closed semantics."""
+    if not terms:
+        raise ValueError("require() requires at least one term")
+    compiled: list[dict] = []
+    for term in terms:
+        if isinstance(term, dict) and term.get("kind") == "when":
+            then = term.get("then")
+            if not isinstance(then, dict) or then.get("kind") != "match":
+                raise ValueError(
+                    "when(...) wrapping a scoring term is only valid in score(); "
+                    "require() terms are label comparisons",
+                )
+            compiled.append(term)
+        else:
+            compiled.append(_compile_match(term, "require()"))
+    return compiled
 
 
 def validate_worker_metrics(payload: Any, max_keys: int = MAX_METRICS) -> dict[str, float] | None:
@@ -352,6 +638,20 @@ def pick_worker(
         if not isinstance(term, dict):
             logger.warning(f"Malformed routing term ignored: {term!r}")
             return None
+        if term.get("kind") == "when":
+            # Input-gated score term: inactive conditions skip it; a
+            # malformed condition degrades the whole policy like any other
+            # malformed term.
+            active = _when_condition_active(term, input_value)
+            if isinstance(active, str):
+                logger.warning(f"Malformed routing term ignored: {term!r}")
+                return None
+            if not active:
+                continue
+            term = term.get("then")
+            if not isinstance(term, dict):
+                logger.warning(f"Malformed routing term ignored: {term!r}")
+                return None
         kind = term.get("kind")
         weight = _as_float(term.get("weight", 1.0))
         if weight is None or weight <= 0:
@@ -365,7 +665,19 @@ def pick_worker(
             continue
 
         selector = term.get("selector")
-        if not isinstance(selector, str):
+        if kind == "prefer" and isinstance(selector, dict):
+            # Dynamic label key (label_for/service): resolve once per term
+            # against the execution input. Unresolved input or an invalid
+            # resolved key means the term cannot discriminate — everyone
+            # scores 0 for it — while a malformed spec degrades the policy.
+            key, problem = _resolve_selector_key(selector, input_value)
+            if problem is not None:
+                if problem.category == "malformed":
+                    logger.warning(f"Malformed routing term ignored: {term!r}")
+                    return None
+                continue
+            selector = f"label:{key}"
+        elif not isinstance(selector, str):
             logger.warning(f"Malformed routing term ignored: {term!r}")
             return None
 
@@ -409,3 +721,203 @@ def pick_worker(
         eligible,
         key=lambda w: (-totals[w.name], loads.get(w.name, 0), w.name),
     )
+
+
+# ---------------------------------------------------------------------------
+# require(...) evaluation (server-side, inside the dispatch paths)
+# ---------------------------------------------------------------------------
+
+_UNRESOLVED = object()  # sentinel: input path absent (None is a legal value)
+
+
+def _resolve_require_input(input_value: Any, path: str) -> Any:
+    current = input_value
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return _UNRESOLVED
+        current = current[part]
+    return current
+
+
+def _label_value_str(value: Any) -> str:
+    # Labels are strings; input-resolved values compare as their string form,
+    # with bools lowercased to match label conventions ("true"/"false").
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+class _Problem(NamedTuple):
+    """A term-resolution problem — an execution-level fact (worker-independent)
+    by construction.
+
+    ``category`` drives what each consumer does with it:
+    - "unresolved": the input path is absent — the one condition
+      ``optional(...)`` forgives.
+    - "invalid": the input resolved to something no worker could ever carry
+      (bad label key, non-scalar, invalid service name) — fails and
+      diagnoses even under ``optional(...)``.
+    - "malformed": the spec itself is broken (hand-written metadata) —
+      always fails, always diagnoses, degrades a scoring policy.
+    """
+
+    category: str
+    message: str
+
+
+def _resolve_selector_key(selector: Any, input_value: Any) -> tuple[str, _Problem | None]:
+    """Resolve a label selector (static ``"label:key"`` or dynamic
+    ``{"kind": "label", "prefix", "input"}``) to its label key.
+
+    Returns ``(key, None)`` or ``("", problem)``."""
+    if isinstance(selector, str) and selector.startswith("label:"):
+        return selector[len("label:") :], None
+    if isinstance(selector, dict) and selector.get("kind") == "label":
+        prefix, path = selector.get("prefix"), selector.get("input")
+        if not isinstance(prefix, str) or not prefix or not isinstance(path, str) or not path:
+            return "", _Problem("malformed", f"malformed label selector: {selector!r}")
+        resolved = _resolve_require_input(input_value, path)
+        if resolved is _UNRESOLVED:
+            return "", _Problem(
+                "unresolved",
+                f"label key requires input '{path}', which is not present",
+            )
+        if resolved is None or isinstance(resolved, (dict, list)):
+            return "", _Problem("invalid", f"label key input '{path}' must be a scalar")
+        fragment = _label_value_str(resolved)
+        if prefix == SERVICE_LABEL_PREFIX and not is_valid_service_name(fragment):
+            # A name worker registration could never grant would otherwise
+            # park the execution forever instead of failing fast.
+            return "", _Problem(
+                "invalid",
+                f"input '{path}' resolves to an invalid service name: '{fragment}'",
+            )
+        key = prefix + fragment
+        if len(key) > MAX_LABEL_KEY_LENGTH or not _LABEL_KEY_RE.match(key):
+            return "", _Problem(
+                "invalid",
+                f"input '{path}' resolves to an invalid label key: '{key}'",
+            )
+        return key, None
+    return "", _Problem("malformed", f"malformed label selector: {selector!r}")
+
+
+def _resolve_require_term(term: dict, input_value: Any) -> tuple[str, str] | _Problem:
+    """Resolve a match term's label key and comparison value against the
+    execution input. Returns ``(key, value)`` or a :class:`_Problem`."""
+    key, problem = _resolve_selector_key(term.get("selector"), input_value)
+    if problem is not None:
+        if problem.category == "malformed":
+            return problem
+        return _Problem(problem.category, f"affinity {problem.message}")
+
+    if term.get("op") not in _REQUIRE_OPS:
+        return _Problem("malformed", f"malformed affinity term op: {term.get('op')!r}")
+
+    value = term.get("value")
+    if isinstance(value, dict):
+        path = value.get("$input")
+        if not isinstance(path, str) or not path:
+            return _Problem("malformed", f"malformed affinity value: {value!r}")
+        value = _resolve_require_input(input_value, path)
+        if value is _UNRESOLVED:
+            return _Problem(
+                "unresolved",
+                f"affinity term on label '{key}' requires input '{path}', which is not present",
+            )
+    return key, _label_value_str(value)
+
+
+def _when_condition_active(term: dict, input_value: Any) -> bool | str:
+    """Whether a when-term's condition holds. Unresolved input leaves the
+    term inactive (False); a malformed condition is a problem string."""
+    cond = term.get("if")
+    if not isinstance(cond, dict):
+        return f"malformed affinity when-condition: {cond!r}"
+    path, op = cond.get("input"), cond.get("op")
+    if not isinstance(path, str) or not path or op not in _REQUIRE_OPS:
+        return f"malformed affinity when-condition: {cond!r}"
+    resolved = _resolve_require_input(input_value, path)
+    if resolved is _UNRESOLVED:
+        return False
+    expected = cond.get("value")
+    return (resolved == expected) if op == "==" else (resolved != expected)
+
+
+def require_diagnostic(terms: Any, input_value: Any) -> str | None:
+    """Execution-level reason this affinity expression can never match, or None.
+
+    Unresolved input on a non-optional term, an invalid resolved label key,
+    and a malformed spec are properties of the execution alone — no worker
+    could ever satisfy them — so dispatch fails the execution with this
+    message instead of parking it forever. A plain label mismatch is
+    fleet-dependent (a matching worker may join) and never diagnosed here.
+    """
+    if not isinstance(terms, (list, tuple)) or not terms:
+        # require() demands at least one term, so an empty list is
+        # hand-written metadata — malformed, not match-everything.
+        return f"malformed affinity expression: {terms!r}"
+    for term in terms:
+        if not isinstance(term, dict):
+            return f"malformed affinity term: {term!r}"
+        if term.get("kind") == "when":
+            active = _when_condition_active(term, input_value)
+            if isinstance(active, str):
+                return active
+            if not active:
+                continue
+            term = term.get("then")
+            if not isinstance(term, dict) or term.get("kind") != "match":
+                return f"malformed affinity when-term body: {term!r}"
+        elif term.get("kind") != "match":
+            return f"malformed affinity term: {term!r}"
+        resolved = _resolve_require_term(term, input_value)
+        if isinstance(resolved, _Problem):
+            # optional(...) forgives absent input — nothing else: an invalid
+            # resolved key or a malformed spec diagnoses regardless.
+            if resolved.category == "unresolved" and term.get("optional"):
+                continue
+            return resolved.message
+    return None
+
+
+def require_matches(terms: Any, worker_labels: dict[str, str] | None, input_value: Any) -> bool:
+    """Whether a worker's labels satisfy a require(...) affinity expression.
+
+    Fail-closed: any problem (unresolved input on a non-optional term,
+    invalid key, malformed spec) fails the match — mirroring
+    ``require_diagnostic``, which turns those same problems into a terminal
+    dispatch error so fail-closed never means queue-forever.
+    """
+    if not isinstance(terms, (list, tuple)) or not terms:
+        return False
+    labels = worker_labels or {}
+    for term in terms:
+        if not isinstance(term, dict):
+            return False
+        if term.get("kind") == "when":
+            active = _when_condition_active(term, input_value)
+            if isinstance(active, str):
+                return False
+            if not active:
+                continue
+            term = term.get("then")
+            if not isinstance(term, dict) or term.get("kind") != "match":
+                return False
+        elif term.get("kind") != "match":
+            return False
+        resolved = _resolve_require_term(term, input_value)
+        if isinstance(resolved, _Problem):
+            if resolved.category == "unresolved" and term.get("optional"):
+                continue
+            return False
+        key, value = resolved
+        actual = labels.get(key)
+        if term.get("op") == "==":
+            if actual != value:
+                return False
+        # Absent ≠ value holds by design: a worker with no such label passes
+        # a != term (the documented inversion of fail-closed).
+        elif actual == value:
+            return False
+    return True

--- a/flux/runners/docker.py
+++ b/flux/runners/docker.py
@@ -22,7 +22,6 @@ import asyncio
 import contextlib
 import json
 import os
-import re
 import shutil
 import stat
 import subprocess
@@ -197,7 +196,6 @@ _AIRGAPPED_VETOED_FLAGS = frozenset(
 )
 
 
-_SERVICE_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 SERVICE_SOCKET_FILENAME = "service.sock"
 SERVICE_MOUNT_PREFIX = "/run/flux/services"
 
@@ -215,10 +213,14 @@ def _validate_service_sockets(services: dict[str, str]) -> dict[str, str]:
     manager) keeps ``CAP_DAC_OVERRIDE`` and can still create or replace
     the socket across restarts.
     """
+    # Same rule flux.routing.service() validates workflow-side, so an
+    # expression can never target a name registration could not grant.
+    from flux.routing import is_valid_service_name
+
     validated: dict[str, str] = {}
     seen_dirs: set[str] = set()
     for name, host_dir in services.items():
-        if len(name) > 32 or "--" in name or not _SERVICE_NAME_RE.match(name):
+        if not is_valid_service_name(name):
             raise ValueError(
                 f"[flux.workers] airgapped_service_sockets name '{name}' is "
                 "invalid: use lowercase letters, digits, and single hyphens "

--- a/flux/workflow.py
+++ b/flux/workflow.py
@@ -27,7 +27,7 @@ class workflow:
         secret_requests: list[str] | None = None,
         output_storage: OutputStorage | None = None,
         requests: ResourceRequest | None = None,
-        affinity: dict[str, str] | None = None,
+        affinity: dict[str, str] | list[dict] | None = None,
         schedule: Schedule | None = None,
         durability: str = "durable",
         runner: str | None = None,
@@ -42,7 +42,7 @@ class workflow:
             secret_requests (list[str], optional): A list of secret keys required by the workflow. Defaults to an empty list.
             output_storage (OutputStorage | None, optional): The storage configuration for the workflow's output. Defaults to None.
             requests (ResourceRequest | None, optional): The minimum resources, runtime and packages for the workflow. Defaults to None.
-            affinity (dict[str, str] | None, optional): Label-based worker affinity constraints. Workers must have all specified labels to run this workflow. Defaults to None.
+            affinity (dict[str, str] | list[dict] | None, optional): Label-based worker affinity constraints — either a static label dict (workers must carry all listed labels) or an expression built with ``flux.routing.require(...)`` whose terms resolve against the execution input at dispatch. Defaults to None.
             schedule (Schedule | None, optional): The schedule configuration for automatic workflow execution. Defaults to None.
             durability (str, optional): "durable" (default) persists every task-level checkpoint; "transient" keeps only the outer lifecycle.
             runner (str | None, optional): Runner this workflow requires on the worker ("inprocess", "subprocess", or "docker"). Defaults to None, meaning the worker's configured default_runner.
@@ -77,7 +77,7 @@ class workflow:
         secret_requests: list[str] | None = None,
         output_storage: OutputStorage | None = None,
         requests: ResourceRequest | None = None,
-        affinity: dict[str, str] | None = None,
+        affinity: dict[str, str] | list[dict] | None = None,
         schedule: Schedule | None = None,
         durability: str = "durable",
         runner: str | None = None,
@@ -107,6 +107,22 @@ class workflow:
         ):
             raise ValueError(
                 f"routing must be a policy built with flux.routing.score(...), got: {routing!r}",
+            )
+        if (
+            affinity is not None
+            and not isinstance(affinity, dict)
+            and not (
+                isinstance(affinity, list)
+                and affinity
+                and all(
+                    isinstance(term, dict) and term.get("kind") in ("match", "when")
+                    for term in affinity
+                )
+            )
+        ):
+            raise ValueError(
+                "affinity must be a label dict or an expression built with "
+                f"flux.routing.require(...), got: {affinity!r}",
             )
         self._func = func
         self._name = name if name else func.__name__
@@ -158,7 +174,7 @@ class workflow:
         return self._requests
 
     @property
-    def affinity(self) -> dict[str, str] | None:
+    def affinity(self) -> dict[str, str] | list[dict] | None:
         return self._affinity
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.61.0"
+version = "0.62.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/e2e/fixtures/require_workflow.py
+++ b/tests/e2e/fixtures/require_workflow.py
@@ -1,0 +1,12 @@
+from flux import workflow
+from flux.routing import input, label, require, when
+
+
+@workflow.with_options(
+    affinity=require(
+        label("region") == input("region"),
+        when(input("tier") == "dedicated", label("cap.dedicated") == "true"),
+    ),
+)
+async def require_task(ctx):
+    return {"served_region": (ctx.input or {}).get("region")}

--- a/tests/e2e/test_require_affinity.py
+++ b/tests/e2e/test_require_affinity.py
@@ -1,0 +1,82 @@
+"""E2E tests for require(...) affinity expressions: per-execution routing.
+
+One registered workflow, three behaviors driven purely by execution input:
+region-matched dispatch, fail-fast on unresolved input, and a when() gate
+that parks until a capable worker appears. The session's unlabeled
+e2e-worker never matches a require term (fail-closed), so these tests are
+insulated from it.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+pytestmark = pytest.mark.e2e
+
+
+def test_require_routes_by_execution_input(cli):
+    """The same registration serves differently-routed requests."""
+    eu = cli.start_worker("req-eu-worker", labels={"region": "eu-west"})
+    us = cli.start_worker("req-us-worker", labels={"region": "us-east"})
+    try:
+        cli.register(str(FIXTURES / "require_workflow.py"))
+
+        r = cli.run("require_task", '{"region": "eu-west"}')
+        assert r["state"] == "COMPLETED"
+        assert r.get("current_worker") == "req-eu-worker"
+        assert r["output"] == {"served_region": "eu-west"}
+
+        r = cli.run("require_task", '{"region": "us-east"}')
+        assert r["state"] == "COMPLETED"
+        assert r.get("current_worker") == "req-us-worker"
+    finally:
+        cli.stop_worker(eu)
+        cli.stop_worker(us)
+
+
+def test_require_unresolved_input_fails_fast(cli):
+    """Missing required input is a named dispatch error, not a silent queue."""
+    worker = cli.start_worker("req-diag-worker", labels={"region": "eu-west"})
+    try:
+        cli.register(str(FIXTURES / "require_workflow.py"))
+        r = cli.run("require_task", '{"other": 1}', mode="async", timeout=30)
+        final = cli.wait_for_state("require_task", r["execution_id"], "FAILED", timeout=30)
+        assert "region" in str(final)
+    finally:
+        cli.stop_worker(worker)
+
+
+def test_require_when_gate_waits_for_capable_worker(cli):
+    """A when()-gated execution parks until a worker satisfying the gated
+    term connects, then dispatches to it."""
+    plain = cli.start_worker("req-plain-worker", labels={"region": "eu-west"})
+    try:
+        cli.register(str(FIXTURES / "require_workflow.py"))
+        r = cli.run(
+            "require_task",
+            '{"region": "eu-west", "tier": "dedicated"}',
+            mode="async",
+            timeout=30,
+        )
+        exec_id = r["execution_id"]
+
+        time.sleep(3)
+        s = cli.status("require_task", exec_id)
+        assert s["state"] not in ("COMPLETED", "FAILED"), s
+
+        dedicated = cli.start_worker(
+            "req-dedicated-worker",
+            labels={"region": "eu-west", "cap.dedicated": "true"},
+        )
+        try:
+            final = cli.wait_for_state("require_task", exec_id, "COMPLETED", timeout=30)
+            assert final.get("current_worker") == "req-dedicated-worker"
+        finally:
+            cli.stop_worker(dedicated)
+    finally:
+        cli.stop_worker(plain)

--- a/tests/examples/test_affinity_expressions.py
+++ b/tests/examples/test_affinity_expressions.py
@@ -1,0 +1,73 @@
+"""Tests for the affinity-expressions example.
+
+Affinity is a dispatch concern; inline execution runs the workflows in the
+current process, so these verify the workflows themselves and that the
+example's expressions register: each carries a compiled require(...) spec,
+and the catalog extracts the same spec statically from the source.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from examples.affinity_expressions import locality_query, nightly_cleanup, tenant_report
+
+EXAMPLE = Path(__file__).parent.parent.parent / "examples" / "affinity_expressions.py"
+
+
+def test_locality_query_runs_inline():
+    ctx = locality_query.run(
+        {"dc": "eu-central", "dataset": "orders-2026", "query": "count(*)"},
+    )
+    assert ctx.has_finished and ctx.has_succeeded
+    assert ctx.output == {"dataset": "orders-2026", "rows": ["result(count(*))"]}
+
+
+def test_tenant_report_runs_inline():
+    ctx = tenant_report.run({"tenant_id": "acme"})
+    assert ctx.has_finished and ctx.has_succeeded
+    assert ctx.output == {"tenant": "acme", "report": "ok"}
+
+
+def test_nightly_cleanup_runs_inline():
+    ctx = nightly_cleanup.run()
+    assert ctx.has_finished and ctx.has_succeeded
+    assert ctx.output == {"cleaned": True}
+
+
+def test_workflows_carry_compiled_expressions():
+    assert [term["kind"] for term in locality_query.affinity] == [
+        "match",
+        "match",
+        "match",
+        "when",
+    ]
+    # The scoring stage speaks the same vocabulary: a dynamic-key prefer.
+    assert [term["kind"] for term in locality_query.routing["terms"]] == ["prefer", "least"]
+    assert locality_query.routing["terms"][0]["selector"] == {
+        "kind": "label",
+        "prefix": "cache.",
+        "input": "dataset",
+    }
+    assert tenant_report.affinity == [
+        {
+            "kind": "match",
+            "selector": "label:tenant",
+            "op": "==",
+            "value": {"$input": "tenant_id"},
+        },
+    ]
+    assert nightly_cleanup.affinity[0]["op"] == "!="
+
+
+def test_catalog_extraction_matches_decorators():
+    """The AST extraction of the example source agrees with the runtime
+    factories — the guarantee that server-side registration sees exactly
+    what the decorator built."""
+    from flux.catalogs import WorkflowCatalog
+
+    infos = {i.name: i for i in WorkflowCatalog.create().parse(EXAMPLE.read_bytes())}
+    assert infos["locality_query"].affinity == locality_query.affinity
+    assert (infos["locality_query"].metadata or {})["routing"] == locality_query.routing
+    assert infos["tenant_report"].affinity == tenant_report.affinity
+    assert infos["nightly_cleanup"].affinity == nightly_cleanup.affinity

--- a/tests/flux/test_affinity_dispatch.py
+++ b/tests/flux/test_affinity_dispatch.py
@@ -81,11 +81,12 @@ def _create_workflow(cm, name, namespace="default", affinity=None, requests=None
         return wf.id
 
 
-def _create_execution(cm, workflow_id, namespace="default", name="test"):
+def _create_execution(cm, workflow_id, namespace="default", name="test", input=None):
     ctx = ExecutionContext(
         workflow_id=workflow_id,
         workflow_namespace=namespace,
         workflow_name=name,
+        input=input,
     )
     return cm.save(ctx)
 
@@ -353,3 +354,134 @@ def test_dispatch_affinity_matches_but_resources_insufficient(clean_env):
 
     result = cm.next_execution(w1)
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# require(...) affinity expressions (poll-mode dispatch)
+# ---------------------------------------------------------------------------
+
+
+def _require_spec(*terms):
+    from flux.routing import require
+
+    return require(*terms)
+
+
+def test_poll_require_input_driven_match(clean_env):
+    from flux.routing import input as input_, label
+
+    cm, registry = clean_env
+    _register_worker(registry, "eu", labels={"region": "eu-west"})
+    _register_worker(registry, "us", labels={"region": "us-east"})
+    eu, us = registry.get("eu"), registry.get("us")
+
+    wf_id = _create_workflow(
+        cm,
+        "infer",
+        affinity=_require_spec(label("region") == input_("region")),
+    )
+    _create_execution(cm, wf_id, name="infer", input={"region": "eu-west"})
+
+    assert cm.next_execution(us) is None
+    result = cm.next_execution(eu)
+    assert result is not None and result.workflow_name == "infer"
+
+
+def test_poll_require_unresolved_input_fails_execution(clean_env):
+    from flux.routing import input as input_, label
+
+    cm, registry = clean_env
+    _register_worker(registry, "eu", labels={"region": "eu-west"})
+    eu = registry.get("eu")
+
+    wf_id = _create_workflow(
+        cm,
+        "infer",
+        affinity=_require_spec(label("region") == input_("region")),
+    )
+    ctx = _create_execution(cm, wf_id, name="infer", input={"other": 1})
+
+    assert cm.next_execution(eu) is None
+
+    failed = cm.get(ctx.execution_id)
+    assert failed.state == ExecutionState.FAILED
+    [event] = [e for e in failed.events if e.type.name == "WORKFLOW_FAILED"]
+    assert "region" in str(event.value)
+
+
+def test_poll_require_mismatch_parks_execution(clean_env):
+    """A resolvable-but-unmatched expression waits for a matching worker."""
+    from flux.routing import input as input_, label
+
+    cm, registry = clean_env
+    _register_worker(registry, "us", labels={"region": "us-east"})
+    us = registry.get("us")
+
+    wf_id = _create_workflow(
+        cm,
+        "infer",
+        affinity=_require_spec(label("region") == input_("region")),
+    )
+    ctx = _create_execution(cm, wf_id, name="infer", input={"region": "eu-west"})
+
+    assert cm.next_execution(us) is None
+    assert cm.get(ctx.execution_id).state == ExecutionState.CREATED
+
+    _register_worker(registry, "eu", labels={"region": "eu-west"})
+    assert cm.next_execution(registry.get("eu")) is not None
+
+
+def test_poll_require_dynamic_key_and_optional_pin(clean_env):
+    from flux.routing import input as input_, label, label_for, optional
+
+    cm, registry = clean_env
+    _register_worker(registry, "a", labels={"sku.small-8b": "true", "node": "node_a"})
+    _register_worker(registry, "b", labels={"sku.small-8b": "true", "node": "node_b"})
+    a, b = registry.get("a"), registry.get("b")
+
+    wf_id = _create_workflow(
+        cm,
+        "infer",
+        affinity=_require_spec(
+            label_for("sku.", input_("model")) == "true",
+            optional(label("node") == input_("node")),
+        ),
+    )
+    _create_execution(
+        cm,
+        wf_id,
+        name="infer",
+        input={"model": "small-8b", "node": "node_b"},
+    )
+
+    assert cm.next_execution(a) is None
+    assert cm.next_execution(b) is not None
+
+
+def test_resume_fallback_respects_require_expression(clean_env):
+    from flux.routing import input as input_, label
+
+    cm, registry = clean_env
+    _register_worker(registry, "us", labels={"region": "us-east"})
+    _register_worker(registry, "eu", labels={"region": "eu-west"})
+    us, eu = registry.get("us"), registry.get("eu")
+
+    wf_id = _create_workflow(
+        cm,
+        "infer",
+        affinity=_require_spec(label("region") == input_("region")),
+    )
+    ctx = _create_execution(cm, wf_id, name="infer", input={"region": "eu-west"})
+
+    from flux.models import ExecutionContextModel, RepositoryFactory
+
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        model = session.get(ExecutionContextModel, ctx.execution_id)
+        model.state = ExecutionState.RESUMING
+        model.worker_name = None
+        session.commit()
+
+    assert cm.next_resume(us) is None
+    result = cm.next_resume(eu)
+    assert result is not None and result.workflow_name == "infer"

--- a/tests/flux/test_dispatch_batch.py
+++ b/tests/flux/test_dispatch_batch.py
@@ -357,3 +357,171 @@ def test_preferred_worker_persists_in_the_insert_transaction(clean_env):
 
     assignments = cm.next_executions_batch([w2], limit=10)
     assert {c.execution_id: w for c, w in assignments}[ctx.execution_id] == "w2"
+
+
+# ---------------------------------------------------------------------------
+# require(...) affinity expressions (event-mode dispatch parity)
+# ---------------------------------------------------------------------------
+
+
+def _create_execution_with_input(cm, workflow_id, name, input):
+    ctx = ExecutionContext(
+        workflow_id=workflow_id,
+        workflow_namespace="default",
+        workflow_name=name,
+        input=input,
+    )
+    return cm.save(ctx)
+
+
+def test_batch_require_routes_by_input(clean_env):
+    from flux.routing import input as input_, label, require
+
+    cm, registry = clean_env
+    eu = _register_worker(registry, "eu", labels={"region": "eu-west"})
+    us = _register_worker(registry, "us", labels={"region": "us-east"})
+
+    wf_id = _create_workflow(
+        "infer",
+        affinity=require(label("region") == input_("region")),
+    )
+    ctx_eu = _create_execution_with_input(cm, wf_id, "infer", {"region": "eu-west"})
+    ctx_us = _create_execution_with_input(cm, wf_id, "infer", {"region": "us-east"})
+
+    assignments = {
+        ctx.execution_id: worker for ctx, worker in cm.next_executions_batch([eu, us], limit=10)
+    }
+    assert assignments == {ctx_eu.execution_id: "eu", ctx_us.execution_id: "us"}
+
+
+def test_batch_require_unresolved_input_fails_execution(clean_env):
+    from flux.routing import input as input_, label, require
+
+    cm, registry = clean_env
+    eu = _register_worker(registry, "eu", labels={"region": "eu-west"})
+
+    wf_id = _create_workflow(
+        "infer",
+        affinity=require(label("region") == input_("region")),
+    )
+    bad = _create_execution_with_input(cm, wf_id, "infer", {"oops": 1})
+    good = _create_execution_with_input(cm, wf_id, "infer", {"region": "eu-west"})
+
+    assignments = cm.next_executions_batch([eu], limit=10)
+
+    assert [ctx.execution_id for ctx, _ in assignments] == [good.execution_id]
+    states = _states(cm)
+    assert states[bad.execution_id][0] == ExecutionState.FAILED
+    failed = cm.get(bad.execution_id)
+    [event] = [e for e in failed.events if e.type.name == "WORKFLOW_FAILED"]
+    assert "region" in str(event.value)
+
+
+def test_batch_require_mismatch_parks_execution(clean_env):
+    from flux.routing import input as input_, label, require
+
+    cm, registry = clean_env
+    us = _register_worker(registry, "us", labels={"region": "us-east"})
+
+    wf_id = _create_workflow(
+        "infer",
+        affinity=require(label("region") == input_("region")),
+    )
+    ctx = _create_execution_with_input(cm, wf_id, "infer", {"region": "eu-west"})
+
+    assert cm.next_executions_batch([us], limit=10) == []
+    assert _states(cm)[ctx.execution_id][0] == ExecutionState.CREATED
+
+
+def test_batch_require_when_gate(clean_env):
+    from flux.routing import input as input_, label, require, when
+
+    cm, registry = clean_env
+    plain = _register_worker(registry, "plain", labels={"region": "eu"})
+    dedicated = _register_worker(
+        registry,
+        "dedicated",
+        labels={"region": "eu", "cap.dedicated": "true"},
+    )
+
+    wf_id = _create_workflow(
+        "infer",
+        affinity=require(
+            label("region") == "eu",
+            when(input_("tier") == "dedicated", label("cap.dedicated") == "true"),
+        ),
+    )
+    gated = _create_execution_with_input(cm, wf_id, "infer", {"tier": "dedicated"})
+
+    # Only the dedicated worker is eligible for the gated execution.
+    assignments = cm.next_executions_batch([plain, dedicated], limit=10)
+    assert [(ctx.execution_id, w) for ctx, w in assignments] == [
+        (gated.execution_id, "dedicated"),
+    ]
+
+
+def test_batch_resume_respects_require_expression(clean_env):
+    from flux.routing import input as input_, label, require
+
+    cm, registry = clean_env
+    us = _register_worker(registry, "us", labels={"region": "us-east"})
+    eu = _register_worker(registry, "eu", labels={"region": "eu-west"})
+
+    wf_id = _create_workflow(
+        "infer",
+        affinity=require(label("region") == input_("region")),
+    )
+    ctx = _create_execution_with_input(cm, wf_id, "infer", {"region": "eu-west"})
+    _force_state(ctx.execution_id, ExecutionState.RESUMING, worker_name=None)
+
+    assignments = cm.next_resumes_batch([us, eu], limit=10)
+    assert [(c.execution_id, w) for c, w in assignments] == [(ctx.execution_id, "eu")]
+
+
+def test_batch_pairs_require_floor_with_dynamic_prefer(clean_env):
+    """require() as the hard floor, a dynamic-key prefer() as the soft
+    preference: eligible workers are filtered by datacenter, then the one
+    holding a warm cache copy of the requested dataset wins despite load."""
+    from flux.models import WorkflowModel
+    from flux.routing import input as input_, label, label_for, least, load, prefer, require, score
+
+    cm, registry = clean_env
+    warm = _register_worker(registry, "warm", labels={"dc": "eu", "cache.orders": "true"})
+    cold = _register_worker(registry, "cold", labels={"dc": "eu"})
+    other = _register_worker(registry, "other", labels={"dc": "us", "cache.orders": "true"})
+
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        wf = WorkflowModel(
+            id="default/locality",
+            name="locality",
+            version=1,
+            imports=[],
+            source=b"async def placeholder(ctx): pass",
+            affinity=require(label("dc") == input_("dc")),
+            metadata={
+                "routing": score(
+                    prefer(label_for("cache.", input_("dataset")) == "true", weight=10),
+                    least(load()),
+                ),
+            },
+        )
+        session.add(wf)
+        session.commit()
+
+    # Load the warm worker up so least(load()) alone would pick cold.
+    busy_wf = _create_workflow("busy")
+    for _ in range(3):
+        ctx = _create_execution(cm, busy_wf, name="busy")
+        _force_state(ctx.execution_id, ExecutionState.RUNNING, worker_name="warm")
+
+    ctx = ExecutionContext(
+        workflow_id="default/locality",
+        workflow_namespace="default",
+        workflow_name="locality",
+        input={"dc": "eu", "dataset": "orders"},
+    )
+    cm.save(ctx)
+
+    assignments = cm.next_executions_batch([warm, cold, other], limit=10)
+    assert [(c.execution_id, w) for c, w in assignments] == [(ctx.execution_id, "warm")]

--- a/tests/flux/test_require.py
+++ b/tests/flux/test_require.py
@@ -1,0 +1,437 @@
+"""require(...) affinity expressions: the DSL factories and their fail-closed
+evaluation semantics (every row of the semantics table, plus guardrails)."""
+
+from __future__ import annotations
+
+import pytest
+
+from flux.routing import (
+    Condition,
+    InputCondition,
+    label,
+    label_for,
+    least,
+    most,
+    optional,
+    prefer,
+    require,
+    require_diagnostic,
+    require_matches,
+    service,
+    when,
+)
+from flux.routing import input as input_
+
+
+class TestRequireCompile:
+    def test_static_parity_with_dict_affinity(self):
+        assert require(label("gpu") == "a100") == [
+            {"kind": "match", "selector": "label:gpu", "op": "==", "value": "a100"},
+        ]
+
+    def test_input_driven_value(self):
+        assert require(label("region") == input_("region")) == [
+            {
+                "kind": "match",
+                "selector": "label:region",
+                "op": "==",
+                "value": {"$input": "region"},
+            },
+        ]
+
+    def test_negation(self):
+        assert require(label("maintenance") != "true")[0]["op"] == "!="
+
+    def test_dynamic_label_key(self):
+        assert require(label_for("sku.", input_("model")) == "true") == [
+            {
+                "kind": "match",
+                "selector": {"kind": "label", "prefix": "sku.", "input": "model"},
+                "op": "==",
+                "value": "true",
+            },
+        ]
+
+    def test_service_sugar_static_and_dynamic(self):
+        assert require(service("inference")) == [
+            {
+                "kind": "match",
+                "selector": "label:flux.service.inference",
+                "op": "==",
+                "value": "true",
+            },
+        ]
+        assert require(service(input_("model")))[0]["selector"] == {
+            "kind": "label",
+            "prefix": "flux.service.",
+            "input": "model",
+        }
+
+    def test_optional_flag(self):
+        term = require(optional(label("node") == input_("node")))[0]
+        assert term["optional"] is True
+
+    def test_optional_wraps_service(self):
+        term = require(optional(service("inference")))[0]
+        assert term["optional"] is True
+        assert term["selector"] == "label:flux.service.inference"
+
+    def test_when_compiles_input_condition(self):
+        assert require(
+            when(input_("tier") == "dedicated", label("cap.dedicated") == "true"),
+        ) == [
+            {
+                "kind": "when",
+                "if": {"input": "tier", "op": "==", "value": "dedicated"},
+                "then": {
+                    "kind": "match",
+                    "selector": "label:cap.dedicated",
+                    "op": "==",
+                    "value": "true",
+                },
+            },
+        ]
+
+    def test_require_needs_terms(self):
+        with pytest.raises(ValueError, match="at least one term"):
+            require()
+
+    def test_ordered_comparisons_rejected(self):
+        with pytest.raises(ValueError, match="only == and !="):
+            require(label("size") > "10")
+
+    def test_non_label_selectors_rejected(self):
+        from flux.routing import load, metric, resource
+
+        for selector in (metric("temp"), resource("cpu_available"), load()):
+            with pytest.raises(ValueError, match="labels only"):
+                require(selector == 1)
+
+    def test_label_for_requires_prefix_and_input_ref(self):
+        with pytest.raises(ValueError, match="non-empty string prefix"):
+            label_for("", input_("model"))
+        with pytest.raises(ValueError, match="input"):
+            label_for("sku.", "small-8b")
+        with pytest.raises(ValueError, match="not a valid label key prefix"):
+            label_for("../", input_("model"))
+
+    def test_service_rejects_invalid_names(self):
+        # Static names are held to the worker-side socket-name rule
+        # (lowercase/digits/single hyphens, max 32) so an expression can
+        # never target a name registration could not grant.
+        for bad in ("../etc", "Foo", "a--b", "a" * 33, "-lead"):
+            with pytest.raises(ValueError, match="lowercase letters"):
+                service(bad)
+        with pytest.raises(ValueError, match="service name or input"):
+            service(42)
+        assert service("small-8b")["selector"] == "label:flux.service.small-8b"
+
+    def test_when_condition_must_be_input_condition(self):
+        with pytest.raises(ValueError, match="input"):
+            when(label("x") == "y", label("a") == "b")
+
+    def test_input_condition_ops_and_values(self):
+        cond = input_("tier") == "dedicated"
+        assert isinstance(cond, InputCondition)
+        assert (input_("tier") != "shared").op == "!="
+        with pytest.raises(ValueError, match="constants"):
+            input_("a") == input_("b")
+        with pytest.raises(ValueError, match="only == and !="):
+            InputCondition(input_("a"), "<", 1)
+        with pytest.raises(ValueError, match="must be a constant"):
+            InputCondition(input_("a"), "==", [1])
+
+    def test_optional_and_when_reject_non_match_terms(self):
+        with pytest.raises(ValueError, match="label comparison"):
+            optional({"kind": "when"})
+        with pytest.raises(ValueError, match="label comparison"):
+            when(input_("t") == 1, "junk")
+
+    def test_dynamic_selector_in_score_terms(self):
+        # prefer() speaks the dynamic vocabulary (soft counterpart of a
+        # require term); least()/most() reject it — labels have no ordering.
+        dynamic = label_for("sku.", input_("model"))
+        assert prefer(dynamic == "true")["selector"] == {
+            "kind": "label",
+            "prefix": "sku.",
+            "input": "model",
+        }
+        with pytest.raises(ValueError, match="no ordering"):
+            least(dynamic)
+        with pytest.raises(ValueError, match="no ordering"):
+            most(dynamic)
+
+    def test_condition_still_usable_for_score(self):
+        # require() must not break the score() vocabulary.
+        cond = label("region") == input_("region")
+        assert isinstance(cond, Condition)
+        assert prefer(cond)["selector"] == "label:region"
+
+
+class TestRequireMatches:
+    """One test per row of the evaluation-semantics table."""
+
+    def test_unresolved_input_fails_closed(self):
+        spec = require(label("region") == input_("region"))
+        assert not require_matches(spec, {"region": "eu-west"}, {})
+        assert not require_matches(spec, {"region": "eu-west"}, None)
+
+    def test_resolved_input_label_absent(self):
+        spec = require(label("region") == input_("region"))
+        assert not require_matches(spec, {}, {"region": "eu-west"})
+
+    def test_resolved_input_label_equal(self):
+        spec = require(label("region") == input_("region"))
+        assert require_matches(spec, {"region": "eu-west"}, {"region": "eu-west"})
+
+    def test_negation_absent_label_passes(self):
+        spec = require(label("maintenance") != "true")
+        assert require_matches(spec, {}, None)
+        assert require_matches(spec, {"maintenance": "false"}, None)
+        assert not require_matches(spec, {"maintenance": "true"}, None)
+
+    def test_optional_unresolved_skips(self):
+        spec = require(optional(label("node") == input_("node")))
+        assert require_matches(spec, {}, {})
+
+    def test_optional_forgives_only_absent_input(self):
+        # An invalid resolved key or a non-scalar input is an execution-level
+        # error, not a missing pin — optional() does not paper over it.
+        spec = require(optional(label_for("sku.", input_("model")) == "true"))
+        assert require_matches(spec, {"sku.x": "true"}, {})  # absent: skipped
+        assert not require_matches(spec, {"sku.x": "true"}, {"model": "../x"})
+        assert not require_matches(spec, {"sku.x": "true"}, {"model": {"nested": 1}})
+
+    def test_dynamic_service_name_validated_on_resolution(self):
+        from flux.routing import service
+
+        spec = require(service(input_("model")))
+        assert require_matches(spec, {"flux.service.small-8b": "true"}, {"model": "small-8b"})
+        # A name worker registration could never grant fails closed...
+        assert not require_matches(spec, {"flux.service.small-8b": "true"}, {"model": "Big_8B"})
+        # ...and diagnoses, so the execution fails fast instead of parking.
+        message = require_diagnostic(spec, {"model": "Big_8B"})
+        assert message is not None and "invalid service name" in message
+
+    def test_optional_resolved_false_still_fails(self):
+        spec = require(optional(label("node") == input_("node")))
+        assert not require_matches(spec, {"node": "a"}, {"node": "b"})
+        assert require_matches(spec, {"node": "b"}, {"node": "b"})
+
+    def test_when_unresolved_condition_is_inactive(self):
+        spec = require(when(input_("tier") == "dedicated", label("cap") == "true"))
+        assert require_matches(spec, {}, {})
+
+    def test_when_active_condition_enforces_term(self):
+        spec = require(when(input_("tier") == "dedicated", label("cap") == "true"))
+        assert not require_matches(spec, {}, {"tier": "dedicated"})
+        assert require_matches(spec, {"cap": "true"}, {"tier": "dedicated"})
+        assert require_matches(spec, {}, {"tier": "shared"})
+
+    def test_dynamic_key_resolution(self):
+        spec = require(label_for("sku.", input_("model")) == "true")
+        assert require_matches(spec, {"sku.small-8b": "true"}, {"model": "small-8b"})
+        assert not require_matches(spec, {"sku.small-8b": "true"}, {"model": "big-70b"})
+
+    def test_dynamic_key_invalid_resolution_fails(self):
+        spec = require(label_for("sku.", input_("model")) == "true")
+        assert not require_matches(spec, {"sku.x": "true"}, {"model": "../x"})
+        assert not require_matches(spec, {"sku.x": "true"}, {"model": {"nested": 1}})
+
+    def test_dotted_input_path(self):
+        spec = require(label("region") == input_("customer.region"))
+        assert require_matches(spec, {"region": "eu"}, {"customer": {"region": "eu"}})
+        assert not require_matches(spec, {"region": "eu"}, {"customer": {}})
+
+    def test_values_compare_as_strings_bools_lowercase(self):
+        spec = require(label("replicas") == input_("n"), label("hipaa") == input_("phi"))
+        assert require_matches(spec, {"replicas": "3", "hipaa": "true"}, {"n": 3, "phi": True})
+
+    def test_terms_are_anded(self):
+        spec = require(label("a") == "1", label("b") == "2")
+        assert require_matches(spec, {"a": "1", "b": "2"}, None)
+        assert not require_matches(spec, {"a": "1"}, None)
+
+    def test_none_and_empty_labels(self):
+        spec = require(label("a") == "1")
+        assert not require_matches(spec, None, None)
+        assert not require_matches(spec, {}, None)
+
+    def test_malformed_specs_fail_closed(self):
+        assert not require_matches({"not": "a list"}, {"a": "1"}, None)
+        # require() demands at least one term: a hand-written empty spec is
+        # malformed, never match-everything.
+        assert not require_matches([], {"a": "1"}, None)
+        assert not require_matches(["not a dict"], {"a": "1"}, None)
+        assert not require_matches([{"kind": "unknown"}], {"a": "1"}, None)
+        assert not require_matches(
+            [{"kind": "match", "selector": "metric:temp", "op": "==", "value": "1"}],
+            {"a": "1"},
+            None,
+        )
+        assert not require_matches(
+            [{"kind": "match", "selector": "label:a", "op": "<", "value": "1"}],
+            {"a": "1"},
+            None,
+        )
+
+    def test_malformed_hand_written_metadata_fails_closed(self):
+        # Terms the factories cannot produce, but hand-edited wf_metadata can.
+        bad_dynamic = {
+            "kind": "match",
+            "selector": {"kind": "label", "prefix": 1, "input": "x"},
+            "op": "==",
+            "value": "1",
+        }
+        bad_value = {"kind": "match", "selector": "label:a", "op": "==", "value": {"$input": ""}}
+        bad_if = {"kind": "when", "if": "junk", "then": {"kind": "match"}}
+        bad_if_fields = {"kind": "when", "if": {"input": "", "op": "<"}, "then": {}}
+        bad_then = {"kind": "when", "if": {"input": "t", "op": "==", "value": 1}, "then": "junk"}
+        for term in (bad_dynamic, bad_value, bad_if, bad_if_fields):
+            assert not require_matches([term], {"a": "1"}, {"t": 1})
+        assert not require_matches([bad_then], {"a": "1"}, {"t": 1})
+
+
+class TestRequireDiagnostic:
+    """Worker-independent problems become dispatch errors, never eternal queues."""
+
+    def test_unresolved_input_names_the_path(self):
+        spec = require(label("region") == input_("region"))
+        message = require_diagnostic(spec, {})
+        assert message is not None and "'region'" in message
+
+    def test_unresolved_dynamic_key_names_the_path(self):
+        spec = require(label_for("sku.", input_("model")) == "true")
+        message = require_diagnostic(spec, {})
+        assert message is not None and "'model'" in message
+
+    def test_invalid_resolved_key_names_the_key(self):
+        spec = require(label_for("sku.", input_("model")) == "true")
+        message = require_diagnostic(spec, {"model": "../etc"})
+        assert message is not None and "invalid label key" in message
+
+    def test_resolvable_input_no_diagnostic(self):
+        spec = require(label("region") == input_("region"))
+        assert require_diagnostic(spec, {"region": "eu"}) is None
+
+    def test_label_mismatch_is_not_a_diagnostic(self):
+        # A mismatch is fleet-dependent: the execution parks, it does not fail.
+        spec = require(label("gpu") == "a100")
+        assert require_diagnostic(spec, {}) is None
+
+    def test_optional_unresolved_no_diagnostic(self):
+        spec = require(optional(label("node") == input_("node")))
+        assert require_diagnostic(spec, {}) is None
+
+    def test_optional_invalid_resolution_still_diagnoses(self):
+        spec = require(optional(label_for("sku.", input_("model")) == "true"))
+        assert require_diagnostic(spec, {}) is None  # absent input: skipped
+        message = require_diagnostic(spec, {"model": "../x"})
+        assert message is not None and "invalid label key" in message
+        message = require_diagnostic(spec, {"model": [1, 2]})
+        assert message is not None and "must be a scalar" in message
+
+    def test_when_unresolved_condition_no_diagnostic(self):
+        spec = require(when(input_("tier") == "dedicated", label("cap") == input_("cap")))
+        assert require_diagnostic(spec, {}) is None
+
+    def test_when_active_term_diagnoses_unresolved_input(self):
+        spec = require(when(input_("tier") == "dedicated", label("cap") == input_("cap")))
+        message = require_diagnostic(spec, {"tier": "dedicated"})
+        assert message is not None and "'cap'" in message
+
+    def test_malformed_hand_written_metadata_diagnoses(self):
+        cases = [
+            {"not": "a list"},
+            [],
+            ["not a dict"],
+            [{"kind": "unknown"}],
+            [
+                {
+                    "kind": "match",
+                    "selector": {"kind": "label", "prefix": 1, "input": "x"},
+                    "op": "==",
+                    "value": "1",
+                },
+            ],
+            [{"kind": "match", "selector": "label:a", "op": "==", "value": {"$input": ""}}],
+            [{"kind": "when", "if": "junk", "then": {"kind": "match"}}],
+            [{"kind": "when", "if": {"input": "", "op": "<"}, "then": {}}],
+            [{"kind": "when", "if": {"input": "t", "op": "==", "value": 1}, "then": "junk"}],
+        ]
+        for spec in cases:
+            assert "malformed" in (require_diagnostic(spec, {"t": 1}) or ""), spec
+
+    def test_malformed_spec_diagnoses_even_under_optional(self):
+        malformed = [{"kind": "match", "selector": "metric:x", "op": "==", "value": "1"}]
+        assert "malformed" in (require_diagnostic(malformed, None) or "")
+        malformed_optional = [dict(malformed[0], optional=True)]
+        assert "malformed" in (require_diagnostic(malformed_optional, None) or "")
+
+    def test_diagnostic_matches_evaluator_verdict(self):
+        # Whenever a diagnostic fires, no worker can match — the pair of
+        # functions must agree or fail-closed would mean queue-forever.
+        specs = [
+            require(label("region") == input_("region")),
+            require(label_for("sku.", input_("model")) == "true"),
+            require(service(input_("model"))),
+        ]
+        for spec in specs:
+            assert require_diagnostic(spec, {}) is not None
+            assert not require_matches(spec, {"region": "eu", "sku.x": "true"}, {})
+
+
+class TestWorkflowOptionValidation:
+    def test_with_options_accepts_require_expression(self):
+        from flux import workflow
+
+        @workflow.with_options(affinity=require(label("gpu") == "a100"))
+        async def wf(ctx):
+            return 1
+
+        assert wf.affinity == require(label("gpu") == "a100")
+
+    def test_with_options_accepts_legacy_dict(self):
+        from flux import workflow
+
+        @workflow.with_options(affinity={"gpu": "a100"})
+        async def wf(ctx):
+            return 1
+
+        assert wf.affinity == {"gpu": "a100"}
+
+    def test_with_options_rejects_junk_affinity(self):
+        from flux import workflow
+
+        for junk in ("gpu=a100", [], ["nope"], [{"kind": "score"}]):
+            with pytest.raises(ValueError, match="affinity must be"):
+                workflow.with_options(affinity=junk)(lambda ctx: None)
+
+
+class TestWorkerMatchesSpecBranch:
+    def _worker(self, labels):
+        class W:
+            pass
+
+        w = W()
+        w.labels = labels
+        w.resources = None
+        w.packages = []
+        w.runners = ["subprocess"]
+        return w
+
+    def test_spec_affinity_uses_input(self):
+        from flux.domain.resource_request import worker_matches
+
+        spec = require(label("region") == input_("region"))
+        worker = self._worker({"region": "eu"})
+        assert worker_matches(worker, None, spec, input_value={"region": "eu"})
+        assert not worker_matches(worker, None, spec, input_value={"region": "us"})
+        assert not worker_matches(worker, None, spec, input_value=None)
+
+    def test_dict_affinity_regression(self):
+        from flux.domain.resource_request import worker_matches
+
+        worker = self._worker({"gpu": "a100"})
+        assert worker_matches(worker, None, {"gpu": "a100"})
+        assert not worker_matches(worker, None, {"gpu": "h100"})

--- a/tests/flux/test_require_catalog.py
+++ b/tests/flux/test_require_catalog.py
@@ -1,0 +1,157 @@
+"""The catalog statically extracts require(...) affinity expressions (AST, no exec)."""
+
+from __future__ import annotations
+
+import pytest
+
+from flux.catalogs import WorkflowCatalog
+
+
+def _parse(source: bytes):
+    return WorkflowCatalog.create().parse(source)
+
+
+def test_require_expression_extracted_into_affinity():
+    source = b"""
+from flux import workflow
+from flux.routing import require, optional, when, label, label_for, service, input
+
+
+@workflow.with_options(
+    affinity=require(
+        service(input("model")),
+        label_for("sku.", input("model")) == "true",
+        optional(label("node") == input("node")),
+        when(input("tier") == "dedicated", label("cap.dedicated") == "true"),
+    ),
+)
+async def infer(ctx):
+    return 1
+
+
+@workflow.with_options(affinity={"gpu": "a100"})
+async def legacy(ctx):
+    return 2
+"""
+    infos = {i.name: i for i in _parse(source)}
+
+    assert infos["infer"].affinity == [
+        {
+            "kind": "match",
+            "selector": {"kind": "label", "prefix": "flux.service.", "input": "model"},
+            "op": "==",
+            "value": "true",
+        },
+        {
+            "kind": "match",
+            "selector": {"kind": "label", "prefix": "sku.", "input": "model"},
+            "op": "==",
+            "value": "true",
+        },
+        {
+            "kind": "match",
+            "selector": "label:node",
+            "op": "==",
+            "value": {"$input": "node"},
+            "optional": True,
+        },
+        {
+            "kind": "when",
+            "if": {"input": "tier", "op": "==", "value": "dedicated"},
+            "then": {
+                "kind": "match",
+                "selector": "label:cap.dedicated",
+                "op": "==",
+                "value": "true",
+            },
+        },
+    ]
+    # The dict form remains valid forever.
+    assert infos["legacy"].affinity == {"gpu": "a100"}
+
+
+def test_reversed_comparison_extracts_symmetrically():
+    source = b"""
+from flux import workflow
+from flux.routing import require, label, input
+
+
+@workflow.with_options(affinity=require("eu-west" == label("region")))
+async def wf(ctx):
+    return 1
+"""
+    [info] = _parse(source)
+    assert info.affinity == [
+        {"kind": "match", "selector": "label:region", "op": "==", "value": "eu-west"},
+    ]
+
+
+def test_static_service_name_extracts():
+    source = b"""
+from flux import workflow
+from flux.routing import require, service
+
+
+@workflow.with_options(affinity=require(service("inference")))
+async def wf(ctx):
+    return 1
+"""
+    [info] = _parse(source)
+    assert info.affinity == [
+        {
+            "kind": "match",
+            "selector": "label:flux.service.inference",
+            "op": "==",
+            "value": "true",
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    ("decorator", "reason"),
+    [
+        ('require(label("x") > "1")', "only == and !="),
+        ('require(label("x") == variable)', "unsupported value expression"),
+        ("require()", "at least one term"),
+        ('require(metric("temp") == 1)', "must be label"),
+        ('require(when(label("x") == "1", label("y") == "1"))', "must be input"),
+        ('require(label_for(prefix, input("m")) == "true")', "literal prefix"),
+        ('require(optional(label("x") == "1", label("y") == "1"))', "exactly one term"),
+        ('require(label("x") == "1", junk="yes")', "no keyword arguments"),
+        ("require(service(42))", "service"),
+        ('require(service("Not_Valid"))', "lowercase letters"),
+        ('require(label("x") == input(42))', "Invalid input"),
+    ],
+)
+def test_unparseable_require_fails_registration_loudly(decorator, reason):
+    source = f"""
+from flux import workflow
+from flux.routing import require, optional, when, label, label_for, service, metric, input
+
+variable = "not-static"
+prefix = "sku."
+
+
+@workflow.with_options(affinity={decorator})
+async def wf(ctx):
+    return 1
+""".encode()
+    with pytest.raises(SyntaxError, match=reason):
+        _parse(source)
+
+
+def test_non_require_call_affinity_stays_none():
+    # Anything that is neither a dict literal nor require(...) keeps the
+    # legacy permissive behavior: no affinity extracted.
+    source = b"""
+from flux import workflow
+
+labels = {"gpu": "a100"}
+
+
+@workflow.with_options(affinity=labels)
+async def wf(ctx):
+    return 1
+"""
+    [info] = _parse(source)
+    assert info.affinity is None

--- a/tests/flux/test_routing.py
+++ b/tests/flux/test_routing.py
@@ -370,3 +370,162 @@ class TestMetricsCaps:
         assert validate_worker_metrics(merged, max_keys=MAX_TOTAL_METRICS) is not None
         over = {f"k{i}": 1.0 for i in range(MAX_TOTAL_METRICS + 1)}
         assert validate_worker_metrics(over, max_keys=MAX_TOTAL_METRICS) is None
+
+
+class TestDynamicScoring:
+    """The require() vocabulary in the score stage: dynamic label keys in
+    prefer(), service() as a preference, and when()-gated score terms."""
+
+    def test_prefer_accepts_dynamic_label_key(self):
+        from flux.routing import label_for
+
+        term = prefer(label_for("cache.", input_ref("dataset")) == "true", weight=5)
+        assert term == {
+            "kind": "prefer",
+            "selector": {"kind": "label", "prefix": "cache.", "input": "dataset"},
+            "op": "==",
+            "value": "true",
+            "weight": 5.0,
+        }
+
+    def test_prefer_accepts_service(self):
+        from flux.routing import service
+
+        term = prefer(service(input_ref("model")), weight=2)
+        assert term["selector"] == {
+            "kind": "label",
+            "prefix": "flux.service.",
+            "input": "model",
+        }
+        assert term["op"] == "==" and term["value"] == "true"
+        assert prefer(service("inference"))["selector"] == "label:flux.service.inference"
+
+    def test_least_and_most_still_reject_dynamic_keys(self):
+        from flux.routing import label_for
+
+        dynamic = label_for("cache.", input_ref("dataset"))
+        with pytest.raises(ValueError, match="no ordering"):
+            least(dynamic)
+        with pytest.raises(ValueError, match="no ordering"):
+            most(dynamic)
+
+    def test_when_wraps_score_terms(self):
+        from flux.routing import when
+
+        term = when(input_ref("fast") == "true", least(load(), weight=10))
+        assert term == {
+            "kind": "when",
+            "if": {"input": "fast", "op": "==", "value": "true"},
+            "then": {"kind": "least", "selector": "load", "weight": 10.0},
+        }
+        assert score(term)["terms"] == [term]
+
+    def test_score_rejects_require_flavored_when(self):
+        from flux.routing import when
+
+        with pytest.raises(ValueError, match="must wrap a prefer"):
+            score(when(input_ref("t") == "1", label("y") == "1"))
+
+    def test_score_rejects_non_dict_terms(self):
+        with pytest.raises(ValueError, match="accepts only"):
+            score("junk")
+
+    def test_require_rejects_score_flavored_when(self):
+        from flux.routing import require, when
+
+        with pytest.raises(ValueError, match="only valid in score"):
+            require(when(input_ref("t") == "1", least(load())))
+
+    def test_pick_worker_resolves_dynamic_key(self):
+        warm = _worker("warm", labels={"cache.orders": "true"})
+        cold = _worker("cold")
+        from flux.routing import label_for
+
+        policy = score(
+            prefer(label_for("cache.", input_ref("dataset")) == "true", weight=10),
+            least(load()),
+        )
+        # Warm wins despite carrying more load.
+        picked = pick_worker(
+            [warm, cold],
+            policy,
+            loads={"warm": 5, "cold": 0},
+            input_value={"dataset": "orders"},
+        )
+        assert picked is warm
+
+    def test_pick_worker_dynamic_key_unresolved_cannot_discriminate(self):
+        # Unresolved input or an invalid resolved key: the term scores 0 for
+        # everyone (like a missing metric); the policy does not degrade.
+        warm = _worker("warm", labels={"cache.orders": "true"})
+        cold = _worker("cold")
+        from flux.routing import label_for
+
+        policy = score(
+            prefer(label_for("cache.", input_ref("dataset")) == "true", weight=10),
+            least(load()),
+        )
+        loads = {"warm": 5, "cold": 0}
+        assert pick_worker([warm, cold], policy, loads=loads, input_value={}) is cold
+        assert (
+            pick_worker([warm, cold], policy, loads=loads, input_value={"dataset": "../x"}) is cold
+        )
+
+    def test_pick_worker_malformed_dynamic_selector_degrades(self):
+        policy = {
+            "terms": [
+                {
+                    "kind": "prefer",
+                    "selector": {"kind": "label", "prefix": 1, "input": "x"},
+                    "op": "==",
+                    "value": "true",
+                    "weight": 1.0,
+                },
+            ],
+        }
+        assert pick_worker([_worker("a")], policy, loads={}, input_value={}) is None
+
+    def test_pick_worker_when_gates_term_on_input(self):
+        from flux.routing import when
+
+        fast = _worker("fast", metrics={"lag": 0.1})
+        slow = _worker("slow", labels={"x": "1"}, metrics={"lag": 9.0})
+        policy = score(
+            prefer(label("x") == "1", weight=1),
+            when(input_ref("fast") == "true", least(metric("lag"), weight=100)),
+        )
+        assert pick_worker([fast, slow], policy, loads={}, input_value={}) is slow
+        assert pick_worker([fast, slow], policy, loads={}, input_value={"fast": "true"}) is fast
+
+    def test_pick_worker_when_unresolved_condition_skips_term(self):
+        from flux.routing import when
+
+        a = _worker("a", labels={"x": "1"})
+        b = _worker("b", metrics={"lag": 0.0})
+        policy = score(
+            prefer(label("x") == "1", weight=1),
+            when(input_ref("fast") == "true", least(metric("lag"), weight=100)),
+        )
+        assert pick_worker([a, b], policy, loads={}, input_value=None) is a
+
+    def test_pick_worker_malformed_when_degrades(self):
+        policy = {"terms": [{"kind": "when", "if": "junk", "then": {"kind": "sticky"}}]}
+        assert pick_worker([_worker("a")], policy, loads={}, input_value={}) is None
+        policy = {
+            "terms": [
+                {"kind": "when", "if": {"input": "t", "op": "==", "value": 1}, "then": "junk"},
+            ],
+        }
+        assert pick_worker([_worker("a")], policy, loads={}, input_value={"t": 1}) is None
+
+    def test_pick_worker_when_wrapped_sticky(self):
+        from flux.routing import when
+
+        a, b = _worker("a"), _worker("b")
+        policy = score(when(input_ref("pin") == "true", sticky(weight=5)), least(load()))
+        loads = {"a": 3, "b": 0}
+        assert (
+            pick_worker([a, b], policy, loads=loads, input_value={"pin": "true"}, preferred="a")
+            is a
+        )
+        assert pick_worker([a, b], policy, loads=loads, input_value={}, preferred="a") is b

--- a/tests/flux/test_routing_catalog.py
+++ b/tests/flux/test_routing_catalog.py
@@ -127,3 +127,64 @@ async def routed(ctx):
     )
     with pytest.raises(SyntaxError, match=message):
         _parse(source)
+
+
+def test_dynamic_vocabulary_extracted_in_score():
+    source = b"""
+from flux import workflow
+from flux.routing import score, prefer, least, when, load, label_for, service, metric, input
+
+
+@workflow.with_options(
+    routing=score(
+        prefer(label_for("cache.", input("dataset")) == "true", weight=5),
+        prefer(service(input("model")), weight=2),
+        when(input("latency_sensitive") == "true", least(metric("lag"), weight=10)),
+        least(load()),
+    ),
+)
+async def routed(ctx):
+    return 1
+"""
+    [info] = _parse(source)
+    terms = (info.metadata or {})["routing"]["terms"]
+    assert terms[0] == {
+        "kind": "prefer",
+        "selector": {"kind": "label", "prefix": "cache.", "input": "dataset"},
+        "op": "==",
+        "value": "true",
+        "weight": 5.0,
+    }
+    assert terms[1]["selector"] == {"kind": "label", "prefix": "flux.service.", "input": "model"}
+    assert terms[2] == {
+        "kind": "when",
+        "if": {"input": "latency_sensitive", "op": "==", "value": "true"},
+        "then": {"kind": "least", "selector": "metric:lag", "weight": 10.0},
+    }
+
+
+@pytest.mark.parametrize(
+    ("term", "reason"),
+    [
+        ('least(label_for("c.", input("d")))', "no ordering"),
+        ('when(label("x") == "1", least(load()))', "must be input"),
+        ('when(input("t") == "1", label("y") == "1")', "expected prefer"),
+        ('when(input("t") == "1", when(input("u") == "1", least(load())))', "when"),
+        ('prefer(label_for(prefix, input("d")) == "true")', "literal prefix"),
+        ("prefer(service(42))", "service"),
+    ],
+)
+def test_unparseable_dynamic_score_terms_fail_loudly(term, reason):
+    source = f"""
+from flux import workflow
+from flux.routing import score, prefer, least, when, load, label, label_for, service, input
+
+prefix = "c."
+
+
+@workflow.with_options(routing=score({term}))
+async def wf(ctx):
+    return 1
+""".encode()
+    with pytest.raises(SyntaxError, match=reason):
+        _parse(source)


### PR DESCRIPTION
Promotes the routing expression vocabulary into a single dynamic-expression system spanning **both dispatch stages**: `affinity=require(...)` as the hard filter, and the same constructs inside `routing=score(...)` as soft preferences. Terms resolve **per execution** against the execution input — one registration serves many differently-routed requests. The dict affinity form remains valid forever with unchanged semantics.

```python
@workflow.with_options(
    affinity=require(
        label("datacenter") == input("dc"),                 # data locality (hard)
        label_for("dataset.", input("dataset")) == "true",  # worker holds a local copy (hard)
        optional(label("node") == input("node")),           # pin only when requested
        when(input("classification") == "restricted",
             label("compliance.hipaa") == "true"),          # gate on requester intent
    ),
    routing=score(
        prefer(label_for("cache.", input("dataset")) == "true", weight=5),  # warm copy (soft)
        least(load()),
    ),
)
async def locality_query(ctx): ...
```

`{"dc": "eu-central", "dataset": "orders-2026"}` reaches only workers in that datacenter labeled `dataset.orders-2026=true`, and among those prefers one with a warm `cache.orders-2026` copy. Same workflow, different eligible sets and rankings, zero catalog churn. Other patterns: tenant isolation (`label("tenant") == input("tenant_id")`), maintenance windows (`label("maintenance") != "true"`).

## Filter stage: `affinity=require(...)`

- **AND-only, `==`/`!=` only** — ordered comparisons on labels are stringly-typed traps; they stay in `routing=` where metrics make them meaningful. Works in **both poll and event dispatch modes** (filtering is a per-worker predicate).
- **Fail-closed with fail-fast diagnostics** — a bare term whose input cannot be resolved matches no worker. Because unresolved input and invalid resolved keys are properties of the execution alone (no worker could ever satisfy them), dispatch **fails the execution** with a named `AffinityResolutionError` instead of parking it forever. A plain label mismatch still parks, exactly like the dict form.
- **`optional(...)` forgives absent input only** — a resolved comparison that is false still fails (optional ≠ decorative), and input resolving to an invalid label key / non-scalar / ungrantable service name fails and diagnoses even under `optional()`.
- **`!=` treats an absent label as passing** — the one documented inversion, so maintenance-window terms work without every worker carrying the label. Deliberately *not* reused: routing's `_compare()`, whose None-short-circuit would break this.
- **`label_for(prefix, input(...))`** — the author declares the namespace, input only completes it; resolved keys are charset/length validated; inputs never create labels, only test them. **`service(...)`** is sugar over the reserved `flux.service.*` labels from #134 (a capability grant a worker cannot fabricate); names are validated against the exact worker-side socket-name rule — the validator lives in `flux.routing` and `flux/runners/docker.py` imports it, so the two ends cannot drift.

## Score stage: the same vocabulary in `routing=score(...)`

- `prefer()` accepts `label_for()` dynamic keys and `service()` — the soft counterparts of their `require()` forms. Unresolved input or an invalid resolved key means the term cannot discriminate (everyone scores 0); the policy does not degrade. `least()`/`most()` reject dynamic keys — label strings have no ordering.
- `when(input(...) == const, term)` gates score terms exactly as it gates require terms (inactive when unresolved). `score()` and `require()` reject each other's `when()` flavor.
- Semantic pairing note: `optional(...)` in `require` is *hard-when-present* (a pin); `prefer(...)` in `score` is *soft-always* (a nudge).

## Implementation

- `flux/routing.py` — `require/optional/when/label_for/service` factories, `InputCondition` (`InputRef` grows `==`/`!=`), the require evaluators (`require_matches` per-worker, `require_diagnostic` worker-independent — they agree by construction so fail-closed never means queue-forever), and `pick_worker` resolving dynamic keys / `when` gates from the execution input already flowing into the dispatch batch.
- `flux/domain/resource_request.py` — `worker_matches()` accepts dict **or** spec-list affinity plus `input_value`; the `affinity` column already stores encoded blobs, so no migration.
- `flux/context_managers.py` — all four dispatch paths (poll claim, resume fallback, execution batch, resume batch) pass `model.input` through; the CREATED-dispatch paths run the diagnostic first and persist the terminal failure.
- `flux/catalogs.py` — `affinity=require(...)` and the extended `routing=score(...)` vocabulary extracted statically through the real factories; unparseable expressions fail registration loudly rather than silently dropping a constraint or preference.

## Tests & docs

- Unit: every row of the semantics table, DSL guardrails, cross-stage `when()` rejection, hand-written malformed metadata (fails closed *and* diagnoses), poll/event parity, resume-path filtering, dict-form regression, AST extraction incl. loud failures. `flux/routing.py` at 100% line coverage.
- Dispatch: batch test pairing a `require()` floor with a dynamic-key `prefer()` (warm worker wins despite higher load; out-of-datacenter warm worker excluded).
- E2E (`tests/e2e/test_require_affinity.py`): one registered workflow served three ways through real server dispatch — input-driven region routing, FAILED-with-diagnostic on unresolved input, and a `when()` gate that parks until a capable worker connects.
- `examples/affinity_expressions.py`: data locality with dynamic dataset labels, a compliance gate, and the floor-plus-preference pairing; tenant isolation; maintenance windows — with inline tests asserting the runs, the compiled specs, and extraction/decorator agreement.
- Docs: `worker-affinity.md` gains "Affinity Expressions" (vocabulary + semantics table); `dynamic-routing.md` gains "Dynamic keys and conditional terms" (the pairing and the optional-vs-prefer distinction).

Addresses all Copilot review feedback: `optional()` no longer forgives invalid resolved keys (absence only), `service()` names are held to the worker-side socket rule at compile and at resolution (fail-fast instead of park-forever), and `input()` extraction errors surface as pointed `SyntaxError`s at registration.

Local validation: pre-commit clean; unit suite 2,898 passed / 9 skipped (Docker- and PostgreSQL-gated, same as CI's SQLite job); e2e 127 passed + the 3 new require tests (the two `github_stars` failures are the sandbox proxy blocking direct `api.github.com`, unrelated — same as #134).

Version: 0.62.0.