### PR TITLE
feat(routing): meta() ordered-op require() filters + when() gating on worker state (#138 follow-up)

### DIFF
--- a/flux/catalogs.py
+++ b/flux/catalogs.py
@@ -648,54 +648,98 @@ class WorkflowCatalog(ABC):
                 return extract_input_ref(value_node)
             fail(f"unsupported value expression at line {getattr(value_node, 'lineno', '?')}")
 
-        _AST_OPS = {ast.Eq: "==", ast.NotEq: "!="}
+        _AST_OPS = {
+            ast.Eq: "==",
+            ast.NotEq: "!=",
+            ast.Lt: "<",
+            ast.LtE: "<=",
+            ast.Gt: ">",
+            ast.GtE: ">=",
+        }
+        _FLIPPED = {"==": "==", "!=": "!=", "<": ">", "<=": ">=", ">": "<", ">=": "<="}
 
         def extract_condition(cond_node: ast.AST) -> Any:
-            """A label comparison: label(...)/label_for(...) vs constant/input."""
+            """A label/meta comparison: label(...)/label_for(...)/meta(...) vs
+            constant/input. Labels stay ==/!=; meta allows ordered ops."""
             if not isinstance(cond_node, ast.Compare) or len(cond_node.ops) != 1:
                 fail(
-                    "require() terms are single label comparisons, "
+                    "require() terms are single comparisons, "
                     'e.g. label("region") == input("region")',
                 )
             op = _AST_OPS.get(type(cond_node.ops[0]))
             if op is None:
-                fail(
-                    f"require() supports only == and != (line {cond_node.lineno}); "
-                    "ordered comparisons belong to routing=",
-                )
+                fail(f"unsupported comparison operator at line {cond_node.lineno}")
             left, right = cond_node.left, cond_node.comparators[0]
-            if call_name(left) in ("label", "label_for", "meta"):
-                selector, value = extract_selector(left), extract_value(right)
-            elif call_name(right) in ("label", "label_for", "meta"):
-                # == and != are symmetric, so no operator flip is needed.
-                selector, value = extract_selector(right), extract_value(left)
+            selector_names = ("label", "label_for", "meta")
+            if call_name(left) in selector_names:
+                sel_name, selector, value = (
+                    call_name(left),
+                    extract_selector(left),
+                    extract_value(right),
+                )
+            elif call_name(right) in selector_names:
+                sel_name, selector, value, op = (
+                    call_name(right),
+                    extract_selector(right),
+                    extract_value(left),
+                    _FLIPPED[op],
+                )
             else:
                 fail("one side of a require() comparison must be label()/label_for()/meta()")
+            if sel_name in ("label", "label_for") and op not in ("==", "!="):
+                fail(
+                    f"require() label terms support only == and != (line {cond_node.lineno}); "
+                    "ordered comparisons need meta() or routing=",
+                )
             try:
                 return routing_dsl.Condition(selector, op, value)
             except ValueError as e:
                 raise SyntaxError(f"Invalid affinity condition: {e}") from e
 
-        def extract_input_condition(cond_node: ast.AST) -> Any:
-            """A when() condition: input(...) vs constant, either order."""
+        def _extract_ms_selector(sel_node: ast.AST) -> Any:
+            name = call_name(sel_node)
+            if name not in ("meta", "metric"):
+                fail("when() worker conditions use meta() or metric()")
+            assert isinstance(sel_node, ast.Call)
+            if len(sel_node.args) != 1 or not isinstance(sel_node.args[0], ast.Constant):
+                fail(f"{name}() takes a literal key")
+            factory = routing_dsl.meta if name == "meta" else routing_dsl.metric
+            try:
+                return factory(sel_node.args[0].value)
+            except (TypeError, ValueError) as e:
+                raise SyntaxError(f"Invalid when() selector '{name}': {e}") from e
+
+        def extract_when_condition(cond_node: ast.AST) -> Any:
+            """A when() condition: input(...) (==/!= only) or a meta()/metric()
+            comparison (any op), either side."""
             if not isinstance(cond_node, ast.Compare) or len(cond_node.ops) != 1:
-                fail('when() takes an input comparison, e.g. input("tier") == "dedicated"')
+                fail("when() takes an input()/meta()/metric() comparison")
             op = _AST_OPS.get(type(cond_node.ops[0]))
             if op is None:
-                fail(f"when() conditions support only == and != (line {cond_node.lineno})")
+                fail(f"unsupported when() operator at line {cond_node.lineno}")
             left, right = cond_node.left, cond_node.comparators[0]
-            if call_name(left) == "input":
-                ref, const = extract_input_ref(left), right
-            elif call_name(right) == "input":
-                ref, const = extract_input_ref(right), left
-            else:
-                fail("one side of a when() condition must be input(...)")
-            if not isinstance(const, ast.Constant):
-                fail("when() conditions compare input(...) against a literal")
-            try:
+            if call_name(left) == "input" or call_name(right) == "input":
+                if op not in ("==", "!="):
+                    fail("when() input conditions support only == and !=")
+                if call_name(left) == "input":
+                    ref, const = extract_input_ref(left), right
+                else:
+                    ref, const = extract_input_ref(right), left
+                if not isinstance(const, ast.Constant):
+                    fail("when() input conditions compare against a literal")
                 return routing_dsl.InputCondition(ref, op, const.value)
+            if call_name(left) in ("meta", "metric"):
+                sel, const = _extract_ms_selector(left), right
+            elif call_name(right) in ("meta", "metric"):
+                sel, const, op = _extract_ms_selector(right), left, _FLIPPED[op]
+            else:
+                fail("one side of a when() condition must be input()/meta()/metric()")
+            if not isinstance(const, ast.Constant):
+                fail("when() worker conditions compare against a literal")
+            try:
+                return routing_dsl.Condition(sel, op, const.value)
             except ValueError as e:
-                raise SyntaxError(f"Invalid affinity when() condition: {e}") from e
+                raise SyntaxError(f"Invalid when() condition: {e}") from e
 
         def extract_service(svc_node: ast.AST) -> Any:
             assert isinstance(svc_node, ast.Call)
@@ -733,7 +777,7 @@ class WorkflowCatalog(ABC):
                         fail("when() takes a condition and a term")
                     terms.append(
                         routing_dsl.when(
-                            extract_input_condition(term_node.args[0]),
+                            extract_when_condition(term_node.args[0]),
                             extract_match_term(term_node.args[1]),
                         ),
                     )
@@ -870,26 +914,50 @@ class WorkflowCatalog(ABC):
             except ValueError as e:
                 raise SyntaxError(f"Invalid routing condition: {e}") from e
 
-        def extract_input_condition(cond_node: ast.AST) -> Any:
-            """A when() condition: input(...) vs constant, either order."""
-            if not isinstance(cond_node, ast.Compare) or len(cond_node.ops) != 1:
-                fail('when() takes an input comparison, e.g. input("tier") == "dedicated"')
-            op = _AST_OPS.get(type(cond_node.ops[0]))
-            if op not in ("==", "!="):
-                fail(f"when() conditions support only == and != (line {cond_node.lineno})")
-            left, right = cond_node.left, cond_node.comparators[0]
-            if call_name(left) == "input":
-                ref, const = extract_input_ref(left), right
-            elif call_name(right) == "input":
-                ref, const = extract_input_ref(right), left
-            else:
-                fail("one side of a when() condition must be input(...)")
-            if not isinstance(const, ast.Constant):
-                fail("when() conditions compare input(...) against a literal")
+        def _extract_ms_selector(sel_node: ast.AST) -> Any:
+            name = call_name(sel_node)
+            if name not in ("meta", "metric"):
+                fail("when() worker conditions use meta() or metric()")
+            assert isinstance(sel_node, ast.Call)
+            if len(sel_node.args) != 1 or not isinstance(sel_node.args[0], ast.Constant):
+                fail(f"{name}() takes a literal key")
+            factory = routing_dsl.meta if name == "meta" else routing_dsl.metric
             try:
+                return factory(sel_node.args[0].value)
+            except (TypeError, ValueError) as e:
+                raise SyntaxError(f"Invalid when() selector '{name}': {e}") from e
+
+        def extract_when_condition(cond_node: ast.AST) -> Any:
+            """A when() condition: input(...) (==/!= only) or a meta()/metric()
+            comparison (any op), either side."""
+            if not isinstance(cond_node, ast.Compare) or len(cond_node.ops) != 1:
+                fail("when() takes an input()/meta()/metric() comparison")
+            op = _AST_OPS.get(type(cond_node.ops[0]))
+            if op is None:
+                fail(f"unsupported when() operator at line {cond_node.lineno}")
+            left, right = cond_node.left, cond_node.comparators[0]
+            if call_name(left) == "input" or call_name(right) == "input":
+                if op not in ("==", "!="):
+                    fail("when() input conditions support only == and !=")
+                if call_name(left) == "input":
+                    ref, const = extract_input_ref(left), right
+                else:
+                    ref, const = extract_input_ref(right), left
+                if not isinstance(const, ast.Constant):
+                    fail("when() input conditions compare against a literal")
                 return routing_dsl.InputCondition(ref, op, const.value)
+            if call_name(left) in ("meta", "metric"):
+                sel, const = _extract_ms_selector(left), right
+            elif call_name(right) in ("meta", "metric"):
+                sel, const, op = _extract_ms_selector(right), left, _FLIPPED[op]
+            else:
+                fail("one side of a when() condition must be input()/meta()/metric()")
+            if not isinstance(const, ast.Constant):
+                fail("when() worker conditions compare against a literal")
+            try:
+                return routing_dsl.Condition(sel, op, const.value)
             except ValueError as e:
-                raise SyntaxError(f"Invalid routing when() condition: {e}") from e
+                raise SyntaxError(f"Invalid when() condition: {e}") from e
 
         def extract_service(svc_node: ast.AST) -> Any:
             assert isinstance(svc_node, ast.Call)
@@ -926,7 +994,7 @@ class WorkflowCatalog(ABC):
                     if len(term_node.args) != 2 or kwargs:
                         fail("when() takes a condition and a term, and no keyword arguments")
                     return routing_dsl.when(
-                        extract_input_condition(term_node.args[0]),
+                        extract_when_condition(term_node.args[0]),
                         extract_term(term_node.args[1]),
                     )
                 if len(term_node.args) != 1:

--- a/flux/domain/resource_request.py
+++ b/flux/domain/resource_request.py
@@ -338,6 +338,7 @@ def worker_matches(
                 worker.labels,
                 input_value,
                 worker_metadata=getattr(worker, "metadata", None),
+                worker_metrics=getattr(worker, "metrics", None),
             ):
                 return False
         elif not ResourceRequest.matches_labels(worker.labels, affinity):

--- a/flux/routing.py
+++ b/flux/routing.py
@@ -473,18 +473,22 @@ def _compile_match(term: Any, context: str) -> dict:
             f'label("region") == input("region"), got: {type(term).__name__}',
         )
     spec = term.selector.spec
