### PR TITLE
Skip a scheduled fire while its previous execution is still running

### DIFF
--- a/flux/api/schedule_routes.py
+++ b/flux/api/schedule_routes.py
@@ -62,6 +62,13 @@ class ScheduleRoutesMixin:
                 next_run_at=schedule.next_run_at.isoformat() if schedule.next_run_at else None,
                 run_count=schedule.run_count,
                 failure_count=schedule.failure_count,
+                skipped_count=getattr(schedule, "skipped_count", 0) or 0,
+                last_skipped_at=(
+                    schedule.last_skipped_at.isoformat()
+                    if getattr(schedule, "last_skipped_at", None)
+                    else None
+                ),
+                overlap_policy=schedule.effective_overlap_policy,
                 run_as_service_account=getattr(schedule, "run_as_service_account", None),
             )
 
@@ -163,6 +170,14 @@ class ScheduleRoutesMixin:
                 # Create schedule from configuration
                 schedule = schedule_factory(request.schedule_config)
 
+                if request.overlap_policy is not None:
+                    from flux.domain.schedule import validate_overlap
+
+                    try:
+                        validate_overlap(request.overlap_policy)
+                    except ValueError as ex:
+                        raise HTTPException(status_code=400, detail=str(ex))
+
                 # Create schedule via manager
                 schedule_manager = create_schedule_manager()
                 schedule_model = schedule_manager.create_schedule(
@@ -174,6 +189,7 @@ class ScheduleRoutesMixin:
                     description=request.description,
                     input_data=request.input_data,
                     run_as_service_account=request.run_as_service_account,
+                    overlap_policy=request.overlap_policy,
                 )
 
                 logger.info(

--- a/flux/api/schedule_routes.py
+++ b/flux/api/schedule_routes.py
@@ -167,16 +167,19 @@ class ScheduleRoutesMixin:
                             },
                         )
 
-                # Create schedule from configuration
-                schedule = schedule_factory(request.schedule_config)
+                # Create schedule from configuration. schedule_factory raises
+                # ValueError for anything malformed in the caller's payload --
+                # a bad cron expression, an unknown timezone, an invalid
+                # overlap -- which is client error, not a server fault. Without
+                # this the generic handler below turns it into a 500.
+                from flux.domain.schedule import validate_overlap
 
-                if request.overlap_policy is not None:
-                    from flux.domain.schedule import validate_overlap
-
-                    try:
+                try:
+                    schedule = schedule_factory(request.schedule_config)
+                    if request.overlap_policy is not None:
                         validate_overlap(request.overlap_policy)
-                    except ValueError as ex:
-                        raise HTTPException(status_code=400, detail=str(ex))
+                except ValueError as ex:
+                    raise HTTPException(status_code=400, detail=str(ex))
 
                 # Create schedule via manager
                 schedule_manager = create_schedule_manager()

--- a/flux/api/schemas.py
+++ b/flux/api/schemas.py
@@ -91,6 +91,9 @@ class ScheduleRequest(BaseModel):
     description: str | None = None
     input_data: Any | None = None
     run_as_service_account: str | None = None
+    # "skip" | "allow". None lets the schedule_config's own policy decide,
+    # falling back to "skip" for newly created schedules.
+    overlap_policy: str | None = None
 
 
 class ScheduleResponse(BaseModel):
@@ -110,6 +113,9 @@ class ScheduleResponse(BaseModel):
     next_run_at: str | None
     run_count: int
     failure_count: int
