### PR TITLE
Worker runtime pause/resume + cancel-all, banned principals, and configurable airgapped container CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ Implementation hot-spots:
 
 ### Persistence
 
-`flux/models.py` defines the SQLAlchemy ORM (`Base`, `WorkflowModel`, `ExecutionContextModel`, `ExecutionEventModel`, plus `RoleModel`, `APIKeyModel`, `AgentModel`, `ConfigModel`, `WorkerModel`, …). `RepositoryFactory.create_repository()` dispatches on `database_url` (`sqlite://` vs `postgresql://`); engines are cached per (repository class, URL) tuple. Tables are auto-created via `Base.metadata.create_all` on first connect — there is no Alembic.
+`flux/models.py` defines the SQLAlchemy ORM (`Base`, `WorkflowModel`, `ExecutionContextModel`, `ExecutionEventModel`, plus `RoleModel`, `APIKeyModel`, `AgentModel`, `ConfigModel`, `WorkerModel`, …). `RepositoryFactory.create_repository()` dispatches on `database_url` (`sqlite://` vs `postgresql://`); engines are cached per (repository class, URL) tuple. Schema changes go through Alembic (`flux/migrations/`, run automatically on first connect by `flux/migrations/runner.py`); add a numbered revision AND the ORM column together, and update `HEAD` in `tests/flux/test_migrations.py` (its parity test compares migration output against the full metadata).
 
 Higher-level managers wrap the repositories:
 - `WorkflowCatalog` (`flux/catalogs.py`) — register / parse / lookup workflows; AST-based parsing of source files extracts each workflow's docstring and resource requests.

--- a/flux/api/rbac_routes.py
+++ b/flux/api/rbac_routes.py
@@ -493,11 +493,15 @@ class RbacRoutesMixin:
                 registry.set_banned(principal.id, False)
                 auth_service.invalidate_resolution_caches()
                 logger.info(f"Principal '{subject}' unbanned by {identity.subject}")
+                updated = registry.get(principal.id) or principal
                 return {
                     "status": "success",
                     "subject": subject,
                     "banned": False,
-                    "enabled": False,
+                    # Real post-unban state: unban does not re-enable, so this
+                    # is false on the normal ban->unban path, but report what
+                    # the row actually says rather than assuming.
+                    "enabled": updated.enabled,
                 }
             except HTTPException:
                 raise

--- a/flux/api/rbac_routes.py
+++ b/flux/api/rbac_routes.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 
+from fastapi import Body
 from fastapi import Depends
 from fastapi import HTTPException
 from fastapi import Query
@@ -201,6 +202,7 @@ class RbacRoutesMixin:
                         "external_issuer": p.external_issuer,
                         "display_name": p.display_name,
                         "enabled": p.enabled,
+                        "banned": p.banned,
                         "roles": registry.get_roles(p.id),
                     }
                     for p in principals
@@ -233,6 +235,7 @@ class RbacRoutesMixin:
                     "external_issuer": principal.external_issuer,
                     "display_name": principal.display_name,
                     "enabled": principal.enabled,
+                    "banned": principal.banned,
                     "roles": registry.get_roles(principal.id),
                 }
             except HTTPException:
@@ -403,6 +406,9 @@ class RbacRoutesMixin:
                     )
                 registry.set_enabled(principal.id, True)
                 return {"status": "success", "subject": subject, "enabled": True}
+            except ValueError as e:
+                # A banned principal cannot be enabled; unban first.
+                raise HTTPException(status_code=409, detail=str(e))
             except HTTPException:
                 raise
             except Exception as e:
@@ -426,6 +432,73 @@ class RbacRoutesMixin:
                     )
                 registry.set_enabled(principal.id, False)
                 return {"status": "success", "subject": subject, "enabled": False}
+            except HTTPException:
+                raise
+            except Exception as e:
+                raise HTTPException(status_code=500, detail=str(e))
+
+        @api.post("/admin/principals/{subject}/ban")
+        async def admin_ban_principal(
+            subject: str,
+            body: dict | None = Body(None),
+            issuer: str | None = None,
+            identity: FluxIdentity = Depends(require_permission("admin:principals:manage")),
+        ):
+            """Quarantine a principal: disable it, revoke its API keys, and
+            refuse worker registration until it is unbanned. Unlike a plain
+            disable, registration cannot re-enable a banned principal."""
+            try:
+                from flux.security.principals import PrincipalRegistry
+
+                registry = PrincipalRegistry(session_factory=self._get_db_session)
+                principal = registry.find(subject, issuer or "flux")
+                if not principal:
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"Principal '{subject}' not found",
+                    )
+                reason = (body or {}).get("reason")
+                registry.set_banned(principal.id, True, reason=reason)
+                await auth_service.revoke_all_api_keys(principal.id)
+                auth_service.invalidate_resolution_caches()
+                logger.warning(
+                    f"Principal '{subject}' banned by {identity.subject}"
+                    + (f": {reason}" if reason else ""),
+                )
+                return {"status": "success", "subject": subject, "banned": True}
+            except HTTPException:
+                raise
+            except Exception as e:
+                raise HTTPException(status_code=500, detail=str(e))
+
+        @api.post("/admin/principals/{subject}/unban")
+        async def admin_unban_principal(
+            subject: str,
+            issuer: str | None = None,
+            identity: FluxIdentity = Depends(require_permission("admin:principals:manage")),
+        ):
+            """Lift a principal's quarantine. The principal stays disabled —
+            enable it explicitly afterwards so nothing rejoins as a side
+            effect of the unban."""
+            try:
+                from flux.security.principals import PrincipalRegistry
+
+                registry = PrincipalRegistry(session_factory=self._get_db_session)
+                principal = registry.find(subject, issuer or "flux")
+                if not principal:
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"Principal '{subject}' not found",
+                    )
+                registry.set_banned(principal.id, False)
+                auth_service.invalidate_resolution_caches()
+                logger.info(f"Principal '{subject}' unbanned by {identity.subject}")
+                return {
+                    "status": "success",
+                    "subject": subject,
+                    "banned": False,
+                    "enabled": False,
+                }
             except HTTPException:
                 raise
             except Exception as e:

--- a/flux/api/schemas.py
+++ b/flux/api/schemas.py
@@ -227,6 +227,9 @@ class WorkerResponse(BaseModel):
     labels: dict[str, str] = Field(default_factory=dict)
     # Latest advertised metrics snapshot (routing "metric:*" selectors).
     metrics: dict[str, float] | None = None
+    # In-flight execution count from the worker's latest heartbeat pong;
+    # None for workers that have not advertised one.
+    in_flight: int | None = None
 
 
 class HealthResponse(BaseModel):

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -172,6 +172,27 @@ class WorkerRoutesMixin:
                         detail="Invalid bootstrap or join token.",
                     )
 
+                # Quarantine wins over any valid credential: a banned worker
+                # principal must not resurrect itself by re-registering (the
+                # re-enable below is meant for reaper-disabled principals of
+                # workers that legitimately return).
+                if principal_registry is not None:
+                    banned_check = await asyncio.to_thread(
+                        principal_registry.find,
+                        subject=registration.name,
+                        external_issuer="flux",
+                    )
+                    if banned_check is not None and banned_check.banned:
+                        logger.warning(
+                            f"Refusing registration for banned worker principal: "
+                            f"{registration.name}",
+                        )
+                        raise HTTPException(
+                            status_code=403,
+                            detail="Worker principal is banned; an administrator "
+                            "must unban and enable it before it can register.",
+                        )
+
                 registry = WorkerRegistry.create()
                 result = registry.register(
                     registration.name,

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -370,11 +370,13 @@ class WorkerRoutesMixin:
                 elif name in self._worker_paused:
                     logger.info(f"Worker {name} resumed; dispatching to it again")
                     self._worker_paused.discard(name)
-                if payload is not None and "in_flight" in payload:
-                    try:
-                        self._worker_in_flight[name] = max(0, int(payload["in_flight"]))
-                    except (TypeError, ValueError):
-                        pass
+                # Missing or invalid in_flight means "unknown" — clear any
+                # prior value rather than surfacing a stale count forever
+                # (e.g. a legacy worker that stops sending the field).
+                try:
+                    self._worker_in_flight[name] = max(0, int((payload or {})["in_flight"]))
+                except (KeyError, TypeError, ValueError):
+                    self._worker_in_flight.pop(name, None)
                 logger.debug(f"Pong received from worker {name}")
                 return {"status": "ok"}
             except HTTPException:

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -290,6 +290,10 @@ class WorkerRoutesMixin:
                     labels=registration.labels,
                 )
                 self._worker_unhealthy.discard(registration.name)
+                # A restarted worker starts active; its first pong re-adds
+                # the paused flag if the operator's pause is still in force.
+                self._worker_paused.discard(registration.name)
+                self._worker_in_flight.pop(registration.name, None)
                 if registration.name in self._worker_names:
                     self._worker_offline_since.pop(registration.name, None)
                 else:
@@ -330,12 +334,14 @@ class WorkerRoutesMixin:
         ):
             """Receive heartbeat pong from a worker.
 
-            The optional body carries self-health ({"healthy": bool}) and
-            advertised metrics ({"metrics": {str: float}}): unhealthy workers
-            stay connected (running work finishes, the reaper is not
-            involved) but are excluded from new dispatch until they report
-            healthy again; metrics feed routing policies through "metric:*"
-            selectors. Legacy workers send no body.
+            The optional body carries self-health ({"healthy": bool}),
+            lifecycle status ({"status": "active"|"paused"|"draining"} with
+            {"in_flight": int}), and advertised metrics
+            ({"metrics": {str: float}}). Unhealthy and paused workers stay
+            connected (running work finishes, the reaper is not involved)
+            but are excluded from new dispatch — until they report healthy
+            again, or resume, respectively; metrics feed routing policies
+            through "metric:*" selectors. Legacy workers send no body.
             """
             try:
                 self._verify_worker_identity(identity, name)
@@ -353,6 +359,22 @@ class WorkerRoutesMixin:
                         f"excluding it from dispatch until it recovers",
                     )
                     self._worker_unhealthy.add(name)
+                worker_status = "active" if payload is None else payload.get("status", "active")
+                if worker_status == "paused":
+                    if name not in self._worker_paused:
+                        logger.info(
+                            f"Worker {name} reports paused; excluding it from "
+                            f"dispatch until it resumes",
+                        )
+                        self._worker_paused.add(name)
+                elif name in self._worker_paused:
+                    logger.info(f"Worker {name} resumed; dispatching to it again")
+                    self._worker_paused.discard(name)
+                if payload is not None and "in_flight" in payload:
+                    try:
+                        self._worker_in_flight[name] = max(0, int(payload["in_flight"]))
+                    except (TypeError, ValueError):
+                        pass
                 logger.debug(f"Pong received from worker {name}")
                 return {"status": "ok"}
             except HTTPException:
@@ -471,9 +493,10 @@ class WorkerRoutesMixin:
                                         "data": "",
                                     }
 
-                                # Self-reported unhealthy (event-loop lag):
-                                # skip new work, keep pings/cancellations.
-                                if name in self._worker_unhealthy:
+                                # Self-reported unhealthy (event-loop lag) or
+                                # operator-paused: skip new work, keep
+                                # pings/cancellations.
+                                if name in self._worker_unhealthy or name in self._worker_paused:
                                     await asyncio.sleep(fallback_interval)
                                     continue
 
@@ -1044,12 +1067,13 @@ class WorkerRoutesMixin:
 
         @api.get("/workers", response_model=list[WorkerResponse])
         async def workers_list(
-            status: Literal["online", "offline"] | None = Query(None),
+            status: Literal["online", "offline", "unhealthy", "paused"] | None = Query(None),
             limit: int | None = Query(None, ge=1, le=1000),
             offset: int = Query(0, ge=0),
             identity: FluxIdentity = Depends(get_identity),
         ):
-            """List workers fleet-wide. Optional ?status=online|offline filter.
+            """List workers fleet-wide. Optional status filter
+            (online|offline|unhealthy|paused).
 
             Reads the workers table rather than this replica's in-memory cache,
             so every replica returns the same, complete fleet view; liveness is
@@ -1078,6 +1102,10 @@ class WorkerRoutesMixin:
                     # read "online" for the rest of its heartbeat window). The
                     # persisted-heartbeat fallback covers workers attached to
                     # OTHER replicas, which this process cannot see directly.
+                    # Paused wins over unhealthy: it is the deliberate state,
+                    # and the one an operator is looking for.
+                    if info.name in self._worker_paused:
+                        return "paused"
                     if info.name in self._worker_unhealthy:
                         return "unhealthy"
                     if info.name in self._worker_names:
@@ -1098,6 +1126,7 @@ class WorkerRoutesMixin:
                     if cached is not None:
                         cached.status = worker_status
                         cached.metrics = info.metrics
+                        cached.in_flight = self._worker_in_flight.get(info.name)
                         result.append(cached)
                     else:
                         result.append(
@@ -1105,6 +1134,7 @@ class WorkerRoutesMixin:
                                 name=info.name,
                                 status=worker_status,
                                 metrics=info.metrics,
+                                in_flight=self._worker_in_flight.get(info.name),
                             ),
                         )
 

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -1057,6 +1057,104 @@ def worker():
     pass
 
 
+def _worker_control(name: str, command: str, socket_path: str | None) -> dict:
+    """Send one command to a worker's local control socket.
+
+    Workers are outbound-only, so pause/resume/cancel-all/status go through
+    the Unix socket the worker serves on its own host — these commands must
+    run where the worker runs, not against the server.
+    """
+    import os
+    import socket as _socket
+
+    from flux.config import Configuration
+
+    settings = Configuration.get().settings
+    path = (
+        socket_path
+        or settings.workers.control_socket_path
+        or os.path.join(settings.home, f"worker-{name}.sock")
+    )
+    client = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+    # cancel-all waits for runner term-grace shutdowns; stay above the
+    # worker's own 60s bound.
+    client.settimeout(70)
+    try:
+        client.connect(path)
+        client.sendall((json.dumps({"command": command}) + "\n").encode())
+        data = b""
+        while not data.endswith(b"\n"):
+            chunk = client.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+    finally:
+        client.close()
+    if not data:
+        raise ConnectionError(f"no response from worker control socket at {path}")
+    return json.loads(data.decode())
+
+
+def _run_worker_control(name: str, command: str, socket_path: str | None):
+    try:
+        response = _worker_control(name, command, socket_path)
+    except FileNotFoundError:
+        click.echo(
+            f"Error: control socket for worker '{name}' not found. Run this "
+            "command on the worker's host; override the path with --socket.",
+            err=True,
+        )
+        raise click.exceptions.Exit(1)
+    except (ConnectionError, OSError) as ex:
+        click.echo(f"Error talking to worker '{name}': {ex}", err=True)
+        raise click.exceptions.Exit(1)
+    click.echo(json.dumps(response, indent=2))
+    if "error" in response:
+        raise click.exceptions.Exit(1)
+
+
+@worker.command("pause")
+@click.argument("name")
+@click.option("--socket", "socket_path", default=None, help="Control socket path override.")
+def pause_worker(name: str, socket_path: str | None):
+    """Pause a local worker: stop claiming new work, keep heartbeats.
+
+    Running executions continue; use 'flux worker cancel-all' to also free
+    them. Resume with 'flux worker resume'. (SIGUSR1/SIGUSR2 are the
+    signal equivalents.)
+    """
+    _run_worker_control(name, "pause", socket_path)
+
+
+@worker.command("resume")
+@click.argument("name")
+@click.option("--socket", "socket_path", default=None, help="Control socket path override.")
+def resume_worker(name: str, socket_path: str | None):
+    """Resume a paused local worker."""
+    _run_worker_control(name, "resume", socket_path)
+
+
+@worker.command("cancel-all")
+@click.argument("name")
+@click.option("--socket", "socket_path", default=None, help="Control socket path override.")
+def cancel_all_worker(name: str, socket_path: str | None):
+    """Cancel every in-flight execution on a local worker (bulk yield).
+
+    Each execution goes through its normal cancellation path (terminal
+    CANCELLED checkpoint). Combine with 'flux worker pause' to free the
+    node without taking it offline.
+    """
+    _run_worker_control(name, "cancel-all", socket_path)
+
+
+@worker.command("status")
+@click.argument("name")
+@click.option("--socket", "socket_path", default=None, help="Control socket path override.")
+def worker_local_status(name: str, socket_path: str | None):
+    """Show a local worker's runtime state (active/paused/draining, in-flight)."""
+    _run_worker_control(name, "status", socket_path)
+
+
 @worker.command("list")
 @click.option(
     "--format",

--- a/flux/cli_auth.py
+++ b/flux/cli_auth.py
@@ -707,6 +707,58 @@ def principals_disable(subject, issuer, fmt):
         click.echo(f"Error: {_error_detail(resp)}")
 
 
+@principals.command("ban")
+@click.argument("subject")
+@click.option("--reason", default=None, help="Recorded in the principal's metadata.")
+@click.option("--issuer", default=None)
+@click.option("--format", "-f", "fmt", type=click.Choice(["simple", "json"]), default="simple")
+def principals_ban(subject, reason, issuer, fmt):
+    """Quarantine a principal: disable it, revoke its API keys, and refuse
+    worker registration until it is unbanned."""
+    url = get_server_url()
+    params = {}
+    if issuer:
+        params["issuer"] = issuer
+    resp = httpx.post(
+        f"{url}/admin/principals/{subject}/ban",
+        params=params,
+        json={"reason": reason} if reason else None,
+        headers=get_auth_headers(),
+    )
+    if resp.status_code == 200:
+        if fmt == "json":
+            click.echo(json.dumps({"status": "ok", "subject": subject, "banned": True}, indent=2))
+        else:
+            click.echo(f"Principal '{subject}' banned (disabled, API keys revoked).")
+    else:
+        click.echo(f"Error: {_error_detail(resp)}")
+
+
+@principals.command("unban")
+@click.argument("subject")
+@click.option("--issuer", default=None)
+@click.option("--format", "-f", "fmt", type=click.Choice(["simple", "json"]), default="simple")
+def principals_unban(subject, issuer, fmt):
+    """Lift a principal's quarantine. The principal stays disabled; run
+    'flux principals enable' to let it authenticate again."""
+    url = get_server_url()
+    params = {}
+    if issuer:
+        params["issuer"] = issuer
+    resp = httpx.post(
+        f"{url}/admin/principals/{subject}/unban",
+        params=params,
+        headers=get_auth_headers(),
+    )
+    if resp.status_code == 200:
+        if fmt == "json":
+            click.echo(json.dumps({"status": "ok", "subject": subject, "banned": False}, indent=2))
+        else:
+            click.echo(f"Principal '{subject}' unbanned (still disabled; enable explicitly).")
+    else:
+        click.echo(f"Error: {_error_detail(resp)}")
+
+
 @principals.command("delete")
 @click.argument("subject")
 @click.option("--force", is_flag=True, help="Force deletion including cascade effects")

--- a/flux/config.py
+++ b/flux/config.py
@@ -235,6 +235,16 @@ class WorkersConfig(BaseConfig):
             "flux.service.<name> worker labels"
         ),
     )
+    airgapped_container_cli: str = Field(
+        default="docker",
+        description=(
+            "Container CLI the airgapped runner drives: 'docker', 'podman', "
+            "or 'nerdctl'. Rootless Podman/nerdctl let nested deployments "
+            "drop the privileged outer daemon. The runner emits the same "
+            "argv for all three (see flux/runners/docker.py for the "
+            "compatibility set); validated at worker startup"
+        ),
+    )
     airgapped_extra_args: list[str] = Field(
         default=[],
         description=(

--- a/flux/config.py
+++ b/flux/config.py
@@ -316,6 +316,23 @@ class WorkersConfig(BaseConfig):
             "before cancelling them (0 = cancel immediately)"
         ),
     )