-    is_matchable = (
-        isinstance(spec, str) and (spec.startswith("label:") or spec.startswith("meta:"))
-    ) or (isinstance(spec, dict) and spec.get("kind") == "label")
+    is_meta = isinstance(spec, str) and spec.startswith("meta:")
+    is_matchable = (isinstance(spec, str) and (spec.startswith("label:") or is_meta)) or (
+        isinstance(spec, dict) and spec.get("kind") == "label"
+    )
     if not is_matchable:
         raise ValueError(
             f"require() terms compare labels or metadata (label()/label_for()/meta()); "
             f"metric()/resource()/load() belong to requests= and routing=, got: '{spec}'",
         )
-    if term.op not in _REQUIRE_OPS:
+    # Labels are stringly-typed, so ordered comparisons stay out; metadata is
+    # properly typed (str|number), so meta() terms may use the ordered ops.
+    allowed_ops = _OPS if is_meta else _REQUIRE_OPS
+    if term.op not in allowed_ops:
         raise ValueError(
-            f"require() supports only == and != (ordered comparisons on labels are "
-            f"stringly-typed traps; use routing= for metrics), got: '{term.op}'",
+            f"require() label terms support only == and != (ordered comparisons on labels "
+            f"are stringly-typed traps); use meta() or routing=, got: '{term.op}'",
         )
     return {"kind": "match", "selector": spec, "op": term.op, "value": term.value}
 