+    skipped_count: int = 0
+    last_skipped_at: str | None = None
+    overlap_policy: str = "allow"
     run_as_service_account: str | None = None
 
 

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -1639,6 +1639,15 @@ def schedule():
     help="Service account to run the schedule as (required when auth is enabled)",
 )
 @click.option(
+    "--overlap",
+    type=click.Choice(["skip", "allow"]),
+    default="skip",
+    help=(
+        "What a due fire does while the previous execution is still running: "
+        "skip it (default) or dispatch anyway"
+    ),
+)
+@click.option(
     "--format",
     "-f",
     type=click.Choice(["simple", "json"]),
@@ -1661,6 +1670,7 @@ def create_schedule(
     description: str | None,
     input: str | None,
     run_as: str | None,
+    overlap: str,
     format: str,
     server_url: str | None,
 ):
@@ -1708,6 +1718,7 @@ def create_schedule(
             "description": description,
             "input_data": input_data,
             "run_as_service_account": run_as,
+            "overlap_policy": overlap,
         }
 
         base_url = server_url or get_server_url()
@@ -1725,6 +1736,7 @@ def create_schedule(
             )
             click.echo(f"Schedule ID: {result['id']}")
             click.echo(f"Next run: {result.get('next_run_at', 'Not scheduled')}")
+            click.echo(f"On overlap: {result.get('overlap_policy', 'allow')}")
 
     except Exception as ex:
         click.echo(f"Error creating schedule: {str(ex)}", err=True)
@@ -1837,6 +1849,16 @@ def show_schedule(schedule_id: str, format: str, server_url: str | None):
             click.echo(f"Next run: {schedule.get('next_run_at', 'Not scheduled')}")
             click.echo(f"Total runs: {schedule['run_count']}")
             click.echo(f"Failures: {schedule['failure_count']}")
+            click.echo(f"On overlap: {schedule.get('overlap_policy', 'allow')}")
+            skipped = schedule.get("skipped_count", 0)
+            if skipped:
+                # Only shown when non-zero: a schedule skipping every fire looks
+                # idle otherwise, since a skip produces no execution and history
+                # is derived from executions.
+                click.echo(
+                    f"Skipped (overlap): {skipped}"
+                    f" | last: {schedule.get('last_skipped_at', 'never')}",
+                )
 
             if schedule.get("description"):
                 click.echo(f"Description: {schedule['description']}")

--- a/flux/domain/schedule.py
+++ b/flux/domain/schedule.py
@@ -27,14 +27,34 @@ class ScheduleStatus(Enum):
     DISABLED = "disabled"
 
 
+#: What a due fire does when the schedule's previous execution is still running.
+#: ``skip`` drops this occurrence and advances to the next; ``allow`` dispatches
+#: anyway, which is the historical behavior.
+OVERLAP_SKIP = "skip"
+OVERLAP_ALLOW = "allow"
+OVERLAP_POLICIES = (OVERLAP_SKIP, OVERLAP_ALLOW)
+
+
+def validate_overlap(policy: str) -> str:
+    if policy not in OVERLAP_POLICIES:
+        raise ValueError(
+            f"overlap must be one of {', '.join(OVERLAP_POLICIES)}, got: '{policy}'",
+        )
+    return policy
+
+
 class Schedule(ABC):
     """Abstract base class for all schedule types"""
 
-    def __init__(self, timezone: str = "UTC"):
+    def __init__(self, timezone: str = "UTC", overlap: str = OVERLAP_SKIP):
         """Initialize schedule with timezone
 
         Args:
             timezone: Timezone for schedule execution (default: UTC)
+            overlap: What a due fire does while the previous execution is still
+                running -- "skip" (default) drops the occurrence, "allow"
+                dispatches anyway. Schedules created before this option existed
+                read as "allow", so upgrading changes no existing behavior.
         """
         # Reject "local" timezone as it's not portable across systems
         if timezone == "local":
@@ -50,6 +70,7 @@ class Schedule(ABC):
             raise ValueError(f"Invalid timezone '{timezone}': {e}")
 
         self.timezone = timezone
+        self.overlap = validate_overlap(overlap)
 
     @property
     @abstractmethod
@@ -96,14 +117,15 @@ class Schedule(ABC):
 class CronSchedule(Schedule):
     """Cron-based schedule implementation"""
 
-    def __init__(self, cron_expression: str, timezone: str = "UTC"):
+    def __init__(self, cron_expression: str, timezone: str = "UTC", overlap: str = OVERLAP_SKIP):
         """Initialize cron schedule
 
         Args:
             cron_expression: Standard cron expression (5 or 6 fields)
             timezone: Timezone for schedule execution
+            overlap: "skip" (default) or "allow" -- see Schedule
         """
-        super().__init__(timezone)
+        super().__init__(timezone, overlap)
 
         if not self._is_valid_cron(cron_expression):
             raise ValueError(f"Invalid cron expression: {cron_expression}")
@@ -166,6 +188,7 @@ class CronSchedule(Schedule):
             "type": ScheduleType.CRON.value,
             "cron_expression": self.cron_expression,
             "timezone": self.timezone,
+            "overlap": self.overlap,
         }
 
     @classmethod
@@ -174,6 +197,7 @@ class CronSchedule(Schedule):
         return cls(
             cron_expression=data["cron_expression"],
             timezone=data.get("timezone", "UTC"),
+            overlap=data.get("overlap", OVERLAP_SKIP),
         )
 
 
@@ -190,6 +214,7 @@ class IntervalSchedule(Schedule):
         timezone: str = "UTC",
         start_time: datetime | None = None,
         end_time: datetime | None = None,
+        overlap: str = OVERLAP_SKIP,
     ):
         """Initialize interval schedule
 
@@ -202,8 +227,9 @@ class IntervalSchedule(Schedule):
             timezone: Timezone for schedule execution
             start_time: Optional start time for the schedule
             end_time: Optional end time for the schedule
+            overlap: "skip" (default) or "allow" -- see Schedule
         """
