### PR TITLE
Add server-side worker metadata: control-plane facts in affinity/score() (#138)

### DIFF
--- a/docs/advanced-features/dynamic-routing.md
+++ b/docs/advanced-features/dynamic-routing.md
@@ -41,6 +41,7 @@ A policy is a weighted combination of terms over **selectors**:
 |---|---|---|
 | `label("key")` | worker labels (`--label key=value`) | static (set at registration) |
 | `metric("key")` | worker-advertised metrics (built-in `flux.*` or your provider's) | refreshed every `metrics_interval` |
+| `meta("key")` | server-side worker metadata (`flux worker metadata set` — admin-written, worker-unspoofable; see [Worker Affinity](worker-affinity.md#server-side-worker-metadata)) | live, re-read at dispatch |
 | `resource("field")` | `cpu_total`, `cpu_available`, `memory_total`, `memory_available`, `disk_total`, `disk_free` | registration-time snapshot (prefer `metric("flux.cpu_percent")` etc. for live values) |
 | `load()` | active executions on the worker | live, computed at dispatch |
 

--- a/docs/advanced-features/worker-affinity.md
+++ b/docs/advanced-features/worker-affinity.md
@@ -170,6 +170,11 @@ affinity=require(label("maintenance") != "true")
   `flux.` label prefix is reserved (workers reject user labels under it),
   this is a capability grant a worker cannot fabricate. See
   [Airgapped Execution](airgapped-execution.md).
+- `meta(key) == value` / `meta(key) != value` — compare **server-side
+  worker metadata** (written through the admin API, never by the worker)
+  instead of a self-advertised label. Same `==`/`!=` semantics as `label`,
+  including the absent-≠-value inversion. See
+  [Server-Side Worker Metadata](#server-side-worker-metadata) below.
 - `optional(term)` — skipped when its input is absent; a resolved
   comparison that is false still fails the match, and input that resolves
   to something invalid (bad label key, non-scalar, invalid service name)
@@ -209,6 +214,47 @@ rather than silently dropping a hard constraint.
 
 See `examples/affinity_expressions.py` for runnable data-locality, tenant
 isolation, and maintenance-window patterns.
+
+## Server-Side Worker Metadata
+
+Labels are the right channel for what a worker declares about itself; some
+routing inputs are facts the **control plane** asserts about a worker —
+policy flags, drain hints, centrally-computed scores. Worker **metadata** is
+a third attribute channel for exactly that: a server-held
+`dict[str, str | float]` written only through an authenticated admin API
+(`admin:workers:manage`) and consumed through the `meta(...)` selector.
+
+```bash
+flux worker metadata set   my-worker maintenance=true weight=0.8
+flux worker metadata show  my-worker
+flux worker metadata unset my-worker maintenance
+flux worker metadata clear my-worker
+```
+
+or over HTTP: `PUT /admin/workers/{name}/metadata` with
+`{"metadata": {"maintenance": "true"}, "replace": false}` (merge by
+default), `GET`/`DELETE` on the same path, and
+`DELETE .../metadata/{key}` for a single key. `GET /workers` surfaces the
+current values.
+
+```python
+# Soft-drain a worker without touching the worker or the workflows
+affinity=require(meta("maintenance") != "true")
+```
+
+Properties that distinguish metadata from labels:
+
+- **Authoritative.** Workers have no write path to it — registration never
+  touches it — and `meta(...)` reads only this dict, so no label or metric
+  a worker advertises can satisfy a `meta` term.
+- **Hot.** Updates take effect on the next dispatch: the dispatch
+  transaction re-reads the values, no worker re-registration or reconnect
+  involved.
+- **Durable.** Values survive worker reconnect and re-registration; they
+  live and die with the worker's registry row.
+- **Numeric-capable.** String values suit `require(...)` equality; numeric
+  values participate in `score()` ranking via `least(meta(...))` /
+  `most(meta(...))` — see [Dynamic Routing](dynamic-routing.md).
 
 ## Beyond Hard Constraints
 

--- a/docs/specs/2026-07-20-worker-metadata-spec.md
+++ b/docs/specs/2026-07-20-worker-metadata-spec.md
@@ -1,0 +1,199 @@
+# Spec: server-side worker metadata — control-plane facts in affinity/score()
+
+**Date:** 2026-07-20 · **Status:** draft for review (issue #138)
+· **Motivating use case:** routing inputs the control plane asserts
+*about* a worker — authoritative, numeric, hot-updatable — alongside the
+labels a worker advertises about itself.
+
+## Motivation
+
+A worker's routing-relevant attributes today are **self-advertised**:
+labels and metrics applied at registration / heartbeat. That is the
+right channel for capability the worker declares about itself, and the
+wrong channel for three kinds of input:
+
+1. **Authority.** A compromised or misconfigured worker can advertise
+   any label or metric. Some routing inputs (policy flags, quality
+   scores, drain hints) must be writable only by the control plane.
+2. **Update cadence.** Labels change only at re-registration. Values
+   recomputed periodically by an operator or controller should take
+   effect on the next dispatch without bouncing the worker.
+3. **Type.** Labels are string predicates. Centrally-computed values
+   are often numeric and want to participate in `score()` ranking, not
+   just equality filtering.
+
+## Design
+
+### A third worker attribute channel
+
+Workers gain **metadata**: a server-held `dict[str, str | float]`
+written exclusively through an authenticated admin API. It sits beside
+the two self-advertised channels and is consumed by dispatch through a
+dedicated selector, so the channels can never collide or spoof each
+other:
+
+| channel  | written by            | selector      | typical use            |
+|----------|-----------------------|---------------|------------------------|
+| labels   | worker (registration) | `label(key)`  | capability, topology   |
+| metrics  | worker (heartbeat)    | `metric(key)` | load, health signals   |
+| metadata | control plane (admin) | `meta(key)`   | policy, weights, drain |
+
+No reserved prefix is needed: `meta("x")` reads only the metadata dict,
+`label("x")` reads only labels. A worker that advertises a label named
+like a metadata key gains nothing — the selector namespaces are
+disjoint by construction. Workers have **no write path** to metadata:
+registration does not accept it and never touches the column, so it
+survives worker reconnect and re-registration unchanged.
+
+### Storage
+
+New nullable `workers.worker_metadata` column (`Base64Type`, matching
+`labels`/`metrics`), Alembic revision `0013_worker_metadata`, additive.
+Lifetime is the worker row's lifetime: there is no worker-delete API
+today, and if one is added the column goes with the row — no separate
+GC is required.
+
+### Values
+
+- Keys: non-empty strings, ≤ 64 chars, same shape as label keys
+  (`[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?`). At most 64 keys per
+  worker.
+- Values: strings (≤ 256 chars) or finite numbers. Numbers are stored
+  as `float`; booleans are accepted at the API edge and stored as
+  `"true"`/`"false"` strings, matching label conventions.
+
+Validation lives beside `validate_worker_metrics` in `flux/routing.py`
+(`validate_worker_metadata`) so the API edge and any future writers
+share one rule. Invalid payloads are a 400 — unlike metrics, metadata
+is an operator command channel, not a hint channel, so errors must
+surface, not drop.
+
+## Admin API
+
+All routes require `admin:workers:manage` (the existing worker-admin
+permission, already used for join tokens). Reads too: metadata is an
+operator control channel, and `GET /workers` already surfaces the
+values for general visibility.
+
+```
+GET    /admin/workers/{name}/metadata            → {"metadata": {...}}
+PUT    /admin/workers/{name}/metadata            body {"metadata": {...}, "replace": false}
+DELETE /admin/workers/{name}/metadata/{key}      → remaining metadata
+DELETE /admin/workers/{name}/metadata            → {} (clear)
+```
+
+- `PUT` merges by default (`replace=true` swaps the whole dict) and
+  returns the resulting metadata, so controllers can read-modify-write
+  without a second round trip.
+- Unknown worker → 404. Invalid keys/values/counts → 400 with the
+  offending key in the message. Deleting an absent key is idempotent.
+- `GET /workers` and `GET /workers/{name}` gain a `metadata` field on
+  `WorkerResponse` — the read-back API for tooling, no new permission.
+
+## Dispatch consumption
+
+New selector in the routing DSL (`flux/routing.py`):
+
+```python
+from flux.routing import require, score, meta, least, most, prefer
+
+@workflow.with_options(
+    affinity=require(meta("maintenance") != "true"),      # hard filter
+    routing=score(
+        most(meta("weight"), weight=5),                   # numeric ranking
+        prefer(meta("tier") == "gold", weight=2),
+        least(load()),
+    ),
+)
+```
+
+- `require(...)`: `meta(...)` comparisons join `label(...)`/
+  `label_for(...)` as valid terms, `==`/`!=` only, compared in string
+  form (numbers via `str(float)`; authors should filter on string
+  metadata and rank on numeric metadata). Fail-closed semantics are
+  unchanged: an absent key fails `==` and passes `!=` (the documented
+  inversion, which makes `meta("maintenance") != "true"` work without
+  seeding every worker). `optional()`/`when()` compose unchanged.
+  There is no dynamic `meta_for(...)` — metadata keys are static;
+  input-completed keys can be added later if a use case appears.
+- `score(...)`: `meta(...)` is valid in `prefer()` (equality) and in
+  `least()`/`most()` (numeric, 0–1 normalized across the eligible set
+  like every other term; non-numeric or absent values score 0).
+- The AST extractors (`_extract_require`, `_extract_routing`) accept
+  `meta` exactly like `label`/`metric` — policies remain data, no user
+  code runs on the server.
+- Static dict affinity (`affinity={"k": "v"}`) is untouched — it keeps
+  matching labels only.
+
+### Freshness: effective on the next dispatch, no reconnect
+
+The event dispatcher ranks in-memory `WorkerInfo` snapshots taken at
+SSE connect, and admin writes can land on any replica. Two mechanisms
+keep dispatch honest:
+
+1. **Refresh inside the dispatch transaction.** `next_executions_batch`
+   and `next_resumes_batch` load the candidate workers' metadata in one
+   PK-indexed query per batch and overwrite each `WorkerInfo.metadata`
+   before matching/scoring. The poll path (`next_execution`,
+   constrained branch) refreshes the polling worker the same way. This
+   makes "updates take effect on the next claim/dispatch" true by
+   construction on every replica, at the cost of one cheap query per
+   dispatch cycle.
+2. **Wake on write.** The admin write also updates the local replica's
+   in-memory copies (`_worker_info`, `_worker_cache`) and sets the
+   dispatch wakeup (local `_work_available` + cross-replica NOTIFY), so
+   an execution parked waiting for `require(meta(...))` dispatches
+   promptly after the operator flips the value rather than on the next
+   fallback tick.
+
+## CLI
+
+Sub-group under the existing `flux worker` group, server-side (unlike
+`pause`/`resume`, which drive the local control socket):
+
+```
+flux worker metadata show  NAME
+flux worker metadata set   NAME key=value [key=value ...] [--string] [--replace]
+flux worker metadata unset NAME KEY
+flux worker metadata clear NAME
+```
+
+`set` parses values as numbers when they look numeric (`--string`
+forces string typing); `--replace` swaps the dict instead of merging.
+Output is the resulting metadata as JSON, matching the other admin
+groups.
+
+## Security analysis (delta from today)
+
+- Metadata is written only through `admin:workers:manage` routes; the
+  worker-facing surface (registration, pong, checkpoint) cannot touch
+  it. A hostile worker can therefore *observe* its metadata (via the
+  unpermissioned `GET /workers`, same as labels) but not change it.
+- The `meta()` selector reads only the server-held dict, so no label or
+  metric a worker advertises can satisfy a `meta(...)` term — the
+  authoritative channel cannot be spoofed across the boundary.
+- Values are bounded (count, key length, value length) at the API edge,
+  so the column cannot be grown without bound by a compromised admin
+  token any faster than any other admin write.
+
+## Testing
+
+- Unit: validation (`validate_worker_metadata`), registry CRUD +
+  survival across re-registration, `meta()` DSL factories + AST
+  extraction, `require_matches`/`pick_worker` with metadata (filtering,
+  ranking, absent-key semantics), admin route auth + 404/400 paths,
+  dispatch-time refresh (stale in-memory snapshot, fresh DB value
+  wins).
+- Migration parity: `tests/flux/test_migrations.py` HEAD →
+  `0013_worker_metadata`.
+- E2E: register a workflow with `affinity=require(meta("allowed") ==
+  "true")`; run it — execution stays queued; set the metadata via
+  `flux worker metadata set`; assert it dispatches and completes
+  without the worker reconnecting.
+
+## Rollout / compatibility
+
+Additive throughout: nullable column, new routes, new selector. Old
+workflows and workers are unaffected; a `meta(...)` policy evaluated
+against a fleet with no metadata behaves like any absent selector value
+(fails `==` requires, scores 0). No config knobs.

--- a/flux/api/schemas.py
+++ b/flux/api/schemas.py
@@ -227,6 +227,9 @@ class WorkerResponse(BaseModel):
     labels: dict[str, str] = Field(default_factory=dict)
     # Latest advertised metrics snapshot (routing "metric:*" selectors).
     metrics: dict[str, float] | None = None
+    # Admin-written, server-held metadata (routing "meta:*" selectors);
+    # the read-back surface for operators and tooling.
+    metadata: dict[str, str | float] | None = None
     # In-flight execution count from the worker's latest heartbeat pong;
     # None for workers that have not advertised one.
     in_flight: int | None = None

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -184,7 +184,11 @@ class WorkerRoutesMixin:
                 updates = validate_worker_metadata(body.get("metadata"))
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
-            replace = bool(body.get("replace", False))
+            replace = body.get("replace", False)
+            # Strict boolean: a truthy non-boolean (say, the string "false")
+            # must not silently trigger a full replacement.
+            if not isinstance(replace, bool):
+                raise HTTPException(status_code=400, detail="'replace' must be a boolean")
             registry = WorkerRegistry.create()
             try:
                 result = await asyncio.to_thread(

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -135,6 +135,100 @@ class WorkerRoutesMixin:
                 "expires_at": expires_at.replace(tzinfo=_tz.utc).isoformat(),
             }
 
+        def _apply_worker_metadata(name: str, metadata: dict) -> dict:
+            """Propagate a metadata write: refresh this replica's in-memory
+            copies and wake dispatch everywhere, so an execution parked on a
+            require(meta(...)) term dispatches promptly instead of waiting
+            for the fallback tick. Cross-replica in-memory copies stay stale
+            until their next dispatch transaction, which re-reads the column.
+            """
+            info = self._worker_info.get(name)
+            if info is not None:
+                setattr(info, "metadata", metadata or None)
+            cached = self._worker_cache.get(name)
+            if cached is not None:
+                cached.metadata = metadata or None
+            self._notify_next_worker()
+            return {"metadata": metadata}
+
+        @api.get("/admin/workers/{name}/metadata")
+        async def worker_metadata_get(
+            name: str,
+            identity: FluxIdentity = Depends(require_permission("admin:workers:manage")),
+        ):
+            """Read a worker's admin-written metadata (operator read-back)."""
+            registry = WorkerRegistry.create()
+            try:
+                info = await asyncio.to_thread(registry.get, name)
+            except WorkerNotFoundError:
+                raise HTTPException(status_code=404, detail=f"Worker '{name}' not found")
+            return {"metadata": info.metadata or {}}
+
+        @api.put("/admin/workers/{name}/metadata")
+        async def worker_metadata_put(
+            name: str,
+            body: dict = Body(...),
+            identity: FluxIdentity = Depends(require_permission("admin:workers:manage")),
+        ):
+            """Set worker metadata: merge by default, replace on request.
+
+            Body: ``{"metadata": {key: str|number|bool, ...}, "replace": false}``.
+            Returns the resulting metadata so controllers can read-modify-write
+            without a second round trip. Values are validated
+            (``flux.routing.validate_worker_metadata``); invalid payloads are a
+            400 — metadata is an operator command channel, not a hint channel.
+            """
+            from flux.routing import validate_worker_metadata
+
+            try:
+                updates = validate_worker_metadata(body.get("metadata"))
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
+            replace = bool(body.get("replace", False))
+            registry = WorkerRegistry.create()
+            try:
+                result = await asyncio.to_thread(
+                    registry.set_metadata,
+                    name,
+                    updates,
+                    replace,
+                )
+            except WorkerNotFoundError:
+                raise HTTPException(status_code=404, detail=f"Worker '{name}' not found")
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
+            logger.info(f"Worker {name} metadata updated by {identity.subject}")
+            return _apply_worker_metadata(name, result)
+
+        @api.delete("/admin/workers/{name}/metadata/{key}")
+        async def worker_metadata_delete_key(
+            name: str,
+            key: str,
+            identity: FluxIdentity = Depends(require_permission("admin:workers:manage")),
+        ):
+            """Remove one metadata key (idempotent); returns the remainder."""
+            registry = WorkerRegistry.create()
+            try:
+                result = await asyncio.to_thread(registry.delete_metadata, name, key)
+            except WorkerNotFoundError:
+                raise HTTPException(status_code=404, detail=f"Worker '{name}' not found")
+            logger.info(f"Worker {name} metadata key '{key}' removed by {identity.subject}")
+            return _apply_worker_metadata(name, result)
+
+        @api.delete("/admin/workers/{name}/metadata")
+        async def worker_metadata_clear(
+            name: str,
+            identity: FluxIdentity = Depends(require_permission("admin:workers:manage")),
+        ):
+            """Clear all of a worker's metadata."""
+            registry = WorkerRegistry.create()
+            try:
+                result = await asyncio.to_thread(registry.delete_metadata, name, None)
+            except WorkerNotFoundError:
+                raise HTTPException(status_code=404, detail=f"Worker '{name}' not found")
+            logger.info(f"Worker {name} metadata cleared by {identity.subject}")
+            return _apply_worker_metadata(name, result)
+
         @api.post("/workers/register")
         @_register_limited
         async def workers_register(
@@ -288,6 +382,9 @@ class WorkerRoutesMixin:
                     if registration.packages
                     else [],
                     labels=registration.labels,
+                    # Server-held: registration never writes it, so a
+                    # re-registering worker keeps its admin-written metadata.
+                    metadata=result.metadata,
                 )
                 self._worker_unhealthy.discard(registration.name)
                 # A restarted worker starts active; its first pong re-adds
@@ -1036,6 +1133,7 @@ class WorkerRoutesMixin:
                 else [],
                 labels=w.labels if isinstance(w.labels, dict) else {},
                 metrics=getattr(w, "metrics", None),
+                metadata=getattr(w, "metadata", None),
             )
 
             if w.runtime:
@@ -1128,6 +1226,7 @@ class WorkerRoutesMixin:
                     if cached is not None:
                         cached.status = worker_status
                         cached.metrics = info.metrics
+                        cached.metadata = info.metadata
                         cached.in_flight = self._worker_in_flight.get(info.name)
                         result.append(cached)
                     else:
@@ -1136,6 +1235,7 @@ class WorkerRoutesMixin:
                                 name=info.name,
                                 status=worker_status,
                                 metrics=info.metrics,
+                                metadata=info.metadata,
                                 in_flight=self._worker_in_flight.get(info.name),
                             ),
                         )

--- a/flux/catalogs.py
+++ b/flux/catalogs.py
@@ -617,13 +617,14 @@ class WorkflowCatalog(ABC):
         def extract_selector(sel_node: ast.AST) -> Any:
             name = call_name(sel_node)
             assert isinstance(sel_node, ast.Call)
-            if name == "label":
+            if name in ("label", "meta"):
+                factory = routing_dsl.label if name == "label" else routing_dsl.meta
                 if len(sel_node.args) == 1 and isinstance(sel_node.args[0], ast.Constant):
                     try:
-                        return routing_dsl.label(sel_node.args[0].value)
+                        return factory(sel_node.args[0].value)
                     except (TypeError, ValueError) as e:
-                        raise SyntaxError(f"Invalid affinity selector 'label': {e}") from e
-                fail("label() takes a literal key")
+                        raise SyntaxError(f"Invalid affinity selector '{name}': {e}") from e
+                fail(f"{name}() takes a literal key")
             if name == "label_for":
                 if (
                     len(sel_node.args) == 2
@@ -638,7 +639,7 @@ class WorkflowCatalog(ABC):
                     except (TypeError, ValueError) as e:
                         raise SyntaxError(f"Invalid affinity selector 'label_for': {e}") from e
                 fail("label_for() takes a literal prefix and input(...)")
-            fail(f"expected label()/label_for(), got '{name}'")
+            fail(f"expected label()/label_for()/meta(), got '{name}'")
 
         def extract_value(value_node: ast.AST) -> Any:
             if isinstance(value_node, ast.Constant):
@@ -663,13 +664,13 @@ class WorkflowCatalog(ABC):
                     "ordered comparisons belong to routing=",
                 )
             left, right = cond_node.left, cond_node.comparators[0]
-            if call_name(left) in ("label", "label_for"):
+            if call_name(left) in ("label", "label_for", "meta"):
                 selector, value = extract_selector(left), extract_value(right)
-            elif call_name(right) in ("label", "label_for"):
+            elif call_name(right) in ("label", "label_for", "meta"):
                 # == and != are symmetric, so no operator flip is needed.
                 selector, value = extract_selector(right), extract_value(left)
             else:
-                fail("one side of a require() comparison must be label()/label_for()")
+                fail("one side of a require() comparison must be label()/label_for()/meta()")
             try:
                 return routing_dsl.Condition(selector, op, value)
             except ValueError as e:
@@ -779,6 +780,7 @@ class WorkflowCatalog(ABC):
         _SELECTOR_FACTORIES: dict[str, Callable[..., Any]] = {
             "label": routing_dsl.label,
             "metric": routing_dsl.metric,
+            "meta": routing_dsl.meta,
             "resource": routing_dsl.resource,
             "load": routing_dsl.load,
         }
@@ -795,7 +797,9 @@ class WorkflowCatalog(ABC):
         def extract_selector(sel_node: ast.AST) -> Any:
             name = call_name(sel_node)
             if name is None:
-                fail(f"expected label()/label_for()/metric()/resource()/load(), got '{name}'")
+                fail(
+                    f"expected label()/label_for()/metric()/meta()/resource()/load(), got '{name}'",
+                )
             assert isinstance(sel_node, ast.Call)
             if name == "label_for":
                 if (
@@ -813,7 +817,9 @@ class WorkflowCatalog(ABC):
                 fail("label_for() takes a literal prefix and input(...)")
             factory = _SELECTOR_FACTORIES.get(name or "")
             if factory is None:
-                fail(f"expected label()/label_for()/metric()/resource()/load(), got '{name}'")
+                fail(
+                    f"expected label()/label_for()/metric()/meta()/resource()/load(), got '{name}'",
+                )
             args = []
             for arg in sel_node.args:
                 if not isinstance(arg, ast.Constant):

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -1232,6 +1232,119 @@ def show_worker(name: str, server_url: str | None):
         click.echo(f"Error showing worker: {str(ex)}", err=True)
 
 
+@worker.group("metadata")
+def worker_metadata():
+    """Manage server-side worker metadata (admin-written routing facts).
+
+    Metadata is held by the server and consumed by dispatch through
+    meta(...) selectors in affinity=require(...) and routing=score(...);
+    workers cannot write it. Requires the admin:workers:manage permission.
+    """
+    pass
+
+
+def _parse_metadata_pairs(pairs: tuple[str, ...], as_string: bool) -> dict:
+    metadata: dict = {}
+    for pair in pairs:
+        key, sep, value = pair.partition("=")
+        if not sep or not key:
+            raise click.BadParameter(f"expected key=value, got '{pair}'")
+        if not as_string:
+            try:
+                metadata[key] = float(value)
+                continue
+            except ValueError:
+                pass
+        metadata[key] = value
+    return metadata
+
+
+def _worker_metadata_request(method: str, url: str, **kwargs) -> None:
+    try:
+        with get_http_client() as client:
+            response = client.request(method, url, **kwargs)
+            response.raise_for_status()
+            click.echo(json.dumps(response.json(), indent=2))
+    except httpx.HTTPStatusError as ex:
+        detail = ""
+        try:
+            detail = ex.response.json().get("detail", "")
+        except Exception:
+            pass
+        click.echo(f"Error: {detail or ex}", err=True)
+        raise click.exceptions.Exit(1)
+    except Exception as ex:
+        click.echo(f"Error: {ex}", err=True)
+        raise click.exceptions.Exit(1)
+
+
+@worker_metadata.command("show")
+@click.argument("name")
+@click.option("--server-url", "-cp-url", default=None, help="Server URL to connect to.")
+def worker_metadata_show(name: str, server_url: str | None):
+    """Show a worker's metadata."""
+    base_url = server_url or get_server_url()
+    _worker_metadata_request("GET", f"{base_url}/admin/workers/{name}/metadata")
+
+
+@worker_metadata.command("set")
+@click.argument("name")
+@click.argument("pairs", nargs=-1, required=True, metavar="KEY=VALUE...")
+@click.option(
+    "--string",
+    "as_string",
+    is_flag=True,
+    default=False,
+    help="Keep numeric-looking values as strings.",
+)
+@click.option(
+    "--replace",
+    is_flag=True,
+    default=False,
+    help="Replace all metadata instead of merging.",
+)
+@click.option("--server-url", "-cp-url", default=None, help="Server URL to connect to.")
+def worker_metadata_set(
+    name: str,
+    pairs: tuple[str, ...],
+    as_string: bool,
+    replace: bool,
+    server_url: str | None,
+):
+    """Set metadata keys on a worker (merged into existing metadata).
+
+    Values that parse as numbers are stored numerically (usable in
+    routing=score() ranking); pass --string to force string typing for
+    require(...) equality terms.
+    """
+    metadata = _parse_metadata_pairs(pairs, as_string)
+    base_url = server_url or get_server_url()
+    _worker_metadata_request(
+        "PUT",
+        f"{base_url}/admin/workers/{name}/metadata",
+        json={"metadata": metadata, "replace": replace},
+    )
+
+
+@worker_metadata.command("unset")
+@click.argument("name")
+@click.argument("key")
+@click.option("--server-url", "-cp-url", default=None, help="Server URL to connect to.")
+def worker_metadata_unset(name: str, key: str, server_url: str | None):
+    """Remove one metadata key from a worker (idempotent)."""
+    base_url = server_url or get_server_url()
+    _worker_metadata_request("DELETE", f"{base_url}/admin/workers/{name}/metadata/{key}")
+
+
+@worker_metadata.command("clear")
+@click.argument("name")
+@click.option("--server-url", "-cp-url", default=None, help="Server URL to connect to.")
+def worker_metadata_clear(name: str, server_url: str | None):
+    """Clear all metadata from a worker."""
+    base_url = server_url or get_server_url()
+    _worker_metadata_request("DELETE", f"{base_url}/admin/workers/{name}/metadata")
+
+
 # =============================================================================
 # Health Command
 # =============================================================================

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -539,6 +539,7 @@ class DatabaseContextManager(ContextManager):
             if not self._is_least_loaded_worker(worker, session):
                 return None
 
+            self._refresh_worker_metadata(session, [worker])
             model, workflow = self._next_matching_execution(
                 worker,
                 session,
@@ -635,6 +636,7 @@ class DatabaseContextManager(ContextManager):
             result = sticky_query.first()
 
             if result is None:
+                self._refresh_worker_metadata(session, [worker])
                 fallback_query = (
                     session.query(ExecutionContextModel, WorkflowModel)
                     .join(WorkflowModel)
@@ -740,6 +742,28 @@ class DatabaseContextManager(ContextManager):
         loads.update(dict(rows))
         return loads
 
+    def _refresh_worker_metadata(self, session: Session, workers: list[WorkerInfo]) -> None:
+        """Overwrite each WorkerInfo's server-held metadata from the DB.
+
+        Dispatch matches against in-memory snapshots taken at SSE connect,
+        but admin metadata writes can land on any replica at any time — so
+        every dispatch transaction re-reads the column (one PK-indexed query
+        per batch), making updates effective on the next claim/dispatch
+        without the worker reconnecting.
+        """
+        if not workers:
+            return
+        from flux.models import WorkerModel
+
+        rows = (
+            session.query(WorkerModel.name, WorkerModel.worker_metadata)
+            .filter(WorkerModel.name.in_([w.name for w in workers]))
+            .all()
+        )
+        metadata = dict(rows)
+        for w in workers:
+            w.metadata = metadata.get(w.name) or None
+
     def next_executions_batch(
         self,
         workers: list[WorkerInfo],
@@ -759,6 +783,7 @@ class DatabaseContextManager(ContextManager):
         assignments: list[tuple[ExecutionContext, str]] = []
         with self.session() as session:
             loads = self._worker_load_map(session, [w.name for w in workers])
+            self._refresh_worker_metadata(session, workers)
             query = (
                 session.query(ExecutionContextModel, WorkflowModel)
                 .join(WorkflowModel)
@@ -880,6 +905,7 @@ class DatabaseContextManager(ContextManager):
 
             remaining = limit - len(assignments)
             if remaining > 0:
+                self._refresh_worker_metadata(session, workers)
                 unassigned = (
                     session.query(ExecutionContextModel, WorkflowModel)
                     .join(WorkflowModel)

--- a/flux/domain/resource_request.py
+++ b/flux/domain/resource_request.py
@@ -333,7 +333,12 @@ def worker_matches(
         if isinstance(affinity, (list, tuple)):
             from flux.routing import require_matches
 
-            if not require_matches(affinity, worker.labels, input_value):
+            if not require_matches(
+                affinity,
+                worker.labels,
+                input_value,
+                worker_metadata=getattr(worker, "metadata", None),
+            ):
                 return False
         elif not ResourceRequest.matches_labels(worker.labels, affinity):
             return False

--- a/flux/migrations/versions/0013_worker_metadata.py
+++ b/flux/migrations/versions/0013_worker_metadata.py
@@ -1,0 +1,43 @@
+"""Add workers.worker_metadata: admin-written key/value metadata.
+
+Server-held ``dict[str, str | float]`` written only through the
+``/admin/workers/{name}/metadata`` routes — never by the worker — and
+consumed by dispatch through ``meta(...)`` selectors in ``require(...)``
+affinity expressions and ``score(...)`` routing policies. Additive and
+nullable; NULL means no operator has attached metadata to the worker.
+
+Revision ID: 0013_worker_metadata
+Revises: 0012_principal_banned
+Create Date: 2026-07-20
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0013_worker_metadata"
+down_revision: str | None = "0012_principal_banned"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "workers"
+_COLUMN = "worker_metadata"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    if _COLUMN not in existing:
+        # Matches Base64Type's storage: TEXT on PostgreSQL, VARCHAR elsewhere.
+        column_type = sa.TEXT() if bind.dialect.name == "postgresql" else sa.String()
+        op.add_column(_TABLE, sa.Column(_COLUMN, column_type, nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    if _COLUMN in existing:
+        op.drop_column(_TABLE, _COLUMN)

--- a/flux/models.py
+++ b/flux/models.py
@@ -512,6 +512,13 @@ class WorkerModel(Base):
     # metric(...) selectors and surfaced in GET /workers. NULL only when the
     # worker publishes nothing (built-ins disabled and no provider).
     metrics = Column(Base64Type(), nullable=True)
+    # Admin-written key/value metadata (validated dict[str, str|float]).
+    # Written only through the /admin/workers/{name}/metadata routes — the
+    # worker has no write path to it, so registration must never touch this
+    # column (that is what makes meta(...) selectors unspoofable and lets the
+    # values survive reconnect/re-registration). "worker_metadata" because
+    # "metadata" is reserved on SQLAlchemy declarative classes.
+    worker_metadata = Column(Base64Type(), nullable=True)
 
     runtime = relationship("WorkerRuntimeModel", back_populates="worker", uselist=False)
     packages = relationship("WorkerPackageModel", back_populates="worker")

--- a/flux/routing.py
+++ b/flux/routing.py
@@ -35,6 +35,7 @@ routing.
 Selectors:
     ``label(key)``      worker label value
     ``metric(key)``     worker-advertised metric (``[flux.workers] metrics_provider``)
+    ``meta(key)``       server-held metadata (admin-written, worker-unspoofable)
     ``resource(field)`` worker resource field (cpu/memory/disk totals and availables)
     ``load()``          active executions on the worker (built-in)
 
@@ -210,6 +211,12 @@ def metric(key: str) -> Selector:
     return Selector("metric", key)
 
 
+def meta(key: str) -> Selector:
+    """Server-held worker metadata (written via the admin API, never by the
+    worker — the control-plane-authoritative counterpart of ``label``)."""
+    return Selector("meta", key)
+
+
 def resource(field: str) -> Selector:
     """Worker resource field (cpu/memory/disk totals and availables)."""
     return Selector("resource", field)
@@ -287,7 +294,8 @@ def _validate_weight(weight: Any) -> float:
 def _require_selector(value: Any, term: str) -> Selector:
     if not isinstance(value, Selector):
         raise ValueError(
-            f"{term}() takes a selector (label/metric/resource/load), got: {type(value).__name__}",
+            f"{term}() takes a selector (label/metric/meta/resource/load), "
+            f"got: {type(value).__name__}",
         )
     if not isinstance(value.spec, str):
         raise ValueError(
@@ -404,7 +412,9 @@ def score(*terms: dict) -> dict:
 # unresolved condition). ``!=`` treats an absent label as passing (absent ≠
 # value) — the one deliberate inversion, so maintenance-window style terms
 # work without every worker carrying the label. Resolved input values are
-# compared against labels as strings (bools as "true"/"false").
+# compared against labels/metadata as strings (bools as "true"/"false").
+# ``meta(...)`` terms read the server-held metadata dict instead of labels —
+# the control-plane-authoritative channel a worker cannot advertise into.
 
 _REQUIRE_OPS = ("==", "!=")
 
@@ -458,13 +468,13 @@ def _compile_match(term: Any, context: str) -> dict:
             f'label("region") == input("region"), got: {type(term).__name__}',
         )
     spec = term.selector.spec
-    is_label = (isinstance(spec, str) and spec.startswith("label:")) or (
-        isinstance(spec, dict) and spec.get("kind") == "label"
-    )
-    if not is_label:
+    is_matchable = (
+        isinstance(spec, str) and (spec.startswith("label:") or spec.startswith("meta:"))
+    ) or (isinstance(spec, dict) and spec.get("kind") == "label")
+    if not is_matchable:
         raise ValueError(
-            f"require() terms compare labels only (label()/label_for()); metric()/"
-            f"resource()/load() belong to requests= and routing=, got: '{spec}'",
+            f"require() terms compare labels or metadata (label()/label_for()/meta()); "
+            f"metric()/resource()/load() belong to requests= and routing=, got: '{spec}'",
         )
     if term.op not in _REQUIRE_OPS:
         raise ValueError(
@@ -533,6 +543,54 @@ def require(*terms: Condition | dict) -> list[dict]:
     return compiled
 
 
+# Guardrails for admin-written worker metadata. Kept beside the metrics
+# validator so every writer shares one rule; unlike metrics (a hint channel),
+# invalid metadata raises — it is an operator command channel.
+MAX_METADATA_KEYS = 64
+MAX_METADATA_KEY_LENGTH = 64
+MAX_METADATA_VALUE_LENGTH = 256
+
+
+def validate_worker_metadata(payload: Any) -> dict[str, str | float]:
+    """Sanitize an admin-written metadata mapping into ``dict[str, str | float]``.
+
+    Keys are label-shaped; values are strings (bounded), finite numbers
+    (stored as float), or booleans (stored as "true"/"false" to match label
+    conventions). Raises ``ValueError`` naming the offending key.
+    """
+    if not isinstance(payload, dict):
+        raise ValueError("metadata must be an object of key/value pairs")
+    if len(payload) > MAX_METADATA_KEYS:
+        raise ValueError(f"metadata is limited to {MAX_METADATA_KEYS} keys")
+    metadata: dict[str, str | float] = {}
+    for key, value in payload.items():
+        if (
+            not isinstance(key, str)
+            or not key
+            or len(key) > MAX_METADATA_KEY_LENGTH
+            or not _LABEL_KEY_RE.match(key)
+        ):
+            raise ValueError(f"invalid metadata key: {key!r}")
+        if isinstance(value, bool):
+            metadata[key] = "true" if value else "false"
+        elif isinstance(value, (int, float)):
+            value = float(value)
+            if not math.isfinite(value):
+                raise ValueError(f"metadata value for '{key}' must be finite")
+            metadata[key] = value
+        elif isinstance(value, str):
+            if len(value) > MAX_METADATA_VALUE_LENGTH:
+                raise ValueError(
+                    f"metadata value for '{key}' exceeds {MAX_METADATA_VALUE_LENGTH} chars",
+                )
+            metadata[key] = value
+        else:
+            raise ValueError(
+                f"metadata value for '{key}' must be a string, number, or boolean",
+            )
+    return metadata
+
+
 def validate_worker_metrics(payload: Any, max_keys: int = MAX_METRICS) -> dict[str, float] | None:
     """Sanitize a worker-advertised metrics mapping. Returns None when the
     payload is unusable — metrics are a hint channel, never an error channel."""
@@ -573,6 +631,8 @@ def _selector_value(worker: WorkerInfo, selector: str, loads: dict[str, int]) ->
         return (worker.labels or {}).get(key)
     if kind == "metric":
         return (getattr(worker, "metrics", None) or {}).get(key)
+    if kind == "meta":
+        return (getattr(worker, "metadata", None) or {}).get(key)
     if kind == "resource":
         resources = worker.resources
         return getattr(resources, key, None) if resources else None
@@ -802,14 +862,20 @@ def _resolve_selector_key(selector: Any, input_value: Any) -> tuple[str, _Proble
     return "", _Problem("malformed", f"malformed label selector: {selector!r}")
 
 
-def _resolve_require_term(term: dict, input_value: Any) -> tuple[str, str] | _Problem:
-    """Resolve a match term's label key and comparison value against the
-    execution input. Returns ``(key, value)`` or a :class:`_Problem`."""
-    key, problem = _resolve_selector_key(term.get("selector"), input_value)
-    if problem is not None:
-        if problem.category == "malformed":
-            return problem
-        return _Problem(problem.category, f"affinity {problem.message}")
+def _resolve_require_term(term: dict, input_value: Any) -> tuple[str, str, str] | _Problem:
+    """Resolve a match term's selector kind, key, and comparison value against
+    the execution input. Returns ``(kind, key, value)`` — kind is ``"label"``
+    or ``"meta"`` — or a :class:`_Problem`."""
+    selector = term.get("selector")
+    if isinstance(selector, str) and selector.startswith("meta:"):
+        kind, key = "meta", selector[len("meta:") :]
+    else:
+        kind = "label"
+        key, problem = _resolve_selector_key(selector, input_value)
+        if problem is not None:
+            if problem.category == "malformed":
+                return problem
+            return _Problem(problem.category, f"affinity {problem.message}")
 
     if term.get("op") not in _REQUIRE_OPS:
         return _Problem("malformed", f"malformed affinity term op: {term.get('op')!r}")
@@ -823,9 +889,9 @@ def _resolve_require_term(term: dict, input_value: Any) -> tuple[str, str] | _Pr
         if value is _UNRESOLVED:
             return _Problem(
                 "unresolved",
-                f"affinity term on label '{key}' requires input '{path}', which is not present",
+                f"affinity term on {kind} '{key}' requires input '{path}', which is not present",
             )
-    return key, _label_value_str(value)
+    return kind, key, _label_value_str(value)
 
 
 def _when_condition_active(term: dict, input_value: Any) -> bool | str:
@@ -881,8 +947,14 @@ def require_diagnostic(terms: Any, input_value: Any) -> str | None:
     return None
 
 
-def require_matches(terms: Any, worker_labels: dict[str, str] | None, input_value: Any) -> bool:
-    """Whether a worker's labels satisfy a require(...) affinity expression.
+def require_matches(
+    terms: Any,
+    worker_labels: dict[str, str] | None,
+    input_value: Any,
+    worker_metadata: dict[str, Any] | None = None,
+) -> bool:
+    """Whether a worker's labels and server-held metadata satisfy a
+    require(...) affinity expression.
 
     Fail-closed: any problem (unresolved input on a non-optional term,
     invalid key, malformed spec) fails the match — mirroring
@@ -892,6 +964,7 @@ def require_matches(terms: Any, worker_labels: dict[str, str] | None, input_valu
     if not isinstance(terms, (list, tuple)) or not terms:
         return False
     labels = worker_labels or {}
+    metadata = worker_metadata or {}
     for term in terms:
         if not isinstance(term, dict):
             return False
@@ -911,8 +984,11 @@ def require_matches(terms: Any, worker_labels: dict[str, str] | None, input_valu
             if resolved.category == "unresolved" and term.get("optional"):
                 continue
             return False
-        key, value = resolved
-        actual = labels.get(key)
+        kind, key, value = resolved
+        raw = metadata.get(key) if kind == "meta" else labels.get(key)
+        # Metadata values may be numeric; they compare in string form like
+        # everything else in require() (rank numerics in routing= instead).
+        actual = None if raw is None else _label_value_str(raw)
         if term.get("op") == "==":
             if actual != value:
                 return False

--- a/flux/routing.py
+++ b/flux/routing.py
@@ -177,6 +177,11 @@ class Selector:
             raise ValueError(
                 f"unknown resource field '{key}'; expected one of {_RESOURCE_FIELDS}",
             )
+        if kind == "meta" and (len(key) > MAX_METADATA_KEY_LENGTH or not _LABEL_KEY_RE.match(key)):
+            # The admin API can never write such a key
+            # (validate_worker_metadata), so a term naming one would be
+            # permanently unsatisfiable — fail at authoring time instead.
+            raise ValueError(f"invalid metadata key: {key!r}")
         self.spec = f"{kind}:{key}"
 
     def __eq__(self, other: Any) -> Condition:  # type: ignore[override]

--- a/flux/worker_registry.py
+++ b/flux/worker_registry.py
@@ -71,6 +71,7 @@ class WorkerInfo:
         last_seen_at: datetime | None = None,
         runners: list[str] | None = None,
         metrics: dict[str, float] | None = None,
+        metadata: dict[str, str | float] | None = None,
     ):
         self.name = name
         self.runtime = runtime
@@ -88,6 +89,9 @@ class WorkerInfo:
         # Latest metrics snapshot from the worker's heartbeat pong; read by
         # routing policies ("metric:*" selectors). None until the first report.
         self.metrics = dict(metrics) if metrics else None
+        # Server-held, admin-written metadata ("meta:*" selectors). Never
+        # touched by the worker itself; survives reconnect/re-registration.
+        self.metadata = dict(metadata) if metadata else None
 
 
 class WorkerRegistry(ABC):
@@ -136,6 +140,24 @@ class WorkerRegistry(ABC):
         fleet_size / metrics_interval, independent of heartbeat rate.
         """
         raise NotImplementedError()
+
+    @abstractmethod
+    def set_metadata(
+        self,
+        name: str,
+        updates: dict[str, str | float],
+        replace: bool = False,
+    ) -> dict[str, str | float]:  # pragma: no cover
+        """Merge (or replace) the worker's admin-written metadata and return
+        the resulting mapping. Values must already be validated
+        (``flux.routing.validate_worker_metadata``)."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def delete_metadata(self, name: str, key: str | None = None) -> dict[str, str | float]:
+        """Remove one metadata key (idempotent) or, with ``key=None``, clear
+        all metadata. Returns the remaining mapping."""
+        raise NotImplementedError()  # pragma: no cover
 
     @abstractmethod
     def find_stale(self, threshold: datetime) -> Sequence[str]:  # pragma: no cover
@@ -248,6 +270,66 @@ class DatabaseWorkerRegistry(WorkerRegistry):
             )
             session.commit()
 
+    def set_metadata(
+        self,
+        name: str,
+        updates: dict[str, str | float],
+        replace: bool = False,
+    ) -> dict[str, str | float]:
+        from flux.models import WorkerModel
+
+        with self.session() as session:
+            try:
+                # Read-modify-write under the row lock so concurrent admin
+                # merges cannot drop each other's keys.
+                model = (
+                    session.query(WorkerModel)
+                    .filter(WorkerModel.name == name)
+                    .with_for_update()
+                    .first()
+                )
+                if not model:
+                    raise WorkerNotFoundError(name)
+                current = {} if replace else dict(model.worker_metadata or {})
+                current.update(updates)
+                # Per-key validation happens at the API edge; the count cap
+                # must be re-checked here because merges accumulate.
+                from flux.routing import MAX_METADATA_KEYS
+
+                if len(current) > MAX_METADATA_KEYS:
+                    raise ValueError(f"metadata is limited to {MAX_METADATA_KEYS} keys")
+                model.worker_metadata = current
+                session.commit()
+                return current
+            except Exception:
+                session.rollback()
+                raise
+
+    def delete_metadata(self, name: str, key: str | None = None) -> dict[str, str | float]:
+        from flux.models import WorkerModel
+
+        with self.session() as session:
+            try:
+                model = (
+                    session.query(WorkerModel)
+                    .filter(WorkerModel.name == name)
+                    .with_for_update()
+                    .first()
+                )
+                if not model:
+                    raise WorkerNotFoundError(name)
+                current = dict(model.worker_metadata or {})
+                if key is None:
+                    current = {}
+                else:
+                    current.pop(key, None)
+                model.worker_metadata = current or None
+                session.commit()
+                return current
+            except Exception:
+                session.rollback()
+                raise
+
     def record_heartbeats(self, names: Sequence[str]) -> None:
         if not names:
             return
@@ -355,4 +437,5 @@ class DatabaseWorkerRegistry(WorkerRegistry):
             last_seen_at=model.last_seen_at,
             runners=model.runners,
             metrics=model.metrics,
+            metadata=model.worker_metadata,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.63.0"
+version = "0.64.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -309,6 +309,23 @@ class FluxCLI:
     def worker_local_status(self, name: str) -> dict:
         return self._json(["worker", "status", name])
 
+    # -- admin: worker metadata (server-side) ------------------------------
+
+    def worker_metadata_show(self, name: str) -> dict:
+        return self._server_json(["worker", "metadata", "show", name])
+
+    def worker_metadata_set(self, name: str, *pairs: str, replace: bool = False) -> dict:
+        args = ["worker", "metadata", "set", name, *pairs]
+        if replace:
+            args.append("--replace")
+        return self._server_json(args)
+
+    def worker_metadata_unset(self, name: str, key: str) -> dict:
+        return self._server_json(["worker", "metadata", "unset", name, key])
+
+    def worker_metadata_clear(self, name: str) -> dict:
+        return self._server_json(["worker", "metadata", "clear", name])
+
     # -- admin: roles ------------------------------------------------------
 
     def role_create(self, name: str, permissions: list[str]) -> dict:

--- a/tests/e2e/fixtures/metadata_workflow.py
+++ b/tests/e2e/fixtures/metadata_workflow.py
@@ -1,0 +1,9 @@
+from flux import workflow
+from flux.routing import meta, require
+
+
+@workflow.with_options(
+    affinity=require(meta("dispatch.allowed") == "true"),
+)
+async def metadata_gated(ctx):
+    return {"served": True}

--- a/tests/e2e/test_worker_metadata.py
+++ b/tests/e2e/test_worker_metadata.py
@@ -1,0 +1,58 @@
+"""E2E test for server-side worker metadata (issue #138).
+
+An execution gated on require(meta(...)) parks while no worker carries the
+metadata, then dispatches — without the worker reconnecting — once an
+operator sets the value through `flux worker metadata set`. Also pins the
+CLI read-back surface (show/unset/clear) and the GET /workers exposure.
+
+The session's shared e2e-worker never matches the gate (fail-closed require
+against a worker with no metadata), so this module is insulated from it.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+pytestmark = pytest.mark.e2e
+
+
+def test_metadata_gates_dispatch_and_hot_updates(cli):
+    worker = cli.start_worker("meta-gated-worker")
+    try:
+        cli.register(str(FIXTURES / "metadata_workflow.py"))
+        r = cli.run("metadata_gated", "{}", mode="async", timeout=30)
+        exec_id = r["execution_id"]
+
+        # No worker carries the metadata: the execution must park, not fail.
+        time.sleep(3)
+        s = cli.status("metadata_gated", exec_id)
+        assert s["state"] not in ("COMPLETED", "FAILED"), s
+
+        # Operator flips the flag; the running worker must pick the execution
+        # up without re-registering or reconnecting.
+        result = cli.worker_metadata_set("meta-gated-worker", "dispatch.allowed=true")
+        assert result["metadata"] == {"dispatch.allowed": "true"}
+
+        final = cli.wait_for_state("metadata_gated", exec_id, "COMPLETED", timeout=30)
+        assert final.get("current_worker") == "meta-gated-worker"
+        assert final["output"] == {"served": True}
+
+        # Read-back: CLI show and the fleet listing both surface the value.
+        shown = cli.worker_metadata_show("meta-gated-worker")
+        assert shown["metadata"] == {"dispatch.allowed": "true"}
+        listed = {w["name"]: w for w in cli.worker_list()}
+        assert listed["meta-gated-worker"]["metadata"] == {"dispatch.allowed": "true"}
+
+        # Numeric values merge in as floats; unset/clear round-trip.
+        merged = cli.worker_metadata_set("meta-gated-worker", "weight=5")
+        assert merged["metadata"] == {"dispatch.allowed": "true", "weight": 5.0}
+        after_unset = cli.worker_metadata_unset("meta-gated-worker", "weight")
+        assert after_unset["metadata"] == {"dispatch.allowed": "true"}
+        assert cli.worker_metadata_clear("meta-gated-worker")["metadata"] == {}
+    finally:
+        cli.stop_worker(worker)

--- a/tests/flux/test_migrations.py
+++ b/tests/flux/test_migrations.py
@@ -13,7 +13,7 @@ import flux.security.models  # noqa: F401
 from flux.migrations.runner import current_revision, run_migrations
 from flux.models import Base
 
-HEAD = "0012_principal_banned"
+HEAD = "0013_worker_metadata"
 BASELINE = "0001_baseline"
 
 # A representative index added after the original create_all schema, used to

--- a/tests/flux/test_migrations_postgresql.py
+++ b/tests/flux/test_migrations_postgresql.py
@@ -28,7 +28,7 @@ pytestmark = [
     ),
 ]
 
-HEAD = "0012_principal_banned"
+HEAD = "0013_worker_metadata"
 _BACKFILL_INDEX = "ix_executions_workflow_id"
 
 

--- a/tests/flux/test_require.py
+++ b/tests/flux/test_require.py
@@ -104,7 +104,7 @@ class TestRequireCompile:
         from flux.routing import load, metric, resource
 
         for selector in (metric("temp"), resource("cpu_available"), load()):
-            with pytest.raises(ValueError, match="labels only"):
+            with pytest.raises(ValueError, match="labels or metadata"):
                 require(selector == 1)
 
     def test_label_for_requires_prefix_and_input_ref(self):

--- a/tests/flux/test_server_cancellation.py
+++ b/tests/flux/test_server_cancellation.py
@@ -366,10 +366,12 @@ class TestWorkerEndpoints:
         fresh.name = "worker-1"
         fresh.last_seen_at = datetime.now(timezone.utc).replace(tzinfo=None)
         fresh.metrics = None
+        fresh.metadata = None
         stale = MagicMock()
         stale.name = "worker-2"
         stale.last_seen_at = None  # never heartbeated -> offline
         stale.metrics = None
+        stale.metadata = None
         mock_registry = MagicMock()
         mock_registry.list.return_value = [fresh, stale]
         mock_registry_create.return_value = mock_registry
@@ -410,6 +412,7 @@ class TestWorkerEndpoints:
         mock_worker.resources = None
         mock_worker.packages = [{"name": "numpy", "version": "1.24.0"}]
         mock_worker.metrics = None
+        mock_worker.metadata = None
 
         mock_registry.get.return_value = mock_worker
         mock_registry_create.return_value = mock_registry

--- a/tests/flux/test_worker_metadata.py
+++ b/tests/flux/test_worker_metadata.py
@@ -1,0 +1,368 @@
+"""Server-side, admin-writable worker metadata (issue #138).
+
+Covers the validation rule, the registry CRUD (including survival across
+re-registration — the property that makes the channel authoritative), the
+meta(...) selector in require()/score() evaluation, the dispatch-time DB
+refresh (admin writes land on the next dispatch without a reconnect), and
+the /admin/workers/{name}/metadata routes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from flux.errors import WorkerNotFoundError
+from flux.routing import (
+    MAX_METADATA_KEYS,
+    label,
+    least,
+    load,
+    meta,
+    metric,
+    most,
+    pick_worker,
+    prefer,
+    require,
+    require_matches,
+    score,
+    validate_worker_metadata,
+)
+from flux.worker_registry import WorkerInfo
+from tests.flux.test_dispatch_batch import (
+    _register_worker,
+    clean_env,  # noqa: F401 - pytest fixture
+)
+
+
+def _create_workflow(name, affinity=None, routing=None, namespace="default"):
+    from flux.models import RepositoryFactory, WorkflowModel
+
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        wf = WorkflowModel(
+            id=f"{namespace}/{name}",
+            name=name,
+            version=1,
+            imports=[],
+            source=b"async def placeholder(ctx): pass",
+            namespace=namespace,
+            affinity=affinity,
+            metadata={"routing": routing} if routing is not None else None,
+        )
+        session.add(wf)
+        session.commit()
+        return wf.id
+
+
+class TestValidation:
+    def test_values_normalize_to_str_or_float(self):
+        result = validate_worker_metadata({"weight": 5, "tier": "gold", "drain": True})
+        assert result == {"weight": 5.0, "tier": "gold", "drain": "true"}
+
+    def test_false_becomes_the_label_convention_string(self):
+        assert validate_worker_metadata({"drain": False}) == {"drain": "false"}
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "not-a-dict",
+            {"": 1},
+            {"bad key!": 1},
+            {"k" * 65: 1},
+            {"inf": float("inf")},
+            {"nan": float("nan")},
+            {"long": "v" * 257},
+            {"obj": {"nested": 1}},
+            {k: 1 for k in (f"key{i}" for i in range(MAX_METADATA_KEYS + 1))},
+        ],
+    )
+    def test_invalid_payloads_raise(self, payload):
+        with pytest.raises(ValueError):
+            validate_worker_metadata(payload)
+
+
+class TestDsl:
+    def test_meta_in_require_terms(self):
+        terms = require(meta("maintenance") != "true", label("region") == "eu")
+        assert terms[0] == {
+            "kind": "match",
+            "selector": "meta:maintenance",
+            "op": "!=",
+            "value": "true",
+        }
+
+    def test_meta_in_score_terms(self):
+        policy = score(most(meta("weight")), prefer(meta("tier") == "gold"))
+        assert policy["terms"][0]["selector"] == "meta:weight"
+        assert policy["terms"][1]["selector"] == "meta:tier"
+
+    def test_metric_still_rejected_in_require(self):
+        with pytest.raises(ValueError, match="metric\\(\\)"):
+            require(metric("fitness") == 1)
+
+
+class TestRequireMatches:
+    def test_meta_term_reads_metadata_not_labels(self):
+        terms = require(meta("tier") == "gold")
+        # The same key as a label must not satisfy a meta term — the channels
+        # are disjoint, which is what makes metadata unspoofable.
+        assert not require_matches(terms, {"tier": "gold"}, None)
+        assert require_matches(terms, {}, None, worker_metadata={"tier": "gold"})
+
+    def test_absent_key_fails_eq_and_passes_ne(self):
+        assert not require_matches(require(meta("tier") == "gold"), {}, None)
+        assert require_matches(require(meta("maintenance") != "true"), {}, None)
+
+    def test_numeric_metadata_compares_in_string_form(self):
+        terms = require(meta("weight") == "5.0")
+        assert require_matches(terms, {}, None, worker_metadata={"weight": 5.0})
+
+
+class TestPickWorker:
+    def test_most_meta_ranks_numeric_metadata(self):
+        w1 = WorkerInfo("w1", metadata={"weight": 1.0})
+        w2 = WorkerInfo("w2", metadata={"weight": 9.0})
+        policy = score(most(meta("weight"), weight=10), least(load()))
+        assert pick_worker([w1, w2], policy, loads={"w1": 0, "w2": 0}).name == "w2"
+
+    def test_absent_metadata_scores_zero(self):
+        w1 = WorkerInfo("w1")
+        w2 = WorkerInfo("w2", metadata={"weight": 0.1})
+        policy = score(most(meta("weight")))
+        assert pick_worker([w1, w2], policy, loads={"w1": 0, "w2": 0}).name == "w2"
+
+    def test_prefer_meta_equality(self):
+        w1 = WorkerInfo("w1", metadata={"tier": "silver"})
+        w2 = WorkerInfo("w2", metadata={"tier": "gold"})
+        policy = score(prefer(meta("tier") == "gold", weight=5))
+        assert pick_worker([w1, w2], policy, loads={"w1": 0, "w2": 0}).name == "w2"
+
+
+class TestRegistry:
+    def test_set_merges_and_returns_result(self, clean_env):  # noqa: F811
+        _cm, registry = clean_env
+        _register_worker(registry, "w1")
+        assert registry.set_metadata("w1", {"a": "1"}) == {"a": "1"}
+        assert registry.set_metadata("w1", {"b": 2.0}) == {"a": "1", "b": 2.0}
+        assert registry.get("w1").metadata == {"a": "1", "b": 2.0}
+
+    def test_replace_swaps_the_dict(self, clean_env):  # noqa: F811
+        _cm, registry = clean_env
+        _register_worker(registry, "w1")
+        registry.set_metadata("w1", {"a": "1", "b": "2"})
+        assert registry.set_metadata("w1", {"c": "3"}, replace=True) == {"c": "3"}
+
+    def test_delete_key_is_idempotent_and_clear_empties(self, clean_env):  # noqa: F811
+        _cm, registry = clean_env
+        _register_worker(registry, "w1")
+        registry.set_metadata("w1", {"a": "1", "b": "2"})
+        assert registry.delete_metadata("w1", "a") == {"b": "2"}
+        assert registry.delete_metadata("w1", "missing") == {"b": "2"}
+        assert registry.delete_metadata("w1", None) == {}
+        assert registry.get("w1").metadata is None
+
+    def test_unknown_worker_raises(self, clean_env):  # noqa: F811
+        _cm, registry = clean_env
+        with pytest.raises(WorkerNotFoundError):
+            registry.set_metadata("ghost", {"a": "1"})
+        with pytest.raises(WorkerNotFoundError):
+            registry.delete_metadata("ghost", "a")
+
+    def test_metadata_survives_re_registration(self, clean_env):  # noqa: F811
+        _cm, registry = clean_env
+        _register_worker(registry, "w1")
+        registry.set_metadata("w1", {"tier": "gold"})
+        # A worker reconnecting re-registers with fresh labels; the
+        # admin-written channel must come through untouched.
+        _register_worker(registry, "w1", labels={"gpu": "true"})
+        info = registry.get("w1")
+        assert info.labels == {"gpu": "true"}
+        assert info.metadata == {"tier": "gold"}
+
+    def test_merge_cannot_exceed_the_key_cap(self, clean_env):  # noqa: F811
+        _cm, registry = clean_env
+        _register_worker(registry, "w1")
+        registry.set_metadata("w1", {f"key{i}": 1.0 for i in range(MAX_METADATA_KEYS)})
+        with pytest.raises(ValueError, match="limited"):
+            registry.set_metadata("w1", {"one-more": 1.0})
+
+
+class TestDispatch:
+    def _create_execution(self, cm, workflow_id, name, input_value=None):
+        from flux.domain.execution_context import ExecutionContext
+
+        ctx = ExecutionContext(
+            workflow_id=workflow_id,
+            workflow_namespace="default",
+            workflow_name=name,
+            input=input_value,
+        )
+        return cm.save(ctx)
+
+    def test_require_meta_gates_dispatch_and_hot_updates(self, clean_env):  # noqa: F811
+        cm, registry = clean_env
+        worker = _register_worker(registry, "w1")
+        _create_workflow("gated", affinity=require(meta("allowed") == "true"))
+        ctx = self._create_execution(cm, "default/gated", "gated")
+
+        # No metadata yet: the worker is not eligible, the row stays queued.
+        assert cm.next_executions_batch([worker], limit=10) == []
+
+        # Admin write, then the SAME in-memory WorkerInfo (stale snapshot, as
+        # held by the dispatcher) must match on the next batch — the dispatch
+        # transaction re-reads the column.
+        registry.set_metadata("w1", {"allowed": "true"})
+        assignments = cm.next_executions_batch([worker], limit=10)
+        assert [(c.execution_id, w) for c, w in assignments] == [(ctx.execution_id, "w1")]
+
+    def test_score_meta_ranks_from_fresh_db_values(self, clean_env):  # noqa: F811
+        cm, registry = clean_env
+        w1 = _register_worker(registry, "w1")
+        w2 = _register_worker(registry, "w2")
+        registry.set_metadata("w2", {"weight": 9.0})
+        # Stale in-memory value pointing the other way must lose to the DB.
+        w1.metadata = {"weight": 99.0}
+        _create_workflow("weighted", routing=score(most(meta("weight"))))
+        ctx = self._create_execution(cm, "default/weighted", "weighted")
+
+        assignments = cm.next_executions_batch([w1, w2], limit=10)
+        assert [(c.execution_id, w) for c, w in assignments] == [(ctx.execution_id, "w2")]
+
+
+class TestAdminRoutes:
+    @pytest.fixture
+    def client_env(self, tmp_path):
+        from fastapi.testclient import TestClient
+
+        from flux.config import Configuration
+        from flux.server import Server
+        from flux.worker_registry import DatabaseWorkerRegistry
+
+        Configuration.get().override(database_url=f"sqlite:///{tmp_path / 'meta.db'}")
+        from flux.models import DatabaseRepository
+
+        DatabaseRepository._engines.clear()
+        server = Server("127.0.0.1", 0)
+        client = TestClient(server._create_api())
+        registry = DatabaseWorkerRegistry()
+        from tests.flux.test_dispatch_batch import _make_resources, _make_runtime
+
+        registry.register(
+            name="w1",
+            runtime=_make_runtime(),
+            packages=[],
+            resources=_make_resources(),
+        )
+        yield client, server, registry
+        DatabaseRepository._engines.clear()
+
+    def test_put_merges_and_returns_result(self, client_env):
+        client, _server, registry = client_env
+        resp = client.put(
+            "/admin/workers/w1/metadata",
+            json={"metadata": {"tier": "gold", "weight": 5}},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"metadata": {"tier": "gold", "weight": 5.0}}
+
+        resp = client.put("/admin/workers/w1/metadata", json={"metadata": {"drain": True}})
+        assert resp.json()["metadata"] == {"tier": "gold", "weight": 5.0, "drain": "true"}
+
+        resp = client.put(
+            "/admin/workers/w1/metadata",
+            json={"metadata": {"only": "this"}, "replace": True},
+        )
+        assert resp.json()["metadata"] == {"only": "this"}
+        assert registry.get("w1").metadata == {"only": "this"}
+
+    def test_get_reads_back_and_delete_removes(self, client_env):
+        client, _server, _registry = client_env
+        client.put("/admin/workers/w1/metadata", json={"metadata": {"a": "1", "b": "2"}})
+
+        assert client.get("/admin/workers/w1/metadata").json() == {
+            "metadata": {"a": "1", "b": "2"},
+        }
+        assert client.delete("/admin/workers/w1/metadata/a").json() == {"metadata": {"b": "2"}}
+        # Idempotent: deleting an absent key is not an error.
+        assert client.delete("/admin/workers/w1/metadata/a").status_code == 200
+        assert client.delete("/admin/workers/w1/metadata").json() == {"metadata": {}}
+
+    def test_unknown_worker_is_404(self, client_env):
+        client, _server, _registry = client_env
+        assert client.get("/admin/workers/ghost/metadata").status_code == 404
+        assert (
+            client.put("/admin/workers/ghost/metadata", json={"metadata": {"a": "1"}}).status_code
+            == 404
+        )
+        assert client.delete("/admin/workers/ghost/metadata/a").status_code == 404
+
+    def test_invalid_payload_is_400(self, client_env):
+        client, _server, _registry = client_env
+        assert (
+            client.put("/admin/workers/w1/metadata", json={"metadata": {"bad key!": 1}}).status_code
+            == 400
+        )
+        assert client.put("/admin/workers/w1/metadata", json={}).status_code == 400
+
+    def test_write_refreshes_in_memory_copies(self, client_env):
+        client, server, registry = client_env
+        # Simulate a connected worker: the dispatcher's snapshot and the
+        # response cache both live in server memory.
+        info = registry.get("w1")
+        server._worker_info["w1"] = info
+        from flux.api.schemas import WorkerResponse
+
+        server._worker_cache["w1"] = WorkerResponse(name="w1")
+
+        client.put("/admin/workers/w1/metadata", json={"metadata": {"tier": "gold"}})
+        assert info.metadata == {"tier": "gold"}
+        assert server._worker_cache["w1"].metadata == {"tier": "gold"}
+
+        client.delete("/admin/workers/w1/metadata")
+        assert info.metadata is None
+        assert server._worker_cache["w1"].metadata is None
+
+    def test_workers_list_surfaces_metadata(self, client_env):
+        client, _server, _registry = client_env
+        client.put("/admin/workers/w1/metadata", json={"metadata": {"tier": "gold"}})
+        (worker,) = client.get("/workers").json()
+        assert worker["metadata"] == {"tier": "gold"}
+
+
+class TestCatalogExtraction:
+    def _parse(self, source: bytes):
+        from flux.catalogs import WorkflowCatalog
+
+        return WorkflowCatalog.create().parse(source)
+
+    def test_meta_extracted_in_require_and_score(self):
+        source = b"""
+from flux import workflow
+from flux.routing import require, score, meta, most, prefer
+
+@workflow.with_options(
+    affinity=require(meta("maintenance") != "true"),
+    routing=score(most(meta("weight")), prefer(meta("tier") == "gold")),
+)
+async def routed(ctx):
+    return ctx.input
+"""
+        (info,) = self._parse(source)
+        assert info.affinity == [
+            {"kind": "match", "selector": "meta:maintenance", "op": "!=", "value": "true"},
+        ]
+        routing = info.metadata["routing"]
+        assert routing["terms"][0]["selector"] == "meta:weight"
+        assert routing["terms"][1]["selector"] == "meta:tier"
+
+    def test_invalid_meta_key_fails_registration(self):
+        source = b"""
+from flux import workflow
+from flux.routing import require, meta
+
+@workflow.with_options(affinity=require(meta("") == "x"))
+async def broken(ctx):
+    return ctx.input
+"""
+        with pytest.raises(SyntaxError, match="meta"):
+            self._parse(source)

--- a/tests/flux/test_worker_metadata.py
+++ b/tests/flux/test_worker_metadata.py
@@ -100,6 +100,14 @@ class TestDsl:
         with pytest.raises(ValueError, match="metric\\(\\)"):
             require(metric("fitness") == 1)
 
+    @pytest.mark.parametrize("key", ["bad key!", "k" * 65, ".leading", "trailing."])
+    def test_unwritable_meta_keys_rejected_at_authoring(self, key):
+        # The admin API could never write these keys, so a term naming one
+        # would be permanently unsatisfiable — meta() must reject them with
+        # the same diagnostic as validate_worker_metadata.
+        with pytest.raises(ValueError, match="invalid metadata key"):
+            meta(key)
+
 
 class TestRequireMatches:
     def test_meta_term_reads_metadata_not_labels(self):
@@ -365,14 +373,15 @@ async def routed(ctx):
         assert routing["terms"][0]["selector"] == "meta:weight"
         assert routing["terms"][1]["selector"] == "meta:tier"
 
-    def test_invalid_meta_key_fails_registration(self):
-        source = b"""
+    @pytest.mark.parametrize("key", ["", "bad key!"])
+    def test_invalid_meta_key_fails_registration(self, key):
+        source = f"""
 from flux import workflow
 from flux.routing import require, meta
 
-@workflow.with_options(affinity=require(meta("") == "x"))
+@workflow.with_options(affinity=require(meta({key!r}) == "x"))
 async def broken(ctx):
     return ctx.input
-"""
+""".encode()
         with pytest.raises(SyntaxError, match="meta"):
             self._parse(source)

--- a/tests/flux/test_worker_metadata.py
+++ b/tests/flux/test_worker_metadata.py
@@ -304,6 +304,16 @@ class TestAdminRoutes:
         )
         assert client.put("/admin/workers/w1/metadata", json={}).status_code == 400
 
+    def test_non_boolean_replace_is_400_not_a_wipe(self, client_env):
+        client, _server, registry = client_env
+        client.put("/admin/workers/w1/metadata", json={"metadata": {"keep": "me"}})
+        resp = client.put(
+            "/admin/workers/w1/metadata",
+            json={"metadata": {"a": "1"}, "replace": "false"},
+        )
+        assert resp.status_code == 400
+        assert registry.get("w1").metadata == {"keep": "me"}
+
     def test_write_refreshes_in_memory_copies(self, client_env):
         client, server, registry = client_env
         # Simulate a connected worker: the dispatcher's snapshot and the


### PR DESCRIPTION
Closes #138.

## Why

A worker's routing-relevant attributes today are all **self-advertised** (labels at registration, metrics on the heartbeat). That channel is wrong for facts the control plane asserts *about* a worker: it isn't authoritative (a compromised worker can advertise anything), it isn't hot (labels change only at re-registration), and it isn't numeric-rankable. Operators need control-plane-owned routing inputs — drain hints, policy flags, centrally computed weights — that take effect without bouncing workers.

## What

A third worker attribute channel: **metadata** (`dict[str, str | float]`), server-held and writable only through the admin API. Spec in `docs/specs/2026-07-20-worker-metadata-spec.md`.

- **Storage**: nullable `workers.worker_metadata` column (Alembic `0013`, additive). Registration never touches it, so values survive reconnect/re-registration — and since workers have no write path to it, `meta(...)` terms cannot be spoofed by any label or metric a worker advertises. Lifetime is the worker row's lifetime.
- **Admin API**: `GET/PUT/DELETE /admin/workers/{name}/metadata` (+ `DELETE .../metadata/{key}`) under the existing `admin:workers:manage` permission. `PUT` merges by default, `replace: true` swaps; values are validated at the edge (label-shaped keys, bounded counts/lengths, finite numbers; invalid → 400). `GET /workers` surfaces the values as the read-back for tooling.
- **Dispatch**: new `meta(key)` selector in the routing DSL — a hard filter in `affinity=require(...)` (`==`/`!=` with label semantics, including the absent-≠-value inversion, so `require(meta("maintenance") != "true")` works without seeding every worker) and a ranking term in `routing=score()` (`least`/`most` on numeric values, `prefer` on equality). AST extraction accepts `meta` like `label`/`metric`, so policies stay data.
- **Freshness**: the dispatch transaction re-reads the column per batch (one PK-indexed query), making updates effective on the next claim/dispatch on **every** replica without a worker reconnect. Admin writes also refresh the writing replica's in-memory copies and wake dispatch, so an execution parked on a `require(meta(...))` gate dispatches promptly.
- **CLI**: `flux worker metadata show|set|unset|clear` (server-side, unlike the local-socket `pause`/`resume`).

## Testing

- 37 unit tests (`tests/flux/test_worker_metadata.py`): validation, registry CRUD + survival across re-registration + merge cap, `require`/`score` evaluation with metadata, dispatch-time refresh beating a stale in-memory snapshot, admin route auth/404/400, catalog AST extraction.
- New e2e (`tests/e2e/test_worker_metadata.py`): an execution gated on `require(meta("dispatch.allowed") == "true")` parks, then dispatches after `flux worker metadata set` — no worker restart — and the CLI read-back/unset/clear round-trips.
- Migration parity HEADs bumped to `0013_worker_metadata`.
- Full unit suite: 2990 passed. E2E suite (`-m "not ollama"`): 139 passed; the only 2 failures are `test_subflows.py::*github_stars*`, which call the live GitHub API and fail in the sandbox on its TLS-intercepting proxy (`CERTIFICATE_VERIFY_FAILED`) — unrelated to this change.

Version bumped to 0.64.0 (minor, feature).