### PR TITLE
feat(security): first-admin bootstrap and presentation-boundary secret redaction (#154, #147)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,8 @@ Higher-level managers wrap the repositories:
 
 - Two auth layers: **OIDC** (`providers/oidc.py`) and **API keys** (`providers/api_key.py`). Both feed into a `FluxIdentity`; `AuthService` resolves it to a permission set via `RoleModel` rows. Built-in roles: `admin` (`*`), `operator`, `viewer`, `worker`.
 - **Bootstrap token** (`bootstrap_token.py`) — used once by a worker to obtain an API key + service-principal during `POST /workers/register`. If the server's `[flux.workers] bootstrap_token` is unset, one is auto-generated and persisted to `<home>/bootstrap-token` on first start; surface it via `flux server bootstrap-token`.
+- **Admin bootstrap** (`admin_bootstrap.py`, #154) — the human analog: on the first auth-enabled start with no enabled admin principal, a random admin API key is minted (hash in DB, bound to the built-in `admin` role) and the plaintext written to `<home>/admin-bootstrap-key` (0600). Init-only; `flux server admin-key [--rotate]` prints/rotates host-locally.
+- **Presentation redaction** (`redaction.py`, #147 phase 1) — execution-read API responses are scrubbed of known secret values by value identity (config `[flux.security] redact_secrets_in_responses`, default on). Presentation-boundary only: the event log and replay are untouched.
 - **Execution token** (`execution_token.py`) — short-lived JWT scoped to a single execution; used by the worker when calling back into the server during a workflow.
 - Most server routes go through `Depends(require_permission("workflow:{namespace}:{name}:run"))` etc. Permissions follow `resource:scope:scope:verb` with `*` wildcards.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ poetry run flux config    set|get|list|remove
 poetry run flux agent     create|apply|list|show|update|delete
 poetry run flux roles | principals | auth                        # security admin
 poetry run flux server bootstrap-token                           # print the auto-generated worker token
+poetry run flux server admin-key [--rotate]                      # print/rotate the first-admin bootstrap key (#154)
 ```
 
 ### Pytest markers (pyproject.toml)

--- a/flux/api/execution_routes.py
+++ b/flux/api/execution_routes.py
@@ -226,7 +226,9 @@ class ExecutionRoutesMixin:
                     logger.debug(
                         f"Found execution {execution_id} in state: {summary['state']}",
                     )
-                    return summary
+                    from flux.security.redaction import redact_response
+
+                    return await redact_response(summary)
 
                 ctx = manager.get(execution_id)
 
@@ -273,7 +275,13 @@ class ExecutionRoutesMixin:
                 result = dto.summary() if not detailed else dto
 
                 logger.debug(f"Found execution {execution_id} in state: {ctx.state.value}")
-                return result
+                # Presentation-boundary secret redaction (issue #147 phase 1):
+                # the detailed DTO carries every task's recorded inputs and
+                # outputs, and execution:*:read is a much wider grant than
+                # secret-read. The stored event log is untouched.
+                from flux.security.redaction import redact_response
+
+                return await redact_response(result)
 
             except ExecutionContextNotFoundError:
                 raise HTTPException(

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -1597,17 +1597,22 @@ def server_bootstrap_token(rotate: bool):
         "Mint a fresh admin bootstrap key (revoking the previous one) and "
         "persist it. Runs directly against the server's database — a running "
         "server picks the new key up on its next lookup, since keys are "
-        "verified against the stored hash per request."
+        "verified against the stored hash per request. The key only "
+        "authenticates when the API-key provider "
+        "([flux.security.auth.api_keys] enabled = true) is on."
     ),
 )
 def server_admin_key(rotate: bool):
     """Print the admin bootstrap API key (or rotate it). Host-local.
 
     Reading prints the persisted file at <home>/admin-bootstrap-key; it is
-    written on the first auth-enabled server start when no admin principal
-    exists (issue #154). This command operates on the local config and
-    datastore only — the first admin credential is never served over the
-    network; the boundary is access to the server host's disk.
+    written on the first server start with auth and the API-key provider
+    enabled, when no admin principal exists (issue #154). API keys are only
+    accepted while [flux.security.auth.api_keys] is enabled — in an
+    OIDC-only deployment this key cannot authenticate; grant the admin role
+    to an OIDC principal instead. This command operates on the local config
+    and datastore only — the first admin credential is never served over
+    the network; the boundary is access to the server host's disk.
     """
     import asyncio as _asyncio
 
@@ -1621,6 +1626,13 @@ def server_admin_key(rotate: bool):
         from flux.models import RepositoryFactory
         from flux.security.auth_service import AuthService
         from flux.security.principals import PrincipalRegistry
+
+        if not settings.security.auth.api_keys.enabled:
+            click.echo(
+                "Warning: [flux.security.auth.api_keys] is disabled — the minted "
+                "key cannot authenticate until that provider is enabled.",
+                err=True,
+            )
 
         repo = RepositoryFactory.create_repository()
         registry = PrincipalRegistry(session_factory=repo.session)

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -1588,6 +1588,67 @@ def server_bootstrap_token(rotate: bool):
     raise click.exceptions.Exit(1)
 
 
+@server_group.command("admin-key")
+@click.option(
+    "--rotate",
+    is_flag=True,
+    default=False,
+    help=(
+        "Mint a fresh admin bootstrap key (revoking the previous one) and "
+        "persist it. Runs directly against the server's database — a running "
+        "server picks the new key up on its next lookup, since keys are "
+        "verified against the stored hash per request."
+    ),
+)
+def server_admin_key(rotate: bool):
+    """Print the admin bootstrap API key (or rotate it). Host-local.
+
+    Reading prints the persisted file at <home>/admin-bootstrap-key; it is
+    written on the first auth-enabled server start when no admin principal
+    exists (issue #154). This command operates on the local config and
+    datastore only — the first admin credential is never served over the
+    network; the boundary is access to the server host's disk.
+    """
+    import asyncio as _asyncio
+
+    from flux.config import Configuration
+    from flux.security import admin_bootstrap
+
+    settings = Configuration.get().settings
+    home = settings.home
+
+    if rotate:
+        from flux.models import RepositoryFactory
+        from flux.security.auth_service import AuthService
+        from flux.security.principals import PrincipalRegistry
+
+        repo = RepositoryFactory.create_repository()
+        registry = PrincipalRegistry(session_factory=repo.session)
+        auth_service = AuthService(
+            config=settings.security.auth,
+            session_factory=repo.session,
+            registry=registry,
+        )
+        # Roles may not exist yet on a database the server never started on.
+        auth_service.seed_built_in_roles()
+        key = _asyncio.run(admin_bootstrap.rotate(auth_service, registry, home))
+        click.echo(key)
+        return
+
+    persisted = admin_bootstrap.read_persisted(home)
+    if persisted:
+        click.echo(persisted)
+        return
+
+    click.echo(
+        "No admin bootstrap key found. Start the server with auth enabled to "
+        "generate one (first run only), or run 'flux server admin-key --rotate' "
+        "to mint one now.",
+        err=True,
+    )
+    raise click.exceptions.Exit(1)
+
+
 @cli.group()
 def schedule():
     """Manage workflow schedules."""

--- a/flux/security/admin_bootstrap.py
+++ b/flux/security/admin_bootstrap.py
@@ -1,0 +1,144 @@
+"""First-admin bootstrap (issue #154).
+
+API keys are minted through ``POST /admin/principals/{subject}/keys``,
+which requires an admin — so the first admin used to be reachable only by
+running the server with auth disabled. This module is the ``kubeadm
+admin.conf`` analog: on the first auth-enabled start with **no admin
+principal**, it mints a random admin API key, stores only its hash in the
+database bound to the built-in ``admin`` role, and writes the plaintext to
+``<home>/admin-bootstrap-key`` (mode 0600).
+
+Load-bearing properties (deliberately mirroring the worker bootstrap
+token and kubeadm):
+
+- **Generated per-install**, never a fixed default (CWE-798).
+- **Delivered via a host-local 0600 file, not over the network** — the
+  boundary is "can read the server host's disk".
+- **Init-only**: seeding is a no-op whenever any enabled principal already
+  holds the admin role, so restarts never re-mint and deleting the
+  bootstrap principal after creating real admins retires it for good.
+- **Rotatable** via ``flux server admin-key --rotate``.
+- **Bound to the built-in admin role**, not a bespoke grant.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+from collections.abc import Callable
+
+from flux.security.bootstrap_token import read_persisted as _read_file
+from flux.security.bootstrap_token import write as _write_file
+
+if TYPE_CHECKING:
+    from flux.security.auth_service import AuthService
+    from flux.security.principals import PrincipalRegistry
+
+logger = logging.getLogger(__name__)
+
+ADMIN_KEY_FILENAME = "admin-bootstrap-key"
+ADMIN_SUBJECT = "admin"
+ADMIN_ISSUER = "flux"
+ADMIN_KEY_NAME = "bootstrap"
+ADMIN_ROLE = "admin"
+
+
+def read_persisted(home: str | Path) -> str | None:
+    """Return the persisted admin bootstrap key if present, else None."""
+    return _read_file(home, ADMIN_KEY_FILENAME)
+
+
+def has_admin_principal(session_factory: Callable) -> bool:
+    """True if any enabled principal holds the admin role.
+
+    This is the init-only guard: once an admin exists — bootstrap-seeded or
+    operator-created — seeding never runs again.
+    """
+    from flux.security.principals import PrincipalModel, PrincipalRoleModel
+
+    session = session_factory()
+    try:
+        row = (
+            session.query(PrincipalRoleModel)
+            .join(PrincipalModel, PrincipalModel.id == PrincipalRoleModel.principal_id)
+            .filter(
+                PrincipalRoleModel.role_name == ADMIN_ROLE,
+                PrincipalModel.enabled.is_(True),
+            )
+            .first()
+        )
+        return row is not None
+    finally:
+        session.close()
+
+
+async def _mint(
+    auth_service: AuthService,
+    registry: PrincipalRegistry,
+    home: str | Path,
+) -> str:
+    """Create/repair the bootstrap admin principal and mint a fresh key.
+
+    Idempotent against partial prior runs: an existing principal is reused,
+    the role grant is re-asserted, and a stale key of the same name is
+    revoked before the new one is created.
+    """
+    principal = registry.find(ADMIN_SUBJECT, ADMIN_ISSUER)
+    if principal is None:
+        principal = registry.create(
+            type="user",
+            subject=ADMIN_SUBJECT,
+            external_issuer=ADMIN_ISSUER,
+            display_name="Bootstrap admin",
+            metadata={"via": "admin-bootstrap"},
+        )
+    registry.assign_role(principal.id, ADMIN_ROLE, assigned_by="admin-bootstrap")
+
+    try:
+        await auth_service.revoke_api_key(principal.id, ADMIN_KEY_NAME)
+    except ValueError:
+        pass  # no stale key — the common case
+    key = await auth_service.create_api_key(principal.id, ADMIN_KEY_NAME)
+    _write_file(home, key, ADMIN_KEY_FILENAME)
+    return key
+
+
+async def ensure_admin_key(
+    auth_service: AuthService,
+    registry: PrincipalRegistry,
+    session_factory: Callable,
+    home: str | Path,
+) -> str | None:
+    """Seed the first admin credential; no-op when an admin already exists.
+
+    Returns the plaintext key when one was minted this call, else None.
+    Called from the server's lifespan startup hook when auth is enabled —
+    after ``seed_built_in_roles``, so the admin role row exists.
+    """
+    if has_admin_principal(session_factory):
+        return None
+    key = await _mint(auth_service, registry, home)
+    logger.warning(
+        "No admin principal found; generated an admin bootstrap API key at "
+        "%s (subject '%s', bound to the '%s' role). Retrieve it via "
+        "'flux server admin-key'.",
+        Path(home) / ADMIN_KEY_FILENAME,
+        ADMIN_SUBJECT,
+        ADMIN_ROLE,
+    )
+    return key
+
+
+async def rotate(
+    auth_service: AuthService,
+    registry: PrincipalRegistry,
+    home: str | Path,
+) -> str:
+    """Force-mint a fresh key for the bootstrap admin principal.
+
+    Unlike ``ensure_admin_key`` this runs regardless of other admins — it
+    rotates *this* credential, invalidating the previous one (the old hash
+    row is replaced).
+    """
+    return await _mint(auth_service, registry, home)

--- a/flux/security/bootstrap_token.py
+++ b/flux/security/bootstrap_token.py
@@ -31,27 +31,30 @@ TOKEN_FILENAME = "bootstrap-token"
 _FILE_MODE = stat.S_IRUSR | stat.S_IWUSR  # 0600
 
 
-def _path(home: str | Path) -> Path:
-    return Path(home) / TOKEN_FILENAME
+def _path(home: str | Path, filename: str = TOKEN_FILENAME) -> Path:
+    return Path(home) / filename
 
 
-def read_persisted(home: str | Path) -> str | None:
-    """Return the persisted bootstrap token if present, else None."""
-    p = _path(home)
+def read_persisted(home: str | Path, filename: str = TOKEN_FILENAME) -> str | None:
+    """Return the persisted secret file's contents if present, else None."""
+    p = _path(home, filename)
     if not p.exists():
         return None
     return p.read_text().strip() or None
 
 
-def write(home: str | Path, token: str) -> Path:
-    """Persist ``token`` to ``<home>/bootstrap-token`` with mode 0600.
+def write(home: str | Path, token: str, filename: str = TOKEN_FILENAME) -> Path:
+    """Persist ``token`` to ``<home>/<filename>`` with mode 0600.
 
     Creates the file atomically with restrictive permissions: ``os.open`` with
     ``O_CREAT|O_TRUNC`` and ``mode=0600`` ensures the file never briefly exists
     with the umask-derived permissions before the chmod. Falls back to a
     second chmod for the case where the file already existed with wider mode.
+
+    ``filename`` defaults to the worker bootstrap token; the admin-key
+    bootstrap (issue #154) reuses this helper for its own 0600 file.
     """
-    p = _path(home)
+    p = _path(home, filename)
     p.parent.mkdir(parents=True, exist_ok=True)
     flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
     fd = os.open(str(p), flags, _FILE_MODE)

--- a/flux/security/config.py
+++ b/flux/security/config.py
@@ -120,5 +120,14 @@ class SecurityConfig(_BaseConfig):
             "and resume, so it only needs to outlive one continuous run."
         ),
     )
+    redact_secrets_in_responses: bool = Field(
+        default=True,
+        description=(
+            "Redact known secret values (by value identity, from the secret "
+            "store) in execution-read API responses and therefore CLI "
+            "rendering (issue #147 phase 1). Presentation-boundary only: the "
+            "stored event log and replay behavior are unchanged."
+        ),
+    )
 
     model_config = {"arbitrary_types_allowed": True}

--- a/flux/security/redaction.py
+++ b/flux/security/redaction.py
@@ -1,0 +1,123 @@
+"""Presentation-boundary secret redaction (issue #147, phase 1).
+
+Task return values are persisted verbatim to the event log — that store is
+the replay substrate, so it cannot be scrubbed at rest without changing
+replay behavior. What *can* be scrubbed safely is the presentation
+boundary: execution-read API responses (and therefore the CLI, which
+renders them) are visible to every holder of ``execution:*:read`` — a far
+wider grant than secret-read.
+
+This module redacts, by **value identity**, every string the
+``SecretManager`` knows: a task that returned a bare token, or an API
+response with an embedded credential, is caught without any author
+annotation, whatever the surrounding key is called. Storage-level
+redaction (an opt-in ``redact_output`` with explicit re-execute-instead-
+of-replay semantics) is phase 2 and deliberately not here.
+
+Redaction is best-effort presentation hygiene: a failure inside it is
+logged and the response served unredacted, because breaking every
+execution read on a secrets-store hiccup is a worse trade — the event log
+itself is unchanged either way.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+REDACTED = "***REDACTED***"
+
+# Values shorter than this are never redacted: scrubbing "1" or "true"
+# would riddle responses with false positives while protecting nothing.
+MIN_SECRET_LENGTH = 6
+
+# Secret values are re-read (and decrypted) at most this often per process;
+# execution reads between refreshes reuse the cached set.
+_CACHE_TTL_SECONDS = 30.0
+
+_cache: tuple[float, list[str]] | None = None
+
+
+def _redactable(values: dict[str, Any]) -> list[str]:
+    """The string secret values worth scrubbing, longest first.
+
+    Longest-first ordering keeps a secret that contains another secret as a
+    substring from leaving recognizable fragments behind.
+    """
+    return sorted(
+        {v for v in values.values() if isinstance(v, str) and len(v.strip()) >= MIN_SECRET_LENGTH},
+        key=len,
+        reverse=True,
+    )
+
+
+async def collect_secret_values(*, refresh: bool = False) -> list[str]:
+    """All redactable secret values known to the current SecretManager.
+
+    Cached for a short TTL so status polls don't decrypt the whole secret
+    store on every request. ``refresh=True`` bypasses the cache (tests).
+    """
+    global _cache
+    now = time.monotonic()
+    if not refresh and _cache is not None and now - _cache[0] < _CACHE_TTL_SECONDS:
+        return _cache[1]
+
+    from flux.secret_managers import SecretManager
+
+    manager = SecretManager.current()
+    names = manager.all()
+    values = await manager.get(names) if names else {}
+    result = _redactable(values)
+    _cache = (now, result)
+    return result
+
+
+def redact_values(obj: Any, values: list[str]) -> Any:
+    """Return ``obj`` with every occurrence of ``values`` replaced.
+
+    Walks plain JSON-shaped structures (dict / list / tuple / str); other
+    scalars pass through untouched. Keys are scrubbed as well as values — a
+    secret used as a dict key is as leaked as one in a value.
+    """
+    if not values:
+        return obj
+    if isinstance(obj, str):
+        for value in values:
+            if value in obj:
+                obj = obj.replace(value, REDACTED)
+        return obj
+    if isinstance(obj, dict):
+        return {redact_values(k, values): redact_values(v, values) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [redact_values(item, values) for item in obj]
+    return obj
+
+
+async def redact_response(payload: Any) -> Any:
+    """Redact known secret values from an outgoing API payload.
+
+    No-op when ``[flux.security] redact_secrets_in_responses`` is false or
+    no redactable secrets exist. The payload is first reduced to plain JSON
+    structures with FastAPI's own encoder, so redaction sees exactly the
+    representation that would leave the server.
+    """
+    from flux.config import Configuration
+
+    try:
+        if not Configuration.get().settings.security.redact_secrets_in_responses:
+            return payload
+        values = await collect_secret_values()
+        if not values:
+            return payload
+        from fastapi.encoders import jsonable_encoder
+
+        return redact_values(jsonable_encoder(payload), values)
+    except Exception:
+        logger.error(
+            "Secret redaction failed; serving the response unredacted",
+            exc_info=True,
+        )
+        return payload

--- a/flux/server.py
+++ b/flux/server.py
@@ -1295,7 +1295,14 @@ class Server(
             # seed_built_in_roles (the app was constructed before lifespan
             # fires), so the admin role row exists. Init-only: a no-op
             # whenever any enabled admin principal already exists.
-            if startup_settings.security.auth.enabled:
+            # Requires the API-key provider: in an OIDC-only deployment the
+            # minted key could never authenticate, so nothing is seeded —
+            # the first admin there is an OIDC principal granted the admin
+            # role instead.
+            if (
+                startup_settings.security.auth.enabled
+                and startup_settings.security.auth.api_keys.enabled
+            ):
                 from flux.security import admin_bootstrap
 
                 try:

--- a/flux/server.py
+++ b/flux/server.py
@@ -1289,6 +1289,25 @@ class Server(
             )
             self._bootstrap_token = token
 
+            # First-admin bootstrap (issue #154): with auth enabled and no
+            # admin principal yet, seed one with a random API key delivered
+            # via a host-local 0600 file — never over the network. Runs after
+            # seed_built_in_roles (the app was constructed before lifespan
+            # fires), so the admin role row exists. Init-only: a no-op
+            # whenever any enabled admin principal already exists.
+            if startup_settings.security.auth.enabled:
+                from flux.security import admin_bootstrap
+
+                try:
+                    await admin_bootstrap.ensure_admin_key(
+                        auth_service,
+                        principal_registry,
+                        self._get_db_session,
+                        startup_settings.home,
+                    )
+                except Exception:
+                    logger.error("Admin-key bootstrap failed", exc_info=True)
+
             # All blocking DB work reaches the loop through asyncio.to_thread,
             # which uses the loop's default executor — normally capped at
             # min(32, cpu+4) threads, an invisible throughput ceiling shared

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.68.0"
+version = "0.69.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/security/test_admin_bootstrap.py
+++ b/tests/security/test_admin_bootstrap.py
@@ -1,0 +1,219 @@
+"""First-admin bootstrap (issue #154).
+
+On the first auth-enabled start with no admin principal, the server seeds
+a bootstrap admin: random API key, hash-only in the database bound to the
+built-in admin role, plaintext delivered via a host-local 0600 file.
+Init-only, idempotent against partial runs, rotatable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import stat
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from flux.models import Base
+from flux.security import admin_bootstrap
+from flux.security.auth_service import AuthService
+from flux.security.principals import PrincipalRegistry
+
+
+@pytest.fixture
+def session_factory():
+    import flux.security.models  # noqa: F401 — register security models on Base
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+@pytest.fixture
+def registry(session_factory):
+    return PrincipalRegistry(session_factory=session_factory)
+
+
+@pytest.fixture
+def auth_service(session_factory, registry):
+    from flux.config import Configuration
+
+    service = AuthService(
+        config=Configuration.get().settings.security.auth,
+        session_factory=session_factory,
+        registry=registry,
+    )
+    service.seed_built_in_roles()
+    return service
+
+
+def _key_rows(session_factory, principal_id):
+    from flux.security.models import APIKeyModel
+
+    session = session_factory()
+    try:
+        return session.query(APIKeyModel).filter_by(principal_id=principal_id).all()
+    finally:
+        session.close()
+
+
+class TestEnsureAdminKey:
+    async def test_first_run_seeds_admin_with_hashed_key_and_0600_file(
+        self,
+        auth_service,
+        registry,
+        session_factory,
+        tmp_path,
+    ):
+        key = await admin_bootstrap.ensure_admin_key(
+            auth_service,
+            registry,
+            session_factory,
+            tmp_path,
+        )
+
+        assert key is not None
+        principal = registry.find(admin_bootstrap.ADMIN_SUBJECT, admin_bootstrap.ADMIN_ISSUER)
+        assert principal is not None
+        assert "admin" in registry.get_roles(principal.id)
+
+        # Only the hash is stored, and it matches the delivered plaintext.
+        rows = _key_rows(session_factory, principal.id)
+        assert len(rows) == 1
+        assert rows[0].key_hash == hashlib.sha256(key.encode()).hexdigest()
+        assert key not in rows[0].key_hash
+
+        key_file = tmp_path / admin_bootstrap.ADMIN_KEY_FILENAME
+        assert key_file.read_text().strip() == key
+        assert stat.S_IMODE(key_file.stat().st_mode) == 0o600
+        assert admin_bootstrap.read_persisted(tmp_path) == key
+
+    async def test_second_run_is_a_noop(self, auth_service, registry, session_factory, tmp_path):
+        first = await admin_bootstrap.ensure_admin_key(
+            auth_service,
+            registry,
+            session_factory,
+            tmp_path,
+        )
+        second = await admin_bootstrap.ensure_admin_key(
+            auth_service,
+            registry,
+            session_factory,
+            tmp_path,
+        )
+        assert first is not None
+        assert second is None, "restarts must never re-mint"
+        # The delivered file still holds the first key.
+        assert admin_bootstrap.read_persisted(tmp_path) == first
+
+    async def test_existing_admin_principal_suppresses_seeding(
+        self,
+        auth_service,
+        registry,
+        session_factory,
+        tmp_path,
+    ):
+        operator = registry.create(
+            type="user",
+            subject="ops@example.com",
+            external_issuer="https://idp.example.com",
+        )
+        registry.assign_role(operator.id, "admin")
+
+        seeded = await admin_bootstrap.ensure_admin_key(
+            auth_service,
+            registry,
+            session_factory,
+            tmp_path,
+        )
+        assert seeded is None
+        assert not (tmp_path / admin_bootstrap.ADMIN_KEY_FILENAME).exists()
+        assert registry.find(admin_bootstrap.ADMIN_SUBJECT, admin_bootstrap.ADMIN_ISSUER) is None
+
+    async def test_disabled_admin_does_not_count(
+        self,
+        auth_service,
+        registry,
+        session_factory,
+        tmp_path,
+    ):
+        stale = registry.create(
+            type="user",
+            subject="gone@example.com",
+            external_issuer="https://idp.example.com",
+        )
+        registry.assign_role(stale.id, "admin")
+        registry.set_enabled(stale.id, False)
+
+        seeded = await admin_bootstrap.ensure_admin_key(
+            auth_service,
+            registry,
+            session_factory,
+            tmp_path,
+        )
+        assert seeded is not None, "a disabled admin is not a usable admin"
+
+    async def test_partial_prior_run_is_repaired(
+        self,
+        auth_service,
+        registry,
+        session_factory,
+        tmp_path,
+    ):
+        """A crash between principal creation and key minting must not brick
+        the bootstrap: the principal is reused and a key is minted."""
+        registry.create(
+            type="user",
+            subject=admin_bootstrap.ADMIN_SUBJECT,
+            external_issuer=admin_bootstrap.ADMIN_ISSUER,
+        )  # exists, but holds no role and no key
+
+        key = await admin_bootstrap.ensure_admin_key(
+            auth_service,
+            registry,
+            session_factory,
+            tmp_path,
+        )
+        assert key is not None
+        principal = registry.find(admin_bootstrap.ADMIN_SUBJECT, admin_bootstrap.ADMIN_ISSUER)
+        assert "admin" in registry.get_roles(principal.id)
+        assert len(_key_rows(session_factory, principal.id)) == 1
+
+
+class TestRotate:
+    async def test_rotate_replaces_key_and_file(
+        self,
+        auth_service,
+        registry,
+        session_factory,
+        tmp_path,
+    ):
+        first = await admin_bootstrap.ensure_admin_key(
+            auth_service,
+            registry,
+            session_factory,
+            tmp_path,
+        )
+        second = await admin_bootstrap.rotate(auth_service, registry, tmp_path)
+
+        assert second != first
+        principal = registry.find(admin_bootstrap.ADMIN_SUBJECT, admin_bootstrap.ADMIN_ISSUER)
+        rows = _key_rows(session_factory, principal.id)
+        assert len(rows) == 1, "the previous key hash must be gone"
+        assert rows[0].key_hash == hashlib.sha256(second.encode()).hexdigest()
+        assert admin_bootstrap.read_persisted(tmp_path) == second
+
+    async def test_rotate_bootstraps_from_nothing(
+        self,
+        auth_service,
+        registry,
+        session_factory,
+        tmp_path,
+    ):
+        """--rotate on a fresh install mints the principal and key outright."""
+        key = await admin_bootstrap.rotate(auth_service, registry, tmp_path)
+        assert key is not None
+        principal = registry.find(admin_bootstrap.ADMIN_SUBJECT, admin_bootstrap.ADMIN_ISSUER)
+        assert "admin" in registry.get_roles(principal.id)
+        assert admin_bootstrap.read_persisted(tmp_path) == key

--- a/tests/security/test_redaction.py
+++ b/tests/security/test_redaction.py
@@ -1,0 +1,139 @@
+"""Presentation-boundary secret redaction (issue #147, phase 1).
+
+Known secret values are scrubbed by value identity from execution-read
+API responses. The stored event log is untouched — this is presentation
+hygiene for the wide ``execution:*:read`` grant, not storage redaction.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from flux.security import redaction
+from flux.security.redaction import (
+    REDACTED,
+    collect_secret_values,
+    redact_response,
+    redact_values,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    redaction._cache = None
+    yield
+    redaction._cache = None
+
+
+class TestRedactValues:
+    def test_bare_string_value(self):
+        assert redact_values("sk-live-abcdef123", ["sk-live-abcdef123"]) == REDACTED
+
+    def test_embedded_occurrence(self):
+        out = redact_values(
+            "Bearer sk-live-abcdef123 granted",
+            ["sk-live-abcdef123"],
+        )
+        assert out == f"Bearer {REDACTED} granted"
+
+    def test_nested_structures(self):
+        payload = {
+            "events": [
+                {"value": {"token": "sk-live-abcdef123", "count": 3}},
+                {"value": ["ok", "sk-live-abcdef123"]},
+            ],
+        }
+        out = redact_values(payload, ["sk-live-abcdef123"])
+        assert out["events"][0]["value"]["token"] == REDACTED
+        assert out["events"][0]["value"]["count"] == 3
+        assert out["events"][1]["value"] == ["ok", REDACTED]
+
+    def test_secret_used_as_dict_key(self):
+        out = redact_values({"sk-live-abcdef123": "x"}, ["sk-live-abcdef123"])
+        assert out == {REDACTED: "x"}
+
+    def test_multiple_secrets_longest_first_leaves_no_fragments(self):
+        # "inner" is a substring of "prefix-inner-suffix"; longest-first
+        # replacement must not leave recognizable pieces of the longer one.
+        values = sorted(
+            ["inner-secret", "wrap-inner-secret-tail"],
+            key=len,
+            reverse=True,
+        )
+        out = redact_values("saw wrap-inner-secret-tail today", values)
+        assert "inner-secret" not in out
+        assert "tail" not in out.replace(REDACTED, "")
+
+    def test_non_string_scalars_untouched(self):
+        payload = {"n": 42, "f": 1.5, "b": True, "none": None}
+        assert redact_values(payload, ["sk-live-abcdef123"]) == payload
+
+    def test_no_values_is_identity(self):
+        payload = {"token": "sk-live-abcdef123"}
+        assert redact_values(payload, []) is payload
+
+
+class TestCollectSecretValues:
+    async def test_only_long_strings_collected_longest_first(self):
+        manager = MagicMock()
+        manager.all.return_value = ["a", "b", "c", "d"]
+        manager.get = AsyncMock(
+            return_value={
+                "a": "short",  # < MIN_SECRET_LENGTH
+                "b": 123456789,  # not a string
+                "c": "sk-live-abcdef123",
+                "d": "sk-live-abcdef123-and-more",
+            },
+        )
+        with patch("flux.secret_managers.SecretManager.current", return_value=manager):
+            values = await collect_secret_values(refresh=True)
+        assert values == ["sk-live-abcdef123-and-more", "sk-live-abcdef123"]
+
+    async def test_empty_store_collects_nothing(self):
+        manager = MagicMock()
+        manager.all.return_value = []
+        manager.get = AsyncMock()
+        with patch("flux.secret_managers.SecretManager.current", return_value=manager):
+            assert await collect_secret_values(refresh=True) == []
+        manager.get.assert_not_awaited()
+
+
+class TestRedactResponse:
+    def _manager(self):
+        manager = MagicMock()
+        manager.all.return_value = ["token"]
+        manager.get = AsyncMock(return_value={"token": "sk-live-abcdef123"})
+        return manager
+
+    async def test_redacts_payload(self):
+        with patch(
+            "flux.secret_managers.SecretManager.current",
+            return_value=self._manager(),
+        ):
+            out = await redact_response({"output": "sk-live-abcdef123"})
+        assert out == {"output": REDACTED}
+
+    async def test_config_gate_off_is_identity(self):
+        from flux.config import Configuration
+
+        Configuration.get().override(security={"redact_secrets_in_responses": False})
+        try:
+            with patch(
+                "flux.secret_managers.SecretManager.current",
+                return_value=self._manager(),
+            ):
+                payload = {"output": "sk-live-abcdef123"}
+                assert await redact_response(payload) is payload
+        finally:
+            Configuration.get().override(security={"redact_secrets_in_responses": True})
+
+    async def test_redaction_failure_serves_unredacted(self):
+        """Best-effort: a secrets-store failure must not break execution
+        reads; the unredacted payload is served and the failure logged."""
+        manager = MagicMock()
+        manager.all.side_effect = RuntimeError("store down")
+        with patch("flux.secret_managers.SecretManager.current", return_value=manager):
+            payload = {"output": "sk-live-abcdef123"}
+            assert await redact_response(payload) == payload


### PR DESCRIPTION
Closes #154
Part of #147 (phase 1 — phase 2, opt-in storage-level redaction, was deferred in the sequence plan, so #147 stays open; close it manually if phase 1 is deemed sufficient).

PR4 in the issue sequence plan (follows #159, #160, #161) — the security batch. One commit per issue.

## #154 — First-admin bootstrap (`e990d5f`)

API keys are minted through `POST /admin/principals/{subject}/keys`, which requires an admin — so the only path to the first admin was running the server with auth disabled: the safe path required an unsafe intermediate state with no forcing function to leave it.

New `flux/security/admin_bootstrap.py`, the `kubeadm admin.conf` analog, mirroring the existing worker bootstrap-token mechanism:

- On the first start with **auth and the API-key provider enabled** and **no enabled principal holding the admin role**, the lifespan hook creates an `admin` principal bound to the built-in admin role, mints a random API key, stores **only its hash**, and writes the plaintext to `<home>/admin-bootstrap-key` (0600) via the same atomic-write helper as the worker token (now filename-parameterized). OIDC-only deployments seed nothing — a key that cannot authenticate would be pointless; the first admin there is an OIDC principal granted the admin role.
- Load-bearing properties: generated per-install, never a fixed default (CWE-798); delivered via a **host-local 0600 file, never over the network** — the boundary is access to the server host's disk; **init-only** — a no-op whenever any enabled admin exists, so restarts never re-mint and retiring the bootstrap principal after creating real admins retires the mechanism; rotatable; bound to the built-in role, not a bespoke grant.
- `flux server admin-key [--rotate]` prints or rotates host-locally against config + datastore, exactly like `flux server bootstrap-token`. Rotation revokes the previous hash row, repairs a partial prior run, and warns when the current config cannot accept API keys.

The declarative IaC seed (`FLUX_SECURITY__AUTH__BOOTSTRAP_ADMIN_KEY`) listed as an optional complement in the issue is not included — it can follow if demand appears.

## #147 phase 1 — Presentation-boundary secret redaction (`9cbedb4`)

Task return values are persisted verbatim to the event log; that store is the replay substrate and cannot be scrubbed at rest without changing replay behavior (the hard constraint the issue identified). The safe half ships here: `GET /executions/{id}` responses — summary and detailed, and therefore `flux execution show` — are scrubbed of every string value the SecretManager holds, **by value identity**: a bare returned token or an embedded credential is caught with no author annotation, whatever the surrounding key is called (key-name matching was rejected in the issue's analysis — a bare `str` has no key to match).

Mechanics: longest-first replacement so overlapping secrets leave no fragments; values under 6 chars skipped against false-positive noise; dict keys scrubbed like values; the payload is reduced with FastAPI's own encoder first so redaction sees exactly the representation leaving the server; secret values cached 30s so status polls don't decrypt the whole store per request. Config gate `[flux.security] redact_secrets_in_responses` (default on). Best-effort by design: a secrets-store failure logs and serves the response unredacted rather than breaking every execution read — the stored log is identical either way.

## Review follow-ups (`72d5329`)

Admin bootstrap gated on the API-key provider being enabled (OIDC-only deployments seed nothing); CLI help documents the requirement and `--rotate` warns when the config cannot accept the minted key.

## Tests

19 new tests: `tests/security/test_admin_bootstrap.py` (hash-only storage + 0600 mode, init-only no-op on restart, existing/disabled admin handling, partial-run repair, rotation semantics) and `tests/security/test_redaction.py` (nested structures, dict keys, overlapping secrets, min-length skip, config gate, fail-open).

## Verification

- `pre-commit`: passed on all touched files
- Unit suite (`pytest tests/ --ignore=tests/e2e`): 3123 passed, 21 skipped; full `tests/security/` re-run after the review fix: 444 passed
- E2E (`-m "not ollama"`): 139 passed; only the 2 known github-stars failures (`api.github.com` blocked with 403 in this sandbox — same as the previous PRs, green in CI)
- Version 0.68.0 → 0.69.0