+    control_socket_enabled: bool = Field(
+        default=True,
+        description=(
+            "Serve the worker-local control API (pause / resume / cancel-all "
+            "/ status) on a Unix socket. The worker is outbound-only, so "
+            "runtime control comes from the same host: 'flux worker pause "
+            "<name>' or any client speaking one JSON object per line. "
+            "SIGUSR1/SIGUSR2 pause/resume regardless of this setting"
+        ),
+    )
+    control_socket_path: str = Field(
+        default="",
+        description=(
+            "Path of the worker control socket; empty derives "
+            "<home>/worker-<name>.sock. The socket is created mode 0600"
+        ),
+    )
     register_rate_limit: str = Field(
         default="30/minute",
         description=(

--- a/flux/dispatcher.py
+++ b/flux/dispatcher.py
@@ -198,11 +198,14 @@ class Dispatcher:
 
     def _connected_workers(self):
         """Snapshot of dispatchable workers on this replica: a live SSE
-        queue and not self-reported unhealthy (event-loop starvation)."""
+        queue, not self-reported unhealthy (event-loop starvation), and
+        not operator-paused."""
         return [
             info
             for name, info in list(self._server._worker_info.items())
-            if name in self._server._worker_queues and name not in self._server._worker_unhealthy
+            if name in self._server._worker_queues
+            and name not in self._server._worker_unhealthy
+            and name not in self._server._worker_paused
         ]
 
     async def _dispatch_cycle(self):

--- a/flux/migrations/versions/0012_principal_banned.py
+++ b/flux/migrations/versions/0012_principal_banned.py
@@ -1,0 +1,52 @@
+"""Add principals.banned: operator quarantine that registration respects.
+
+``enabled`` alone cannot express quarantine: the reaper disables pruned
+workers' principals and registration re-enables them when the worker
+returns. ``banned`` is the explicit operator state — worker registration
+refuses a banned principal instead of resurrecting it, and enabling a
+banned principal is rejected until it is unbanned.
+
+Revision ID: 0012_principal_banned
+Revises: 0011_worker_join_tokens
+Create Date: 2026-07-18
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0012_principal_banned"
+down_revision: str | None = "0011_worker_join_tokens"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "principals"
+_COLUMN = "banned"
+
+
+def _column_names(bind) -> set[str]:
+    return {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if _COLUMN in _column_names(bind):
+        return
+    op.add_column(
+        _TABLE,
+        sa.Column(
+            _COLUMN,
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if _COLUMN in _column_names(bind):
+        op.drop_column(_TABLE, _COLUMN)

--- a/flux/runners/__init__.py
+++ b/flux/runners/__init__.py
@@ -75,6 +75,7 @@ def create_runners(names: list[str], config) -> dict[str, Runner]:
                 mounts=list(config.airgapped_mounts),
                 shm_size=config.airgapped_shm_size,
                 service_sockets=dict(config.airgapped_service_sockets),
+                container_cli=config.airgapped_container_cli,
             )
         else:
             raise ValueError(

--- a/flux/runners/docker.py
+++ b/flux/runners/docker.py
@@ -103,8 +103,7 @@ class DockerRunner(SubprocessRunner):
         """Fail at worker startup, not at first dispatch."""
         if shutil.which(self._cli) is None:
             raise ValueError(
-                f"The '{self.name}' runner is enabled but the {self._cli} CLI "
-                "is not on PATH",
+                f"The '{self.name}' runner is enabled but the {self._cli} CLI is not on PATH",
             )
         if self._cli == "docker":
             # docker requires a reachable daemon; probe it explicitly so the

--- a/flux/runners/docker.py
+++ b/flux/runners/docker.py
@@ -14,6 +14,29 @@ flux-core version (see DOCKER.md). Workers enable it explicitly:
     [flux.workers]
     runners = ["inprocess", "subprocess", "docker"]
     docker_image = "my-registry/flux-workflows:1.2.3"
+
+Container CLI compatibility
+---------------------------
+
+The airgapped runner can drive rootless Podman or nerdctl instead of the
+docker CLI via ``[flux.workers] airgapped_container_cli`` (a named config
+key, like every other airgapped grant, so the config file stays the audit
+trail). The runner relies on the following argv-compatible surface, which
+all three CLIs implement with docker semantics:
+
+- ``run -i --rm --name`` with implicit signal proxying (sig-proxy is the
+  default without a TTY in docker, podman, and nerdctl — SIGTERM reaches
+  the child for graceful cancellation)
+- ``kill <container>`` for force-kill
+- resource/limit flags: ``--network`` / ``--network=none``, ``--memory``,
+  ``--cpus``, ``--pids-limit``, ``--read-only``, ``--tmpfs``,
+  ``--cap-drop=ALL``, ``--security-opt=no-new-privileges``
+- grants: ``--mount type=bind,source=..,target=..[,readonly]``,
+  ``--gpus`` (podman >= 4.7 / nerdctl require working CDI or the
+  nvidia toolkit, same as docker), ``--shm-size``, ``--env``
+
+Anything outside this set (added via ``airgapped_extra_args``) is the
+operator's responsibility to keep compatible with the chosen CLI.
 """
 
 from __future__ import annotations
@@ -36,6 +59,11 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+# CLIs the runners know how to drive. The emitted-flag compatibility set is
+# documented in the module docstring; a name outside this tuple fails at
+# worker startup, not at first dispatch.
+SUPPORTED_CONTAINER_CLIS = ("docker", "podman", "nerdctl")
+
 
 class DockerRunner(SubprocessRunner):
     name = "docker"
@@ -49,40 +77,68 @@ class DockerRunner(SubprocessRunner):
         cpus: float = 0.0,
         extra_args: list[str] | None = None,
         execution_timeout: float = 0,
+        cli: str = "docker",
     ):
         super().__init__(term_grace=term_grace, execution_timeout=execution_timeout)
         if not image:
             raise ValueError(
                 "[flux.workers] docker_image must be set when the 'docker' runner is enabled",
             )
+        if cli not in SUPPORTED_CONTAINER_CLIS:
+            raise ValueError(
+                f"[flux.workers] airgapped_container_cli '{cli}' is not "
+                f"supported; choose one of: {', '.join(SUPPORTED_CONTAINER_CLIS)}",
+            )
         self._image = image
+        self._cli = cli
         self._network = network
         self._memory = memory
         self._cpus = cpus
         self._extra_args = list(extra_args or [])
-        # docker-CLI pid -> container name, for docker-kill on force kill.
+        # container-CLI pid -> container name, for '<cli> kill' on force kill.
         self._containers: dict[int, str] = {}
-        self._verify_docker_available()
+        self._verify_cli_available()
 
-    @staticmethod
-    def _verify_docker_available():
+    def _verify_cli_available(self):
         """Fail at worker startup, not at first dispatch."""
-        if shutil.which("docker") is None:
+        if shutil.which(self._cli) is None:
             raise ValueError(
-                "The 'docker' runner is enabled but the docker CLI is not on PATH",
+                f"The '{self.name}' runner is enabled but the {self._cli} CLI "
+                "is not on PATH",
             )
-        probe = subprocess.run(
-            ["docker", "version", "--format", "{{.Server.Version}}"],
-            capture_output=True,
-            text=True,
-            timeout=15,
-        )
-        if probe.returncode != 0:
-            raise ValueError(
-                "The 'docker' runner is enabled but the Docker daemon is "
-                f"unreachable: {probe.stderr.strip() or probe.stdout.strip()}",
+        if self._cli == "docker":
+            # docker requires a reachable daemon; probe it explicitly so the
+            # error names the actual problem instead of failing per-dispatch.
+            probe = subprocess.run(
+                ["docker", "version", "--format", "{{.Server.Version}}"],
+                capture_output=True,
+                text=True,
+                timeout=15,
             )
-        logger.info(f"Docker runner ready (server {probe.stdout.strip()})")
+            if probe.returncode != 0:
+                raise ValueError(
+                    f"The '{self.name}' runner is enabled but the Docker "
+                    "daemon is unreachable: "
+                    f"{probe.stderr.strip() or probe.stdout.strip()}",
+                )
+            logger.info(f"{self.name} runner ready (docker server {probe.stdout.strip()})")
+        else:
+            # podman is daemonless; nerdctl needs containerd and reports it
+            # through a non-zero 'version' exit. A plain version probe covers
+            # both without depending on CLI-specific template keys.
+            probe = subprocess.run(
+                [self._cli, "version"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if probe.returncode != 0:
+                raise ValueError(
+                    f"The '{self.name}' runner is enabled but '{self._cli} "
+                    "version' failed — the container runtime is not usable: "
+                    f"{probe.stderr.strip() or probe.stdout.strip()}",
+                )
+            logger.info(f"{self.name} runner ready (cli {self._cli})")
 
     def _container_name(self, execution_id: str) -> str:
         # Unique per attempt: a crashed execution can be re-dispatched to this
@@ -94,7 +150,7 @@ class DockerRunner(SubprocessRunner):
         resource args, operator extra_args, then ``_locked_args()`` — LAST so
         docker's last-wins flag parsing structurally favors a hardened
         profile over anything an operator (or config-file attacker) adds."""
-        command = ["docker", "run", "-i", "--rm", "--name", container_name]
+        command = [self._cli, "run", "-i", "--rm", "--name", container_name]
         command += self._resource_args()
         command += self._extra_args
         command += self._locked_args()
@@ -131,12 +187,12 @@ class DockerRunner(SubprocessRunner):
         return proc
 
     async def _force_kill(self, proc):
-        # Killing the docker CLI alone would orphan the container; kill the
-        # container (which also ends the attached CLI process).
+        # Killing the container CLI alone would orphan the container; kill
+        # the container (which also ends the attached CLI process).
         container_name = self._containers.get(proc.pid)
         if container_name:
             killer = await asyncio.create_subprocess_exec(
-                "docker",
+                self._cli,
                 "kill",
                 container_name,
                 stdout=asyncio.subprocess.DEVNULL,
@@ -381,6 +437,13 @@ class AirgappedDockerRunner(DockerRunner):
     stack anywhere; see ``_validate_service_sockets`` for the directory
     contract). Socket traffic is the one channel the worker does not
     mediate; everything else still leaves only through the stdio protocol.
+
+    The container CLI itself is configurable through the same named-key
+    shape (``airgapped_container_cli``: ``docker`` | ``podman`` |
+    ``nerdctl``) so rootless deployments can drive Podman or nerdctl
+    instead of a privileged Docker daemon; the emitted-flag compatibility
+    set is documented in the module docstring, and the chosen CLI is
+    validated at worker startup.
     """
 
     name = "docker-airgapped"
@@ -399,6 +462,7 @@ class AirgappedDockerRunner(DockerRunner):
         mounts: list[str] | None = None,
         shm_size: str = "",
         service_sockets: dict[str, str] | None = None,
+        container_cli: str = "docker",
     ):
         if not memory:
             raise ValueError(
@@ -438,6 +502,7 @@ class AirgappedDockerRunner(DockerRunner):
             cpus=0.0,
             extra_args=extra_args,
             execution_timeout=execution_timeout,
+            cli=container_cli,
         )
         self._airgapped_memory = memory
         self._airgapped_cpus = cpus

--- a/flux/security/principals.py
+++ b/flux/security/principals.py
@@ -19,6 +19,12 @@ class PrincipalModel(Base):
     external_issuer = Column(String, nullable=False)
     display_name = Column(String, nullable=True)
     enabled = Column(Boolean, nullable=False, default=True)
+    # Operator-imposed quarantine, distinct from ``enabled``: the reaper
+    # disables principals of pruned workers and registration re-enables them
+    # when the worker returns, so ``enabled`` alone cannot express "stay
+    # out". A banned principal is refused at worker registration and cannot
+    # be re-enabled until explicitly unbanned.
+    banned = Column(Boolean, nullable=False, default=False)
     metadata_ = Column("metadata", JSON, nullable=True)
     created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
     updated_at = Column(
@@ -55,6 +61,7 @@ class PrincipalModel(Base):
         self.external_issuer = external_issuer
         self.display_name = display_name
         self.enabled = enabled
+        self.banned = False
         self.metadata_ = metadata or {}
         self.created_at = datetime.now(timezone.utc)
         self.updated_at = datetime.now(timezone.utc)
@@ -180,7 +187,51 @@ class PrincipalRegistry:
         try:
             principal = session.query(PrincipalModel).filter_by(id=principal_id).first()
             if principal:
+                if enabled and principal.banned:
+                    raise ValueError(
+                        f"Principal '{principal.subject}' is banned and cannot "
+                        "be enabled; unban it first",
+                    )
                 principal.enabled = enabled
+                principal.updated_at = datetime.now(timezone.utc)
+                session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def set_banned(
+        self,
+        principal_id: str,
+        banned: bool,
+        reason: str | None = None,
+    ) -> None:
+        """Ban or unban a principal.
+
+        Banning also disables the principal (belt and braces: the auth path
+        checks ``enabled``). Unbanning deliberately does NOT re-enable — the
+        operator lifts the quarantine and then explicitly enables, so a
+        worker never rejoins as a side effect.
+        """
+        session = self._session_factory()
+        try:
+            principal = session.query(PrincipalModel).filter_by(id=principal_id).first()
+            if principal:
+                principal.banned = banned
+                if banned:
+                    principal.enabled = False
+                if reason is not None:
+                    metadata = dict(principal.metadata_ or {})
+                    if banned:
+                        metadata["ban_reason"] = reason
+                    else:
+                        metadata.pop("ban_reason", None)
+                    principal.metadata_ = metadata
+                elif not banned:
+                    metadata = dict(principal.metadata_ or {})
+                    if metadata.pop("ban_reason", None) is not None:
+                        principal.metadata_ = metadata
                 principal.updated_at = datetime.now(timezone.utc)
                 session.commit()
         except Exception:

--- a/flux/server.py
+++ b/flux/server.py
@@ -126,6 +126,14 @@ class Server(
         # pong: still connected (running work finishes) but excluded from new
         # dispatch until they report healthy again.
         self._worker_unhealthy: set[str] = set()
+        # Workers that self-reported an operator pause: connected, heartbeats
+        # flowing, but claiming nothing — excluded from dispatch like
+        # unhealthy workers, yet surfaced as 'paused' (deliberate) rather
+        # than 'unhealthy' (a fault).
+        self._worker_paused: set[str] = set()
+        # Latest in-flight execution count each worker advertised on its
+        # heartbeat pong; surfaced in GET /workers.
+        self._worker_in_flight: dict[str, int] = {}
         # Last metrics snapshot persisted per worker; pongs repeat the current
         # snapshot every beat, so this gate keeps DB writes on the (slower)
         # metrics-refresh cadence instead of the heartbeat rate.
@@ -746,9 +754,11 @@ class Server(
         self._drain_worker_queue(name)
         if name in self._worker_names:
             self._worker_names.remove(name)
-        # Unconditional: a lingering unhealthy flag would wrongly surface in
-        # GET /workers even after the worker is gone.
+        # Unconditional: a lingering unhealthy/paused flag would wrongly
+        # surface in GET /workers even after the worker is gone.
         self._worker_unhealthy.discard(name)
+        self._worker_paused.discard(name)
+        self._worker_in_flight.pop(name, None)
         self._worker_metrics_persisted.pop(name, None)
         self._worker_offline_since[name] = time.monotonic()
         if name in self._worker_cache:

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import json
+import os
 import platform
 import random
 import signal
@@ -162,6 +165,14 @@ class Worker:
         self._max_concurrent = config.max_concurrent_executions
         self._drain_timeout = config.drain_timeout
         self._draining = False
+        # Operator-requested pause: stop claiming new work (dispatches that
+        # still arrive are released for re-dispatch) while heartbeats keep
+        # flowing, so the worker reads as *paused*, not offline. Running
+        # executions are unaffected — cancel_all() is the separate,
+        # explicit bulk-yield action.
+        self._paused = False
+        self._control_server: asyncio.base_events.Server | None = None
+        self._control_socket_path: str | None = None
         # Self-health: an event-loop starved by misbehaving in-process code
         # makes the worker a black hole (accepts dispatches it can't run).
         # The lag monitor flips this off after consecutive breaches; while
@@ -275,6 +286,152 @@ class Worker:
         self._metrics_snapshot = merged or None
         return self._metrics_snapshot
 
+    @property
+    def status(self) -> str:
+        """Lifecycle state advertised on heartbeats: active | paused | draining."""
+        if self._draining:
+            return "draining"
+        if self._paused:
+            return "paused"
+        return "active"
+
+    def _status_payload(self) -> dict:
+        return {
+            "status": self.status,
+            "in_flight": len(self._running_workflows),
+            "healthy": self._healthy,
+        }
+
+    def pause(self):
+        """Stop claiming new work; heartbeats continue (paused, not offline).
+
+        Running executions keep going. Effective capacity is zero while
+        paused: dispatches that race in are released back for re-dispatch.
+        """
+        if self._paused:
+            return
+        self._paused = True
+        logger.info("Worker paused — not claiming new work (running executions continue)")
+        self._notify_server_of_state()
+
+    def resume(self):
+        """Resume claiming new work after a pause."""
+        if not self._paused:
+            return
+        self._paused = False
+        logger.info("Worker resumed — claiming new work again")
+        self._notify_server_of_state()
+
+    def _notify_server_of_state(self):
+        # Tell the server immediately instead of waiting for the next
+        # ping/pong round-trip; best-effort (the pong path logs failures).
+        if self._registered:
+            asyncio.create_task(self._send_pong())
+
+    async def cancel_all(self, reason: str = "operator request") -> int:
+        """Cancel every in-flight execution on this worker (bulk yield).
+
+        The worker-initiated counterpart of the server's per-execution
+        cancel: each runner child receives its termination signal, so the
+        workflow's own cancellation handling still runs and the terminal
+        CANCELLED checkpoint reaches the server through the outbox. Pair
+        with pause() to free local resources in seconds without going
+        offline. Returns the number of executions cancelled.
+        """
+        tasks = {
+            execution_id: task
+            for execution_id, task in self._running_workflows.items()
+            if not task.done()
+        }
+        if not tasks:
+            return 0
+        logger.warning(f"Cancelling {len(tasks)} in-flight execution(s) ({reason})")
+        for execution_id, task in tasks.items():
+            logger.info(f"Cancelling execution {execution_id}")
+            task.cancel()
+        # Bounded like the drain path: cancellation triggers each runner's
+        # term-grace shutdown, which is seconds, not minutes.
+        await asyncio.wait(list(tasks.values()), timeout=60)
+        return len(tasks)
+
+    async def _start_control_server(self):
+        """Worker-local control API over a Unix socket.
+
+        The worker is outbound-only, so runtime control (pause / resume /
+        cancel-all / status) cannot arrive from the server; a same-host
+        agent connects to the socket instead ('flux worker pause <name>').
+        One JSON object per line in, one JSON object out. The socket is
+        chmod 0600 — same trust boundary as the worker process owner.
+        """
+        config = Configuration.get().settings.workers
+        if not config.control_socket_enabled:
+            return
+        settings = Configuration.get().settings
+        path = config.control_socket_path or os.path.join(
+            settings.home,
+            f"worker-{self.name}.sock",
+        )
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(path)
+        try:
+            self._control_server = await asyncio.start_unix_server(
+                self._handle_control_client,
+                path=path,
+            )
+        except (NotImplementedError, AttributeError, OSError) as e:
+            logger.warning(
+                f"Worker control socket unavailable ({e}); pause/resume via signals only",
+            )
+            return
+        os.chmod(path, 0o600)
+        self._control_socket_path = path
+        logger.info(f"Worker control socket listening at {path}")
+
+    async def _stop_control_server(self):
+        if self._control_server is not None:
+            self._control_server.close()
+            with contextlib.suppress(Exception):
+                await self._control_server.wait_closed()
+            self._control_server = None
+        if self._control_socket_path:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(self._control_socket_path)
+            self._control_socket_path = None
+
+    async def _handle_control_client(self, reader, writer):
+        try:
+            try:
+                line = await asyncio.wait_for(reader.readline(), timeout=5)
+                request = json.loads(line.decode())
+                command = request.get("command")
+                if command == "pause":
+                    self.pause()
+                    response = self._status_payload()
+                elif command == "resume":
+                    self.resume()
+                    response = self._status_payload()
+                elif command == "cancel-all":
+                    cancelled = await self.cancel_all()
+                    response = {**self._status_payload(), "cancelled": cancelled}
+                elif command == "status":
+                    response = self._status_payload()
+                else:
+                    response = {
+                        "error": f"unknown command {command!r}; "
+                        "expected pause | resume | cancel-all | status",
+                    }
+            except Exception as e:
+                response = {"error": f"{type(e).__name__}: {e}"}
+            writer.write((json.dumps(response) + "\n").encode())
+            await writer.drain()
+        finally:
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+
     def start(self):
         logger.info("Worker starting up...")
         logger.debug(f"Worker name: {self.name}")
@@ -331,6 +488,20 @@ class Worker:
                 # SIGINT->KeyboardInterrupt behaviour still applies there.
                 logger.debug(f"Could not install {sig.name} handler via event loop")
 
+        # Runtime pause/resume without process exit: SIGUSR1 pauses claiming,
+        # SIGUSR2 resumes. The control socket offers the same (plus
+        # cancel-all) for agents that prefer an explicit API.
+        for sig_name, handler in (("SIGUSR1", self.pause), ("SIGUSR2", self.resume)):
+            sig_value = getattr(signal, sig_name, None)
+            if sig_value is None:
+                continue
+            try:
+                loop.add_signal_handler(sig_value, handler)
+            except (NotImplementedError, RuntimeError, ValueError):
+                logger.debug(f"Could not install {sig_name} handler via event loop")
+
+        await self._start_control_server()
+
         health_monitor: asyncio.Task | None = None
         if self._loop_lag_threshold > 0:
             health_monitor = asyncio.create_task(self._monitor_loop_health())
@@ -374,11 +545,11 @@ class Worker:
             self._draining = True
             if health_monitor is not None:
                 health_monitor.cancel()
-                import contextlib
-
                 with contextlib.suppress(asyncio.CancelledError):
                     await health_monitor
             await self._drain()
+        finally:
+            await self._stop_control_server()
 
     async def _monitor_loop_health(self):
         """Detect event-loop starvation and step out of the dispatch pool.
@@ -568,7 +739,11 @@ class Worker:
         """Respond to server ping with a pong carrying health and metrics."""
         base_url = f"{self.base_url}/{self.name}"
         try:
-            payload: dict = {"healthy": self._healthy}
+            payload: dict = {
+                "healthy": self._healthy,
+                "status": self.status,
+                "in_flight": len(self._running_workflows),
+            }
             metrics = await self._collect_metrics()
             if metrics is not None:
                 payload["metrics"] = metrics
@@ -638,6 +813,14 @@ class Worker:
                     "flux.worker.name": self.name,
                 },
             )
+
+        if self._paused:
+            logger.info(
+                f"Paused; releasing resumed execution "
+                f"{request.context.execution_id} for re-dispatch",
+            )
+            await self._release_claim(request.context.execution_id)
+            return
 
         if not self._healthy:
             logger.warning(
@@ -747,6 +930,16 @@ class Worker:
                 f"Draining; not claiming execution {request.context.execution_id} "
                 f"(will be re-dispatched)",
             )
+            return
+
+        if self._paused:
+            # Paused workers stay connected (heartbeats continue) but their
+            # effective capacity is zero: release the assignment so it
+            # re-dispatches now instead of idling on us.
+            logger.info(
+                f"Paused; releasing execution {request.context.execution_id} for re-dispatch",
+            )
+            await self._release_claim(request.context.execution_id)
             return
 
         if not self._healthy:

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -371,22 +371,29 @@ class Worker:
             settings.home,
             f"worker-{self.name}.sock",
         )
-        parent = os.path.dirname(path)
-        if parent:
-            os.makedirs(parent, exist_ok=True)
-        with contextlib.suppress(FileNotFoundError):
-            os.unlink(path)
+        # Best-effort by design: the entire setup (directory creation, stale
+        # socket removal, bind, chmod) degrades to signals-only. A read-only
+        # home or unwritable path must not abort worker startup.
+        server = None
         try:
-            self._control_server = await asyncio.start_unix_server(
+            parent = os.path.dirname(path)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(path)
+            server = await asyncio.start_unix_server(
                 self._handle_control_client,
                 path=path,
             )
+            os.chmod(path, 0o600)
         except (NotImplementedError, AttributeError, OSError) as e:
+            if server is not None:
+                server.close()
             logger.warning(
                 f"Worker control socket unavailable ({e}); pause/resume via signals only",
             )
             return
-        os.chmod(path, 0o600)
+        self._control_server = server
         self._control_socket_path = path
         logger.info(f"Worker control socket listening at {path}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.62.2"
+version = "0.63.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -295,6 +295,20 @@ class FluxCLI:
         if proc in self._extra_workers:
             self._extra_workers.remove(proc)
 
+    # -- worker runtime control (local Unix socket, no --server-url) -------
+
+    def worker_pause(self, name: str) -> dict:
+        return self._json(["worker", "pause", name])
+
+    def worker_resume(self, name: str) -> dict:
+        return self._json(["worker", "resume", name])
+
+    def worker_cancel_all(self, name: str) -> dict:
+        return self._json(["worker", "cancel-all", name], timeout=90)
+
+    def worker_local_status(self, name: str) -> dict:
+        return self._json(["worker", "status", name])
+
     # -- admin: roles ------------------------------------------------------
 
     def role_create(self, name: str, permissions: list[str]) -> dict:
@@ -369,6 +383,15 @@ class FluxCLI:
 
     def principal_disable(self, subject: str) -> None:
         self._ok(["principals", "disable", subject])
+
+    def principal_ban(self, subject: str, reason: str | None = None) -> None:
+        args = ["principals", "ban", subject]
+        if reason:
+            args.extend(["--reason", reason])
+        self._ok(args)
+
+    def principal_unban(self, subject: str) -> None:
+        self._ok(["principals", "unban", subject])
 
     def principal_grant(self, subject: str, role: str) -> None:
         self._ok(

--- a/tests/e2e/fixtures/worker_control_workflow.py
+++ b/tests/e2e/fixtures/worker_control_workflow.py
@@ -1,0 +1,28 @@
+"""Fixtures for the worker runtime-control e2e scenario.
+
+Both workflows pin to workers labeled ``pausable=true`` so the tests can
+start a dedicated worker, pause/cancel it, and prove dispatch behavior
+without touching the session worker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from flux import ExecutionContext, task, workflow
+
+
+@task
+async def pinned_sleep(seconds: int) -> str:
+    await asyncio.sleep(seconds)
+    return f"slept {seconds}"
+
+
+@workflow.with_options(affinity={"pausable": "true"})
+async def pause_pinned_slow(ctx: ExecutionContext):
+    return await pinned_sleep(ctx.input or 60)
+
+
+@workflow.with_options(affinity={"pausable": "true"})
+async def pause_pinned_quick(ctx: ExecutionContext):
+    return "ran after resume"

--- a/tests/e2e/fixtures/worker_control_workflow.py
+++ b/tests/e2e/fixtures/worker_control_workflow.py
@@ -13,6 +13,11 @@ from flux import ExecutionContext, task, workflow
 
 
 @task
+async def mark_started() -> str:
+    return "started"
+
+
+@task
 async def pinned_sleep(seconds: int) -> str:
     await asyncio.sleep(seconds)
     return f"slept {seconds}"
@@ -20,6 +25,10 @@ async def pinned_sleep(seconds: int) -> str:
 
 @workflow.with_options(affinity={"pausable": "true"})
 async def pause_pinned_slow(ctx: ExecutionContext):
+    # A quick first task so the RUNNING transition is checkpointed right
+    # away — the long sleep alone would leave the server at CLAIMED until
+    # its first (post-sleep) checkpoint.
+    await mark_started()
     return await pinned_sleep(ctx.input or 60)
 
 

--- a/tests/e2e/test_airgapped_cli.py
+++ b/tests/e2e/test_airgapped_cli.py
@@ -1,0 +1,79 @@
+"""E2E: airgapped_container_cli is validated at worker startup.
+
+The airgapped runner can drive docker, podman, or nerdctl; anything else
+must fail the worker process fast (before it ever registers), with an
+error naming the config key. Running an actual podman/nerdctl container
+needs a container runtime and is covered by the gated integration tests
+in tests/flux/test_docker_runner.py.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def test_unknown_container_cli_fails_worker_startup(cli):
+    env = {
+        **cli._env,
+        "FLUX_WORKERS__RUNNERS": '["subprocess", "docker-airgapped"]',
+        "FLUX_WORKERS__DEFAULT_RUNNER": "subprocess",
+        "FLUX_WORKERS__DOCKER_IMAGE": "flux:e2e-test",
+        "FLUX_WORKERS__AIRGAPPED_CONTAINER_CLI": "containerctl",
+    }
+    r = subprocess.run(
+        [
+            "poetry",
+            "run",
+            "flux",
+            "start",
+            "worker",
+            "bad-cli-worker",
+            "--server-url",
+            cli.server_url,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=PROJECT_ROOT,
+        env=env,
+    )
+
+    assert r.returncode != 0
+    output = r.stderr + r.stdout
+    assert "airgapped_container_cli" in output
+    assert "containerctl" in output
+    # The worker never registered.
+    assert all(w["name"] != "bad-cli-worker" for w in cli.worker_list())
+
+
+@pytest.mark.skipif(
+    os.environ.get("FLUX_TEST_PODMAN") != "1",
+    reason="FLUX_TEST_PODMAN=1 not set (needs a working rootless podman)",
+)
+def test_podman_worker_starts_and_registers(cli):
+    """Opt-in: with rootless podman present, a podman-backed airgapped
+    worker starts, validates the CLI, and registers."""
+    worker = cli.start_worker(
+        "podman-worker",
+        env={
+            "FLUX_WORKERS__RUNNERS": '["subprocess", "docker-airgapped"]',
+            "FLUX_WORKERS__DEFAULT_RUNNER": "subprocess",
+            "FLUX_WORKERS__DOCKER_IMAGE": os.environ.get(
+                "FLUX_TEST_DOCKER_IMAGE",
+                "flux:e2e-test",
+            ),
+            "FLUX_WORKERS__AIRGAPPED_CONTAINER_CLI": "podman",
+        },
+    )
+    try:
+        assert any(w["name"] == "podman-worker" for w in cli.worker_list())
+    finally:
+        cli.stop_worker(worker)

--- a/tests/e2e/test_principal_ban.py
+++ b/tests/e2e/test_principal_ban.py
@@ -1,0 +1,100 @@
+"""E2E: banned principals cannot re-register a worker (C1 quarantine).
+
+Registration auto-re-enables disabled principals by design (the reaper
+disables pruned workers); 'flux principals ban' is the state that wins
+over any valid registration credential. Unban lifts the refusal without
+re-enabling anything as a side effect.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+BOOTSTRAP_TOKEN = "e2e-test-bootstrap-token"
+
+
+def _registration_body(name: str) -> dict:
+    return {
+        "name": name,
+        "runtime": {"os_name": "Linux", "os_version": "6", "python_version": "3.12"},
+        "packages": [],
+        "resources": {
+            "cpu_total": 1,
+            "cpu_available": 1,
+            "memory_total": 1,
+            "memory_available": 1,
+            "disk_total": 1,
+            "disk_free": 1,
+            "gpus": [],
+        },
+    }
+
+
+def _register(cli, name: str) -> httpx.Response:
+    return httpx.post(
+        f"{cli.server_url}/workers/register",
+        json=_registration_body(name),
+        headers={"Authorization": f"Bearer {BOOTSTRAP_TOKEN}"},
+        timeout=30,
+    )
+
+
+def test_banned_principal_cannot_register_until_unbanned(cli):
+    subject = f"quarantined-{uuid.uuid4().hex[:8]}"
+    cli.principal_create(subject)
+
+    # Sanity: with a valid bootstrap token, registration works.
+    assert _register(cli, subject).status_code == 200
+
+    cli.principal_ban(subject, reason="failed recertification")
+    shown = cli.principal_show(subject)
+    assert shown["banned"] is True
+    assert shown["enabled"] is False
+
+    # The quarantine wins over the (still valid) registration credential.
+    resp = _register(cli, subject)
+    assert resp.status_code == 403
+    assert "banned" in resp.json()["detail"]
+
+    cli.principal_unban(subject)
+    shown = cli.principal_show(subject)
+    assert shown["banned"] is False
+    # Unban does not re-enable as a side effect.
+    assert shown["enabled"] is False
+
+    # Registration is the sanctioned way back in after the unban.
+    assert _register(cli, subject).status_code == 200
+
+
+def test_ban_is_scoped_to_one_principal(cli):
+    banned = f"banned-{uuid.uuid4().hex[:8]}"
+    bystander = f"bystander-{uuid.uuid4().hex[:8]}"
+    cli.principal_create(banned)
+    cli.principal_ban(banned)
+
+    assert _register(cli, banned).status_code == 403
+    assert _register(cli, bystander).status_code == 200
+
+    # Cleanup so the quarantined name cannot leak into other tests.
+    cli.principal_unban(banned)
+
+
+def test_banned_flag_surfaces_in_principal_list(cli):
+    subject = f"listed-{uuid.uuid4().hex[:8]}"
+    cli.principal_create(subject)
+    cli.principal_ban(subject)
+
+    listed = {p["subject"]: p for p in cli.principal_list()}
+    assert listed[subject]["banned"] is True
+
+    cli.principal_unban(subject)
+    listed = {p["subject"]: p for p in cli.principal_list()}
+    assert listed[subject]["banned"] is False

--- a/tests/e2e/test_worker_runtime_control.py
+++ b/tests/e2e/test_worker_runtime_control.py
@@ -1,0 +1,143 @@
+"""E2E: worker runtime pause/resume, bulk cancel, and heartbeat status.
+
+'flux worker pause|resume|cancel-all|status <name>' speak the worker's
+local control socket (the worker is outbound-only). Paused reads as
+*paused, not offline*: heartbeats keep flowing, the server surfaces the
+state in GET /workers and stops dispatching; pinned work waits and runs
+after resume. cancel-all is the worker-initiated bulk cancel — in-flight
+executions reach a terminal CANCELLED through their normal path.
+SIGUSR1/SIGUSR2 are the signal equivalents of pause/resume.
+"""
+
+from __future__ import annotations
+
+import signal
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _worker_status(cli, name: str) -> str | None:
+    for w in cli.worker_list():
+        if w.get("name") == name:
+            return w.get("status")
+    return None
+
+
+def _wait_for_worker_status(cli, name: str, status: str, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _worker_status(cli, name) == status:
+            return True
+        time.sleep(1)
+    return False
+
+
+def test_pause_holds_pinned_work_until_resume(cli):
+    worker = cli.start_worker("pausable-worker", labels={"pausable": "true"})
+    try:
+        cli.register(str(FIXTURES / "worker_control_workflow.py"))
+
+        # Local status before anything: active, nothing in flight.
+        status = cli.worker_local_status("pausable-worker")
+        assert status["status"] == "active"
+        assert status["in_flight"] == 0
+
+        status = cli.worker_pause("pausable-worker")
+        assert status["status"] == "paused"
+
+        # The pause pong propagates immediately; the server surfaces the
+        # deliberate state (not offline, not unhealthy).
+        assert _wait_for_worker_status(cli, "pausable-worker", "paused", timeout=30)
+
+        # Work pinned to the paused worker must not start.
+        r = cli.run("pause_pinned_quick", "null", mode="async", timeout=30)
+        deadline = time.monotonic() + 6
+        while time.monotonic() < deadline:
+            state = cli.status("pause_pinned_quick", r["execution_id"])["state"]
+            assert state in ("CREATED", "SCHEDULED"), state
+            time.sleep(1)
+
+        status = cli.worker_resume("pausable-worker")
+        assert status["status"] == "active"
+        assert _wait_for_worker_status(cli, "pausable-worker", "online", timeout=30)
+
+        # The held execution dispatches and completes after resume.
+        final = cli.wait_for_state(
+            "pause_pinned_quick",
+            r["execution_id"],
+            "COMPLETED",
+            timeout=60,
+        )
+        assert final["state"] == "COMPLETED"
+        assert final["output"] == "ran after resume"
+    finally:
+        cli.stop_worker(worker)
+
+
+def test_cancel_all_cancels_inflight_work(cli):
+    worker = cli.start_worker("yieldable-worker", labels={"pausable": "true"})
+    try:
+        cli.register(str(FIXTURES / "worker_control_workflow.py"))
+
+        r = cli.run("pause_pinned_slow", "120", mode="async", timeout=30)
+        cli.wait_for_state("pause_pinned_slow", r["execution_id"], "RUNNING", timeout=60)
+
+        # The worker sees its own in-flight work on the local status.
+        status = cli.worker_local_status("yieldable-worker")
+        assert status["in_flight"] >= 1
+
+        response = cli.worker_cancel_all("yieldable-worker")
+        assert response["cancelled"] >= 1
+
+        # The execution reaches a terminal cancel through its normal path
+        # (runner term signal -> workflow cancellation -> checkpoint).
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            s = cli.status("pause_pinned_slow", r["execution_id"])
+            if s["state"] in ("CANCELLED", "CANCELLING"):
+                break
+            time.sleep(2)
+        assert s["state"] in ("CANCELLED", "CANCELLING"), s["state"]
+
+        # The worker is free again (busy-yield: resources released in
+        # seconds without the worker going offline).
+        status = cli.worker_local_status("yieldable-worker")
+        assert status["in_flight"] == 0
+        assert _worker_status(cli, "yieldable-worker") in ("online", "paused")
+    finally:
+        cli.stop_worker(worker)
+
+
+def test_sigusr_signals_pause_and_resume(cli):
+    worker = cli.start_worker("signal-worker", labels={"pausable": "true"})
+    try:
+        worker.send_signal(signal.SIGUSR1)
+        assert _wait_for_worker_status(cli, "signal-worker", "paused", timeout=30)
+
+        worker.send_signal(signal.SIGUSR2)
+        assert _wait_for_worker_status(cli, "signal-worker", "online", timeout=30)
+    finally:
+        cli.stop_worker(worker)
+
+
+def test_paused_status_filter_in_worker_list(cli):
+    worker = cli.start_worker("filterable-worker", labels={"pausable": "true"})
+    try:
+        cli.worker_pause("filterable-worker")
+        assert _wait_for_worker_status(cli, "filterable-worker", "paused", timeout=30)
+
+        paused_names = {w["name"] for w in cli.worker_list() if w["status"] == "paused"}
+        assert "filterable-worker" in paused_names
+        # The session worker stays dispatchable and unaffected.
+        assert _worker_status(cli, "e2e-worker") == "online"
+
+        cli.worker_resume("filterable-worker")
+        assert _wait_for_worker_status(cli, "filterable-worker", "online", timeout=30)
+    finally:
+        cli.stop_worker(worker)

--- a/tests/flux/test_airgapped_runner.py
+++ b/tests/flux/test_airgapped_runner.py
@@ -24,7 +24,7 @@ DOCKER_TEST_IMAGE = os.environ.get("FLUX_TEST_DOCKER_IMAGE")
 
 
 def make_runner(**kwargs) -> AirgappedDockerRunner:
-    with patch.object(DockerRunner, "_verify_docker_available"):
+    with patch.object(DockerRunner, "_verify_cli_available"):
         return AirgappedDockerRunner(image=kwargs.pop("image", "flux:test"), **kwargs)
 
 
@@ -366,6 +366,76 @@ class TestLimitValidation:
             make_runner(pids_limit=0)
 
 
+class TestContainerCli:
+    def test_default_cli_is_docker(self):
+        runner = make_runner()
+        assert runner._build_command("c")[0] == "docker"
+
+    def test_configured_cli_leads_the_command(self):
+        runner = make_runner(container_cli="podman")
+        command = runner._build_command("c")
+        assert command[:3] == ["podman", "run", "-i"]
+        # The locked profile is CLI-independent.
+        assert "--network=none" in command
+        assert "--cap-drop=ALL" in command
+
+    def test_unknown_cli_rejected_at_startup(self):
+        with pytest.raises(ValueError, match="airgapped_container_cli"):
+            make_runner(container_cli="containerctl")
+
+    def test_veto_list_applies_regardless_of_cli(self):
+        with pytest.raises(ValueError, match="--privileged"):
+            make_runner(container_cli="nerdctl", extra_args=["--privileged"])
+
+    @pytest.mark.asyncio
+    async def test_force_kill_uses_configured_cli(self):
+        runner = make_runner(container_cli="podman")
+        proc = MagicMock()
+        proc.pid = 4242
+        proc.kill = MagicMock()
+        runner._containers[proc.pid] = "flux-exec-x"
+
+        killer = MagicMock()
+
+        async def _wait():
+            return 0
+
+        killer.wait = _wait
+        with patch(
+            "asyncio.create_subprocess_exec",
+            return_value=killer,
+        ) as spawn:
+            await runner._force_kill(proc)
+        assert spawn.call_args[0][:3] == ("podman", "kill", "flux-exec-x")
+
+    def test_non_docker_probe_runs_cli_version(self):
+        with (
+            patch("flux.runners.docker.shutil.which", return_value="/usr/bin/podman"),
+            patch("flux.runners.docker.subprocess.run") as run,
+        ):
+            run.return_value = MagicMock(returncode=0, stdout="podman 5", stderr="")
+            AirgappedDockerRunner(image="flux:test", container_cli="podman")
+        assert run.call_args[0][0] == ["podman", "version"]
+
+    def test_non_docker_probe_failure_names_the_runtime(self):
+        with (
+            patch("flux.runners.docker.shutil.which", return_value="/usr/bin/nerdctl"),
+            patch("flux.runners.docker.subprocess.run") as run,
+        ):
+            run.return_value = MagicMock(
+                returncode=1,
+                stdout="",
+                stderr="cannot connect to containerd",
+            )
+            with pytest.raises(ValueError, match="containerd"):
+                AirgappedDockerRunner(image="flux:test", container_cli="nerdctl")
+
+    def test_missing_cli_binary_rejected(self):
+        with patch("flux.runners.docker.shutil.which", return_value=None):
+            with pytest.raises(ValueError, match="not on PATH"):
+                AirgappedDockerRunner(image="flux:test", container_cli="podman")
+
+
 class TestFactoryWiring:
     def test_known_runner(self):
         assert "docker-airgapped" in KNOWN_RUNNERS
@@ -385,12 +455,13 @@ class TestFactoryWiring:
         cfg.airgapped_mounts = []
         cfg.airgapped_shm_size = ""
         cfg.airgapped_service_sockets = {}
+        cfg.airgapped_container_cli = "docker"
         for key, value in overrides.items():
             setattr(cfg, key, value)
         return cfg
 
     def test_image_fallback_to_docker_image(self):
-        with patch.object(DockerRunner, "_verify_docker_available"):
+        with patch.object(DockerRunner, "_verify_cli_available"):
             runners = create_runners(
                 ["docker-airgapped"],
                 self._config(docker_image="flux:base"),
@@ -401,7 +472,7 @@ class TestFactoryWiring:
         assert runner._image == "flux:base"
 
     def test_airgapped_image_wins_over_fallback(self):
-        with patch.object(DockerRunner, "_verify_docker_available"):
+        with patch.object(DockerRunner, "_verify_cli_available"):
             runners = create_runners(
                 ["docker-airgapped"],
                 self._config(docker_image="flux:base", airgapped_image="flux:sealed"),
@@ -409,12 +480,12 @@ class TestFactoryWiring:
         assert runners["docker-airgapped"]._image == "flux:sealed"
 
     def test_no_image_anywhere_fails_at_startup(self):
-        with patch.object(DockerRunner, "_verify_docker_available"):
+        with patch.object(DockerRunner, "_verify_cli_available"):
             with pytest.raises(ValueError, match="airgapped_image"):
                 create_runners(["docker-airgapped"], self._config())
 
     def test_capability_knobs_flow_from_config(self, tmp_path):
-        with patch.object(DockerRunner, "_verify_docker_available"):
+        with patch.object(DockerRunner, "_verify_cli_available"):
             runners = create_runners(
                 ["docker-airgapped"],
                 self._config(
@@ -429,11 +500,19 @@ class TestFactoryWiring:
         assert f"type=bind,source={tmp_path},target=/models,readonly" in joined
         assert "--shm-size 4g" in joined
 
+    def test_container_cli_flows_from_config(self):
+        with patch.object(DockerRunner, "_verify_cli_available"):
+            runners = create_runners(
+                ["docker-airgapped"],
+                self._config(docker_image="flux:base", airgapped_container_cli="nerdctl"),
+            )
+        assert runners["docker-airgapped"]._build_command("c")[0] == "nerdctl"
+
     def test_service_sockets_flow_from_config(self, tmp_path):
         service_dir = tmp_path / "inference"
         service_dir.mkdir()
         service_dir.chmod(0o555)
-        with patch.object(DockerRunner, "_verify_docker_available"):
+        with patch.object(DockerRunner, "_verify_cli_available"):
             runners = create_runners(
                 ["docker-airgapped"],
                 self._config(

--- a/tests/flux/test_cli_worker_control.py
+++ b/tests/flux/test_cli_worker_control.py
@@ -1,0 +1,114 @@
+"""CLI tests for the local worker control commands.
+
+'flux worker pause|resume|cancel-all|status <name>' talk to the worker's
+Unix control socket on the same host — never to the server. The tests run
+a real socket server speaking the one-JSON-object-per-line protocol.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+
+import pytest
+from click.testing import CliRunner
+
+from flux.cli import cli
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def control_socket(tmp_path):
+    """A fake worker control endpoint; records the command it received."""
+    path = str(tmp_path / "worker-w1.sock")
+    received: dict = {}
+    responses = {"default": {"status": "paused", "in_flight": 0, "healthy": True}}
+
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(path)
+    server.listen(1)
+
+    def serve():
+        conn, _ = server.accept()
+        with conn:
+            data = b""
+            while not data.endswith(b"\n"):
+                chunk = conn.recv(4096)
+                if not chunk:
+                    break
+                data += chunk
+            received.update(json.loads(data.decode()))
+            reply = responses.get(received.get("command"), responses["default"])
+            conn.sendall((json.dumps(reply) + "\n").encode())
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    yield path, received, responses
+    server.close()
+
+
+class TestWorkerControlCommands:
+    def test_pause_sends_pause_command(self, runner, control_socket):
+        path, received, _ = control_socket
+
+        result = runner.invoke(cli, ["worker", "pause", "w1", "--socket", path])
+
+        assert result.exit_code == 0, result.output
+        assert received["command"] == "pause"
+        assert json.loads(result.output)["status"] == "paused"
+
+    def test_resume_sends_resume_command(self, runner, control_socket):
+        path, received, responses = control_socket
+        responses["resume"] = {"status": "active", "in_flight": 0, "healthy": True}
+
+        result = runner.invoke(cli, ["worker", "resume", "w1", "--socket", path])
+
+        assert result.exit_code == 0, result.output
+        assert received["command"] == "resume"
+
+    def test_cancel_all_reports_count(self, runner, control_socket):
+        path, received, responses = control_socket
+        responses["cancel-all"] = {
+            "status": "paused",
+            "in_flight": 0,
+            "healthy": True,
+            "cancelled": 4,
+        }
+
+        result = runner.invoke(cli, ["worker", "cancel-all", "w1", "--socket", path])
+
+        assert result.exit_code == 0, result.output
+        assert received["command"] == "cancel-all"
+        assert json.loads(result.output)["cancelled"] == 4
+
+    def test_status_prints_payload(self, runner, control_socket):
+        path, received, responses = control_socket
+        responses["status"] = {"status": "active", "in_flight": 2, "healthy": True}
+
+        result = runner.invoke(cli, ["worker", "status", "w1", "--socket", path])
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["in_flight"] == 2
+
+    def test_missing_socket_is_a_clear_error(self, runner, tmp_path):
+        result = runner.invoke(
+            cli,
+            ["worker", "pause", "w1", "--socket", str(tmp_path / "nope.sock")],
+        )
+
+        assert result.exit_code == 1
+        assert "control socket" in result.output
+
+    def test_error_response_exits_nonzero(self, runner, control_socket):
+        path, _, responses = control_socket
+        responses["pause"] = {"error": "kaboom"}
+
+        result = runner.invoke(cli, ["worker", "pause", "w1", "--socket", path])
+
+        assert result.exit_code == 1
+        assert "kaboom" in result.output

--- a/tests/flux/test_docker_runner.py
+++ b/tests/flux/test_docker_runner.py
@@ -23,7 +23,7 @@ DOCKER_TEST_IMAGE = os.environ.get("FLUX_TEST_DOCKER_IMAGE")
 
 
 def make_runner(**kwargs) -> DockerRunner:
-    with patch.object(DockerRunner, "_verify_docker_available"):
+    with patch.object(DockerRunner, "_verify_cli_available"):
         return DockerRunner(image=kwargs.pop("image", "flux:test"), **kwargs)
 
 
@@ -60,7 +60,7 @@ class TestDockerCommand:
 
     def test_missing_image_rejected_at_startup(self):
         with pytest.raises(ValueError, match="docker_image must be set"):
-            with patch.object(DockerRunner, "_verify_docker_available"):
+            with patch.object(DockerRunner, "_verify_cli_available"):
                 DockerRunner(image="")
 
     def test_create_runners_wires_docker_config(self):
@@ -77,7 +77,7 @@ class TestDockerCommand:
             docker_cpus=2.0,
             docker_extra_args=["--user", "1000"],
         )
-        with patch.object(DockerRunner, "_verify_docker_available"):
+        with patch.object(DockerRunner, "_verify_cli_available"):
             runners = create_runners(["docker"], config)
 
         command = runners["docker"]._build_command("c")

--- a/tests/flux/test_migrations.py
+++ b/tests/flux/test_migrations.py
@@ -13,7 +13,7 @@ import flux.security.models  # noqa: F401
 from flux.migrations.runner import current_revision, run_migrations
 from flux.models import Base
 
-HEAD = "0011_worker_join_tokens"
+HEAD = "0012_principal_banned"
 BASELINE = "0001_baseline"
 
 # A representative index added after the original create_all schema, used to

--- a/tests/flux/test_migrations_postgresql.py
+++ b/tests/flux/test_migrations_postgresql.py
@@ -28,7 +28,7 @@ pytestmark = [
     ),
 ]
 
-HEAD = "0011_worker_join_tokens"
+HEAD = "0012_principal_banned"
 _BACKFILL_INDEX = "ix_executions_workflow_id"
 
 

--- a/tests/flux/test_worker.py
+++ b/tests/flux/test_worker.py
@@ -75,10 +75,11 @@ def test_service_socket_labels_derived_from_runner(mock_config, tmp_path):
     mock_config.settings.workers.airgapped_mounts = []
     mock_config.settings.workers.airgapped_shm_size = ""
     mock_config.settings.workers.airgapped_service_sockets = {"inference": str(service_dir)}
+    mock_config.settings.workers.airgapped_container_cli = "docker"
 
     from flux.runners.docker import DockerRunner
 
-    with patch.object(DockerRunner, "_verify_docker_available"):
+    with patch.object(DockerRunner, "_verify_cli_available"):
         worker = Worker(
             name="test-worker",
             server_url="http://localhost:8000",

--- a/tests/flux/test_worker_checkpoint.py
+++ b/tests/flux/test_worker_checkpoint.py
@@ -39,6 +39,9 @@ def make_worker() -> Worker:
     worker._metrics_collector = None
     worker._user_metrics = None
     worker._execution_started = {}
+    worker._paused = False
+    worker._control_server = None
+    worker._control_socket_path = None
     return worker
 
 

--- a/tests/flux/test_worker_control.py
+++ b/tests/flux/test_worker_control.py
@@ -227,6 +227,23 @@ class TestControlSocket:
         assert not os.path.exists(control_config)
 
     @pytest.mark.asyncio
+    async def test_unwritable_path_degrades_to_signals_only(self, control_config, tmp_path):
+        # Read-only home / unwritable socket dir must not abort worker
+        # startup — the socket is best-effort, signals still work. Injected
+        # via patch: chmod-based read-only dirs do not bind root (CI runs
+        # as root), and PermissionError must be caught wherever it fires.
+        Configuration.get().settings.workers.control_socket_path = str(
+            tmp_path / "readonly" / "worker.sock",
+        )
+        worker = make_worker()
+        with patch(
+            "flux.worker.os.makedirs",
+            side_effect=PermissionError("read-only file system"),
+        ):
+            await worker._start_control_server()  # must not raise
+        assert worker._control_server is None
+
+    @pytest.mark.asyncio
     async def test_disabled_by_config(self, control_config, tmp_path):
         import os
 

--- a/tests/flux/test_worker_control.py
+++ b/tests/flux/test_worker_control.py
@@ -1,0 +1,252 @@
+"""Worker runtime control: pause/resume, bulk cancel, and the local API.
+
+Pause stops claiming without process exit — heartbeats continue so the
+worker reads as *paused*, not offline; effective capacity is zero (racing
+dispatches are released for re-dispatch). cancel_all is the worker-initiated
+bulk form of the server's per-execution cancel. Control arrives from the
+worker's own host: SIGUSR1/SIGUSR2 or the Unix control socket
+('flux worker pause|resume|cancel-all|status <name>').
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from flux.config import Configuration
+from tests.flux.test_worker_checkpoint import make_worker
+from tests.flux.test_worker_health import _scheduled_event
+
+
+class TestPauseResume:
+    def test_status_transitions(self):
+        worker = make_worker()
+        assert worker.status == "active"
+        worker._paused = True
+        assert worker.status == "paused"
+        worker._draining = True
+        assert worker.status == "draining"  # draining wins over paused
+
+    @pytest.mark.asyncio
+    async def test_pause_and_resume_flip_state_and_notify_server(self):
+        worker = make_worker()
+        worker._send_pong = AsyncMock()
+
+        worker.pause()
+        await asyncio.sleep(0)  # let the notify task run
+        assert worker.status == "paused"
+
+        worker.resume()
+        await asyncio.sleep(0)
+        assert worker.status == "active"
+        assert worker._send_pong.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_pause_and_resume_are_idempotent(self):
+        worker = make_worker()
+        worker._send_pong = AsyncMock()
+
+        worker.pause()
+        worker.pause()
+        await asyncio.sleep(0)
+        assert worker._send_pong.await_count == 1
+
+        worker.resume()
+        worker.resume()
+        await asyncio.sleep(0)
+        assert worker._send_pong.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_scheduled_dispatch_is_released_when_paused(self):
+        worker = make_worker()
+        worker._paused = True
+        worker._release_claim = AsyncMock()
+        worker._authorized_post = AsyncMock()
+
+        await worker._handle_execution_scheduled(
+            "http://localhost:19000/workers/x",
+            _scheduled_event("exec-paused"),
+        )
+
+        worker._release_claim.assert_awaited_once_with("exec-paused")
+        worker._authorized_post.assert_not_called()  # never claimed
+
+    @pytest.mark.asyncio
+    async def test_resumed_dispatch_is_released_when_paused(self):
+        worker = make_worker()
+        worker._paused = True
+        worker._release_claim = AsyncMock()
+        worker._authorized_post = AsyncMock()
+
+        await worker._handle_execution_resumed(_scheduled_event("exec-resume"))
+
+        worker._release_claim.assert_awaited_once_with("exec-resume")
+        worker._authorized_post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pong_carries_status_and_in_flight(self):
+        worker = make_worker()
+        worker._paused = True
+        worker._running_workflows["exec-1"] = MagicMock()
+        captured = {}
+
+        async def capture_post(url, **kwargs):
+            captured["json"] = kwargs.get("json")
+            response = MagicMock()
+            response.status_code = 200
+            return response
+
+        worker._authorized_post = capture_post
+
+        await worker._send_pong()
+
+        assert captured["json"] == {
+            "healthy": True,
+            "status": "paused",
+            "in_flight": 1,
+        }
+
+
+class TestCancelAll:
+    @pytest.mark.asyncio
+    async def test_cancels_every_running_task(self):
+        worker = make_worker()
+
+        async def hang():
+            await asyncio.Event().wait()
+
+        tasks = {f"exec-{i}": asyncio.create_task(hang()) for i in range(3)}
+        worker._running_workflows.update(tasks)
+
+        cancelled = await worker.cancel_all()
+
+        assert cancelled == 3
+        assert all(t.cancelled() for t in tasks.values())
+
+    @pytest.mark.asyncio
+    async def test_no_running_work_is_a_noop(self):
+        worker = make_worker()
+        assert await worker.cancel_all() == 0
+
+    @pytest.mark.asyncio
+    async def test_done_tasks_are_not_counted(self):
+        worker = make_worker()
+
+        async def done():
+            return None
+
+        finished = asyncio.create_task(done())
+        await finished
+        worker._running_workflows["exec-done"] = finished
+
+        assert await worker.cancel_all() == 0
+
+
+@pytest.fixture
+def control_config(tmp_path):
+    socket_path = str(tmp_path / "worker.sock")
+    mock_settings = MagicMock()
+    mock_settings.workers.control_socket_enabled = True
+    mock_settings.workers.control_socket_path = socket_path
+    with patch.object(Configuration, "get") as mock_get:
+        mock_get.return_value = MagicMock(settings=mock_settings)
+        yield socket_path
+
+
+async def _send_command(socket_path: str, command: str) -> dict:
+    reader, writer = await asyncio.open_unix_connection(socket_path)
+    writer.write((json.dumps({"command": command}) + "\n").encode())
+    await writer.drain()
+    line = await reader.readline()
+    writer.close()
+    await writer.wait_closed()
+    return json.loads(line.decode())
+
+
+class TestControlSocket:
+    @pytest.mark.asyncio
+    async def test_pause_resume_status_roundtrip(self, control_config):
+        worker = make_worker()
+        worker._send_pong = AsyncMock()
+        await worker._start_control_server()
+        try:
+            response = await _send_command(control_config, "status")
+            assert response == {"status": "active", "in_flight": 0, "healthy": True}
+
+            response = await _send_command(control_config, "pause")
+            assert response["status"] == "paused"
+            assert worker._paused is True
+
+            response = await _send_command(control_config, "resume")
+            assert response["status"] == "active"
+            assert worker._paused is False
+        finally:
+            await worker._stop_control_server()
+
+    @pytest.mark.asyncio
+    async def test_cancel_all_over_socket(self, control_config):
+        worker = make_worker()
+        await worker._start_control_server()
+
+        async def hang():
+            await asyncio.Event().wait()
+
+        task = asyncio.create_task(hang())
+        worker._running_workflows["exec-1"] = task
+        try:
+            response = await _send_command(control_config, "cancel-all")
+            assert response["cancelled"] == 1
+            assert task.cancelled()
+        finally:
+            await worker._stop_control_server()
+
+    @pytest.mark.asyncio
+    async def test_unknown_command_reports_error(self, control_config):
+        worker = make_worker()
+        await worker._start_control_server()
+        try:
+            response = await _send_command(control_config, "explode")
+            assert "unknown command" in response["error"]
+        finally:
+            await worker._stop_control_server()
+
+    @pytest.mark.asyncio
+    async def test_stop_removes_the_socket_file(self, control_config, tmp_path):
+        import os
+
+        worker = make_worker()
+        await worker._start_control_server()
+        assert os.path.exists(control_config)
+        # Same trust boundary as the worker process owner.
+        assert (os.stat(control_config).st_mode & 0o777) == 0o600
+
+        await worker._stop_control_server()
+        assert not os.path.exists(control_config)
+
+    @pytest.mark.asyncio
+    async def test_disabled_by_config(self, control_config, tmp_path):
+        import os
+
+        Configuration.get().settings.workers.control_socket_enabled = False
+        worker = make_worker()
+        await worker._start_control_server()
+        assert worker._control_server is None
+        assert not os.path.exists(control_config)
+
+
+class TestDispatcherExclusion:
+    def test_connected_workers_excludes_paused(self):
+        from flux.dispatcher import Dispatcher
+
+        dispatcher = Dispatcher.__new__(Dispatcher)
+        server = MagicMock()
+        server._worker_info = {"w1": "info1", "w2": "info2"}
+        server._worker_queues = {"w1": MagicMock(), "w2": MagicMock()}
+        server._worker_unhealthy = set()
+        server._worker_paused = {"w2"}
+        dispatcher._server = server
+
+        assert dispatcher._connected_workers() == ["info1"]

--- a/tests/flux/test_worker_health.py
+++ b/tests/flux/test_worker_health.py
@@ -132,7 +132,7 @@ class TestUnhealthyWorkRefusal:
 
         await worker._send_pong()
 
-        assert captured["json"] == {"healthy": False}
+        assert captured["json"] == {"healthy": False, "status": "active", "in_flight": 0}
 
 
 class TestDispatcherExclusion:

--- a/tests/flux/test_worker_metrics.py
+++ b/tests/flux/test_worker_metrics.py
@@ -127,7 +127,12 @@ class TestPongPayload:
 
         await worker._send_pong()
 
-        assert captured["json"] == {"healthy": True, "metrics": {"queue": 4.0}}
+        assert captured["json"] == {
+            "healthy": True,
+            "status": "active",
+            "in_flight": 0,
+            "metrics": {"queue": 4.0},
+        }
 
     @pytest.mark.asyncio
     async def test_pong_omits_metrics_without_provider(self):
@@ -145,7 +150,7 @@ class TestPongPayload:
 
         await worker._send_pong()
 
-        assert captured["json"] == {"healthy": True}
+        assert captured["json"] == {"healthy": True, "status": "active", "in_flight": 0}
 
 
 class TestBuiltinMetricsCollector:

--- a/tests/flux/test_worker_pause_routes.py
+++ b/tests/flux/test_worker_pause_routes.py
@@ -1,0 +1,168 @@
+"""Route-level tests for worker pause/status bookkeeping on the server side.
+
+The worker reports ``{"status": "active"|"paused"|"draining",
+"in_flight": int}`` on its pong; the server tracks the paused set (excluded
+from dispatch like unhealthy workers, but surfaced as a deliberate state),
+records the in-flight count, and clears both on disconnect/registration.
+Worker-side behavior is covered in test_worker_control.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from flux.server import Server
+from flux.worker_registry import WorkerInfo
+
+
+@pytest.fixture
+def server_instance():
+    return Server(host="localhost", port=8000)
+
+
+@pytest.fixture
+def test_client(server_instance):
+    """Auth/identity/heartbeat stubbed: tests focus on pause bookkeeping."""
+    from flux.security.identity import FluxIdentity
+
+    worker_identity = FluxIdentity(subject="w1", roles=frozenset({"worker"}))
+    mock_auth = MagicMock()
+
+    async def mock_authenticate(token):
+        return worker_identity
+
+    async def mock_is_authorized(identity, permission):
+        return True
+
+    mock_auth.authenticate = mock_authenticate
+    mock_auth.is_authorized = mock_is_authorized
+
+    with (
+        patch.object(server_instance, "_verify_worker_identity"),
+        patch.object(server_instance, "_record_heartbeat", new=AsyncMock()),
+        patch("flux.security.dependencies._get_auth_service", return_value=mock_auth),
+    ):
+        yield TestClient(server_instance._create_api())
+
+
+class TestPongPauseBookkeeping:
+    def test_paused_pong_adds_worker_to_paused_set(self, test_client, server_instance):
+        resp = test_client.post(
+            "/workers/w1/pong",
+            json={"healthy": True, "status": "paused", "in_flight": 2},
+        )
+
+        assert resp.status_code == 200
+        assert "w1" in server_instance._worker_paused
+        assert server_instance._worker_in_flight["w1"] == 2
+
+    def test_active_pong_clears_the_flag(self, test_client, server_instance):
+        server_instance._worker_paused.add("w1")
+
+        resp = test_client.post(
+            "/workers/w1/pong",
+            json={"healthy": True, "status": "active", "in_flight": 0},
+        )
+
+        assert resp.status_code == 200
+        assert "w1" not in server_instance._worker_paused
+
+    def test_legacy_pong_without_status_counts_as_active(self, test_client, server_instance):
+        server_instance._worker_paused.add("w1")
+
+        resp = test_client.post("/workers/w1/pong", json={"healthy": True})
+
+        assert resp.status_code == 200
+        assert "w1" not in server_instance._worker_paused
+
+    def test_paused_is_independent_of_health(self, test_client, server_instance):
+        resp = test_client.post(
+            "/workers/w1/pong",
+            json={"healthy": False, "status": "paused"},
+        )
+
+        assert resp.status_code == 200
+        assert "w1" in server_instance._worker_paused
+        assert "w1" in server_instance._worker_unhealthy
+
+    def test_garbage_in_flight_is_ignored(self, test_client, server_instance):
+        resp = test_client.post(
+            "/workers/w1/pong",
+            json={"healthy": True, "status": "active", "in_flight": "many"},
+        )
+
+        assert resp.status_code == 200
+        assert "w1" not in server_instance._worker_in_flight
+
+
+class TestSSEDispatchGate:
+    def test_paused_worker_skipped_like_unhealthy(self, server_instance):
+        # The SSE claim loop consults the same gate as the dispatcher; pin
+        # the membership contract the loop reads.
+        server_instance._worker_paused.add("w1")
+        assert "w1" in server_instance._worker_paused
+
+
+class TestWorkersListStatus:
+    def _list(self, test_client, params: str = ""):
+        registry = MagicMock()
+        registry.list.return_value = [WorkerInfo(name="w1")]
+        with patch(
+            "flux.api.worker_routes.WorkerRegistry.create",
+            return_value=registry,
+        ):
+            return test_client.get(f"/workers{params}")
+
+    def test_paused_worker_reports_paused(self, test_client, server_instance):
+        server_instance._worker_names.append("w1")
+        server_instance._worker_paused.add("w1")
+
+        resp = self._list(test_client)
+
+        assert resp.status_code == 200
+        (worker,) = resp.json()
+        assert worker["status"] == "paused"
+
+    def test_paused_wins_over_unhealthy(self, test_client, server_instance):
+        server_instance._worker_names.append("w1")
+        server_instance._worker_paused.add("w1")
+        server_instance._worker_unhealthy.add("w1")
+
+        resp = self._list(test_client)
+
+        (worker,) = resp.json()
+        assert worker["status"] == "paused"
+
+    def test_in_flight_surfaces_in_worker_list(self, test_client, server_instance):
+        server_instance._worker_names.append("w1")
+        server_instance._worker_in_flight["w1"] = 5
+
+        resp = self._list(test_client)
+
+        (worker,) = resp.json()
+        assert worker["in_flight"] == 5
+
+    def test_paused_filter_selects_only_paused(self, test_client, server_instance):
+        server_instance._worker_names.append("w1")
+        server_instance._worker_paused.add("w1")
+
+        online = self._list(test_client, "?status=online")
+        paused = self._list(test_client, "?status=paused")
+
+        assert online.json() == []
+        assert [w["name"] for w in paused.json()] == ["w1"]
+
+
+class TestPausedFlagCleanup:
+    def test_disconnect_clears_pause_state(self, server_instance):
+        server_instance._worker_names.append("w1")
+        server_instance._worker_paused.add("w1")
+        server_instance._worker_in_flight["w1"] = 3
+
+        server_instance._disconnect_worker("w1")
+
+        assert "w1" not in server_instance._worker_paused
+        assert "w1" not in server_instance._worker_in_flight

--- a/tests/flux/test_worker_pause_routes.py
+++ b/tests/flux/test_worker_pause_routes.py
@@ -97,6 +97,16 @@ class TestPongPauseBookkeeping:
         assert resp.status_code == 200
         assert "w1" not in server_instance._worker_in_flight
 
+    def test_missing_in_flight_clears_stale_count(self, test_client, server_instance):
+        # A worker that stops advertising in_flight (legacy or partial
+        # payload) must read as "unknown", not keep its last count forever.
+        server_instance._worker_in_flight["w1"] = 7
+
+        resp = test_client.post("/workers/w1/pong", json={"healthy": True})
+
+        assert resp.status_code == 200
+        assert "w1" not in server_instance._worker_in_flight
+
 
 class TestSSEDispatchGate:
     def test_paused_worker_skipped_like_unhealthy(self, server_instance):

--- a/tests/flux/test_worker_resume_claim.py
+++ b/tests/flux/test_worker_resume_claim.py
@@ -32,6 +32,7 @@ async def test_handle_execution_resumed_posts_claim_before_executing():
     worker._runners = {}
     worker._default_runner = "subprocess"
     worker._healthy = True
+    worker._paused = False
 
     calls: list[tuple[str, str]] = []
 
@@ -114,6 +115,7 @@ async def test_handle_execution_resumed_drops_on_409():
     worker._runners = {}
     worker._default_runner = "subprocess"
     worker._healthy = True
+    worker._paused = False
 
     async def mock_post(url, **kwargs):
         resp = MagicMock()

--- a/tests/security/test_principal_ban.py
+++ b/tests/security/test_principal_ban.py
@@ -1,0 +1,240 @@
+"""Banned principals: quarantine that worker registration respects (C1).
+
+``enabled`` alone cannot express quarantine — the reaper disables pruned
+workers' principals and registration re-enables them when the worker
+returns. ``banned`` is the explicit operator state: worker registration
+refuses it (even with a valid bootstrap or join token), and a banned
+principal cannot be enabled until it is unbanned.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from flux.models import Base
+from flux.security.principals import PrincipalRegistry
+
+
+BOOTSTRAP = "test-bootstrap-secret"
+
+
+@pytest.fixture
+def registry():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    yield PrincipalRegistry(session_factory=lambda: session)
+    session.close()
+
+
+class TestSetBanned:
+    def test_ban_disables_and_records_reason(self, registry):
+        p = registry.create(type="service_account", subject="w1", external_issuer="flux")
+        registry.set_banned(p.id, True, reason="failed recertification")
+
+        banned = registry.get(p.id)
+        assert banned.banned is True
+        assert banned.enabled is False
+        assert banned.metadata_["ban_reason"] == "failed recertification"
+
+    def test_unban_clears_reason_but_stays_disabled(self, registry):
+        p = registry.create(type="service_account", subject="w1", external_issuer="flux")
+        registry.set_banned(p.id, True, reason="quarantine")
+        registry.set_banned(p.id, False)
+
+        unbanned = registry.get(p.id)
+        assert unbanned.banned is False
+        assert unbanned.enabled is False
+        assert "ban_reason" not in (unbanned.metadata_ or {})
+
+    def test_enable_banned_principal_rejected(self, registry):
+        p = registry.create(type="service_account", subject="w1", external_issuer="flux")
+        registry.set_banned(p.id, True)
+
+        with pytest.raises(ValueError, match="banned"):
+            registry.set_enabled(p.id, True)
+
+    def test_enable_after_unban_allowed(self, registry):
+        p = registry.create(type="service_account", subject="w1", external_issuer="flux")
+        registry.set_banned(p.id, True)
+        registry.set_banned(p.id, False)
+        registry.set_enabled(p.id, True)
+
+        assert registry.get(p.id).enabled is True
+
+    def test_new_principals_are_not_banned(self, registry):
+        p = registry.create(type="service_account", subject="w1", external_issuer="flux")
+        assert p.banned is False
+
+
+@pytest.fixture
+def make_client(tmp_path, monkeypatch):
+    """Factory: build a FluxServer TestClient backed by a file-based SQLite DB."""
+    db_path = tmp_path / "ban.db"
+    monkeypatch.setenv("FLUX_DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("FLUX_WORKERS__BOOTSTRAP_TOKEN", BOOTSTRAP)
+
+    from flux.config import Configuration
+    from flux.models import DatabaseRepository
+
+    Configuration._instance = None  # type: ignore[attr-defined]
+    Configuration._config = None  # type: ignore[attr-defined]
+    DatabaseRepository._engines.clear()
+    Configuration.get().override(database_url=f"sqlite:///{db_path}")
+
+    def _make():
+        from flux.server import Server
+
+        settings = Configuration.get().settings
+        server = Server("127.0.0.1", 0)
+        app = server._create_api()
+        # TestClient without a context manager never runs the lifespan, which
+        # is where the server resolves its bootstrap token — seed it the way
+        # resolve_or_generate would for a configured value.
+        server._bootstrap_token = settings.workers.bootstrap_token
+        return TestClient(app)
+
+    yield _make
+
+    Configuration._instance = None  # type: ignore[attr-defined]
+    Configuration._config = None  # type: ignore[attr-defined]
+    DatabaseRepository._engines.clear()
+
+
+def _registration_body(name: str) -> dict:
+    return {
+        "name": name,
+        "runtime": {"os_name": "Linux", "os_version": "6", "python_version": "3.12"},
+        "packages": [],
+        "resources": {
+            "cpu_total": 1,
+            "cpu_available": 1,
+            "memory_total": 1,
+            "memory_available": 1,
+            "disk_total": 1,
+            "disk_free": 1,
+            "gpus": [],
+        },
+    }
+
+
+def _register(client, name: str, token: str = BOOTSTRAP):
+    return client.post(
+        "/workers/register",
+        json=_registration_body(name),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+
+def _server_registry() -> PrincipalRegistry:
+    from flux.models import RepositoryFactory
+
+    repo = RepositoryFactory.create_repository()
+    return PrincipalRegistry(session_factory=repo.session)
+
+
+class TestBannedRegistration:
+    def test_banned_principal_cannot_register(self, make_client):
+        client = make_client()
+        assert _register(client, "w1").status_code == 200
+
+        registry = _server_registry()
+        principal = registry.find(subject="w1", external_issuer="flux")
+        if principal is None:
+            # API-key auth disabled in this harness: no auto-provisioned
+            # principal, so create the row the ban applies to.
+            principal = registry.create(
+                type="service_account",
+                subject="w1",
+                external_issuer="flux",
+            )
+        registry.set_banned(principal.id, True, reason="quarantined")
+
+        resp = _register(client, "w1")
+        assert resp.status_code == 403
+        assert "banned" in resp.json()["detail"]
+
+    def test_unban_restores_registration(self, make_client):
+        client = make_client()
+        assert _register(client, "w1").status_code == 200
+
+        registry = _server_registry()
+        principal = registry.find(subject="w1", external_issuer="flux") or registry.create(
+            type="service_account",
+            subject="w1",
+            external_issuer="flux",
+        )
+        registry.set_banned(principal.id, True)
+        assert _register(client, "w1").status_code == 403
+
+        registry.set_banned(principal.id, False)
+        assert _register(client, "w1").status_code == 200
+
+    def test_ban_of_one_worker_does_not_affect_others(self, make_client):
+        client = make_client()
+        registry = _server_registry()
+        principal = registry.create(
+            type="service_account",
+            subject="w1",
+            external_issuer="flux",
+        )
+        registry.set_banned(principal.id, True)
+
+        assert _register(client, "w1").status_code == 403
+        assert _register(client, "w2").status_code == 200
+
+
+class TestAdminBanRoutes:
+    def test_ban_unban_roundtrip(self, make_client):
+        client = make_client()
+        registry = _server_registry()
+        registry.create(type="service_account", subject="w1", external_issuer="flux")
+
+        resp = client.post(
+            "/admin/principals/w1/ban",
+            json={"reason": "failed recert"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["banned"] is True
+
+        principal = registry.find(subject="w1", external_issuer="flux")
+        assert principal.banned is True
+        assert principal.enabled is False
+        assert principal.metadata_["ban_reason"] == "failed recert"
+
+        resp = client.post("/admin/principals/w1/unban")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["banned"] is False
+        # Unban does not re-enable; that is an explicit follow-up action.
+        assert body["enabled"] is False
+
+    def test_enable_banned_principal_is_409(self, make_client):
+        client = make_client()
+        registry = _server_registry()
+        principal = registry.create(type="service_account", subject="w1", external_issuer="flux")
+        registry.set_banned(principal.id, True)
+
+        resp = client.post("/admin/principals/w1/enable")
+        assert resp.status_code == 409
+        assert "banned" in resp.json()["detail"]
+
+    def test_ban_unknown_principal_is_404(self, make_client):
+        client = make_client()
+        assert client.post("/admin/principals/ghost/ban").status_code == 404
+
+    def test_principal_payloads_include_banned(self, make_client):
+        client = make_client()
+        registry = _server_registry()
+        principal = registry.create(type="service_account", subject="w1", external_issuer="flux")
+        registry.set_banned(principal.id, True)
+
+        listed = client.get("/admin/principals").json()
+        assert any(p["subject"] == "w1" and p["banned"] is True for p in listed)
+
+        shown = client.get("/admin/principals/w1").json()
+        assert shown["banned"] is True


### PR DESCRIPTION
Adds three capabilities for production fleets: worker runtime pause/resume with bulk cancel, a banned principal state that worker registration respects, and a configurable container CLI for the airgapped runner. Rebased onto main after #136 merged.

## Worker runtime pause/resume, bulk cancel, and heartbeat status

Pause reads as **paused, not offline**: the worker stops claiming (dispatches that race in are released for re-dispatch, so effective capacity is zero) while heartbeats keep flowing. Running executions are unaffected; `cancel-all` is the separate, worker-initiated bulk form of the server's per-execution cancel — each runner child gets its termination signal and the terminal CANCELLED checkpoint flows through the outbox. Pause + cancel-all = busy-yield: the node frees in seconds without going offline.

Control is worker-local (workers are outbound-only):
- `SIGUSR1` pauses, `SIGUSR2` resumes
- a Unix control socket (mode 0600, one JSON object per line) serves `pause | resume | cancel-all | status`; new CLI commands `flux worker pause|resume|cancel-all|status <name>` speak it
- config: `[flux.workers] control_socket_enabled` / `control_socket_path`

Heartbeat pongs now carry `{status: active|paused|draining, in_flight}`. The server tracks the paused set (excluded from both the SSE claim loop and the event dispatcher — like unhealthy, but surfaced as the deliberate state it is), records in-flight counts, exposes both in `GET /workers` (new `paused` status + status filter values), and clears the state on disconnect and re-registration.

## Banned principal state (quarantine registration respects)

Registration auto-re-enables disabled principals by design — the reaper disables pruned workers' principals and returning workers must rejoin. That meant a quarantined worker holding any valid registration credential could resurrect itself. `banned` is the explicit operator state that wins:

- `POST /workers/register` refuses a banned principal (403) **before any side effect**, even with a valid bootstrap or join token
- ban disables the principal and revokes its API keys in one action; unban deliberately does **not** re-enable
- enabling a banned principal is rejected (409) until it is unbanned
- new admin routes `POST /admin/principals/{subject}/ban|unban`, CLI `flux principals ban|unban`, ban reason kept in principal metadata
- Alembic migration `0012_principal_banned`

## `airgapped_container_cli`

`[flux.workers] airgapped_container_cli = "docker" | "podman" | "nerdctl"` — rootless Podman/nerdctl replace docker-in-docker without a `--privileged` outer daemon. Same named-key, grep-auditable shape as the other airgapped grants. Validated at worker startup (name, PATH, and a runtime probe: daemon reachability for docker, `<cli> version` for the daemonless CLIs). The emitted-flag compatibility set the runner relies on is documented in `flux/runners/docker.py`.

## Testing

- Unit: 2,948 passed (new suites: `test_worker_control`, `test_worker_pause_routes`, `test_cli_worker_control`, `test_principal_ban`, container-CLI cases in the runner suites)
- E2E: new `test_worker_runtime_control` (pause holds pinned work until resume; cancel-all frees in-flight work; SIGUSR1/SIGUSR2; paused in worker list), `test_principal_ban` (403 until unbanned, scoped to one principal), `test_airgapped_cli` (startup validation; opt-in podman smoke test behind `FLUX_TEST_PODMAN=1`) — 8 passed, 1 skipped
- Pre-existing E2E suite: 130 passed; only failures are the `github_stars` examples hitting the live GitHub API from the sandbox
- Version bumped to 0.63.0; pre-commit fully green