-        super().__init__(timezone)
+        super().__init__(timezone, overlap)
 
         self.interval = timedelta(
             seconds=seconds,
@@ -272,6 +298,7 @@ class IntervalSchedule(Schedule):
             "type": ScheduleType.INTERVAL.value,
             "interval_seconds": int(self.interval.total_seconds()),
             "timezone": self.timezone,
+            "overlap": self.overlap,
             "start_time": self.start_time.isoformat() if self.start_time else None,
             "end_time": self.end_time.isoformat() if self.end_time else None,
             "last_run_time": self.last_run_time.isoformat() if self.last_run_time else None,
@@ -283,6 +310,7 @@ class IntervalSchedule(Schedule):
         instance = cls(
             seconds=data.get("interval_seconds", 0),
             timezone=data.get("timezone", "UTC"),
+            overlap=data.get("overlap", OVERLAP_SKIP),
             start_time=datetime.fromisoformat(data["start_time"])
             if data.get("start_time")
             else None,
@@ -298,14 +326,15 @@ class IntervalSchedule(Schedule):
 class OnceSchedule(Schedule):
     """One-time schedule for specific datetime execution"""
 
-    def __init__(self, run_time: datetime, timezone: str = "UTC"):
+    def __init__(self, run_time: datetime, timezone: str = "UTC", overlap: str = OVERLAP_SKIP):
         """Initialize one-time schedule
 
         Args:
             run_time: Specific time to run the workflow
             timezone: Timezone for schedule execution
+            overlap: "skip" (default) or "allow" -- see Schedule
         """
-        super().__init__(timezone)
+        super().__init__(timezone, overlap)
         self.run_time = run_time
         self.executed = False
 
@@ -359,6 +388,7 @@ class OnceSchedule(Schedule):
             "type": ScheduleType.ONCE.value,
             "run_time": self.run_time.isoformat(),
             "timezone": self.timezone,
+            "overlap": self.overlap,
             "executed": self.executed,
         }
 
@@ -368,12 +398,13 @@ class OnceSchedule(Schedule):
         instance = cls(
             run_time=datetime.fromisoformat(data["run_time"]),
             timezone=data.get("timezone", "UTC"),
+            overlap=data.get("overlap", OVERLAP_SKIP),
         )
         instance.executed = data.get("executed", False)
         return instance
 
 
-def cron(expression: str, timezone: str = "UTC") -> CronSchedule:
+def cron(expression: str, timezone: str = "UTC", overlap: str = OVERLAP_SKIP) -> CronSchedule:
     """Create a cron schedule
 
     Args:
@@ -383,7 +414,7 @@ def cron(expression: str, timezone: str = "UTC") -> CronSchedule:
     Returns:
         CronSchedule instance
     """
-    return CronSchedule(expression, timezone)
+    return CronSchedule(expression, timezone, overlap)
 
 
 def interval(
@@ -395,6 +426,7 @@ def interval(
     timezone: str = "UTC",
     start_time: datetime | None = None,
     end_time: datetime | None = None,
+    overlap: str = OVERLAP_SKIP,
 ) -> IntervalSchedule:
     """Create an interval schedule
 
@@ -420,10 +452,11 @@ def interval(
         timezone=timezone,
         start_time=start_time,
         end_time=end_time,
+        overlap=overlap,
     )
 
 
-def once(run_time: datetime, timezone: str = "UTC") -> OnceSchedule:
+def once(run_time: datetime, timezone: str = "UTC", overlap: str = OVERLAP_SKIP) -> OnceSchedule:
     """Create a one-time schedule
 
     Args:
@@ -433,7 +466,7 @@ def once(run_time: datetime, timezone: str = "UTC") -> OnceSchedule:
     Returns:
         OnceSchedule instance
     """
-    return OnceSchedule(run_time, timezone)
+    return OnceSchedule(run_time, timezone, overlap)
 
 
 def schedule_factory(data: dict[str, Any]) -> Schedule:

--- a/flux/domain/schedule.py
+++ b/flux/domain/schedule.py
@@ -53,8 +53,13 @@ class Schedule(ABC):
             timezone: Timezone for schedule execution (default: UTC)
             overlap: What a due fire does while the previous execution is still
                 running -- "skip" (default) drops the occurrence, "allow"
-                dispatches anyway. Schedules created before this option existed
-                read as "allow", so upgrading changes no existing behavior.
+                dispatches anyway.
+
+                A Schedule always carries a concrete policy. The back-compat
+                rule for schedules stored before this option existed lives at
+                the persistence layer instead: ``ScheduleModel.overlap_policy``
+                is NULL for those rows and ``effective_overlap_policy`` reads
+                NULL as "allow", so upgrading changes no existing behavior.
         """
         # Reject "local" timezone as it's not portable across systems
         if timezone == "local":

--- a/flux/migrations/versions/0014_schedule_overlap_policy.py
+++ b/flux/migrations/versions/0014_schedule_overlap_policy.py
@@ -1,0 +1,52 @@
+"""Add schedules.overlap_policy plus skip accounting.
+
+``overlap_policy`` decides what a due fire does while the schedule's previous
+execution is still running. It is deliberately nullable with no server default:
+existing rows stay NULL, which ``ScheduleModel.effective_overlap_policy`` reads
+as "allow" -- exactly the behavior those schedules already had. Only schedules
+created after this revision carry an explicit policy, so upgrading changes
+nothing for anyone already running.
+
+``skipped_count`` / ``last_skipped_at`` keep a skipped occurrence visible: it
+produces no execution, and schedule history is derived from executions, so
+without them a schedule quietly skipping every fire would look idle.
+
+Revision ID: 0014_schedule_overlap_policy
+Revises: 0013_worker_metadata
+Create Date: 2026-07-26
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0014_schedule_overlap_policy"
+down_revision: str | None = "0013_worker_metadata"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "schedules"
+_COLUMNS: tuple[tuple[str, sa.types.TypeEngine, dict], ...] = (
+    ("overlap_policy", sa.String(), {"nullable": True}),
+    ("skipped_count", sa.Integer(), {"nullable": False, "server_default": "0"}),
+    ("last_skipped_at", sa.DateTime(), {"nullable": True}),
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    for name, column_type, kwargs in _COLUMNS:
+        if name not in existing:
+            op.add_column(_TABLE, sa.Column(name, column_type, **kwargs))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    for name, _, _ in reversed(_COLUMNS):
+        if name in existing:
+            op.drop_column(_TABLE, name)

--- a/flux/models.py
+++ b/flux/models.py
@@ -901,9 +901,17 @@ class ScheduleModel(Base):
     # Service account to run scheduled executions as (required when auth is enabled)
     run_as_service_account = Column(String, nullable=True)
 
+    # What a due fire does while this schedule's previous execution is still
+    # running. NULL on pre-existing rows and read as "allow" -- the historical
+    # behavior -- so upgrading never changes an existing schedule. Newly created
+    # schedules default to "skip".
+    overlap_policy = Column(String, nullable=True)
+
     # Statistics
     run_count = Column(Integer, nullable=False, default=0)
     failure_count = Column(Integer, nullable=False, default=0)
+    skipped_count = Column(Integer, nullable=False, default=0, server_default="0")
+    last_skipped_at = Column(DateTime, nullable=True)
 
     # Relationships
     workflow = relationship("WorkflowModel", backref="schedules")
@@ -928,6 +936,7 @@ class ScheduleModel(Base):
         status: ScheduleStatus = ScheduleStatus.ACTIVE,
         run_as_service_account: str | None = None,
         workflow_namespace: str = "default",
+        overlap_policy: str | None = None,
     ):
         self.workflow_id = workflow_id
         self.workflow_namespace = workflow_namespace
@@ -939,7 +948,17 @@ class ScheduleModel(Base):
         self.status = status
         self.input_data = input_data
         self.run_as_service_account = run_as_service_account
+        # An explicit argument wins; otherwise take the policy off the Schedule
+        # object. getattr guards schedules pickled before `overlap` existed.
+        self.overlap_policy = overlap_policy or getattr(schedule, "overlap", None)
         self.next_run_at = schedule.next_run_time()
+
+    @property
+    def effective_overlap_policy(self) -> str:
+        """The policy to enforce. NULL (pre-existing rows) reads as "allow"."""
+        from flux.domain.schedule import OVERLAP_ALLOW
+
+        return self.overlap_policy or OVERLAP_ALLOW
 
     def get_schedule(self) -> Schedule:
         """Get the Schedule object from stored configuration"""
@@ -963,14 +982,13 @@ class ScheduleModel(Base):
 
         return current_time >= self.next_run_at
 
-    def mark_run(self, run_time: datetime | None = None):
-        """Mark that the schedule was executed"""
-        if run_time is None:
-            run_time = datetime.now(timezone.utc)
+    def _advance(self, run_time: datetime):
+        """Move the schedule past ``run_time`` to its next occurrence.
 
-        self.last_run_at = run_time
-        self.run_count += 1
-
+        Shared by ``mark_run`` and ``mark_skipped``: a skipped occurrence has to
+        advance exactly like a dispatched one, or the schedule stays due and is
+        re-evaluated on every poll.
+        """
         # Sync the embedded schedule object state for IntervalSchedule
         schedule = self.get_schedule()
         from flux.domain.schedule import IntervalSchedule
@@ -981,6 +999,29 @@ class ScheduleModel(Base):
             self.schedule_config = schedule
 
         self.update_next_run()
+
+    def mark_run(self, run_time: datetime | None = None):
+        """Mark that the schedule was executed"""
+        if run_time is None:
+            run_time = datetime.now(timezone.utc)
+
+        self.last_run_at = run_time
+        self.run_count += 1
+        self._advance(run_time)
+
+    def mark_skipped(self, run_time: datetime | None = None):
+        """Mark that a due occurrence was skipped because the previous run is still active.
+
+        Deliberately does NOT touch ``last_run_at`` or ``run_count`` -- nothing
+        ran. The occurrence is counted separately so a schedule quietly skipping
+        every fire is visible rather than looking idle.
+        """
+        if run_time is None:
+            run_time = datetime.now(timezone.utc)
+
+        self.last_skipped_at = run_time
+        self.skipped_count = (self.skipped_count or 0) + 1
+        self._advance(run_time)
 
     def mark_failure(self):
         """Mark that the schedule execution failed"""

--- a/flux/schedule_manager.py
+++ b/flux/schedule_manager.py
@@ -48,6 +48,7 @@ class ScheduleManager(ABC):
         input_data: Any = None,
         run_as_service_account: str | None = None,
         workflow_namespace: str = "default",
+        overlap_policy: str | None = None,
     ) -> ScheduleModel:
         """Create a new schedule"""
         pass
@@ -129,6 +130,16 @@ class ScheduleManager(ABC):
         pass
 
     @abstractmethod
+    def has_active_execution(self, schedule_id: str) -> bool:
+        """True when an execution this schedule started has not reached a terminal state."""
+        pass
+
+    @abstractmethod
+    def record_skip(self, schedule_id: str, run_time: datetime) -> None:
+        """Persist a skipped occurrence: count it and advance next_run_at."""
+        pass
+
+    @abstractmethod
     def get_schedule_history(
         self,
         schedule_id: str,
@@ -155,6 +166,7 @@ class DatabaseScheduleManager(ScheduleManager):
         input_data: Any = None,
         run_as_service_account: str | None = None,
         workflow_namespace: str = "default",
+        overlap_policy: str | None = None,
     ) -> ScheduleModel:
         """Create a new schedule"""
         try:
@@ -183,6 +195,7 @@ class DatabaseScheduleManager(ScheduleManager):
                     description=description,
                     input_data=input_data,
                     run_as_service_account=run_as_service_account,
+                    overlap_policy=overlap_policy,
                 )
 
                 session.add(schedule_model)
@@ -452,6 +465,64 @@ class DatabaseScheduleManager(ScheduleManager):
         except Exception:
             logger.error(
                 f"Failed to record run for schedule '{schedule_id}'",
+                exc_info=True,
+            )
+
+    def has_active_execution(self, schedule_id: str) -> bool:
+        """True when an execution this schedule started has not reached a terminal state.
+
+        Executions carry their originating ``schedule_id`` (indexed), so this is
+        a single bounded lookup rather than a scan. Called inside the dispatch
+        lock, which is what makes the check-then-dispatch sequence safe against
+        another replica firing the same schedule concurrently.
+
+        Fails **open** (returns False, so the schedule dispatches) — a lookup
+        error must not silently stop a schedule from ever running again.
+        """
+        from flux.domain.events import ExecutionState
+
+        terminal = (
+            ExecutionState.COMPLETED,
+            ExecutionState.FAILED,
+            ExecutionState.CANCELLED,
+        )
+        try:
+            with self._repository.session() as session:
+                return (
+                    session.query(ExecutionContextModel.execution_id)
+                    .filter(
+                        ExecutionContextModel.schedule_id == schedule_id,
+                        ExecutionContextModel.state.notin_(terminal),
+                    )
+                    .first()
+                    is not None
+                )
+        except Exception:
+            logger.error(
+                f"Overlap check failed for schedule '{schedule_id}'; dispatching anyway",
+                exc_info=True,
+            )
+            return False
+
+    def record_skip(self, schedule_id: str, run_time: datetime) -> None:
+        """Persist a skipped occurrence and advance to the next one.
+
+        Never raises — see ``record_run``. Advancing matters: without it the
+        schedule stays due and is re-evaluated on every poll.
+        """
+        try:
+            with self._repository.session() as session:
+                model = session.query(ScheduleModel).filter(ScheduleModel.id == schedule_id).first()
+                if model is None:
+                    logger.warning(
+                        f"Schedule '{schedule_id}' disappeared before its skip could be recorded",
+                    )
+                    return
+                model.mark_skipped(run_time)
+                session.commit()
+        except Exception:
+            logger.error(
+                f"Failed to record skip for schedule '{schedule_id}'",
                 exc_info=True,
             )
 

--- a/flux/server.py
+++ b/flux/server.py
@@ -18,6 +18,7 @@ from slowapi.middleware import SlowAPIMiddleware
 from flux import ExecutionContext
 from flux.catalogs import WorkflowCatalog, WorkflowInfo
 from flux.config import Configuration
+from flux.domain.schedule import OVERLAP_SKIP
 from flux.workflow import workflow
 from flux.context_managers import ContextManager
 from flux.errors import WorkflowNotFoundError
@@ -1019,6 +1020,22 @@ class Server(
                         # Trigger each due schedule
                         for schedule in due_schedules:
                             try:
+                                # Overlap guard. Inside the dispatch lock, so the
+                                # check-then-dispatch pair cannot interleave with
+                                # another replica firing the same schedule. The
+                                # skip still advances next_run_at -- otherwise the
+                                # schedule stays due and is re-checked every poll.
+                                if (
+                                    schedule.effective_overlap_policy == OVERLAP_SKIP
+                                    and schedule_manager.has_active_execution(schedule.id)
+                                ):
+                                    logger.info(
+                                        f"Skipping schedule '{schedule.name}': previous "
+                                        "execution is still running (overlap policy: skip)",
+                                    )
+                                    schedule_manager.record_skip(schedule.id, current_time)
+                                    continue
+
                                 await self._trigger_scheduled_workflow(schedule, current_time)
                             except Exception as e:
                                 # The trigger path already recorded the failure before

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.66.0"
+version = "0.67.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.65.0"
+version = "0.66.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_migrations.py
+++ b/tests/flux/test_migrations.py
@@ -13,7 +13,7 @@ import flux.security.models  # noqa: F401
 from flux.migrations.runner import current_revision, run_migrations
 from flux.models import Base
 
-HEAD = "0013_worker_metadata"
+HEAD = "0014_schedule_overlap_policy"
 BASELINE = "0001_baseline"
 
 # A representative index added after the original create_all schema, used to

--- a/tests/flux/test_migrations_postgresql.py
+++ b/tests/flux/test_migrations_postgresql.py
@@ -28,7 +28,7 @@ pytestmark = [
     ),
 ]
 
-HEAD = "0013_worker_metadata"
+HEAD = "0014_schedule_overlap_policy"
 _BACKFILL_INDEX = "ix_executions_workflow_id"
 
 

--- a/tests/flux/test_schedule_http_namespace.py
+++ b/tests/flux/test_schedule_http_namespace.py
@@ -141,3 +141,53 @@ async def process(ctx):
     assert billing_body["workflow_namespace"] == "billing"
     assert analytics_body["workflow_namespace"] == "analytics"
     assert billing_body["workflow_id"] != analytics_body["workflow_id"]
+
+
+def _register_hello(client):
+    source = b"""
+from flux import workflow
+
+@workflow
+async def hello(ctx):
+    return "hi"
+"""
+    r = _register_source(client, source, "hello.py")
+    assert r.status_code == 200, r.text
+
+
+@pytest.mark.parametrize(
+    "bad_config,detail_fragment",
+    [
+        ({"type": "cron", "cron_expression": "not a cron"}, "cron"),
+        ({"type": "cron", "cron_expression": "* * * * *", "overlap": "bogus"}, "overlap"),
+        ({"type": "cron", "cron_expression": "* * * * *", "timezone": "Mars/Olympus"}, "timezone"),
+    ],
+    ids=["bad-cron", "bad-overlap", "bad-timezone"],
+)
+def test_malformed_schedule_config_is_a_client_error(client, bad_config, detail_fragment):
+    """A malformed payload is the caller's fault -- 400, not a 500 leaking an
+    internal failure. schedule_factory raises ValueError for each of these."""
+    _register_hello(client)
+
+    r = client.post(
+        "/schedules",
+        json={"workflow_name": "hello", "name": "sched", "schedule_config": bad_config},
+    )
+    assert r.status_code == 400, f"expected 400, got {r.status_code}: {r.text}"
+    assert detail_fragment in r.text.lower()
+
+
+def test_invalid_overlap_policy_field_is_a_client_error(client):
+    _register_hello(client)
+
+    r = client.post(
+        "/schedules",
+        json={
+            "workflow_name": "hello",
+            "name": "sched",
+            "schedule_config": {"type": "cron", "cron_expression": "* * * * *"},
+            "overlap_policy": "sometimes",
+        },
+    )
+    assert r.status_code == 400, f"expected 400, got {r.status_code}: {r.text}"
+    assert "overlap" in r.text.lower()

--- a/tests/flux/test_schedule_overlap.py
+++ b/tests/flux/test_schedule_overlap.py
@@ -108,27 +108,27 @@ def test_no_executions_means_no_overlap(manager):
     assert manager.has_active_execution(_create(manager).id) is False
 
 
-@pytest.mark.parametrize(
-    "state",
-    [
-        ExecutionState.CREATED,
-        ExecutionState.SCHEDULED,
-        ExecutionState.CLAIMED,
-        ExecutionState.RUNNING,
-        ExecutionState.PAUSED,
-        ExecutionState.CANCELLING,
-    ],
-)
+#: The query is `state NOT IN (terminal)`, so every other state counts as an
+#: overlap. Derived from the enum rather than listed, so a state added later is
+#: covered automatically instead of silently escaping these tests.
+TERMINAL_STATES = (ExecutionState.COMPLETED, ExecutionState.FAILED, ExecutionState.CANCELLED)
+NON_TERMINAL_STATES = [s for s in ExecutionState if s not in TERMINAL_STATES]
+
+
+def test_the_state_split_covers_the_whole_enum():
+    """Guards the two parametrizations below against drift in ExecutionState."""
+    assert set(NON_TERMINAL_STATES) | set(TERMINAL_STATES) == set(ExecutionState)
+    assert not set(NON_TERMINAL_STATES) & set(TERMINAL_STATES)
+
+
+@pytest.mark.parametrize("state", NON_TERMINAL_STATES)
 def test_non_terminal_execution_is_an_overlap(manager, state):
     sch = _create(manager)
     _add_execution(manager, sch.id, f"exec-{state.value}", state)
     assert manager.has_active_execution(sch.id) is True
 
 
-@pytest.mark.parametrize(
-    "state",
-    [ExecutionState.COMPLETED, ExecutionState.FAILED, ExecutionState.CANCELLED],
-)
+@pytest.mark.parametrize("state", TERMINAL_STATES)
 def test_terminal_execution_is_not_an_overlap(manager, state):
     sch = _create(manager)
     _add_execution(manager, sch.id, f"exec-{state.value}", state)

--- a/tests/flux/test_schedule_overlap.py
+++ b/tests/flux/test_schedule_overlap.py
@@ -1,0 +1,237 @@
+"""Overlap policy: a due fire must not stack on a still-running execution.
+
+The dispatch cycle used to be trigger-and-forget, so a workflow slower than its
+own interval accumulated concurrent executions without bound -- every worker
+slot filling with copies of one schedule while unrelated work starved.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from flux.config import Configuration
+from flux.domain.events import ExecutionState
+from flux.domain.schedule import interval
+from flux.schedule_manager import create_schedule_manager
+
+
+@pytest.fixture
+def manager(tmp_path):
+    Configuration.get().override(database_url=f"sqlite:///{tmp_path / 'overlap.db'}")
+    from flux.models import DatabaseRepository
+
+    DatabaseRepository._engines.clear()
+    yield create_schedule_manager()
+    DatabaseRepository._engines.clear()
+
+
+def _create(manager, name="s1", **kwargs):
+    return manager.create_schedule(
+        workflow_id="wid",
+        workflow_name="wf",
+        workflow_namespace="default",
+        name=name,
+        schedule=kwargs.pop("schedule", interval(minutes=5)),
+        **kwargs,
+    )
+
+
+def _add_execution(manager, schedule_id, execution_id, state):
+    from flux.models import ExecutionContextModel
+
+    with manager._repository.session() as session:
+        session.add(
+            ExecutionContextModel(
+                execution_id=execution_id,
+                workflow_id="wid",
+                workflow_name="wf",
+                input=None,
+                state=state,
+                schedule_id=schedule_id,
+            ),
+        )
+        session.commit()
+
+
+def _future():
+    return datetime.now(timezone.utc) + timedelta(days=1)
+
+
+def _make_due_now(manager, schedule_id):
+    """Backdate next_run_at so the real scheduler loop, which uses wall-clock
+    ``datetime.now()``, sees this schedule as due in the cycle under test."""
+    from flux.models import ScheduleModel
+
+    with manager._repository.session() as session:
+        row = session.query(ScheduleModel).filter(ScheduleModel.id == schedule_id).first()
+        row.next_run_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+        session.commit()
+
+
+# -- policy resolution ---------------------------------------------------------
+
+
+def test_new_schedules_default_to_skip(manager):
+    assert _create(manager).effective_overlap_policy == "skip"
+
+
+def test_policy_comes_off_the_schedule_object(manager):
+    sch = _create(manager, schedule=interval(minutes=5, overlap="allow"))
+    assert manager.get_schedule(sch.id).effective_overlap_policy == "allow"
+
+
+def test_explicit_argument_wins_over_the_schedule_object(manager):
+    sch = _create(manager, schedule=interval(minutes=5, overlap="skip"), overlap_policy="allow")
+    assert manager.get_schedule(sch.id).effective_overlap_policy == "allow"
+
+
+def test_null_policy_reads_as_allow(manager):
+    """Rows written before this column existed keep their old behavior."""
+    from flux.models import ScheduleModel
+
+    sch = _create(manager)
+    with manager._repository.session() as session:
+        row = session.query(ScheduleModel).filter(ScheduleModel.id == sch.id).first()
+        row.overlap_policy = None  # simulate a pre-migration row
+        session.commit()
+
+    assert manager.get_schedule(sch.id).effective_overlap_policy == "allow"
+
+
+# -- the overlap query ---------------------------------------------------------
+
+
+def test_no_executions_means_no_overlap(manager):
+    assert manager.has_active_execution(_create(manager).id) is False
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        ExecutionState.CREATED,
+        ExecutionState.SCHEDULED,
+        ExecutionState.CLAIMED,
+        ExecutionState.RUNNING,
+        ExecutionState.PAUSED,
+        ExecutionState.CANCELLING,
+    ],
+)
+def test_non_terminal_execution_is_an_overlap(manager, state):
+    sch = _create(manager)
+    _add_execution(manager, sch.id, f"exec-{state.value}", state)
+    assert manager.has_active_execution(sch.id) is True
+
+
+@pytest.mark.parametrize(
+    "state",
+    [ExecutionState.COMPLETED, ExecutionState.FAILED, ExecutionState.CANCELLED],
+)
+def test_terminal_execution_is_not_an_overlap(manager, state):
+    sch = _create(manager)
+    _add_execution(manager, sch.id, f"exec-{state.value}", state)
+    assert manager.has_active_execution(sch.id) is False
+
+
+def test_another_schedules_execution_is_not_an_overlap(manager):
+    mine = _create(manager, name="mine")
+    theirs = _create(manager, name="theirs")
+    _add_execution(manager, theirs.id, "exec-theirs", ExecutionState.RUNNING)
+    assert manager.has_active_execution(mine.id) is False
+
+
+# -- recording a skip ----------------------------------------------------------
+
+
+def test_record_skip_counts_and_advances_without_marking_a_run(manager):
+    sch = _create(manager)
+    before = sch.next_run_at
+
+    manager.record_skip(sch.id, datetime.now(timezone.utc))
+
+    fresh = manager.get_schedule(sch.id)
+    assert fresh.skipped_count == 1
+    assert fresh.last_skipped_at is not None
+    assert fresh.next_run_at != before, "a skipped occurrence must still advance"
+    # Nothing ran, so the run stats must be untouched.
+    assert fresh.run_count == 0
+    assert fresh.last_run_at is None
+
+
+def test_skipped_schedule_stops_being_due(manager):
+    """Without the advance the schedule stays due and is re-checked every poll."""
+    sch = _create(manager)
+    assert [d.id for d in manager.get_due_schedules(current_time=_future())] == [sch.id]
+
+    manager.record_skip(sch.id, datetime.now(timezone.utc))
+
+    assert manager.get_due_schedules(current_time=datetime.now(timezone.utc)) == []
+
+
+def test_record_skip_on_deleted_schedule_does_not_raise(manager):
+    sch = _create(manager)
+    manager.delete_schedule(sch.id)
+    manager.record_skip(sch.id, datetime.now(timezone.utc))
+
+
+# -- the dispatch decision -----------------------------------------------------
+
+
+async def _run_one_scheduler_cycle(server):
+    """Drive the real ``_scheduler_loop`` through exactly one iteration.
+
+    The loop sleeps *before* doing its work, so clearing the run flag from the
+    patched sleep lets this cycle complete and then exits. Testing the real loop
+    matters: a test that re-implements the guard would pass even if the guard
+    were missing from the dispatch path.
+    """
+    server.scheduler_running = True
+    server.poll_interval = 0
+
+    async def _stop_after_this_cycle(_seconds):
+        server.scheduler_running = False
+
+    with patch("flux.server.asyncio.sleep", _stop_after_this_cycle):
+        await server._scheduler_loop()
+
+
+async def test_dispatch_skips_when_a_previous_execution_is_still_running(manager):
+    """The guard fires inside the real loop: no execution created, skip recorded."""
+    from flux.server import Server
+
+    sch = _create(manager, name="busy")
+    _add_execution(manager, sch.id, "exec-inflight", ExecutionState.RUNNING)
+    _make_due_now(manager, sch.id)
+
+    server = Server("127.0.0.1", 0)
+    with patch.object(Server, "_create_execution") as create:
+        await _run_one_scheduler_cycle(server)
+        # The guard must short-circuit before the trigger path builds anything.
+        create.assert_not_called()
+
+    fresh = manager.get_schedule(sch.id)
+    assert fresh.skipped_count == 1
+    assert fresh.run_count == 0
+    assert fresh.last_run_at is None
+
+
+async def test_allow_policy_still_dispatches_over_a_running_execution(manager):
+    """Back-compat: the historical behavior is preserved for allow."""
+    from flux.server import Server
+
+    sch = _create(manager, name="stacker", schedule=interval(minutes=5, overlap="allow"))
+    _add_execution(manager, sch.id, "exec-inflight", ExecutionState.RUNNING)
+    _make_due_now(manager, sch.id)
+
+    server = Server("127.0.0.1", 0)
+    mock_ctx = MagicMock()
+    mock_ctx.execution_id = "exec-second"
+    with patch.object(Server, "_create_execution", return_value=mock_ctx) as create:
+        await _run_one_scheduler_cycle(server)
+        create.assert_called_once()
+
+    fresh = manager.get_schedule(sch.id)
+    assert fresh.run_count == 1, "allow must still dispatch over a running execution"
+    assert fresh.skipped_count == 0


