### PR TITLE
fix(cli): make agent definition files apply idempotently (#148)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ poetry run flux execution list|show
 poetry run flux schedule create|list|show|pause|resume|history|delete
 poetry run flux secrets   set|get|list|remove
 poetry run flux config    set|get|list|remove
-poetry run flux agent     create|list|show|update|delete
+poetry run flux agent     create|apply|list|show|update|delete
 poetry run flux roles | principals | auth                        # security admin
 poetry run flux server bootstrap-token                           # print the auto-generated worker token
 ```

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -2308,6 +2308,57 @@ def agent():
     pass
 
 
+def _inline_agent_file_refs(data: dict) -> dict:
+    """Inline ``tools_file``/``workflow_file``/``skills_dir`` references.
+
+    A definition travels with its code: path references are read on the
+    client and stored as *content* (``skills_dir`` as a JSON bundle of the
+    skill tree). Values that are already content — a multiline scalar, or a
+    JSON object — pass through untouched, so an already-inlined definition
+    round-trips. A single-line value that does not resolve on disk fails
+    loudly: silently storing the path string is the corruption described in
+    issue #148.
+    """
+    for key in ("tools_file", "workflow_file"):
+        value = data.get(key)
+        if not value or not isinstance(value, str):
+            continue
+        if "\n" in value:
+            continue
+        path = Path(value)
+        if path.is_file():
+            data[key] = path.read_text()
+        else:
+            raise click.ClickException(
+                f"{key} '{value}' does not exist (expected a file path or inline content)",
+            )
+
+    value = data.get("skills_dir")
+    if value and isinstance(value, str):
+        try:
+            already_bundled = isinstance(json.loads(value), dict)
+        except ValueError:
+            already_bundled = False
+        if not already_bundled:
+            skills_path = Path(value)
+            if not skills_path.is_dir():
+                raise click.ClickException(
+                    f"skills_dir '{value}' is not a directory "
+                    "(expected a directory path or a bundled skills JSON object)",
+                )
+            skills_data = {}
+            for skill_dir in sorted(skills_path.iterdir()):
+                if skill_dir.is_dir() and (skill_dir / "SKILL.md").exists():
+                    skill_files = {}
+                    for f in sorted(skill_dir.rglob("*")):
+                        if f.is_file():
+                            rel = str(f.relative_to(skills_path))
+                            skill_files[rel] = f.read_text()
+                    skills_data[skill_dir.name] = skill_files
+            data["skills_dir"] = json.dumps(skills_data)
+    return data
+
+
 @agent.command("create")
 @click.argument("name")
 @click.option("--model", "-m", required=False, help="Model in provider/model_name format")
@@ -2405,29 +2456,7 @@ def create_agent(
         if reasoning_effort:
             data["reasoning_effort"] = reasoning_effort
 
-        if data.get("tools_file"):
-            tools_path = Path(data["tools_file"])
-            if tools_path.exists() and tools_path.is_file():
-                data["tools_file"] = tools_path.read_text()
-
-        if data.get("workflow_file"):
-            wf_path = Path(data["workflow_file"])
-            if wf_path.exists() and wf_path.is_file():
-                data["workflow_file"] = wf_path.read_text()
-
-        if data.get("skills_dir"):
-            skills_path = Path(data["skills_dir"])
-            if skills_path.is_dir():
-                skills_data = {}
-                for skill_dir in skills_path.iterdir():
-                    if skill_dir.is_dir() and (skill_dir / "SKILL.md").exists():
-                        skill_files = {}
-                        for f in skill_dir.rglob("*"):
-                            if f.is_file():
-                                rel = str(f.relative_to(skills_path))
-                                skill_files[rel] = f.read_text()
-                        skills_data[skill_dir.name] = skill_files
-                data["skills_dir"] = json.dumps(skills_data)
+        data = _inline_agent_file_refs(data)
 
         definition = AgentDefinition(**data)
 
@@ -2441,6 +2470,8 @@ def create_agent(
         else:
             click.echo(f"Agent '{name}' created successfully.")
 
+    except click.ClickException:
+        raise
     except httpx.HTTPStatusError as ex:
         if ex.response.status_code == 409:
             click.echo(f"Agent '{name}' already exists.", err=True)
@@ -2560,20 +2591,31 @@ def update_agent(
     output_format,
     server_url,
 ):
-    """Update an agent definition."""
+    """Update an agent definition.
+
+    With -f, the file is the complete desired state (replace semantics,
+    mirroring how `create -f` reads it) and file references are inlined the
+    same way; other flags override on top of the file. Without -f, the
+    flags patch the stored definition.
+    """
     import yaml
+
+    from flux.agents.types import AgentDefinition
 
     try:
         base_url = server_url or get_server_url()
-        with get_http_client() as client:
-            get_resp = client.get(f"{base_url}/admin/agents/{name}")
-            get_resp.raise_for_status()
-            data = get_resp.json()
-
         if definition_file:
+            # Replace semantics: build the definition from the file alone.
+            # Merging the raw file over the stored row is what corrupted
+            # inlined tools_file/workflow_file/skills_dir content on every
+            # second apply (issue #148).
             with open(definition_file) as f:
-                file_data = yaml.safe_load(f)
-                data.update(file_data)
+                data = yaml.safe_load(f) or {}
+        else:
+            with get_http_client() as client:
+                get_resp = client.get(f"{base_url}/admin/agents/{name}")
+                get_resp.raise_for_status()
+                data = get_resp.json()
 
         if model:
             data["model"] = model
@@ -2593,6 +2635,10 @@ def update_agent(
 
         data["name"] = name
 
+        if definition_file:
+            data = _inline_agent_file_refs(data)
+            data = AgentDefinition(**data).model_dump()
+
         with get_http_client() as client:
             put_resp = client.put(f"{base_url}/admin/agents/{name}", json=data)
             put_resp.raise_for_status()
@@ -2602,6 +2648,8 @@ def update_agent(
         else:
             click.echo(f"Agent '{name}' updated successfully.")
 
+    except click.ClickException:
+        raise
     except httpx.HTTPStatusError as ex:
         if ex.response.status_code == 404:
             click.echo(f"Agent '{name}' not found.", err=True)
@@ -2611,6 +2659,76 @@ def update_agent(
         click.echo(f"Cannot connect to server at {server_url or get_server_url()}", err=True)
     except Exception as ex:
         click.echo(f"Error updating agent: {str(ex)}", err=True)
+
+
+@agent.command("apply")
+@click.argument("name", required=False)
+@click.option(
+    "--file",
+    "-f",
+    "definition_file",
+    type=click.Path(exists=True),
+    required=True,
+    help="YAML definition file (the complete desired state)",
+)
+@click.option(
+    "--format",
+    "-F",
+    "output_format",
+    type=click.Choice(["simple", "json"]),
+    default="simple",
+)
+@click.option("--server-url", "server_url", default=None, help="Flux server URL")
+def apply_agent(name, definition_file, output_format, server_url):
+    """Create or update an agent from a definition file (idempotent).
+
+    The file is the complete desired state: apply creates the agent when it
+    does not exist and replaces it when it does, so re-running the same file
+    always converges to the same agent. NAME defaults to the ``name`` field
+    in the file.
+    """
+    import yaml
+
+    from flux.agents.types import AgentDefinition
+
+    try:
+        with open(definition_file) as f:
+            data = yaml.safe_load(f) or {}
+        if name:
+            data["name"] = name
+        if not data.get("name"):
+            raise click.ClickException(
+                "Agent name missing: pass NAME or set 'name' in the definition file",
+            )
+        name = data["name"]
+
+        data = _inline_agent_file_refs(data)
+        payload = AgentDefinition(**data).model_dump()
+
+        base_url = server_url or get_server_url()
+        with get_http_client() as client:
+            action = "updated"
+            resp = client.put(f"{base_url}/admin/agents/{name}", json=payload)
+            if resp.status_code == 404:
+                action = "created"
+                resp = client.post(f"{base_url}/admin/agents", json=payload)
+                if resp.status_code == 409:
+                    # Lost a create race; the agent exists now — update it.
+                    action = "updated"
+                    resp = client.put(f"{base_url}/admin/agents/{name}", json=payload)
+            resp.raise_for_status()
+
+        if output_format == "json":
+            click.echo(json.dumps({"status": "ok", "name": name, "action": action}, indent=2))
+        else:
+            click.echo(f"Agent '{name}' {action} successfully.")
+
+    except click.ClickException:
+        raise
+    except httpx.ConnectError:
+        click.echo(f"Cannot connect to server at {server_url or get_server_url()}", err=True)
+    except Exception as ex:
+        click.echo(f"Error applying agent: {str(ex)}", err=True)
 
 
 @agent.command("delete")

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -2327,7 +2327,10 @@ def _inline_agent_file_refs(data: dict) -> dict:
             continue
         path = Path(value)
         if path.is_file():
-            data[key] = path.read_text()
+            try:
+                data[key] = path.read_text()
+            except (OSError, UnicodeDecodeError) as ex:
+                raise click.ClickException(f"Cannot read {key} '{value}': {ex}")
         else:
             raise click.ClickException(
                 f"{key} '{value}' does not exist (expected a file path or inline content)",
@@ -2353,7 +2356,12 @@ def _inline_agent_file_refs(data: dict) -> dict:
                     for f in sorted(skill_dir.rglob("*")):
                         if f.is_file():
                             rel = str(f.relative_to(skills_path))
-                            skill_files[rel] = f.read_text()
+                            try:
+                                skill_files[rel] = f.read_text()
+                            except (OSError, UnicodeDecodeError) as ex:
+                                raise click.ClickException(
+                                    f"Cannot read skills_dir file '{f}': {ex}",
+                                )
                     skills_data[skill_dir.name] = skill_files
             data["skills_dir"] = json.dumps(skills_data)
     return data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.66.1"
+version = "0.67.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_cli_agent_definitions.py
+++ b/tests/flux/test_cli_agent_definitions.py
@@ -1,0 +1,237 @@
+"""Agent definition files apply idempotently (issue #148).
+
+The bugs under test:
+
+- Bug 1 — ``create -f`` inlined ``tools_file``/``workflow_file``/``skills_dir``
+  content but ``update -f`` merged the raw YAML over the stored row, replacing
+  the inlined source with a path string on every second apply.
+- Bug 2 — ``update -f`` merged where the file reads as declarative: a key
+  removed from the file survived on the agent.
+- Gap 3 — no single idempotent "make the agent match this file" operation.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from flux.cli import _inline_agent_file_refs, cli
+
+TOOLS_SOURCE = "from flux import task\n\n\n@task\nasync def greet(name: str) -> str:\n    return f'hi {name}'\n"
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _mock_client(**responses):
+    """Build a MagicMock httpx client whose verbs return preset responses."""
+    client = MagicMock()
+    for verb, response in responses.items():
+        getattr(client, verb).return_value = response
+    client.__enter__ = MagicMock(return_value=client)
+    client.__exit__ = MagicMock(return_value=False)
+    return client
+
+
+def _response(status_code=200, body=None):
+    response = MagicMock()
+    response.status_code = status_code
+    response.raise_for_status = MagicMock()
+    response.json.return_value = body or {}
+    return response
+
+
+def _write_definition(tmp_path, **extra):
+    tools_path = tmp_path / "tools.py"
+    tools_path.write_text(TOOLS_SOURCE)
+    lines = [
+        "name: greeter",
+        "model: openai/gpt-4o",
+        "system_prompt: You greet people.",
+        f"tools_file: {tools_path}",
+    ]
+    lines += [f"{k}: {v}" for k, v in extra.items()]
+    definition = tmp_path / "agent.yaml"
+    definition.write_text("\n".join(lines) + "\n")
+    return definition
+
+
+class TestInlineHelper:
+    def test_multiline_content_passes_through(self):
+        data = {"tools_file": TOOLS_SOURCE, "workflow_file": "line1\nline2\n"}
+        out = _inline_agent_file_refs(dict(data))
+        assert out == data
+
+    def test_bundled_skills_json_passes_through(self):
+        bundle = json.dumps({"myskill": {"myskill/SKILL.md": "# skill"}})
+        out = _inline_agent_file_refs({"skills_dir": bundle})
+        assert out["skills_dir"] == bundle
+
+    def test_missing_path_fails_loudly(self):
+        import click
+
+        with pytest.raises(click.ClickException, match="does not exist"):
+            _inline_agent_file_refs({"tools_file": "./no_such_tools.py"})
+
+    def test_missing_skills_dir_fails_loudly(self):
+        import click
+
+        with pytest.raises(click.ClickException, match="not a directory"):
+            _inline_agent_file_refs({"skills_dir": "./no_such_skills"})
+
+    def test_skills_dir_is_bundled(self, tmp_path):
+        skill = tmp_path / "skills" / "hello"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("# hello skill")
+        out = _inline_agent_file_refs({"skills_dir": str(tmp_path / "skills")})
+        bundle = json.loads(out["skills_dir"])
+        assert bundle["hello"]["hello/SKILL.md"] == "# hello skill"
+
+
+class TestReapplyDoesNotCorrupt:
+    """Bug 1: the same file applied via create and then update must store
+    the same inlined content both times."""
+
+    @patch("flux.cli.httpx.Client")
+    def test_create_then_update_store_identical_content(self, client_class, runner, tmp_path):
+        definition = _write_definition(tmp_path)
+
+        client = _mock_client(post=_response(), put=_response(), get=_response())
+        client_class.return_value = client
+
+        result = runner.invoke(cli, ["agent", "create", "greeter", "-f", str(definition)])
+        assert result.exit_code == 0, result.output
+        created = client.post.call_args.kwargs["json"]
+        assert created["tools_file"] == TOOLS_SOURCE
+
+        result = runner.invoke(cli, ["agent", "update", "greeter", "-f", str(definition)])
+        assert result.exit_code == 0, result.output
+        updated = client.put.call_args.kwargs["json"]
+        assert updated["tools_file"] == TOOLS_SOURCE
+        assert updated == created
+
+
+class TestUpdateFileIsDeclarative:
+    """Bug 2: with -f the file is the complete desired state — a key absent
+    from the file must not survive from the stored definition."""
+
+    @patch("flux.cli.httpx.Client")
+    def test_key_removed_from_file_is_removed_from_agent(self, client_class, runner, tmp_path):
+        definition = _write_definition(tmp_path)  # no "planning" key
+
+        client = _mock_client(put=_response(), get=_response())
+        client_class.return_value = client
+
+        result = runner.invoke(cli, ["agent", "update", "greeter", "-f", str(definition)])
+        assert result.exit_code == 0, result.output
+        # Replace semantics never consult the stored row...
+        client.get.assert_not_called()
+        # ...so planning falls back to the model default rather than a stale
+        # stored True.
+        assert client.put.call_args.kwargs["json"]["planning"] is False
+
+    @patch("flux.cli.httpx.Client")
+    def test_flags_still_patch_without_file(self, client_class, runner):
+        stored = {
+            "name": "greeter",
+            "model": "openai/gpt-4o",
+            "system_prompt": "You greet people.",
+            "planning": True,
+        }
+        client = _mock_client(put=_response(), get=_response(body=dict(stored)))
+        client_class.return_value = client
+
+        result = runner.invoke(cli, ["agent", "update", "greeter", "--model", "openai/gpt-4.1"])
+        assert result.exit_code == 0, result.output
+        client.get.assert_called_once()
+        payload = client.put.call_args.kwargs["json"]
+        assert payload["model"] == "openai/gpt-4.1"
+        assert payload["planning"] is True  # untouched by the patch
+
+
+class TestApply:
+    """Gap 3: one idempotent operation meaning "make the agent match this
+    file"."""
+
+    @patch("flux.cli.httpx.Client")
+    def test_apply_updates_when_agent_exists(self, client_class, runner, tmp_path):
+        definition = _write_definition(tmp_path)
+        client = _mock_client(put=_response(200), post=_response())
+        client_class.return_value = client
+
+        result = runner.invoke(cli, ["agent", "apply", "-f", str(definition)])
+        assert result.exit_code == 0, result.output
+        assert "updated" in result.output
+        client.post.assert_not_called()
+        assert client.put.call_args.kwargs["json"]["tools_file"] == TOOLS_SOURCE
+
+    @patch("flux.cli.httpx.Client")
+    def test_apply_creates_when_agent_missing(self, client_class, runner, tmp_path):
+        definition = _write_definition(tmp_path)
+        client = _mock_client(put=_response(404), post=_response(200))
+        client_class.return_value = client
+
+        result = runner.invoke(cli, ["agent", "apply", "-f", str(definition)])
+        assert result.exit_code == 0, result.output
+        assert "created" in result.output
+        assert client.post.call_args.kwargs["json"]["tools_file"] == TOOLS_SOURCE
+
+    @patch("flux.cli.httpx.Client")
+    def test_apply_twice_sends_identical_payloads(self, client_class, runner, tmp_path):
+        definition = _write_definition(tmp_path)
+        client = _mock_client(put=_response(200))
+        client_class.return_value = client
+
+        assert runner.invoke(cli, ["agent", "apply", "-f", str(definition)]).exit_code == 0
+        first = client.put.call_args.kwargs["json"]
+        assert runner.invoke(cli, ["agent", "apply", "-f", str(definition)]).exit_code == 0
+        second = client.put.call_args.kwargs["json"]
+        assert first == second
+
+    @patch("flux.cli.httpx.Client")
+    def test_apply_recovers_from_create_race(self, client_class, runner, tmp_path):
+        definition = _write_definition(tmp_path)
+        client = _mock_client()
+        # First PUT: 404 (missing) → POST: 409 (someone else created it) →
+        # second PUT: 200.
+        client.put.side_effect = [_response(404), _response(200)]
+        client.post.return_value = _response(409)
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+        client_class.return_value = client
+
+        result = runner.invoke(cli, ["agent", "apply", "-f", str(definition)])
+        assert result.exit_code == 0, result.output
+        assert "updated" in result.output
+        assert client.put.call_count == 2
+
+    @patch("flux.cli.httpx.Client")
+    def test_apply_without_name_anywhere_errors(self, client_class, runner, tmp_path):
+        definition = tmp_path / "agent.yaml"
+        definition.write_text("model: openai/gpt-4o\nsystem_prompt: hi\n")
+        client_class.return_value = _mock_client(put=_response())
+
+        result = runner.invoke(cli, ["agent", "apply", "-f", str(definition)])
+        assert result.exit_code != 0
+        assert "name missing" in result.output.lower()
+
+
+class TestFailLoudOnBrokenReference:
+    @patch("flux.cli.httpx.Client")
+    def test_create_with_missing_tools_file_errors(self, client_class, runner, tmp_path):
+        definition = tmp_path / "agent.yaml"
+        definition.write_text(
+            "name: greeter\nmodel: openai/gpt-4o\nsystem_prompt: hi\ntools_file: ./gone.py\n",
+        )
+        client = _mock_client(post=_response())
+        client_class.return_value = client
+
+        result = runner.invoke(cli, ["agent", "create", "greeter", "-f", str(definition)])
+        assert result.exit_code != 0
+        assert "does not exist" in result.output
+        client.post.assert_not_called()

--- a/tests/flux/test_cli_agent_definitions.py
+++ b/tests/flux/test_cli_agent_definitions.py
@@ -84,6 +84,27 @@ class TestInlineHelper:
         with pytest.raises(click.ClickException, match="not a directory"):
             _inline_agent_file_refs({"skills_dir": "./no_such_skills"})
 
+    def test_unreadable_file_fails_loudly(self, tmp_path):
+        """A read that raises (here: undecodable bytes) must surface as a
+        ClickException, not fall into the commands' generic handler that
+        prints and exits 0."""
+        import click
+
+        bad = tmp_path / "tools.py"
+        bad.write_bytes(b"\xff\xfe\x00 not utf-8")
+        with pytest.raises(click.ClickException, match="Cannot read tools_file"):
+            _inline_agent_file_refs({"tools_file": str(bad)})
+
+    def test_unreadable_skill_file_fails_loudly(self, tmp_path):
+        import click
+
+        skill = tmp_path / "skills" / "hello"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("# hello")
+        (skill / "data.bin").write_bytes(b"\xff\xfe\x00binary")
+        with pytest.raises(click.ClickException, match="Cannot read skills_dir file"):
+            _inline_agent_file_refs({"skills_dir": str(tmp_path / "skills")})
+
     def test_skills_dir_is_bundled(self, tmp_path):
         skill = tmp_path / "skills" / "hello"
         skill.mkdir(parents=True)


### PR DESCRIPTION
Closes #148. PR2 in the issue sequence plan (follows #159).

## Problem

`flux agent create -f` inlines `tools_file`/`workflow_file`/`skills_dir` references into stored *content*, but `update -f` merged the raw YAML over the stored definition. Re-applying the same file therefore replaced the inlined source with a path string — silently, since a path is a valid `str` — breaking the agent on every second apply. `skills_dir` was the worst case: a bundled skill tree degraded to a path that no longer parses as JSON, so `has_skills_bundle()` flipped to `False`. Anyone keeping agent definitions in git hit this on the second run.

## Changes (the three fix directions from #148)

**Bug 1 — one inlining path.** `_inline_agent_file_refs` is now the single helper used by `create -f`, `update -f`, and the new `apply`. Values that are already content — a multiline scalar, or a JSON skills bundle — pass through untouched, so inlined definitions round-trip. A single-line reference that does not resolve on disk **fails loudly** with a `ClickException` instead of storing the path string.

**Bug 2 — `update -f` is declarative.** With `-f`, the file is the complete desired state (mirroring how `create` reads it); the stored row is not fetched or merged, so a key removed from the file is removed from the agent. Flag overrides (`--model`, …) still apply on top of the file. Flag-only updates without `-f` keep today's patch semantics unchanged.

**Gap 3 — idempotent apply.** `flux agent apply [NAME] -f file` upserts: PUT, POST on 404, and a second PUT if it loses a create race to a concurrent client. NAME defaults to the file's `name` field. Applying the same file twice converges to the same agent. Server routes are unchanged; the client-side validation via `AgentDefinition` runs before any request.

## Tests

`tests/flux/test_cli_agent_definitions.py`: create-then-update stores identical inlined content; bundled-skills and multiline-content pass-through; declarative replace drops removed keys and never consults the stored row; flag-only update still patches; apply creates/updates/recovers from the create race and sends identical payloads on repeat; broken or unreadable references fail loudly without reaching the server.

## Verification

- `pre-commit`: passed
- Unit suite (`pytest tests/ --ignore=tests/e2e`): 3054 passed, 21 skipped
- E2E (`-m "not ollama"`): 139 passed; the only 2 failures are the github-stars examples hitting `api.github.com`, blocked (403) in this sandbox — same pre-existing environmental failures as on #159, expected green in CI
- Version 0.66.1 → 0.67.0 (new CLI command)