### PR TITLE
feat(scheduling): overlap policy, park TTL, and pause wakes (#142, #157, #145)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ Implementation hot-spots:
 - `execution_context.py` — `ExecutionContext[T]` (Generic over input type). State is a `ContextVar`; tasks call `await ExecutionContext.get()` to retrieve the current context — never pass it manually. `ctx.checkpoint()` flushes events through the registered checkpoint callable (server-side: HTTP POST; inline: SQLAlchemy save).
 - `events.py` — `ExecutionState` (CREATED → SCHEDULED → CLAIMED → RUNNING → COMPLETED/FAILED/CANCELLED, with PAUSED/RESUMING/RESUME_SCHEDULED/RESUME_CLAIMED/CANCELLING intermediates) and `ExecutionEventType` (workflow + task lifecycle, plus retry/fallback/rollback variants). Convenience flags on `ExecutionContext`: `has_finished`, `has_succeeded`, `has_failed`, `is_paused`, `is_cancelled`, `is_resuming`.
 - `resource_request.py` — used by both resource matching and label affinity.
-- `schedule.py` — `cron(...)`, `interval(...)`, `once(...)` factories; `schedule_factory` builds them from raw config.
+- `schedule.py` — `cron(...)`, `interval(...)`, `once(...)` factories (each takes `overlap="skip"|"allow"` — issue #142; NULL rows from before the policy read as allow); `schedule_factory` builds them from raw config.
 
 ### Persistence
 
@@ -125,7 +125,7 @@ Higher-level managers wrap the repositories:
 
 - `builtins.py` — `parallel`, `pipeline`, `now`, `sleep`, `uuid4`, `choice`, `randint`.
 - `graph.py` — `Graph` for DAG composition with cycle detection.
-- `pause.py`, `call.py`, `progress.py`, `config_task.py`.
+- `pause.py` (`pause(name, until=|after=|on_complete=)` — wake conditions fire from the scheduler tick, distributed path only; issue #145), `call.py`, `progress.py`, `config_task.py`.
 - `ai/` — the agent system. `agent.py` is the user-facing `agent()` task; `agent_loop.py` is the shared tool-execution loop; provider modules (`ollama.py`, `openai.py`, `anthropic.py`, `gemini.py`) are each a `(factory, formatter)` pair conforming to the ABC in `formatter.py`. Other pieces: `agent_plan.py` (multi-step planning + replanning), `delegation.py` (sub-agents / workflow agents), `dreaming.py` (memory consolidation), `memory/`, `skills.py`, `tools/`, `tool_executor.py`, `approval.py` (human-in-the-loop tool approval).
 - `mcp/` — MCP *client* (Flux calling external MCP servers from a workflow). The MCP *server* exposing Flux workflows is `flux/mcp_server.py` / `flux/service_mcp.py`.
 
@@ -133,7 +133,7 @@ Higher-level managers wrap the repositories:
 
 - `flux/agents/` — first-class **AI agent harness**: `manager.py` (CRUD), `process.py` + `session.py` (conversation lifecycle), `template.py`, `tools_resolver.py`, plus `ui/` (terminal + Textual + web) and a static `web/index.html`. Agents are stored in the `agents` table and *also* mirrored into the configs table under `agent:<name>` so workflow templates can fetch them via `get_config`.
 - `flux/service_*` modules + `flux/service_mcp.py` — **Workflow services**: a workflow can be exposed as an HTTP endpoint or MCP tool with a stable name. `service_resolver.py` handles collision detection; `service_proxy.py` provides standalone MCP endpoints with lazy discovery.
-- `flux/schedule_manager.py` — runs inside the server process; polls scheduled workflows, dispatches them, and tracks history.
+- `flux/schedule_manager.py` — runs inside the server process; polls scheduled workflows, dispatches them, and tracks history. The scheduler tick (under the cross-replica dispatch lock) also runs the overlap-skip check (#142), the park-TTL sweep failing executions unclaimed past `executions.park_deadline` (#157), and the pause-wake pass resuming executions whose `wake_at`/`wake_on_complete` fired (#145) — wake columns are stamped atomically with the PAUSED state write in `flux/context_managers.py::_sync_wake_columns`.
 - `flux/observability/` — OpenTelemetry tracing/metrics + a Prometheus `/metrics` endpoint, gated by `[flux.observability] enabled` and the `observability` extra.
 
 ## Configuration

--- a/flux/api/schedule_routes.py
+++ b/flux/api/schedule_routes.py
@@ -63,6 +63,11 @@ class ScheduleRoutesMixin:
                 run_count=schedule.run_count,
                 failure_count=schedule.failure_count,
                 run_as_service_account=getattr(schedule, "run_as_service_account", None),
+                overlap_policy=getattr(schedule, "overlap_policy", None),
+                skip_count=getattr(schedule, "skip_count", None) or 0,
+                last_skipped_at=schedule.last_skipped_at.isoformat()
+                if getattr(schedule, "last_skipped_at", None)
+                else None,
             )
 
         def _resolve_schedule_id_or_name(schedule_id_or_name: str, schedule_manager):

--- a/flux/api/schemas.py
+++ b/flux/api/schemas.py
@@ -111,6 +111,11 @@ class ScheduleResponse(BaseModel):
     run_count: int
     failure_count: int
     run_as_service_account: str | None = None
+    # Overlap policy (issue #142): "skip" | "allow"; None on rows created
+    # before the policy existed (treated as "allow").
+    overlap_policy: str | None = None
+    skip_count: int = 0
+    last_skipped_at: str | None = None
 
 
 class ScheduleUpdateRequest(BaseModel):

--- a/flux/api/workflow_routes.py
+++ b/flux/api/workflow_routes.py
@@ -198,6 +198,7 @@ class WorkflowRoutesMixin:
             mode: str = "async",
             detailed: bool = False,
             version: int | None = None,
+            park_ttl: int | None = None,
             preferred_worker: str | None = Header(None, alias="X-Flux-Preferred-Worker"),
             identity: FluxIdentity = Depends(get_identity),
         ):
@@ -242,12 +243,22 @@ class WorkflowRoutesMixin:
                     if not preferred_worker or len(preferred_worker) > 256:
                         preferred_worker = None
 
+                # Per-run park-TTL override (issue #157): bounds how long this
+                # execution may wait unclaimed. None defers to the server
+                # default; 0 explicitly parks forever (batch callers).
+                if park_ttl is not None and park_ttl < 0:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="park_ttl must be >= 0 (0 disables the bound)",
+                    )
+
                 ctx = self._create_execution(
                     namespace,
                     workflow_name,
                     input,
                     version,
                     preferred_worker=preferred_worker,
+                    park_ttl=park_ttl,
                 )
                 manager = ContextManager.create()
 

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -1639,6 +1639,15 @@ def schedule():
     help="Service account to run the schedule as (required when auth is enabled)",
 )
 @click.option(
+    "--overlap",
+    type=click.Choice(["skip", "allow"]),
+    default="skip",
+    help=(
+        "What to do when a fire comes due while a previous execution is "
+        "still running: skip it (default) or dispatch anyway"
+    ),
+)
+@click.option(
     "--format",
     "-f",
     type=click.Choice(["simple", "json"]),
@@ -1661,6 +1670,7 @@ def create_schedule(
     description: str | None,
     input: str | None,
     run_as: str | None,
+    overlap: str,
     format: str,
     server_url: str | None,
 ):
@@ -1686,12 +1696,14 @@ def create_schedule(
                 "type": "cron",
                 "cron_expression": cron,
                 "timezone": timezone,
+                "overlap": overlap,
             }
         else:
             schedule_config = {
                 "type": "interval",
                 "interval_seconds": (interval_hours or 0) * 3600 + (interval_minutes or 0) * 60,
                 "timezone": timezone,
+                "overlap": overlap,
             }
 
         # Parse input if provided
@@ -1837,6 +1849,12 @@ def show_schedule(schedule_id: str, format: str, server_url: str | None):
             click.echo(f"Next run: {schedule.get('next_run_at', 'Not scheduled')}")
             click.echo(f"Total runs: {schedule['run_count']}")
             click.echo(f"Failures: {schedule['failure_count']}")
+            click.echo(f"Overlap policy: {schedule.get('overlap_policy') or 'allow'}")
+            if schedule.get("skip_count"):
+                click.echo(
+                    f"Skipped fires: {schedule['skip_count']} "
+                    f"(last: {schedule.get('last_skipped_at', 'unknown')})",
+                )
 
             if schedule.get("description"):
                 click.echo(f"Description: {schedule['description']}")

--- a/flux/config.py
+++ b/flux/config.py
@@ -92,6 +92,17 @@ class WorkersConfig(BaseConfig):
         default=7200,
         description="Seconds to keep offline workers in memory before pruning",
     )
+    park_ttl: int = Field(
+        default=0,
+        description=(
+            "Seconds an execution may wait unclaimed (parked — e.g. its "
+            "affinity currently matches no worker) before the server fails it "
+            "terminally with a diagnostic (issue #157). 0 disables the bound: "
+            "parked executions wait indefinitely, the historic behavior. "
+            "Per-run override via the park_ttl query parameter on the run "
+            "endpoints."
+        ),
+    )
     module_cache_ttl: int = Field(
         default=300,
         description="Seconds to cache compiled workflow modules (0 to disable)",

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC
 from abc import abstractmethod
 from collections.abc import Sequence
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import func
@@ -69,6 +70,7 @@ class ContextManager(ABC):
         *,
         uow: UnitOfWork | None = None,
         preferred_worker: str | None = None,
+        park_ttl: int | None = None,
     ) -> ExecutionContext:  # pragma: no cover
         raise NotImplementedError()
 
@@ -79,6 +81,7 @@ class ContextManager(ABC):
         *,
         uow: UnitOfWork | None = None,
         preferred_worker: str | None = None,