### PR DESCRIPTION
Closes #142.

## Problem

The dispatch cycle was trigger-and-forget: it selected everything whose `next_run_at` had passed and fired it, with no check on whether the previous execution of that schedule was still going.

A workflow slower than its own interval therefore accumulated concurrent executions without bound — a 5-minute workflow on a `*/1` cron settles at ~5 in flight, and any transient slowdown compounds from there. On a small worker pool every slot fills with copies of one schedule while unrelated work starves.

`dispatch_lock` already stopped two replicas firing the same schedule in one cycle, but that is a different axis and says nothing about the prior run.

## Change

Schedules carry an **overlap policy**:

- **`skip`** — a due fire whose schedule still has a non-terminal execution is dropped and advanced to the next occurrence.
- **`allow`** — the previous behaviour.

The check runs **inside the dispatch lock the cycle already holds**, so check-then-dispatch cannot interleave with another replica. It is a single indexed lookup — executions already carried an indexed `schedule_id`, so no schema work was needed for the detection itself.

Exposed as `cron(..., overlap=...)`, `interval(..., overlap=...)`, `once(..., overlap=...)`, the API's `overlap_policy` field, and `flux schedule create --overlap skip|allow`.

## Existing schedules are untouched

`overlap_policy` is nullable with no server default. NULL reads as `allow` through `effective_overlap_policy`, so **upgrading changes nothing for anyone already running**. Only schedules created after this revision default to `skip`.