@@ -499,32 +503,42 @@ def optional(term: Condition | dict) -> dict:
     return compiled
 
 
-def when(condition: InputCondition, term: Condition | dict) -> dict:
-    """Apply ``term`` only when an input condition holds.
+def when(condition: Any, term: Condition | dict) -> dict:
+    """Apply ``term`` only when ``condition`` holds.
 
-    The condition resolves from execution input only — it gates on the
-    requester's intent, never on worker attributes. An unresolved condition
-    leaves the term inactive (a widening construct by design, unlike bare
-    require terms, which fail closed).
+    The condition may be ``input(...)`` (requester intent, per-execution,
+    ``==``/``!=`` only) or a ``meta(...)``/``metric(...)`` comparison (dynamic
+    worker state, per-worker, any operator). ``label()``/``resource()``/
+    ``load()`` are not valid conditions — label is static capability (gating a
+    hard constraint on a worker-set label invites a self-dodge), and
+    resource/load are not conditionable state here.
 
-    Valid in both stages: wrapping a label comparison (or ``service(...)``)
-    it gates a ``require(...)`` term; wrapping a ``prefer()``/``least()``/
-    ``most()``/``sticky()`` term it gates a ``score(...)`` term.
+    Valid in both stages: wrapping a require match term it gates a
+    ``require(...)`` term; wrapping a ``prefer()``/``least()``/``most()``/
+    ``sticky()`` term it gates a ``score(...)`` term.
     """
-    if not isinstance(condition, InputCondition):
+    if isinstance(condition, InputCondition):
+        cond_spec = {"input": condition.ref.path, "op": condition.op, "value": condition.value}
+    elif isinstance(condition, Condition):
+        spec = condition.selector.spec
+        if not (isinstance(spec, str) and (spec.startswith("meta:") or spec.startswith("metric:"))):
+            raise ValueError(
+                "when() worker conditions use meta() or metric() (dynamic worker state); "
+                "label()/resource()/load() are not valid when() conditions",
+            )
+        if isinstance(condition.value, dict) and "$input" in condition.value:
+            raise ValueError("when() conditions compare against a constant, not input(...)")
+        cond_spec = {"selector": spec, "op": condition.op, "value": condition.value}
+    else:
         raise ValueError(
-            "when() condition must compare input(...) against a constant, e.g. "
-            f'when(input("tier") == "dedicated", ...), got: {type(condition).__name__}',
+            "when() condition must be input(...), meta(...), or metric(...) compared "
+            f"against a constant, got: {type(condition).__name__}",
         )
     if isinstance(term, dict) and term.get("kind") in _SCORE_TERM_KINDS:
         then = dict(term)
     else:
         then = _compile_match(term, "when()")
-    return {
-        "kind": "when",
-        "if": {"input": condition.ref.path, "op": condition.op, "value": condition.value},
-        "then": then,
-    }
+    return {"kind": "when", "if": cond_spec, "then": then}
 
 
 def require(*terms: Condition | dict) -> list[dict]:
@@ -703,20 +717,47 @@ def pick_worker(
         if not isinstance(term, dict):
             logger.warning(f"Malformed routing term ignored: {term!r}")
             return None
+
+        applies_to = eligible
         if term.get("kind") == "when":
-            # Input-gated score term: inactive conditions skip it; a
-            # malformed condition degrades the whole policy like any other
-            # malformed term.
-            active = _when_condition_active(term, input_value)
-            if isinstance(active, str):
+            cond = term.get("if")
+            then = term.get("then")
+            if not isinstance(then, dict):
                 logger.warning(f"Malformed routing term ignored: {term!r}")
                 return None
-            if not active:
-                continue
-            term = term.get("then")
-            if not isinstance(term, dict):
-                logger.warning(f"Malformed routing term ignored: {term!r}")
-                return None
+            if isinstance(cond, dict) and "input" in cond:
+                # Input-gated score term: inactive conditions skip it; a
+                # malformed condition degrades the whole policy like any
+                # other malformed term.
+                active = _when_condition_active(term, input_value)
+                if isinstance(active, str):
+                    logger.warning(f"Malformed routing term ignored: {term!r}")
+                    return None
+                if not active:
+                    continue
+            else:
+                # Worker-state (meta/metric) condition: evaluate per worker,
+                # scoring only over the subset it holds for.
+                applies_to = []
+                for w in eligible:
+                    a = _when_condition_active(
+                        term,
+                        input_value,
+                        worker_labels=w.labels or {},
+                        worker_metadata=getattr(w, "metadata", None) or {},
+                        worker_metrics=getattr(w, "metrics", None) or {},
+                        loads=loads,
+                        has_worker=True,
+                    )
+                    if isinstance(a, str):
+                        logger.warning(f"Malformed routing term ignored: {term!r}")
+                        return None
+                    if a:
+                        applies_to.append(w)
+                if not applies_to:
+                    continue
+            term = then
+
         kind = term.get("kind")
         weight = _as_float(term.get("weight", 1.0))
         if weight is None or weight <= 0:
@@ -724,7 +765,7 @@ def pick_worker(
             return None
 
         if kind == "sticky":
-            for w in eligible:
+            for w in applies_to:
                 if preferred and w.name == preferred:
                     totals[w.name] += weight
             continue
@@ -754,18 +795,18 @@ def pick_worker(
             right = term.get("value")
             if isinstance(right, dict) and "$input" in right:
                 right = _resolve_input_path(input_value, right["$input"])
-            for w in eligible:
+            for w in applies_to:
                 if _compare(_selector_value(w, selector, loads), op, right):
                     totals[w.name] += weight
             continue
 
         if kind in ("least", "most"):
-            values = {w.name: _as_float(_selector_value(w, selector, loads)) for w in eligible}
+            values = {w.name: _as_float(_selector_value(w, selector, loads)) for w in applies_to}
             present = [v for v in values.values() if v is not None]
             if not present:
                 continue  # nobody has the value; the term cannot discriminate
             lo, hi = min(present), max(present)
-            for w in eligible:
+            for w in applies_to:
                 v = values[w.name]
                 if v is None:
                     continue  # missing scores 0
@@ -867,10 +908,11 @@ def _resolve_selector_key(selector: Any, input_value: Any) -> tuple[str, _Proble
     return "", _Problem("malformed", f"malformed label selector: {selector!r}")
 
 
-def _resolve_require_term(term: dict, input_value: Any) -> tuple[str, str, str] | _Problem:
+def _resolve_require_term(term: dict, input_value: Any) -> tuple[str, str, Any] | _Problem:
     """Resolve a match term's selector kind, key, and comparison value against
     the execution input. Returns ``(kind, key, value)`` — kind is ``"label"``