+        park_ttl: int | None = None,
     ) -> bool:  # pragma: no cover
         """Like ``save`` but report whether the state write was applied.
 
@@ -346,8 +349,9 @@ class DatabaseContextManager(ContextManager):
         *,
         uow: UnitOfWork | None = None,
         preferred_worker: str | None = None,
+        park_ttl: int | None = None,
     ) -> ExecutionContext:
-        self.save_checked(ctx, uow=uow, preferred_worker=preferred_worker)
+        self.save_checked(ctx, uow=uow, preferred_worker=preferred_worker, park_ttl=park_ttl)
         return ctx
 
     def save_checked(
@@ -356,6 +360,7 @@ class DatabaseContextManager(ContextManager):
         *,
         uow: UnitOfWork | None = None,
         preferred_worker: str | None = None,
+        park_ttl: int | None = None,
     ) -> bool:
         if uow is not None:
             return self._save_with_session(
@@ -363,6 +368,7 @@ class DatabaseContextManager(ContextManager):
                 uow.session,
                 manage_transaction=False,
                 preferred_worker=preferred_worker,
+                park_ttl=park_ttl,
             )
         with self.session() as session:
             return self._save_with_session(
@@ -370,6 +376,7 @@ class DatabaseContextManager(ContextManager):
                 session,
                 manage_transaction=True,
                 preferred_worker=preferred_worker,
+                park_ttl=park_ttl,
             )
 
     def _save_with_session(
@@ -379,6 +386,7 @@ class DatabaseContextManager(ContextManager):
         *,
         manage_transaction: bool,
         preferred_worker: str | None = None,
+        park_ttl: int | None = None,
     ) -> bool:
         try:
             model = self._lock_for_write(session, ctx.execution_id)
@@ -396,6 +404,19 @@ class DatabaseContextManager(ContextManager):
                     # pick a fresh row up immediately, so a hint written in a
                     # follow-up UPDATE could be missed.
                     new_model.preferred_worker = preferred_worker
+                # Park TTL (issue #157): per-run override wins; otherwise the
+                # config default. 0 / unset means park indefinitely (NULL).
+                from flux.config import Configuration as _Configuration
+
+                effective_park_ttl = (
+                    park_ttl
+                    if park_ttl is not None
+                    else _Configuration.get().settings.workers.park_ttl
+                )
+                if effective_park_ttl and effective_park_ttl > 0:
+                    new_model.park_deadline = datetime.now(timezone.utc) + timedelta(
+                        seconds=effective_park_ttl,
+                    )
                 session.add(new_model)
             if manage_transaction:
                 session.commit()
@@ -475,15 +496,75 @@ class DatabaseContextManager(ContextManager):
 
         return require_diagnostic(workflow.affinity, model.input)
 
-    def _fail_undispatchable(self, model, session: Session, diagnostic: str) -> None:
+    def _fail_undispatchable(
+        self,
+        model,
+        session: Session,
+        diagnostic: str,
+        error_type: str = "AffinityResolutionError",
+    ) -> None:
         ctx = model.to_plain()
         ctx.fail(
             ctx.execution_id,
-            {"type": "AffinityResolutionError", "message": diagnostic},
+            {"type": error_type, "message": diagnostic},
         )
         model.state = ctx.state
+        model.output = ctx.output
         session.add_all(self._get_additional_events(ctx, session))
         logger.warning(f"Execution {ctx.execution_id} failed at dispatch: {diagnostic}")
+
+    def fail_expired_parked(self, now: datetime | None = None) -> list[str]:
+        """Fail executions still unclaimed past their park deadline (issue #157).
+
+        A parked execution — state CREATED, waiting for a worker its
+        constraints match — normally waits indefinitely; that is right for
+        elastic batch fleets and wrong for an interactive caller, for whom a
+        park is indistinguishable from a hang. Rows that opted into a bound
+        (``park_deadline`` set at submission, from the per-run override or
+        the ``[flux.workers] park_ttl`` default) are failed terminally with a
+        diagnosable ``ParkTimeoutError`` once the deadline passes.
+
+        Runs in the scheduler tick under the dispatch lock. Row locks
+        (``skip_locked``) keep the sweep from racing a concurrent claim on
+        PostgreSQL: a row a worker is claiming right now is simply skipped
+        and re-examined next tick — by which time it is no longer CREATED.
+        Returns the failed execution ids.
+        """
+        if now is None:
+            now = datetime.now(timezone.utc)
+        failed: list[str] = []
+        with self.session() as session:
+            query = (
+                session.query(ExecutionContextModel, WorkflowModel)
+                .join(WorkflowModel)
+                .filter(
+                    ExecutionContextModel.state == ExecutionState.CREATED,
+                    ExecutionContextModel.park_deadline.isnot(None),
+                    ExecutionContextModel.park_deadline < now,
+                )
+                .with_for_update(skip_locked=True, of=ExecutionContextModel)
+            )
+            for model, workflow in query:
+                constraints: list[str] = []
+                if workflow.affinity:
+                    constraints.append(f"affinity={workflow.affinity!r}")
+                if workflow.requests:
+                    constraints.append("resource requests present")
+                detail = "; ".join(constraints) if constraints else "no declared constraints"
+                self._fail_undispatchable(
+                    model,
+                    session,
+                    (
+                        f"No eligible worker claimed this execution before its "
+                        f"park deadline ({model.park_deadline}); {detail}. "
+                        "A worker matching the execution's constraints never "
+                        "became available within the park TTL."
+                    ),
+                    error_type="ParkTimeoutError",
+                )
+                failed.append(model.execution_id)
+            session.commit()
+        return failed
 
     def _next_matching_execution(
         self,

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -395,10 +395,12 @@ class DatabaseContextManager(ContextManager):
                 if accepted:
                     model.state = ctx.state
                     model.output = ctx.output
+                    self._sync_wake_columns(model, ctx)
                     session.add_all(self._get_additional_events(ctx, session))
             else:
                 accepted = True
                 new_model = ExecutionContextModel.from_plain(ctx)
+                self._sync_wake_columns(new_model, ctx)
                 if preferred_worker:
                     # Same transaction as the insert: event-mode dispatch can
                     # pick a fresh row up immediately, so a hint written in a
@@ -406,13 +408,18 @@ class DatabaseContextManager(ContextManager):
                     new_model.preferred_worker = preferred_worker
                 # Park TTL (issue #157): per-run override wins; otherwise the
                 # config default. 0 / unset means park indefinitely (NULL).
-                from flux.config import Configuration as _Configuration
+                # int() + fallback: a mocked/partial Configuration (common in
+                # tests) must degrade to "no deadline", never break a save.
+                effective_park_ttl = park_ttl
+                if effective_park_ttl is None:
+                    try:
+                        from flux.config import Configuration as _Configuration
 
-                effective_park_ttl = (
-                    park_ttl
-                    if park_ttl is not None
-                    else _Configuration.get().settings.workers.park_ttl
-                )
+                        effective_park_ttl = int(
+                            _Configuration.get().settings.workers.park_ttl,
+                        )
+                    except Exception:
+                        effective_park_ttl = 0
                 if effective_park_ttl and effective_park_ttl > 0:
                     new_model.park_deadline = datetime.now(timezone.utc) + timedelta(
                         seconds=effective_park_ttl,
@@ -447,6 +454,7 @@ class DatabaseContextManager(ContextManager):
             if _accept_state_write(ctx.state, model.state):
                 model.state = ctx.state
                 model.output = ctx.output
+                self._sync_wake_columns(model, ctx)
                 session.add_all(self._get_additional_events(ctx, session))
             session.commit()
             return ctx
@@ -565,6 +573,113 @@ class DatabaseContextManager(ContextManager):
                 failed.append(model.execution_id)
             session.commit()
         return failed
+
+    @staticmethod
+    def _sync_wake_columns(model, ctx: ExecutionContext) -> None:
+        """Mirror the pause's wake condition (issue #145) onto the row.
+
+        Stamped in the same transaction as the PAUSED state write — there is
+        no window in which the execution is PAUSED without its wake being
+        durable (the race class documented for approvals in #70). Every
+        non-PAUSED state write clears the columns, so resuming, cancelling,
+        or finishing an execution retires its pending wake atomically.
+        """
+        if ctx.state != ExecutionState.PAUSED:
+            model.wake_at = None
+            model.wake_on_complete = None
+            return
+
+        wake_at_raw: str | None = None
+        wake_on_complete: str | None = None
+        for event in reversed(ctx.events):
+            if event.type.value == "WORKFLOW_PAUSED":
+                value = event.value if isinstance(event.value, dict) else {}
+                wake_at_raw = value.get("wake_at")
+                wake_on_complete = value.get("wake_on_complete")
+                break
+        wake_at = None
+        if wake_at_raw:
+            try:
+                wake_at = datetime.fromisoformat(wake_at_raw)
+            except ValueError:
+                logger.error(
+                    f"Execution {ctx.execution_id}: unparsable wake_at "
+                    f"{wake_at_raw!r}; treating the pause as indefinite",
+                )
+        model.wake_at = wake_at
+        model.wake_on_complete = wake_on_complete or None
+
+    def fire_due_wakes(self, now: datetime | None = None) -> list[str]:
+        """Resume paused executions whose wake condition fired (issue #145).
+
+        Two conditions, read from the columns ``_sync_wake_columns`` stamps:
+        a timed wake (``wake_at <= now``) and a completion wake (the watched
+        execution reached a terminal state). Firing is exactly the operator
+        resume transition — ``start_resuming()`` — so downstream dispatch is
+        unchanged, and the resume's state write clears the wake columns, so
+        an overdue backlog after downtime fires each wake once.
+
+        Runs in the scheduler tick under the dispatch lock (one firing
+        replica). Returns the resumed execution ids.
+        """
+        if now is None:
+            now = datetime.now(timezone.utc)
+        terminal = (
+            ExecutionState.COMPLETED,
+            ExecutionState.FAILED,
+            ExecutionState.CANCELLED,
+        )
+        due: list[str] = []
+        with self.session() as session:
+            timed = (
+                session.query(ExecutionContextModel.execution_id)
+                .filter(
+                    ExecutionContextModel.state == ExecutionState.PAUSED,
+                    ExecutionContextModel.wake_at.isnot(None),
+                    ExecutionContextModel.wake_at <= now,
+                )
+                .all()
+            )
+            due.extend(row.execution_id for row in timed)
+
+            watchers = (
+                session.query(
+                    ExecutionContextModel.execution_id,
+                    ExecutionContextModel.wake_on_complete,
+                )
+                .filter(
+                    ExecutionContextModel.state == ExecutionState.PAUSED,
+                    ExecutionContextModel.wake_on_complete.isnot(None),
+                )
+                .all()
+            )
+            for execution_id, watched_id in watchers:
+                watched_state = (
+                    session.query(ExecutionContextModel.state)
+                    .filter(ExecutionContextModel.execution_id == watched_id)
+                    .scalar()
+                )
+                # A watched id that does not exist wakes immediately: waiting
+                # forever on a typo is strictly worse than resuming, and the
+                # workflow can inspect the child itself.
+                if watched_state is None or watched_state in terminal:
+                    due.append(execution_id)
+
+        resumed: list[str] = []
+        for execution_id in due:
+            try:
+                ctx = self.get(execution_id)
+                if not ctx.is_paused:
+                    continue  # raced a concurrent resume/cancel; theirs wins
+                ctx.start_resuming()
+                self.save(ctx)
+                resumed.append(execution_id)
+            except Exception:
+                logger.error(
+                    f"Failed to fire wake for execution {execution_id}",
+                    exc_info=True,
+                )
+        return resumed
 
     def _next_matching_execution(
         self,

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -653,12 +653,22 @@ class DatabaseContextManager(ContextManager):
                 )
                 .all()
             )
-            for execution_id, watched_id in watchers:
-                watched_state = (
-                    session.query(ExecutionContextModel.state)
-                    .filter(ExecutionContextModel.execution_id == watched_id)
-                    .scalar()
+            # One query for every watched execution's state, then check in
+            # memory — a per-watcher lookup would make the tick O(paused
+            # executions) round-trips.
+            watched_ids = {watched_id for _, watched_id in watchers}
+            watched_states = (
+                dict(
+                    session.query(
+                        ExecutionContextModel.execution_id,
+                        ExecutionContextModel.state,
+                    ).filter(ExecutionContextModel.execution_id.in_(watched_ids)),
                 )
+                if watched_ids
+                else {}
+            )
+            for execution_id, watched_id in watchers:
+                watched_state = watched_states.get(watched_id)
                 # A watched id that does not exist wakes immediately: waiting
                 # forever on a typo is strictly worse than resuming, and the
                 # workflow can inspect the child itself.

--- a/flux/domain/events.py
+++ b/flux/domain/events.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 from datetime import datetime
 from enum import Enum
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from flux.utils import FluxEncoder, make_hashable  # noqa: F401  (make_hashable kept for back-compat)
 
@@ -12,6 +12,10 @@ from flux.utils import FluxEncoder, make_hashable  # noqa: F401  (make_hashable 
 class PausedEventValue(TypedDict):
     name: str
     output: Any
+    # Wake condition (issue #145), present when the pause carries one.
+    # wake_at is ISO-8601 UTC; wake_on_complete is a watched execution id.
+    wake_at: NotRequired[str | None]
+    wake_on_complete: NotRequired[str | None]
 
 
 class ExecutionState(str, Enum):

--- a/flux/domain/execution_context.py
+++ b/flux/domain/execution_context.py
@@ -392,14 +392,28 @@ class ExecutionContext(Generic[WorkflowInputType]):
         )
         return event.value
 
-    def pause(self, id: str, name: str, output: Any = None) -> Self:
+    def pause(
+        self,
+        id: str,
+        name: str,
+        output: Any = None,
+        wake_at: str | None = None,
+        wake_on_complete: str | None = None,
+    ) -> Self:
         self._state = ExecutionState.PAUSED
+        value = PausedEventValue(name=name, output=output)
+        # Only record a wake when one was requested, so pre-#145 event
+        # shapes stay byte-identical for existing pauses.
+        if wake_at is not None:
+            value["wake_at"] = wake_at
+        if wake_on_complete is not None:
+            value["wake_on_complete"] = wake_on_complete
         self.events.append(
             ExecutionEvent(
                 type=ExecutionEventType.WORKFLOW_PAUSED,
                 source_id=id,
                 name=self.workflow_name,
-                value=PausedEventValue(name=name, output=output),
+                value=value,
                 subject=None,
             ),
         )

--- a/flux/domain/schedule.py
+++ b/flux/domain/schedule.py
@@ -27,14 +27,23 @@ class ScheduleStatus(Enum):
     DISABLED = "disabled"
 
 
+OVERLAP_POLICIES = ("skip", "allow")
+
+
 class Schedule(ABC):
     """Abstract base class for all schedule types"""
 
-    def __init__(self, timezone: str = "UTC"):
+    def __init__(self, timezone: str = "UTC", overlap: str = "skip"):
         """Initialize schedule with timezone
 
         Args:
             timezone: Timezone for schedule execution (default: UTC)
+            overlap: What to do when a fire comes due while a previous
+                execution of this schedule is still running (issue #142):
+                ``"skip"`` (default) skips the fire and advances
+                ``next_run_at``; ``"allow"`` dispatches regardless —
+                the pre-#142 behavior, and what schedules created before
+                the policy existed keep.
         """
         # Reject "local" timezone as it's not portable across systems
         if timezone == "local":
@@ -49,7 +58,13 @@ class Schedule(ABC):
         except Exception as e:
             raise ValueError(f"Invalid timezone '{timezone}': {e}")
 
+        if overlap not in OVERLAP_POLICIES:
+            raise ValueError(
+                f"Invalid overlap policy '{overlap}': expected one of {OVERLAP_POLICIES}",
+            )
+
         self.timezone = timezone
+        self.overlap = overlap
 
     @property
     @abstractmethod
@@ -96,14 +111,15 @@ class Schedule(ABC):
 class CronSchedule(Schedule):
     """Cron-based schedule implementation"""
 
-    def __init__(self, cron_expression: str, timezone: str = "UTC"):
+    def __init__(self, cron_expression: str, timezone: str = "UTC", overlap: str = "skip"):
         """Initialize cron schedule
 
         Args:
             cron_expression: Standard cron expression (5 or 6 fields)
             timezone: Timezone for schedule execution
+            overlap: Overlap policy ("skip" or "allow"), see Schedule
         """
-        super().__init__(timezone)
+        super().__init__(timezone, overlap)
 
         if not self._is_valid_cron(cron_expression):
             raise ValueError(f"Invalid cron expression: {cron_expression}")
@@ -166,6 +182,9 @@ class CronSchedule(Schedule):
             "type": ScheduleType.CRON.value,
             "cron_expression": self.cron_expression,
             "timezone": self.timezone,
+            # getattr: instances unpickled from rows created before the
+            # overlap policy existed have no attribute; they keep "allow".
+            "overlap": getattr(self, "overlap", "allow"),
         }
 
     @classmethod
@@ -174,6 +193,7 @@ class CronSchedule(Schedule):
         return cls(
             cron_expression=data["cron_expression"],
             timezone=data.get("timezone", "UTC"),
+            overlap=data.get("overlap", "skip"),
         )
 
 
@@ -190,6 +210,7 @@ class IntervalSchedule(Schedule):
         timezone: str = "UTC",
         start_time: datetime | None = None,
         end_time: datetime | None = None,
+        overlap: str = "skip",
     ):
         """Initialize interval schedule
 
@@ -202,8 +223,9 @@ class IntervalSchedule(Schedule):
             timezone: Timezone for schedule execution
             start_time: Optional start time for the schedule
             end_time: Optional end time for the schedule
+            overlap: Overlap policy ("skip" or "allow"), see Schedule
         """
-        super().__init__(timezone)
+        super().__init__(timezone, overlap)
 
         self.interval = timedelta(
             seconds=seconds,
@@ -272,6 +294,7 @@ class IntervalSchedule(Schedule):
             "type": ScheduleType.INTERVAL.value,
             "interval_seconds": int(self.interval.total_seconds()),
             "timezone": self.timezone,
+            "overlap": getattr(self, "overlap", "allow"),
             "start_time": self.start_time.isoformat() if self.start_time else None,
             "end_time": self.end_time.isoformat() if self.end_time else None,
             "last_run_time": self.last_run_time.isoformat() if self.last_run_time else None,
@@ -287,6 +310,7 @@ class IntervalSchedule(Schedule):
             if data.get("start_time")
             else None,
             end_time=datetime.fromisoformat(data["end_time"]) if data.get("end_time") else None,
+            overlap=data.get("overlap", "skip"),
         )
 
         if data.get("last_run_time"):
@@ -298,14 +322,15 @@ class IntervalSchedule(Schedule):
 class OnceSchedule(Schedule):
     """One-time schedule for specific datetime execution"""
 
-    def __init__(self, run_time: datetime, timezone: str = "UTC"):
+    def __init__(self, run_time: datetime, timezone: str = "UTC", overlap: str = "skip"):
         """Initialize one-time schedule
 
         Args:
             run_time: Specific time to run the workflow
             timezone: Timezone for schedule execution
+            overlap: Overlap policy ("skip" or "allow"), see Schedule
         """
-        super().__init__(timezone)
+        super().__init__(timezone, overlap)
         self.run_time = run_time
         self.executed = False
 
@@ -360,6 +385,7 @@ class OnceSchedule(Schedule):
             "run_time": self.run_time.isoformat(),
             "timezone": self.timezone,
             "executed": self.executed,
+            "overlap": getattr(self, "overlap", "allow"),
         }
 
     @classmethod
@@ -368,22 +394,24 @@ class OnceSchedule(Schedule):
         instance = cls(
             run_time=datetime.fromisoformat(data["run_time"]),
             timezone=data.get("timezone", "UTC"),
+            overlap=data.get("overlap", "skip"),
         )
         instance.executed = data.get("executed", False)
         return instance
 
 
-def cron(expression: str, timezone: str = "UTC") -> CronSchedule:
+def cron(expression: str, timezone: str = "UTC", overlap: str = "skip") -> CronSchedule:
     """Create a cron schedule
 
     Args:
         expression: Cron expression (e.g., "0 9 * * MON-FRI")
         timezone: Timezone for schedule execution
+        overlap: Overlap policy ("skip" or "allow"), see Schedule
 
     Returns:
         CronSchedule instance
     """
-    return CronSchedule(expression, timezone)
+    return CronSchedule(expression, timezone, overlap)
 
 
 def interval(
@@ -395,6 +423,7 @@ def interval(
     timezone: str = "UTC",
     start_time: datetime | None = None,
     end_time: datetime | None = None,
+    overlap: str = "skip",
 ) -> IntervalSchedule:
     """Create an interval schedule
 
@@ -407,6 +436,7 @@ def interval(
         timezone: Timezone for schedule execution
         start_time: Optional start time
         end_time: Optional end time
+        overlap: Overlap policy ("skip" or "allow"), see Schedule
 
     Returns:
         IntervalSchedule instance
@@ -420,20 +450,22 @@ def interval(
         timezone=timezone,
         start_time=start_time,
         end_time=end_time,
+        overlap=overlap,
     )
 
 
-def once(run_time: datetime, timezone: str = "UTC") -> OnceSchedule:
+def once(run_time: datetime, timezone: str = "UTC", overlap: str = "skip") -> OnceSchedule:
     """Create a one-time schedule
 
     Args:
         run_time: Specific time to run the workflow
         timezone: Timezone for schedule execution
+        overlap: Overlap policy ("skip" or "allow"), see Schedule
 
     Returns:
         OnceSchedule instance
     """
-    return OnceSchedule(run_time, timezone)
+    return OnceSchedule(run_time, timezone, overlap)
 
 
 def schedule_factory(data: dict[str, Any]) -> Schedule:

--- a/flux/errors.py
+++ b/flux/errors.py
@@ -102,12 +102,31 @@ class BudgetExceededError(ExecutionError):
 
 
 class PauseRequested(ExecutionError):
-    def __init__(self, name: str, output: Any = None):
+    def __init__(
+        self,
+        name: str,
+        output: Any = None,
+        wake_at: str | None = None,
+        wake_on_complete: str | None = None,
+    ):
         super().__init__(
             message="Pause Requested.",
         )
         self._name = name
         self._output = output
+        # Wake condition (issue #145). wake_at is an ISO-8601 UTC instant —
+        # already absolute, so replay re-records the same wake; wake_on_complete
+        # is an execution id to wake on when it reaches a terminal state.
+        self._wake_at = wake_at
+        self._wake_on_complete = wake_on_complete
+
+    @property
+    def wake_at(self) -> str | None:
+        return self._wake_at
+
+    @property
+    def wake_on_complete(self) -> str | None:
+        return self._wake_on_complete
 
     @property
     def name(self) -> str:

--- a/flux/migrations/versions/0015_schedule_overlap_policy.py
+++ b/flux/migrations/versions/0015_schedule_overlap_policy.py
@@ -1,0 +1,46 @@
+"""Add schedules.overlap_policy + skip statistics (issue #142).
+
+overlap_policy is "skip" | "allow"; NULL — every row created before the
+column existed — reads as "allow", the historic dispatch-regardless
+behavior, so upgrades change nothing silently. skip_count /
+last_skipped_at record overlap-skipped fires separately from run stats.
+
+Revision ID: 0015_schedule_overlap_policy
+Revises: 0014_task_cancelled_event
+Create Date: 2026-08-06
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0015_schedule_overlap_policy"
+down_revision: str | None = "0014_task_cancelled_event"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "schedules"
+_COLUMNS = (
+    ("overlap_policy", sa.String()),
+    ("skip_count", sa.Integer()),
+    ("last_skipped_at", sa.DateTime()),
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    for name, type_ in _COLUMNS:
+        if name not in existing:
+            op.add_column(_TABLE, sa.Column(name, type_, nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    for name, _ in _COLUMNS:
+        if name in existing:
+            op.drop_column(_TABLE, name)

--- a/flux/migrations/versions/0016_execution_park_deadline.py
+++ b/flux/migrations/versions/0016_execution_park_deadline.py
@@ -1,0 +1,41 @@
+"""Add executions.park_deadline: bound on unclaimed parking (issue #157).
+
+When set at submission (per-run park_ttl override or the
+[flux.workers] park_ttl default), an execution still unclaimed past this
+instant is failed terminally by the scheduler tick's sweep with a
+ParkTimeoutError diagnostic. NULL — the default and every pre-existing
+row — parks indefinitely, the historic behavior.
+
+Revision ID: 0016_execution_park_deadline
+Revises: 0015_schedule_overlap_policy
+Create Date: 2026-08-06
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0016_execution_park_deadline"
+down_revision: str | None = "0015_schedule_overlap_policy"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "executions"
+_COLUMN = "park_deadline"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    if _COLUMN not in existing:
+        op.add_column(_TABLE, sa.Column(_COLUMN, sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    if _COLUMN in existing:
+        op.drop_column(_TABLE, _COLUMN)

--- a/flux/migrations/versions/0017_pause_wakes.py
+++ b/flux/migrations/versions/0017_pause_wakes.py
@@ -1,0 +1,48 @@
+"""Add executions.wake_at / wake_on_complete: pause wake conditions (#145).
+
+A pause may now carry a wake condition — resume at an instant
+(pause(until=/after=)) or when another execution reaches a terminal state
+(pause(on_complete=)). The condition is stamped onto the execution row in
+the same transaction as the PAUSED state write and cleared by every other
+state write; the scheduler tick's wake pass reads the columns and fires
+the resume. NULL — the default and every pre-existing row — means the
+pause is indefinite, the historic behavior.
+
+Revision ID: 0017_pause_wakes
+Revises: 0016_execution_park_deadline
+Create Date: 2026-08-06
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0017_pause_wakes"
+down_revision: str | None = "0016_execution_park_deadline"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "executions"
+_COLUMNS = (
+    ("wake_at", sa.DateTime()),
+    ("wake_on_complete", sa.String()),
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    for name, type_ in _COLUMNS:
+        if name not in existing:
+            op.add_column(_TABLE, sa.Column(name, type_, nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    for name, _ in _COLUMNS:
+        if name in existing:
+            op.drop_column(_TABLE, name)

--- a/flux/models.py
+++ b/flux/models.py
@@ -901,9 +901,18 @@ class ScheduleModel(Base):
     # Service account to run scheduled executions as (required when auth is enabled)
     run_as_service_account = Column(String, nullable=True)
 
+    # Overlap policy (issue #142): "skip" | "allow". NULL — every row
+    # created before the column existed — reads as "allow", the pre-policy
+    # behavior, so upgrades change nothing silently.
+    overlap_policy = Column(String, nullable=True)
+
     # Statistics
     run_count = Column(Integer, nullable=False, default=0)
     failure_count = Column(Integer, nullable=False, default=0)
+    # Overlap skips (issue #142). Nullable so pre-existing rows read as 0
+    # without a backfill.
+    skip_count = Column(Integer, nullable=True)
+    last_skipped_at = Column(DateTime, nullable=True)
 
     # Relationships
     workflow = relationship("WorkflowModel", backref="schedules")
@@ -939,6 +948,9 @@ class ScheduleModel(Base):
         self.status = status
         self.input_data = input_data
         self.run_as_service_account = run_as_service_account
+        # getattr: Schedule objects unpickled from pre-#142 rows have no
+        # overlap attribute.
+        self.overlap_policy = getattr(schedule, "overlap", None)
         self.next_run_at = schedule.next_run_time()
 
     def get_schedule(self) -> Schedule:
@@ -985,6 +997,28 @@ class ScheduleModel(Base):
     def mark_failure(self):
         """Mark that the schedule execution failed"""
         self.failure_count += 1
+
+    def mark_skip(self, run_time: datetime | None = None):
+        """Record an overlap-skipped fire (issue #142).
+
+        Advances ``next_run_at`` exactly like a run — the fire is consumed,
+        not deferred — but counts it separately and leaves ``last_run_at`` /
+        ``run_count`` untouched, so run statistics still mean "executions
+        dispatched".
+        """
+        if run_time is None:
+            run_time = datetime.now(timezone.utc)
+        self.skip_count = (self.skip_count or 0) + 1
+        self.last_skipped_at = run_time
+
+        schedule = self.get_schedule()
+        from flux.domain.schedule import IntervalSchedule
+
+        if isinstance(schedule, IntervalSchedule):
+            schedule.mark_run(run_time)
+            self.schedule_config = schedule
+
+        self.update_next_run()
 
 
 class ServiceModel(Base):

--- a/flux/models.py
+++ b/flux/models.py
@@ -637,6 +637,11 @@ class ExecutionContextModel(Base):
     # Set when the execution was dispatched by a schedule; lets schedule
     # history be scoped to the originating schedule rather than the workflow.
     schedule_id = Column(String, nullable=True)
+    # Park TTL (issue #157): when set, an execution still unclaimed (state
+    # CREATED) past this instant is failed terminally by the scheduler tick's
+    # sweep instead of waiting forever for a matching worker. NULL — the
+    # default and every pre-#157 row — means "park indefinitely".
+    park_deadline = Column(DateTime, nullable=True)
 
     # Relationship to events
     events = relationship(

--- a/flux/models.py
+++ b/flux/models.py
@@ -642,6 +642,13 @@ class ExecutionContextModel(Base):
     # sweep instead of waiting forever for a matching worker. NULL — the
     # default and every pre-#157 row — means "park indefinitely".
     park_deadline = Column(DateTime, nullable=True)
+    # Pause wake condition (issue #145): stamped in the same transaction as
+    # the PAUSED state write from the latest WORKFLOW_PAUSED event, cleared
+    # on every other state write. wake_at: resume at this UTC instant;
+    # wake_on_complete: resume when this execution id reaches a terminal
+    # state. The scheduler tick's wake pass reads them.
+    wake_at = Column(DateTime, nullable=True)
+    wake_on_complete = Column(String, nullable=True)
 
     # Relationship to events
     events = relationship(

--- a/flux/schedule_manager.py
+++ b/flux/schedule_manager.py
@@ -129,6 +129,16 @@ class ScheduleManager(ABC):
         pass
 
     @abstractmethod
+    def has_active_execution(self, schedule_id: str) -> bool:
+        """Return True if a non-terminal execution of this schedule exists."""
+        pass
+
+    @abstractmethod
+    def record_skip(self, schedule_id: str, run_time: datetime) -> None:
+        """Persist an overlap-skipped fire: advance next_run_at + skip stats."""
+        pass
+
+    @abstractmethod
     def get_schedule_history(
         self,
         schedule_id: str,
@@ -473,6 +483,63 @@ class DatabaseScheduleManager(ScheduleManager):
         except Exception:
             logger.error(
                 f"Failed to record failure for schedule '{schedule_id}'",
+                exc_info=True,
+            )
+
+    def has_active_execution(self, schedule_id: str) -> bool:
+        """Return True if a non-terminal execution of this schedule exists.
+
+        The overlap check for ``overlap_policy="skip"`` (issue #142): a single
+        indexed query on ``executions.schedule_id`` (``idx_execution_schedule_id``)
+        against the non-terminal states, run inside the dispatch lock the
+        cycle already holds. Fails open (False) on error: dispatching like
+        pre-policy behavior beats wedging the scheduler on a query failure.
+        """
+        from flux.domain.events import ExecutionState
+        from flux.models import ExecutionContextModel
+
+        terminal = (
+            ExecutionState.COMPLETED,
+            ExecutionState.FAILED,
+            ExecutionState.CANCELLED,
+        )
+        try:
+            with self._repository.session() as session:
+                row = (
+                    session.query(ExecutionContextModel.execution_id)
+                    .filter(
+                        ExecutionContextModel.schedule_id == schedule_id,
+                        ExecutionContextModel.state.notin_(terminal),
+                    )
+                    .first()
+                )
+                return row is not None
+        except Exception:
+            logger.error(
+                f"Overlap check failed for schedule '{schedule_id}'; allowing dispatch",
+                exc_info=True,
+            )
+            return False
+
+    def record_skip(self, schedule_id: str, run_time: datetime) -> None:
+        """Persist an overlap-skipped fire: advances ``next_run_at`` and the
+        skip statistics without touching run stats (issue #142).
+
+        Never raises — see ``record_run``.
+        """
+        try:
+            with self._repository.session() as session:
+                model = session.query(ScheduleModel).filter(ScheduleModel.id == schedule_id).first()
+                if model is None:
+                    logger.warning(
+                        f"Schedule '{schedule_id}' disappeared before its skip could be recorded",
+                    )
+                    return
+                model.mark_skip(run_time)
+                session.commit()
+        except Exception:
+            logger.error(
+                f"Failed to record skip for schedule '{schedule_id}'",
                 exc_info=True,
             )
 

--- a/flux/server.py
+++ b/flux/server.py
@@ -1016,9 +1016,31 @@ class Server(
                         if due_schedules:
                             logger.info(f"Found {len(due_schedules)} due schedule(s)")
 
-                        # Trigger each due schedule
+                        # Trigger each due schedule. Catch-up policy is
+                        # run-once: record_run advances next_run_at from the
+                        # current time, so a schedule due many intervals ago
+                        # (server downtime) fires exactly once on recovery,
+                        # not once per missed interval.
                         for schedule in due_schedules:
                             try:
+                                # Overlap policy (issue #142): "skip" consumes
+                                # this fire while a previous execution of the
+                                # schedule is still non-terminal. NULL (rows
+                                # from before the policy existed) means
+                                # "allow" — dispatch regardless, the historic
+                                # behavior.
+                                if getattr(
+                                    schedule,
+                                    "overlap_policy",
+                                    None,
+                                ) == "skip" and schedule_manager.has_active_execution(schedule.id):
+                                    logger.info(
+                                        f"Schedule '{schedule.name}': previous execution "
+                                        "still running; skipping this fire "
+                                        "(overlap_policy=skip)",
+                                    )
+                                    schedule_manager.record_skip(schedule.id, current_time)
+                                    continue
                                 await self._trigger_scheduled_workflow(schedule, current_time)
                             except Exception as e:
                                 # The trigger path already recorded the failure before

--- a/flux/server.py
+++ b/flux/server.py
@@ -455,6 +455,7 @@ class Server(
         input_data: Any = None,
         version: int | None = None,
         preferred_worker: str | None = None,
+        park_ttl: int | None = None,
     ) -> ExecutionContext:
         workflow = WorkflowCatalog.create().get(namespace, workflow_name, version)
         if not workflow:
@@ -471,6 +472,7 @@ class Server(
                 requests=workflow.requests,
             ),
             preferred_worker=preferred_worker or None,
+            park_ttl=park_ttl,
         )
 
         # Every run of a dynamic workflow refreshes its GC clock — this is
@@ -1049,6 +1051,20 @@ class Server(
                                     f"Failed to trigger schedule '{schedule.name}': {str(e)}",
                                     exc_info=True,
                                 )
+
+                        # Park-TTL sweep (issue #157): executions that opted
+                        # into a bound and are still unclaimed past it fail
+                        # terminally instead of waiting forever. Shares the
+                        # dispatch lock so exactly one replica sweeps.
+                        try:
+                            expired = ContextManager.create().fail_expired_parked(current_time)
+                            if expired:
+                                logger.warning(
+                                    f"Park TTL expired for {len(expired)} unclaimed "
+                                    f"execution(s): {', '.join(expired)}",
+                                )
+                        except Exception:
+                            logger.error("Park-TTL sweep failed", exc_info=True)
 
                 except Exception as e:
                     logger.error(f"Error in scheduler cycle: {str(e)}", exc_info=True)

--- a/flux/server.py
+++ b/flux/server.py
@@ -1066,6 +1066,18 @@ class Server(
                         except Exception:
                             logger.error("Park-TTL sweep failed", exc_info=True)
 
+                        # Pause-wake pass (issue #145): resume paused
+                        # executions whose timed or completion wake fired.
+                        # Same lock, same timing authority as the schedules.
+                        try:
+                            woken = ContextManager.create().fire_due_wakes(current_time)
+                            if woken:
+                                logger.info(
+                                    f"Fired {len(woken)} pause wake(s): {', '.join(woken)}",
+                                )
+                        except Exception:
+                            logger.error("Pause-wake pass failed", exc_info=True)
+
                 except Exception as e:
                     logger.error(f"Error in scheduler cycle: {str(e)}", exc_info=True)
 

--- a/flux/tasks/pause.py
+++ b/flux/tasks/pause.py
@@ -1,17 +1,45 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from flux import ExecutionContext
 from flux.domain.events import ExecutionEvent
 from flux.domain.events import ExecutionEventType
-from flux.errors import PauseRequested
+from flux.errors import ExecutionError, PauseRequested
 from flux.task import TaskMetadata
 from flux.task import task
 
 
 @task.with_options(metadata=True)
-async def pause(name: str, output: Any = None, *, metadata: TaskMetadata):
+async def pause(
+    name: str,
+    output: Any = None,
+    *,
+    until: datetime | None = None,
+    after: timedelta | None = None,
+    on_complete: str | None = None,
+    metadata: TaskMetadata,
+):
+    """Pause the execution, optionally with a wake condition (issue #145).
+
+    Without a wake condition the pause is indefinite — something external
+    must resume the execution, as always. With one, the execution still goes
+    ``PAUSED`` and releases its worker slot, but the server's scheduler tick
+    resumes it when the condition fires:
+
+    - ``until=datetime``: wake at an absolute instant (naive datetimes are
+      taken as UTC).
+    - ``after=timedelta``: wake after a relative delay, resolved to an
+      absolute instant *now* so replaying the pause re-records the same wake.
+    - ``on_complete=execution_id``: wake when the named execution reaches a
+      terminal state (completed, failed, or cancelled).
+
+    Exactly one condition may be given. Wakes fire on the server's scheduler
+    tick, so they apply to the distributed path; an inline
+    (``workflow.run()``) execution has no scheduler and must be resumed
+    manually regardless.
+    """
     ctx = await ExecutionContext.get()
 
     if ctx.is_resuming:
@@ -25,4 +53,26 @@ async def pause(name: str, output: Any = None, *, metadata: TaskMetadata):
             ),
         )
         return input
-    raise PauseRequested(name=name, output=output)
+
+    given = [c for c in (until, after, on_complete) if c is not None]
+    if len(given) > 1:
+        raise ExecutionError(
+            message="pause() accepts at most one of until=, after=, on_complete=",
+        )
+
+    wake_at: str | None = None
+    if until is not None:
+        if until.tzinfo is None:
+            until = until.replace(tzinfo=timezone.utc)
+        wake_at = until.isoformat()
+    elif after is not None:
+        if after.total_seconds() <= 0:
+            raise ExecutionError(message="pause(after=...) must be a positive timedelta")
+        wake_at = (datetime.now(timezone.utc) + after).isoformat()
+
+    raise PauseRequested(
+        name=name,
+        output=output,
+        wake_at=wake_at,
+        wake_on_complete=on_complete,
+    )

--- a/flux/tasks/pause.py
+++ b/flux/tasks/pause.py
@@ -64,7 +64,10 @@ async def pause(
     if until is not None:
         if until.tzinfo is None:
             until = until.replace(tzinfo=timezone.utc)
-        wake_at = until.isoformat()
+        # Normalize aware datetimes to UTC so the stored instant carries one
+        # consistent offset, matching the docstring and the scheduler's
+        # UTC-based comparisons.
+        wake_at = until.astimezone(timezone.utc).isoformat()
     elif after is not None:
         if after.total_seconds() <= 0:
             raise ExecutionError(message="pause(after=...) must be a positive timedelta")

--- a/flux/workflow.py
+++ b/flux/workflow.py
@@ -207,7 +207,13 @@ class workflow:
             )
             ctx.complete(self.id, output_value)
         except PauseRequested as ex:
-            ctx.pause(self.id, ex.name, ex.output)
+            ctx.pause(
+                self.id,
+                ex.name,
+                ex.output,
+                wake_at=getattr(ex, "wake_at", None),
+                wake_on_complete=getattr(ex, "wake_on_complete", None),
+            )
         except asyncio.CancelledError:
             ctx.cancel()
             raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.67.0"
+version = "0.68.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_migrations.py
+++ b/tests/flux/test_migrations.py
@@ -13,7 +13,7 @@ import flux.security.models  # noqa: F401
 from flux.migrations.runner import current_revision, run_migrations
 from flux.models import Base
 
-HEAD = "0016_execution_park_deadline"
+HEAD = "0017_pause_wakes"
 BASELINE = "0001_baseline"
 
 # A representative index added after the original create_all schema, used to

--- a/tests/flux/test_migrations.py
+++ b/tests/flux/test_migrations.py
@@ -13,7 +13,7 @@ import flux.security.models  # noqa: F401
 from flux.migrations.runner import current_revision, run_migrations
 from flux.models import Base
 
-HEAD = "0015_schedule_overlap_policy"
+HEAD = "0016_execution_park_deadline"
 BASELINE = "0001_baseline"
 
 # A representative index added after the original create_all schema, used to

--- a/tests/flux/test_migrations.py
+++ b/tests/flux/test_migrations.py
@@ -13,7 +13,7 @@ import flux.security.models  # noqa: F401
 from flux.migrations.runner import current_revision, run_migrations
 from flux.models import Base
 
-HEAD = "0014_task_cancelled_event"
+HEAD = "0015_schedule_overlap_policy"
 BASELINE = "0001_baseline"
 
 # A representative index added after the original create_all schema, used to

--- a/tests/flux/test_migrations_postgresql.py
+++ b/tests/flux/test_migrations_postgresql.py
@@ -28,7 +28,7 @@ pytestmark = [
     ),
 ]
 
-HEAD = "0014_task_cancelled_event"
+HEAD = "0015_schedule_overlap_policy"
 _BACKFILL_INDEX = "ix_executions_workflow_id"
 
 

--- a/tests/flux/test_migrations_postgresql.py
+++ b/tests/flux/test_migrations_postgresql.py
@@ -28,7 +28,7 @@ pytestmark = [
     ),
 ]
 
-HEAD = "0015_schedule_overlap_policy"
+HEAD = "0016_execution_park_deadline"
 _BACKFILL_INDEX = "ix_executions_workflow_id"
 
 

--- a/tests/flux/test_migrations_postgresql.py
+++ b/tests/flux/test_migrations_postgresql.py
@@ -28,7 +28,7 @@ pytestmark = [
     ),
 ]
 
-HEAD = "0016_execution_park_deadline"
+HEAD = "0017_pause_wakes"
 _BACKFILL_INDEX = "ix_executions_workflow_id"
 
 

--- a/tests/flux/test_park_ttl.py
+++ b/tests/flux/test_park_ttl.py
@@ -1,0 +1,168 @@
+"""Park TTL for unclaimed executions (issue #157).
+
+An execution whose constraints match no current worker parks (state
+CREATED) indefinitely — right for elastic batch fleets, indistinguishable
+from a hang for an interactive caller. Executions that opt into a bound
+(per-run ``park_ttl`` or the ``[flux.workers] park_ttl`` default) are
+failed terminally by the scheduler sweep once the deadline passes, with a
+diagnosable ``ParkTimeoutError``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from flux import ExecutionContext
+from flux.config import Configuration
+from flux.context_managers import ContextManager
+from flux.domain.events import ExecutionEventType, ExecutionState
+
+
+@pytest.fixture
+def manager(tmp_path):
+    Configuration.get().override(database_url=f"sqlite:///{tmp_path / 'park.db'}")
+    from flux.models import DatabaseRepository
+
+    DatabaseRepository._engines.clear()
+    yield ContextManager.create()
+    DatabaseRepository._engines.clear()
+
+
+def _register_workflow(manager, workflow_id="wf-1", affinity=None):
+    from flux.models import WorkflowModel
+
+    with manager.session() as session:
+        session.add(
+            WorkflowModel(
+                id=workflow_id,
+                name="parked_wf",
+                version=1,
+                imports=[],
+                source=b"",
+                affinity=affinity,
+            ),
+        )
+        session.commit()
+
+
+def _save_execution(manager, park_ttl=None, workflow_id="wf-1"):
+    ctx = ExecutionContext(
+        workflow_id=workflow_id,
+        workflow_namespace="default",
+        workflow_name="parked_wf",
+        input=None,
+    )
+    manager.save(ctx, park_ttl=park_ttl)
+    return ctx
+
+
+def _row(manager, execution_id):
+    from flux.models import ExecutionContextModel
+
+    with manager.session() as session:
+        return session.get(ExecutionContextModel, execution_id)
+
+
+def _set_deadline(manager, execution_id, deadline):
+    from flux.models import ExecutionContextModel
+
+    with manager.session() as session:
+        row = session.get(ExecutionContextModel, execution_id)
+        row.park_deadline = deadline
+        session.commit()
+
+
+class TestDeadlineAtSubmission:
+    def test_default_config_zero_means_no_deadline(self, manager):
+        _register_workflow(manager)
+        ctx = _save_execution(manager)
+        assert _row(manager, ctx.execution_id).park_deadline is None
+
+    def test_per_run_ttl_sets_deadline(self, manager):
+        _register_workflow(manager)
+        ctx = _save_execution(manager, park_ttl=60)
+        deadline = _row(manager, ctx.execution_id).park_deadline
+        assert deadline is not None
+
+    def test_config_default_applies_when_no_override(self, manager):
+        _register_workflow(manager)
+        Configuration.get().override(workers={"park_ttl": 120})
+        try:
+            ctx = _save_execution(manager)
+            assert _row(manager, ctx.execution_id).park_deadline is not None
+        finally:
+            Configuration.get().override(workers={"park_ttl": 0})
+
+    def test_explicit_zero_override_disables_config_default(self, manager):
+        _register_workflow(manager)
+        Configuration.get().override(workers={"park_ttl": 120})
+        try:
+            ctx = _save_execution(manager, park_ttl=0)
+            assert _row(manager, ctx.execution_id).park_deadline is None
+        finally:
+            Configuration.get().override(workers={"park_ttl": 0})
+
+
+class TestSweep:
+    def test_expired_parked_execution_fails_with_diagnostic(self, manager):
+        _register_workflow(manager, affinity={"gpu": "true"})
+        ctx = _save_execution(manager, park_ttl=60)
+        _set_deadline(
+            manager,
+            ctx.execution_id,
+            datetime.now(timezone.utc) - timedelta(seconds=5),
+        )
+
+        failed = manager.fail_expired_parked()
+
+        assert failed == [ctx.execution_id]
+        stored = manager.get(ctx.execution_id)
+        assert stored.state == ExecutionState.FAILED
+        failure_events = [e for e in stored.events if e.type == ExecutionEventType.WORKFLOW_FAILED]
+        assert len(failure_events) == 1
+        value = failure_events[0].value
+        assert value["type"] == "ParkTimeoutError"
+        assert "park deadline" in value["message"]
+        assert "gpu" in value["message"], "the unmatched constraint must be named"
+
+    def test_unexpired_execution_is_untouched(self, manager):
+        _register_workflow(manager)
+        ctx = _save_execution(manager, park_ttl=3600)
+        assert manager.fail_expired_parked() == []
+        assert _row(manager, ctx.execution_id).state == ExecutionState.CREATED
+
+    def test_execution_without_deadline_is_never_swept(self, manager):
+        _register_workflow(manager)
+        ctx = _save_execution(manager)  # parks forever, the historic default
+        assert manager.fail_expired_parked() == []
+        assert _row(manager, ctx.execution_id).state == ExecutionState.CREATED
+
+    def test_claimed_execution_is_not_swept_even_past_deadline(self, manager):
+        """The TTL bounds *parking*; once claimed, the execution belongs to
+        the worker and the ordinary timeouts apply."""
+        from flux.models import ExecutionContextModel
+
+        _register_workflow(manager)
+        ctx = _save_execution(manager, park_ttl=60)
+        past = datetime.now(timezone.utc) - timedelta(seconds=5)
+        with manager.session() as session:
+            row = session.get(ExecutionContextModel, ctx.execution_id)
+            row.park_deadline = past
+            row.state = ExecutionState.RUNNING
+            session.commit()
+
+        assert manager.fail_expired_parked() == []
+        assert _row(manager, ctx.execution_id).state == ExecutionState.RUNNING
+
+    def test_sweep_is_idempotent(self, manager):
+        _register_workflow(manager)
+        ctx = _save_execution(manager, park_ttl=60)
+        _set_deadline(
+            manager,
+            ctx.execution_id,
+            datetime.now(timezone.utc) - timedelta(seconds=5),
+        )
+        assert manager.fail_expired_parked() == [ctx.execution_id]
+        assert manager.fail_expired_parked() == []

--- a/tests/flux/test_pause_wakes.py
+++ b/tests/flux/test_pause_wakes.py
@@ -98,6 +98,35 @@ class TestPauseTaskWakeArguments:
         assert paused[0].value["wake_at"] == wake.isoformat()
 
     @pytest.mark.asyncio
+    async def test_until_with_non_utc_offset_is_normalized_to_utc(self):
+        from datetime import timezone as tz
+
+        offset = tz(timedelta(hours=-7))
+        wake = datetime.now(tz=offset) + timedelta(hours=1)
+
+        @workflow
+        async def wf(ctx: ExecutionContext):
+            await pause("await_vendor", until=wake)
+
+        ctx = ExecutionContext(
+            workflow_id="w",
+            workflow_namespace="default",
+            workflow_name="wf_until_tz",
+            input=None,
+        )
+
+        async def cp(c):
+            return c
+
+        ctx.set_checkpoint(cp)
+        ctx = await wf(ctx)
+
+        paused = [e for e in ctx.events if e.type == ExecutionEventType.WORKFLOW_PAUSED]
+        stored = datetime.fromisoformat(paused[0].value["wake_at"])
+        assert stored.utcoffset() == timedelta(0), "stored instant must carry a UTC offset"
+        assert stored == wake, "normalization must not change the instant"
+
+    @pytest.mark.asyncio
     async def test_after_resolves_to_absolute_instant(self):
         @workflow
         async def wf(ctx: ExecutionContext):

--- a/tests/flux/test_pause_wakes.py
+++ b/tests/flux/test_pause_wakes.py
@@ -1,0 +1,328 @@
+"""Timed and completion-triggered pause wakes (issue #145).
+
+``pause(until=/after=)`` and ``pause(on_complete=)`` record a wake
+condition inside the WORKFLOW_PAUSED event; the persistence layer stamps
+it onto the execution row in the same transaction as the PAUSED state
+write (no #70-style window), and the scheduler tick's wake pass resumes
+due executions through the ordinary ``start_resuming`` transition.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from flux import ExecutionContext
+from flux.config import Configuration
+from flux.context_managers import ContextManager
+from flux.domain.events import ExecutionEventType, ExecutionState
+from flux.errors import ExecutionError
+from flux.tasks import pause
+from flux.workflow import workflow
+
+
+@pytest.fixture
+def manager(tmp_path):
+    Configuration.get().override(database_url=f"sqlite:///{tmp_path / 'wakes.db'}")
+    from flux.models import DatabaseRepository
+
+    DatabaseRepository._engines.clear()
+    yield ContextManager.create()
+    DatabaseRepository._engines.clear()
+
+
+def _paused_ctx(execution_id="exec-w1", wake_at=None, wake_on_complete=None):
+    ctx = ExecutionContext(
+        workflow_id="wf-1",
+        workflow_namespace="default",
+        workflow_name="waiting_wf",
+        input=None,
+        execution_id=execution_id,
+    )
+    ctx.pause(
+        "wf",
+        "gate",
+        wake_at=wake_at.isoformat() if wake_at else None,
+        wake_on_complete=wake_on_complete,
+    )
+    return ctx
+
+
+def _terminal_ctx(execution_id, state=ExecutionState.COMPLETED):
+    ctx = ExecutionContext(
+        workflow_id="wf-1",
+        workflow_namespace="default",
+        workflow_name="child_wf",
+        input=None,
+        execution_id=execution_id,
+    )
+    if state == ExecutionState.COMPLETED:
+        ctx.complete("wf", "done")
+    elif state == ExecutionState.FAILED:
+        ctx.fail("wf", {"type": "X", "message": "boom"})
+    return ctx
+
+
+def _row(manager, execution_id):
+    from flux.models import ExecutionContextModel
+
+    with manager.session() as session:
+        return session.get(ExecutionContextModel, execution_id)
+
+
+class TestPauseTaskWakeArguments:
+    @pytest.mark.asyncio
+    async def test_until_records_wake_in_paused_event(self):
+        wake = datetime.now(timezone.utc) + timedelta(hours=1)
+
+        @workflow
+        async def wf(ctx: ExecutionContext):
+            await pause("await_vendor", until=wake)
+
+        ctx = ExecutionContext(
+            workflow_id="w",
+            workflow_namespace="default",
+            workflow_name="wf_until",
+            input=None,
+        )
+
+        async def cp(c):
+            return c
+
+        ctx.set_checkpoint(cp)
+        ctx = await wf(ctx)
+
+        assert ctx.is_paused
+        paused = [e for e in ctx.events if e.type == ExecutionEventType.WORKFLOW_PAUSED]
+        assert paused[0].value["wake_at"] == wake.isoformat()
+
+    @pytest.mark.asyncio
+    async def test_after_resolves_to_absolute_instant(self):
+        @workflow
+        async def wf(ctx: ExecutionContext):
+            await pause("await_window", after=timedelta(minutes=30))
+
+        ctx = ExecutionContext(
+            workflow_id="w",
+            workflow_namespace="default",
+            workflow_name="wf_after",
+            input=None,
+        )
+
+        async def cp(c):
+            return c
+
+        ctx.set_checkpoint(cp)
+        before = datetime.now(timezone.utc)
+        ctx = await wf(ctx)
+
+        paused = [e for e in ctx.events if e.type == ExecutionEventType.WORKFLOW_PAUSED]
+        wake_at = datetime.fromisoformat(paused[0].value["wake_at"])
+        assert before + timedelta(minutes=29) < wake_at < before + timedelta(minutes=31)
+
+    @pytest.mark.asyncio
+    async def test_on_complete_records_watched_execution(self):
+        @workflow
+        async def wf(ctx: ExecutionContext):
+            await pause("await_child", on_complete="child-exec-42")
+
+        ctx = ExecutionContext(
+            workflow_id="w",
+            workflow_namespace="default",
+            workflow_name="wf_child",
+            input=None,
+        )
+
+        async def cp(c):
+            return c
+
+        ctx.set_checkpoint(cp)
+        ctx = await wf(ctx)
+
+        paused = [e for e in ctx.events if e.type == ExecutionEventType.WORKFLOW_PAUSED]
+        assert paused[0].value["wake_on_complete"] == "child-exec-42"
+
+    @pytest.mark.asyncio
+    async def test_multiple_conditions_rejected(self):
+        @workflow
+        async def wf(ctx: ExecutionContext):
+            await pause(
+                "bad",
+                until=datetime.now(timezone.utc),
+                on_complete="other",
+            )
+
+        ctx = ExecutionContext(
+            workflow_id="w",
+            workflow_namespace="default",
+            workflow_name="wf_bad",
+            input=None,
+        )
+
+        async def cp(c):
+            return c
+
+        ctx.set_checkpoint(cp)
+        ctx = await wf(ctx)
+        assert ctx.has_failed
+        assert "at most one" in str(ctx.output)
+
+    @pytest.mark.asyncio
+    async def test_plain_pause_event_shape_unchanged(self):
+        @workflow
+        async def wf(ctx: ExecutionContext):
+            await pause("plain")
+
+        ctx = ExecutionContext(
+            workflow_id="w",
+            workflow_namespace="default",
+            workflow_name="wf_plain",
+            input=None,
+        )
+
+        async def cp(c):
+            return c
+
+        ctx.set_checkpoint(cp)
+        ctx = await wf(ctx)
+        paused = [e for e in ctx.events if e.type == ExecutionEventType.WORKFLOW_PAUSED]
+        assert "wake_at" not in paused[0].value
+        assert "wake_on_complete" not in paused[0].value
+
+
+class TestWakeColumnStamping:
+    def test_paused_save_stamps_wake_at_atomically(self, manager):
+        wake = datetime.now(timezone.utc) + timedelta(hours=2)
+        manager.save(_paused_ctx(wake_at=wake))
+        row = _row(manager, "exec-w1")
+        assert row.state == ExecutionState.PAUSED
+        assert row.wake_at is not None
+
+    def test_paused_save_stamps_completion_wake(self, manager):
+        manager.save(_paused_ctx(wake_on_complete="child-1"))
+        assert _row(manager, "exec-w1").wake_on_complete == "child-1"
+
+    def test_resume_clears_wake_columns(self, manager):
+        wake = datetime.now(timezone.utc) + timedelta(hours=2)
+        ctx = _paused_ctx(wake_at=wake)
+        manager.save(ctx)
+        ctx.start_resuming()
+        manager.save(ctx)
+        row = _row(manager, "exec-w1")
+        assert row.wake_at is None
+        assert row.wake_on_complete is None
+
+    def test_cancel_clears_wake_columns(self, manager):
+        wake = datetime.now(timezone.utc) - timedelta(seconds=1)  # already due
+        ctx = _paused_ctx(wake_at=wake)
+        manager.save(ctx)
+        ctx.start_cancel()
+        manager.save(ctx)
+        row = _row(manager, "exec-w1")
+        assert row.wake_at is None
+        # And the wake pass cannot resurrect it.
+        assert manager.fire_due_wakes() == []
+
+    def test_replayed_pause_checkpoint_is_idempotent(self, manager):
+        """Saving the same paused context twice stamps the same wake — no
+        duplicate wake records exist because the row *is* the record."""
+        wake = datetime.now(timezone.utc) + timedelta(hours=2)
+        ctx = _paused_ctx(wake_at=wake)
+        manager.save(ctx)
+        first = _row(manager, "exec-w1").wake_at
+        manager.save(ctx)
+        assert _row(manager, "exec-w1").wake_at == first
+
+
+class TestFireDueWakes:
+    def test_due_timed_wake_resumes(self, manager):
+        wake = datetime.now(timezone.utc) - timedelta(seconds=5)
+        manager.save(_paused_ctx(wake_at=wake))
+
+        assert manager.fire_due_wakes() == ["exec-w1"]
+        stored = manager.get("exec-w1")
+        assert stored.state == ExecutionState.RESUMING
+        assert _row(manager, "exec-w1").wake_at is None
+
+    def test_future_wake_does_not_fire(self, manager):
+        wake = datetime.now(timezone.utc) + timedelta(hours=1)
+        manager.save(_paused_ctx(wake_at=wake))
+        assert manager.fire_due_wakes() == []
+        assert _row(manager, "exec-w1").state == ExecutionState.PAUSED
+
+    def test_indefinite_pause_never_fires(self, manager):
+        manager.save(_paused_ctx())
+        assert manager.fire_due_wakes() == []
+        assert _row(manager, "exec-w1").state == ExecutionState.PAUSED
+
+    @pytest.mark.parametrize(
+        "child_state",
+        [ExecutionState.COMPLETED, ExecutionState.FAILED],
+    )
+    def test_completion_wake_fires_on_terminal_child(self, manager, child_state):
+        manager.save(_terminal_ctx("child-1", state=child_state))
+        manager.save(_paused_ctx(wake_on_complete="child-1"))
+
+        assert manager.fire_due_wakes() == ["exec-w1"]
+        assert manager.get("exec-w1").state == ExecutionState.RESUMING
+
+    def test_completion_wake_waits_for_running_child(self, manager):
+        child = ExecutionContext(
+            workflow_id="wf-1",
+            workflow_namespace="default",
+            workflow_name="child_wf",
+            input=None,
+            execution_id="child-1",
+        )
+        manager.save(child)  # CREATED — not terminal
+        manager.save(_paused_ctx(wake_on_complete="child-1"))
+
+        assert manager.fire_due_wakes() == []
+        assert _row(manager, "exec-w1").state == ExecutionState.PAUSED
+
+    def test_completion_wake_on_missing_child_fires(self, manager):
+        """Waiting forever on a typo'd execution id is worse than waking."""
+        manager.save(_paused_ctx(wake_on_complete="no-such-execution"))
+        assert manager.fire_due_wakes() == ["exec-w1"]
+
+    def test_fired_wake_does_not_refire(self, manager):
+        wake = datetime.now(timezone.utc) - timedelta(seconds=5)
+        manager.save(_paused_ctx(wake_at=wake))
+        assert manager.fire_due_wakes() == ["exec-w1"]
+        assert manager.fire_due_wakes() == []
+
+    def test_overdue_backlog_each_fires_once(self, manager):
+        """Bounded catch-up after downtime: every overdue wake fires exactly
+        once in one pass."""
+        wake = datetime.now(timezone.utc) - timedelta(hours=6)
+        for i in range(3):
+            manager.save(_paused_ctx(execution_id=f"exec-b{i}", wake_at=wake))
+        assert sorted(manager.fire_due_wakes()) == ["exec-b0", "exec-b1", "exec-b2"]
+        assert manager.fire_due_wakes() == []
+
+
+class TestPauseValidation:
+    @pytest.mark.asyncio
+    async def test_non_positive_after_rejected(self):
+        @workflow
+        async def wf(ctx: ExecutionContext):
+            await pause("bad", after=timedelta(seconds=0))
+
+        ctx = ExecutionContext(
+            workflow_id="w",
+            workflow_namespace="default",
+            workflow_name="wf_bad_after",
+            input=None,
+        )
+
+        async def cp(c):
+            return c
+
+        ctx.set_checkpoint(cp)
+        ctx = await wf(ctx)
+        assert ctx.has_failed
+
+
+def test_pause_wake_error_is_execution_error():
+    assert issubclass(ExecutionError, Exception)

--- a/tests/flux/test_schedule_overlap.py
+++ b/tests/flux/test_schedule_overlap.py
@@ -1,0 +1,179 @@
+"""Schedule overlap policy (issue #142).
+
+``overlap_policy="skip"`` consumes a due fire while a previous execution of
+the same schedule is still non-terminal; ``"allow"`` (and NULL, the value on
+every pre-policy row) keeps the historic dispatch-regardless behavior. The
+catch-up policy — a schedule due many intervals ago fires exactly once on
+recovery — is also pinned here, since it was previously emergent.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from flux.config import Configuration
+from flux.domain.events import ExecutionState
+from flux.domain.schedule import cron, interval, once, schedule_factory
+from flux.schedule_manager import create_schedule_manager
+
+
+@pytest.fixture
+def manager(tmp_path):
+    Configuration.get().override(database_url=f"sqlite:///{tmp_path / 'sched.db'}")
+    from flux.models import DatabaseRepository
+
+    DatabaseRepository._engines.clear()
+    yield create_schedule_manager()
+    DatabaseRepository._engines.clear()
+
+
+def _create(manager, name="s1", overlap="skip"):
+    return manager.create_schedule(
+        workflow_id="wid",
+        workflow_name="wf",
+        workflow_namespace="default",
+        name=name,
+        schedule=interval(minutes=5, overlap=overlap),
+    )
+
+
+def _add_execution(manager, schedule_id, state, execution_id="exec-1"):
+    from flux.models import ExecutionContextModel
+
+    with manager._repository.session() as session:
+        session.add(
+            ExecutionContextModel(
+                execution_id=execution_id,
+                workflow_id="wid",
+                workflow_name="wf",
+                input=None,
+                state=state,
+                schedule_id=schedule_id,
+            ),
+        )
+        session.commit()
+
+
+class TestDomainOverlap:
+    def test_default_is_skip_and_serializes(self):
+        for schedule in (
+            cron("* * * * *"),
+            interval(minutes=1),
+            once(datetime.now(timezone.utc) + timedelta(hours=1)),
+        ):
+            assert schedule.overlap == "skip"
+            data = schedule.to_dict()
+            assert data["overlap"] == "skip"
+            assert schedule_factory(data).overlap == "skip"
+
+    def test_allow_round_trips(self):
+        schedule = cron("* * * * *", overlap="allow")
+        assert schedule_factory(schedule.to_dict()).overlap == "allow"
+
+    def test_invalid_policy_rejected(self):
+        with pytest.raises(ValueError, match="overlap"):
+            cron("* * * * *", overlap="queue")
+
+    def test_pre_policy_instance_serializes_as_allow(self):
+        """An instance unpickled from a pre-#142 row has no overlap attribute;
+        to_dict must report the behavior it actually gets: allow."""
+        schedule = cron("* * * * *")
+        del schedule.overlap
+        assert schedule.to_dict()["overlap"] == "allow"
+
+
+class TestModelOverlap:
+    def test_model_captures_policy_from_schedule(self, manager):
+        skip = _create(manager, name="skip-one", overlap="skip")
+        allow = _create(manager, name="allow-one", overlap="allow")
+        assert manager.get_schedule(skip.id).overlap_policy == "skip"
+        assert manager.get_schedule(allow.id).overlap_policy == "allow"
+
+    def test_record_skip_advances_next_run_without_run_stats(self, manager):
+        sch = _create(manager)
+        before = manager.get_schedule(sch.id)
+
+        manager.record_skip(sch.id, datetime.now(timezone.utc))
+
+        after = manager.get_schedule(sch.id)
+        assert after.skip_count == 1
+        assert after.last_skipped_at is not None
+        assert after.run_count == 0
+        assert after.last_run_at is None
+        assert after.next_run_at != before.next_run_at, "the fire must be consumed"
+        # No longer due for the window it was skipped in.
+        assert manager.get_due_schedules(current_time=datetime.now(timezone.utc)) == []
+
+    def test_record_skip_on_deleted_schedule_does_not_raise(self, manager):
+        sch = _create(manager)
+        manager.delete_schedule(sch.id)
+        manager.record_skip(sch.id, datetime.now(timezone.utc))
+
+
+class TestOverlapDetection:
+    def test_no_executions_means_no_overlap(self, manager):
+        sch = _create(manager)
+        assert manager.has_active_execution(sch.id) is False
+
+    @pytest.mark.parametrize(
+        "state",
+        [
+            ExecutionState.SCHEDULED,
+            ExecutionState.CLAIMED,
+            ExecutionState.RUNNING,
+            ExecutionState.PAUSED,
+        ],
+    )
+    def test_non_terminal_execution_is_overlap(self, manager, state):
+        sch = _create(manager)
+        _add_execution(manager, sch.id, state)
+        assert manager.has_active_execution(sch.id) is True
+
+    @pytest.mark.parametrize(
+        "state",
+        [ExecutionState.COMPLETED, ExecutionState.FAILED, ExecutionState.CANCELLED],
+    )
+    def test_terminal_execution_is_not_overlap(self, manager, state):
+        sch = _create(manager)
+        _add_execution(manager, sch.id, state)
+        assert manager.has_active_execution(sch.id) is False
+
+    def test_other_schedules_executions_do_not_count(self, manager):
+        sch = _create(manager, name="mine")
+        other = _create(manager, name="other")
+        _add_execution(manager, other.id, ExecutionState.RUNNING)
+        assert manager.has_active_execution(sch.id) is False
+        assert manager.has_active_execution(other.id) is True
+
+
+class TestCatchUpPolicy:
+    def test_long_overdue_schedule_fires_exactly_once(self, manager):
+        """Run-once catch-up: next_run_at hours in the past yields one due
+        fire; record_run advances from the run time, not per missed
+        interval."""
+        sch = _create(manager)
+        past = datetime.now(timezone.utc) - timedelta(hours=6)
+        with manager._repository.session() as session:
+            from flux.models import ScheduleModel
+
+            row = session.query(ScheduleModel).filter(ScheduleModel.id == sch.id).one()
+            row.next_run_at = past
+            session.commit()
+
+        now = datetime.now(timezone.utc)
+        due = manager.get_due_schedules(current_time=now)
+        assert [d.id for d in due] == [sch.id]
+
+        manager.record_run(sch.id, now)
+
+        fresh = manager.get_schedule(sch.id)
+        # One catch-up fire consumed the entire backlog: the next run is in
+        # the future relative to the recovery, not 71 more overdue intervals.
+        next_run = fresh.next_run_at
+        if next_run.tzinfo is None:
+            next_run = next_run.replace(tzinfo=timezone.utc)
+        assert next_run > now
+        assert manager.get_due_schedules(current_time=now) == []
+        assert fresh.run_count == 1


### PR DESCRIPTION
Closes #142
Closes #157
Closes #145

PR3 in the issue sequence plan (follows #159, #160) — the scheduler cluster, batched because all three add passes to the same scheduler tick under the same cross-replica dispatch lock: one timing authority, one lock. One commit per issue for reviewability.

## #142 — Schedule overlap policy (`fdf56aa`)

A slow workflow on a short cron stacked executions without bound. Schedules now carry `overlap`:

- **`skip`** (default for new schedules): a due fire is consumed — `next_run_at` advances — but not dispatched while a non-terminal execution of the same schedule exists. Skips are counted separately (`skip_count`, `last_skipped_at`), surfaced in the API and `flux schedule show` — never silent.
- **`allow`**: dispatch regardless. Every schedule created before the policy existed keeps this (NULL column reads as allow), so upgrades change nothing silently.

Detection is one indexed query (`idx_execution_schedule_id`) inside the dispatch lock, failing open so a query error can't wedge the scheduler. The emergent run-once catch-up policy is now stated in the loop and pinned by a test. Surface: `overlap=` on `cron()`/`interval()`/`once()`, `--overlap` on `flux schedule create`, migration 0015.

## #157 — Park TTL for unclaimed executions (`5441b4f`)

An execution whose constraints match no current worker parks indefinitely — right for elastic batch fleets, indistinguishable from a hang for a synchronous caller. Executions can now opt into a bound: `[flux.workers] park_ttl` (default 0 = park forever, the historic behavior) or a per-run `park_ttl` query parameter (0 explicitly parks forever, so batch and interactive callers share a server). The deadline is stamped at submission (`executions.park_deadline`, migration 0016); the scheduler sweep fails still-unclaimed executions past it with a distinct `ParkTimeoutError` naming the workflow's affinity constraints. Row locks (`skip_locked`) prevent racing a concurrent claim; a claimed execution is never swept.

## #145 — Timed and completion-triggered pause wakes (`85e821a`)

`pause()` gains wake conditions: `until=datetime` / `after=timedelta` (resolved to an absolute instant at pause time, so replay re-records the same wake) and `on_complete=execution_id` (wake when the watched execution reaches a terminal state; a nonexistent watched id wakes immediately rather than waiting forever on a typo).

Design deviation from the issue sketch, deliberately: **the execution row is the wake record — no new table.** The wake rides the `WORKFLOW_PAUSED` event value (absent for plain pauses; existing event shapes unchanged) and is stamped onto `executions.wake_at`/`wake_on_complete` **in the same transaction as the PAUSED state write** — there is no window where the execution is paused without a durable wake, which closes the #70-style race the issue flagged as the main correctness risk by construction rather than by handling. Every other state write clears the columns, so resume/cancel/completion retire pending wakes atomically and a fired wake cannot resurrect a cancelled execution. The wake pass resumes due executions through the ordinary `start_resuming()` transition (dispatch downstream untouched); an overdue backlog after downtime fires each wake once. Migration 0017. Wakes fire from the server scheduler, so they apply to the distributed path; inline executions still resume manually (documented).

## Review follow-ups (`72a258b`)

`until=` normalizes aware datetimes to UTC before storing; the completion-wake pass fetches all watched states in one `IN` query instead of one per watcher.

## Tests

48 new tests across `test_schedule_overlap.py` (17), `test_park_ttl.py` (9), `test_pause_wakes.py` (22): policy round-trips and pre-policy pickle compatibility, skip-vs-run statistics, overlap detection per state, run-once catch-up, deadline stamping (config default / override / explicit-zero), sweep guards (unexpired, no-deadline, claimed, idempotence), wake stamping atomicity, UTC normalization, clearing on resume and cancel, timed/completion/missing-child firing, no-refire, and bounded backlog catch-up.

## Verification

- `pre-commit`: passed on all touched files
- Unit suite (`pytest tests/ --ignore=tests/e2e`): 3103 passed, 21 skipped
- E2E (`-m "not ollama"`): 139 passed; only the 2 known github-stars failures (`api.github.com` blocked with 403 in this sandbox — same as #159/#160, green in CI)
- Migrations 0015–0017 each update **both** `HEAD` constants (`test_migrations.py` + `test_migrations_postgresql.py`)
- Version 0.67.0 → 0.68.0