That does mean two schedules created either side of the upgrade behave differently. The alternative — defaulting everything to `skip` — would silently change the behaviour of running production schedules on upgrade, which seemed clearly worse.

## Keeping a skip visible

A skip produces no execution, and schedule history is *derived* from executions (`get_schedule_history` reads `executions.schedule_id`; there is no schedule-runs table). Without accounting, a schedule skipping every fire would look idle.

So `skipped_count` and `last_skipped_at` sit alongside the existing run stats and surface in `flux schedule show` when non-zero. `mark_run` and `mark_skipped` share the advance, so a skipped occurrence moves `next_run_at` exactly like a dispatched one — without that the schedule stays due and is re-evaluated on every poll.

## Deliberate call: the overlap lookup fails open

If the query errors, the schedule dispatches anyway. A broken check must not silently stop a schedule from ever running again. Failing closed is defensible if you would rather never risk a stack — worth a look during review.

## Testing

The dispatch tests drive the **real `_scheduler_loop`** through one iteration rather than re-implementing its guard — the loop sleeps before working, so clearing the run flag from a patched sleep yields exactly one cycle. Verified discriminating: removing the guard from `server.py` fails `test_dispatch_skips_when_a_previous_execution_is_still_running`, and it passes again when restored.

Covered: policy resolution (default, from the schedule object, explicit override, NULL-reads-as-allow); the overlap query across **all nine non-terminal and three terminal states**, derived from `ExecutionState` with a guard test asserting the split still covers the whole enum; that another schedule's execution does not count; skip accounting and advance, including that `run_count`/`last_run_at` stay untouched; a skipped schedule stops being due; a deleted schedule does not raise; both policies through the real loop; and 400-on-malformed-payload for bad cron, timezone, and overlap.