-    or ``"meta"`` — or a :class:`_Problem`."""
+    or ``"meta"`` — or a :class:`_Problem`. Meta values stay raw (numeric
+    comparisons need real numbers); label values stringify."""
     selector = term.get("selector")
     if isinstance(selector, str) and selector.startswith("meta:"):
         kind, key = "meta", selector[len("meta:") :]
@@ -882,7 +924,8 @@ def _resolve_require_term(term: dict, input_value: Any) -> tuple[str, str, str] 
                 return problem
             return _Problem(problem.category, f"affinity {problem.message}")
 
-    if term.get("op") not in _REQUIRE_OPS:
+    allowed_ops = _OPS if kind == "meta" else _REQUIRE_OPS
+    if term.get("op") not in allowed_ops:
         return _Problem("malformed", f"malformed affinity term op: {term.get('op')!r}")
 
     value = term.get("value")
@@ -896,23 +939,59 @@ def _resolve_require_term(term: dict, input_value: Any) -> tuple[str, str, str] 
                 "unresolved",
                 f"affinity term on {kind} '{key}' requires input '{path}', which is not present",
             )
+    # Meta keeps its raw value so numeric comparisons coerce correctly; labels
+    # stringify (label semantics).
+    if kind == "meta":
+        return kind, key, value
     return kind, key, _label_value_str(value)
 
 
-def _when_condition_active(term: dict, input_value: Any) -> bool | str:
-    """Whether a when-term's condition holds. Unresolved input leaves the
-    term inactive (False); a malformed condition is a problem string."""
+def _when_condition_active(
+    term: dict,
+    input_value: Any,
+    *,
+    worker_labels: dict[str, Any] | None = None,
+    worker_metadata: dict[str, Any] | None = None,
+    worker_metrics: dict[str, Any] | None = None,
+    loads: dict[str, int] | None = None,
+    has_worker: bool = False,
+) -> bool | str | None:
+    """Whether a when-term's condition holds. Returns True/False, a string for a
+    malformed condition, or None for a per-worker (meta/metric) condition asked
+    without a worker (diagnostic context — the caller skips the term).
+
+    ``input`` conditions resolve once per execution (unresolved → inactive/False,
+    a widening construct). ``meta``/``metric`` conditions resolve per worker
+    against the passed worker state.
+    """
     cond = term.get("if")
     if not isinstance(cond, dict):
         return f"malformed affinity when-condition: {cond!r}"
-    path, op = cond.get("input"), cond.get("op")
-    if not isinstance(path, str) or not path or op not in _REQUIRE_OPS:
-        return f"malformed affinity when-condition: {cond!r}"
-    resolved = _resolve_require_input(input_value, path)
-    if resolved is _UNRESOLVED:
-        return False
-    expected = cond.get("value")
-    return (resolved == expected) if op == "==" else (resolved != expected)
+    if "input" in cond:
+        path, op = cond.get("input"), cond.get("op")
+        if not isinstance(path, str) or not path or op not in _REQUIRE_OPS:
+            return f"malformed affinity when-condition: {cond!r}"
+        resolved = _resolve_require_input(input_value, path)
+        if resolved is _UNRESOLVED:
+            return False
+        expected = cond.get("value")
+        return (resolved == expected) if op == "==" else (resolved != expected)
+    if "selector" in cond:
+        selector, op = cond.get("selector"), cond.get("op")
+        if (
+            not isinstance(selector, str)
+            or not (selector.startswith("meta:") or selector.startswith("metric:"))
+            or op not in _OPS
+        ):
+            return f"malformed affinity when-condition: {cond!r}"
+        if not has_worker:
+            return None  # fleet-dependent; not evaluable in diagnostic context
+        kind, _, key = selector.partition(":")
+        actual = (
+            (worker_metadata or {}).get(key) if kind == "meta" else (worker_metrics or {}).get(key)
+        )
+        return _compare(actual, op, cond.get("value"))
+    return f"malformed affinity when-condition: {cond!r}"
 
 
 def require_diagnostic(terms: Any, input_value: Any) -> str | None:
@@ -935,7 +1014,7 @@ def require_diagnostic(terms: Any, input_value: Any) -> str | None:
             active = _when_condition_active(term, input_value)
             if isinstance(active, str):
                 return active
-            if not active:
+            if active is None or not active:
                 continue
             term = term.get("then")
             if not isinstance(term, dict) or term.get("kind") != "match":
@@ -957,14 +1036,18 @@ def require_matches(
     worker_labels: dict[str, str] | None,
     input_value: Any,
     worker_metadata: dict[str, Any] | None = None,
+    *,
+    worker_metrics: dict[str, Any] | None = None,
+    loads: dict[str, int] | None = None,
 ) -> bool:
     """Whether a worker's labels and server-held metadata satisfy a
     require(...) affinity expression.
 
-    Fail-closed: any problem (unresolved input on a non-optional term,
-    invalid key, malformed spec) fails the match — mirroring
-    ``require_diagnostic``, which turns those same problems into a terminal
-    dispatch error so fail-closed never means queue-forever.
+    Fail-closed: any problem (unresolved input on a non-optional term, invalid
+    key, malformed spec) fails the match — mirroring ``require_diagnostic``,
+    which turns those same problems into a terminal dispatch error so
+    fail-closed never means queue-forever. ``worker_metrics``/``loads`` back
+    ``when()`` conditions gating on worker state.
     """
     if not isinstance(terms, (list, tuple)) or not terms:
         return False