Migration `0014` follows the `0013` convention of inspecting before adding — the legacy-database test builds the schema from current ORM metadata and then replays migrations, so a plain `add_column` fails with `duplicate column name`. Both migration `HEAD` constants (SQLite and PostgreSQL) are updated; they are separate, and missing the PostgreSQL one is what failed the first CI run.

## Review follow-ups (c09cfc5)

- **Malformed `schedule_config` returned 500.** `schedule_factory` raises `ValueError` for a bad cron expression, unknown timezone, or — newly from this branch — an invalid `overlap`, and it fell through to the route's generic handler. Now wrapped, answering 400. This branch widened that surface by adding `overlap` to `from_dict`, so the regression is ours even though the bad-cron and bad-timezone paths predate it. Four tests, each verified to fail (500) against the un-wrapped route.
- **`Schedule.__init__` docstring** claimed pre-existing schedules "read as allow", which is true of stored rows but not of the object being documented. Corrected to attribute the rule to `ScheduleModel.effective_overlap_policy`.
- **Non-terminal state coverage** listed six states while the query is `state NOT IN (terminal)`, leaving `RESUMING`, `RESUME_SCHEDULED` and `RESUME_CLAIMED` untested. Both parametrizations are now derived from the enum.

## Verification

- Unit: **3060 passed**, 21 skipped
- Lint: `pre-commit run --all-files` clean
- Migrations: SQLite suite green; the PostgreSQL suite cannot run in the dev sandbox (docker CLI present, no daemon), so that gate is covered by CI
- E2E: passing in CI

Minor bump to 0.67.0 — new schedules change behaviour by default, and main reached 0.66.0 independently.