@@ -974,8 +1057,16 @@ def require_matches(
         if not isinstance(term, dict):
             return False
         if term.get("kind") == "when":
-            active = _when_condition_active(term, input_value)
-            if isinstance(active, str):
+            active = _when_condition_active(
+                term,
+                input_value,
+                worker_labels=labels,
+                worker_metadata=metadata,
+                worker_metrics=worker_metrics or {},
+                loads=loads or {},
+                has_worker=True,
+            )
+            if isinstance(active, str) or active is None:
                 return False
             if not active:
                 continue
@@ -990,15 +1081,23 @@ def require_matches(
                 continue
             return False
         kind, key, value = resolved
-        raw = metadata.get(key) if kind == "meta" else labels.get(key)
-        # Metadata values may be numeric; they compare in string form like
-        # everything else in require() (rank numerics in routing= instead).
-        actual = None if raw is None else _label_value_str(raw)
-        if term.get("op") == "==":
-            if actual != value:
-                return False
-        # Absent ≠ value holds by design: a worker with no such label passes
-        # a != term (the documented inversion of fail-closed).
-        elif actual == value:
+        op = term.get("op")
+        if op not in _OPS:  # already validated by _resolve_require_term; narrows for mypy
             return False
+        if kind == "meta":
+            raw = metadata.get(key)
+            if op == "!=":
+                # Absent ≠ value holds by design (mirrors the label inversion).
+                if raw is not None and _compare(raw, "==", value):
+                    return False
+            elif raw is None or not _compare(raw, op, value):
+                return False
+        else:  # label — string ==/!= with the absent-!= inversion (unchanged)
+            raw = labels.get(key)
+            actual = None if raw is None else _label_value_str(raw)
+            if op == "==":
+                if actual != value:
+                    return False
+            elif actual == value:
+                return False
     return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.65.0"
+version = "0.66.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_require.py
+++ b/tests/flux/test_require.py
@@ -11,6 +11,8 @@ from flux.routing import (
     label,
     label_for,
     least,
+    meta,
+    metric,
     most,
     optional,
     prefer,
@@ -126,8 +128,10 @@ class TestRequireCompile:
             service(42)
         assert service("small-8b")["selector"] == "label:flux.service.small-8b"
 
-    def test_when_condition_must_be_input_condition(self):
-        with pytest.raises(ValueError, match="input"):
+    def test_when_condition_rejects_label(self):
+        # label() is static capability, not dynamic worker state; when()
+        # conditions are input(...)/meta(...)/metric() only.
+        with pytest.raises(ValueError, match="not valid when"):
             when(label("x") == "y", label("a") == "b")
 
     def test_input_condition_ops_and_values(self):
@@ -435,3 +439,64 @@ class TestWorkerMatchesSpecBranch:
         worker = self._worker({"gpu": "a100"})
         assert worker_matches(worker, None, {"gpu": "a100"})
         assert not worker_matches(worker, None, {"gpu": "h100"})
+
+
+class TestRequireMetaOrderedOps:
+    """meta() terms allow the full ordered-op set (metadata is properly
+    typed str|number); label() stays ==/!= only."""
+
+    def test_meta_ordered_op_matches_and_fails_closed_on_absent(self):
+        spec = require(meta("health") >= 0.8)
+        assert require_matches(spec, {}, None, worker_metadata={"health": 0.9})
+        assert not require_matches(spec, {}, None, worker_metadata={"health": 0.5})
+        assert not require_matches(spec, {}, None, worker_metadata={})
+
+    def test_meta_equality_still_works(self):
+        spec = require(meta("zone") == "eu")
+        assert require_matches(spec, {}, None, worker_metadata={"zone": "eu"})
+        assert not require_matches(spec, {}, None, worker_metadata={"zone": "us"})
+
+    def test_meta_negation_absent_passes(self):
+        spec = require(meta("drain") != "true")
+        assert not require_matches(spec, {}, None, worker_metadata={"drain": "true"})
+        assert require_matches(spec, {}, None, worker_metadata={})
+
+    def test_label_ordered_ops_still_rejected(self):
+        with pytest.raises(ValueError, match="only == and !="):
+            require(label("x") < 5)
+
+
+class TestRequireWhenWorkerState:
+    """when() gating on meta()/metric() (dynamic per-worker state), the
+    counterpart of when(input(...)) gating on requester intent."""
+
+    def test_when_metric_gates_meta_term(self):
+        spec = require(when(metric("queue_depth") >= 100, meta("cleared") == "true"))
+        # Busy and uncleared: the gated term is active and fails.
+        assert not require_matches(
+            spec,
+            {},
+            None,
+            worker_metadata={},
+            worker_metrics={"queue_depth": 200},
+        )
+        # Busy and cleared: the gated term is active and passes.
+        assert require_matches(
+            spec,
+            {},
+            None,
+            worker_metadata={"cleared": "true"},
+            worker_metrics={"queue_depth": 200},
+        )
+        # Idle: the condition is inactive, so the term is skipped entirely.
+        assert require_matches(
+            spec,
+            {},
+            None,
+            worker_metadata={},
+            worker_metrics={"queue_depth": 5},
+        )
+
+    def test_when_rejects_label_condition(self):
+        with pytest.raises(ValueError, match="not valid when"):
+            when(label("gpu") == "true", meta("x") == "1")

--- a/tests/flux/test_require_catalog.py
+++ b/tests/flux/test_require_catalog.py
@@ -155,3 +155,76 @@ async def wf(ctx):
 """
     [info] = _parse(source)
     assert info.affinity is None
+
+
+def test_label_ordered_comparison_still_raises_syntax_error():
+    source = b"""
+from flux import workflow
+from flux.routing import require, label
+
+
+@workflow.with_options(affinity=require(label("x") < 5))
+async def wf(ctx):
+    return 1
+"""
+    with pytest.raises(SyntaxError, match="only == and !="):
+        _parse(source)
+
+
+def test_meta_ordered_comparison_extracts():
+    source = b"""
+from flux import workflow
+from flux.routing import require, meta
+
+
+@workflow.with_options(affinity=require(meta("health") >= 0.8))
+async def wf(ctx):
+    return 1
+"""
+    [info] = _parse(source)
+    assert info.affinity == [
+        {"kind": "match", "selector": "meta:health", "op": ">=", "value": 0.8},
+    ]
+
+
+def test_meta_reversed_ordered_comparison_extracts():
+    source = b"""
+from flux import workflow
+from flux.routing import require, meta
+
+
+@workflow.with_options(affinity=require(0.8 <= meta("health")))
+async def wf(ctx):
+    return 1
+"""
+    [info] = _parse(source)
+    assert info.affinity == [
+        {"kind": "match", "selector": "meta:health", "op": ">=", "value": 0.8},
+    ]
+
+
+def test_when_meta_condition_extracts_in_require():
+    source = b"""
+from flux import workflow
+from flux.routing import require, when, meta, label
+
+
+@workflow.with_options(
+    affinity=require(when(meta("class") == "gpu", label("cleared") == "true")),
+)
+async def wf(ctx):
+    return 1
+"""
+    [info] = _parse(source)
+    assert info.affinity == [
+        {
+            "kind": "when",
+            "if": {"selector": "meta:class", "op": "==", "value": "gpu"},
+            "then": {
+                "kind": "match",
+                "selector": "label:cleared",
+                "op": "==",
+                "value": "true",
+            },
+        },
+    ]

--- a/tests/flux/test_routing.py
+++ b/tests/flux/test_routing.py
@@ -529,3 +529,32 @@ class TestDynamicScoring:
             is a
         )
         assert pick_worker([a, b], policy, loads=loads, input_value={}, preferred="a") is b
+
+
+class TestWhenWorkerState:
+    """when() gating on meta()/metric(): dynamic per-worker state, evaluated
+    per candidate (unlike when(input(...)), which resolves once)."""
+
+    def test_when_meta_excludes_non_matching_worker_from_score(self):
+        from flux.routing import meta, when
+
+        gpu = WorkerInfo(name="gpu", metadata={"class": "gpu", "priority": 5})
+        cpu = WorkerInfo(name="cpu", metadata={"class": "cpu", "priority": 99})
+        policy = score(when(meta("class") == "gpu", most(meta("priority"))))
+
+        winner = pick_worker([gpu, cpu], policy, loads={})
+
+        # cpu is excluded from applies_to (its class isn't "gpu"), so it
+        # scores 0 regardless of its (higher) priority.
+        assert winner.name == "gpu"
+
+    def test_when_metric_excludes_worker_from_prefer(self):
+        from flux.routing import metric, when
+
+        busy = _worker("busy", metrics={"q": 200}, labels={"x": "1"})
+        idle = _worker("idle", metrics={"q": 5}, labels={"x": "1"})
+        policy = score(when(metric("q") < 100, prefer(label("x") == "1", weight=10)))
+
+        winner = pick_worker([busy, idle], policy, loads={})
+
+        assert winner.name == "idle"

--- a/tests/flux/test_routing_catalog.py
+++ b/tests/flux/test_routing_catalog.py
@@ -188,3 +188,32 @@ async def wf(ctx):
 """.encode()
     with pytest.raises(SyntaxError, match=reason):
         _parse(source)
+
+
+def test_when_metric_condition_extracts_in_routing():
+    source = b"""
+from flux import workflow
+from flux.routing import score, prefer, when, metric, label, input
+
+
+@workflow.with_options(
+    routing=score(when(metric("q") < 100, prefer(label("r") == input("r")))),
+)
+async def routed(ctx):
+    return 1
+"""
+    [info] = _parse(source)
+    terms = (info.metadata or {})["routing"]["terms"]
+    assert terms == [
+        {
+            "kind": "when",
+            "if": {"selector": "metric:q", "op": "<", "value": 100},
+            "then": {
+                "kind": "prefer",
+                "selector": "label:r",
+                "op": "==",
+                "value": {"$input": "r"},
+                "weight": 1.0,
+            },
+        },
+    ]


### PR DESCRIPTION
Two additive routing enhancements on top of the merged server-side worker metadata (#138 / #139). Both extend how the `meta()` control-plane attribute channel can be used in dispatch expressions; neither touches the storage/model/admin-API/CLI surface already shipped.

## 1. Ordered numeric ops in `require(meta())`

Worker metadata is properly typed (`str | number`), so `meta()` affinity terms now allow ordered comparisons in addition to `==`/`!=`:

```python
@workflow.with_options(affinity=require(meta("health_score") >= 0.8))
```

This is a **hard numeric floor** — workers below the threshold are excluded from dispatch entirely, not just deranked. Labels remain `==`/`!=` only (they're stringly-typed). Meta comparisons are numeric-aware, preserving the absent-`!=` inversion (a worker missing the key passes a `!=` term) and failing closed on ordered/`==`-against-absent.

## 2. `when()` gating on dynamic worker state

`when()` conditions previously gated only on `input()` (requester intent). They now also accept `meta()` and `metric()` — **dynamic worker state** — evaluated per worker:

```python
# rank by GPU priority, but only among GPU-class workers
score(when(meta("class") == "gpu", most(meta("priority"))))

# apply the region preference only to workers that aren't backlogged
score(when(metric("queue_depth") < 100, prefer(meta("region") == input("region"))))

# busy workers must additionally be cleared
require(when(metric("queue_depth") >= 100, meta("cleared") == "true"))
```

`label()`/`resource()`/`load()` remain invalid as `when()` conditions (label is static capability; gating a hard constraint on a worker-set value invites a self-dodge). `pick_worker` applies a `when(meta/metric)` term over the per-worker active subset (`least`/`most` normalize over that subset; inactive workers score 0); `require_matches`, `require_diagnostic`, and the catalog AST extractor all mirror the runtime semantics.

## Scope
- `flux/routing.py`, `flux/domain/resource_request.py`, `flux/catalogs.py` + tests only.
- No new migration, DB column, admin route, or CLI (all already in main).
- Version bumped `0.65.0 → 0.66.0` (feature).

## Verification
- Focused enhancement tests (routing/require/catalog modules): **154 passed**.
- Full unit suite: **3032 passed, 21 skipped, 0 failed**.
- `pre-commit` (ruff, ruff-format, mypy, pyupgrade) clean.
- Independent adversarial review of the `pick_worker` scoring-loop refactor: approved (existing prefer/least/most/sticky/`when(input)` paths byte-equivalent; per-worker subset scoping correct; fail-closed discipline consistent).
