### PR TITLE
Stamp event timestamps as UTC and emit compact SSE payloads (#168, #169)

### DIFF
--- a/docs/core-concepts/execution-model.md
+++ b/docs/core-concepts/execution-model.md
@@ -203,3 +203,9 @@ for event in ctx.events:
 # Get last event
 last_event = ctx.events[-1]
 ```
+
+`event.time` is a timezone-aware UTC `datetime`. Events are stamped wherever
+they are created — the server stamps scheduling and claim events, the worker
+stamps workflow and task events — so a single log is only orderable if every
+stamp shares one zone. Convert with `event.time.astimezone()` to display a
+local time.

--- a/flux/api/schemas.py
+++ b/flux/api/schemas.py
@@ -314,6 +314,7 @@ def _inject_trace_context(data_payload: str) -> str:
     try:
         event_data = _json.loads(data_payload)
         event_data["trace_context"] = inject_trace_context()
-        return _json.dumps(event_data)
+        # Compact: the result is an SSE data field, which must stay one line.
+        return _json.dumps(event_data, separators=(",", ":"))
     except Exception:
         return data_payload

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -36,7 +36,7 @@ from flux.security.dependencies import get_identity, require_permission
 from flux.security.identity import FluxIdentity
 from flux.servers.models import ExecutionContext as ExecutionContextDTO
 from flux.utils import get_logger
-from flux.utils import to_json
+from flux.utils import to_wire_json
 from flux.worker_registry import WorkerInfo
 from flux.worker_registry import WorkerRegistry
 from flux.api.schemas import (
@@ -617,7 +617,7 @@ class WorkerRoutesMixin:
                                         f"Sending execution to worker {name}: {ctx.execution_id} (workflow: {ctx.workflow_name})",
                                     )
 
-                                    data_payload = _inject_trace_context(to_json(payload_dict))
+                                    data_payload = _inject_trace_context(to_wire_json(payload_dict))
 
                                     yield {
                                         "id": f"{ctx.execution_id}_{uuid4().hex}",
@@ -642,7 +642,7 @@ class WorkerRoutesMixin:
                                         "id": f"{ctx.execution_id}_{uuid4().hex}",
                                         "event": "execution_cancelled",
                                         "data": _inject_trace_context(
-                                            to_json({"context": ctx}),
+                                            to_wire_json({"context": ctx}),
                                         ),
                                     }
 
@@ -664,7 +664,7 @@ class WorkerRoutesMixin:
                                         "id": f"{ctx.execution_id}_{uuid4().hex}",
                                         "event": "execution_resumed",
                                         "data": _inject_trace_context(
-                                            to_json(resume_payload_dict),
+                                            to_wire_json(resume_payload_dict),
                                         ),
                                     }
 

--- a/flux/dispatcher.py
+++ b/flux/dispatcher.py
@@ -25,7 +25,7 @@ from flux.api.schemas import _inject_trace_context
 from flux.config import Configuration
 from flux.context_managers import ContextManager
 from flux.utils import get_logger
-from flux.utils import to_json
+from flux.utils import to_wire_json
 
 if TYPE_CHECKING:
     from flux.server import Server
@@ -253,7 +253,7 @@ class Dispatcher:
                     frame={
                         "id": f"{ctx.execution_id}_{uuid4().hex}",
                         "event": "execution_cancelled",
-                        "data": _inject_trace_context(to_json({"context": ctx})),
+                        "data": _inject_trace_context(to_wire_json({"context": ctx})),
                     },
                 ),
             )
@@ -276,7 +276,7 @@ class Dispatcher:
                     frame={
                         "id": f"{ctx.execution_id}_{uuid4().hex}",
                         "event": event,
-                        "data": _inject_trace_context(to_json(payload)),
+                        "data": _inject_trace_context(to_wire_json(payload)),
                     },
                 ),
             )

--- a/flux/domain/events.py
+++ b/flux/domain/events.py
@@ -2,11 +2,28 @@ from __future__ import annotations
 
 import hashlib
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, TypedDict
 
 from flux.utils import FluxEncoder, make_hashable  # noqa: F401  (make_hashable kept for back-compat)
+
+
+def as_utc(value: datetime | str) -> datetime:
+    """Coerce an event timestamp to timezone-aware UTC.
+
+    Naive values are interpreted as UTC. That is the single rule applied at
+    every boundary — construction, DB load, wire ingest — because a log is
+    stamped on whichever machine creates each event (the server schedules and
+    claims, the worker runs), and mixing naive with aware raises rather than
+    compares. Rows written before events became aware carry local wall time
+    with no offset left to recover; reading them as UTC keeps them orderable.
+    """
+    if isinstance(value, str):
+        value = datetime.fromisoformat(value)
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 class PausedEventValue(TypedDict):
@@ -73,7 +90,7 @@ class ExecutionEvent:
         source_id: str,
         name: str,
         value: Any | None = None,
-        time: datetime | None = None,
+        time: datetime | str | None = None,
         id: str | None = None,
         subject: str | None = None,
     ):
@@ -83,7 +100,7 @@ class ExecutionEvent:
         self.value = value
         self.subject = subject
 
-        self.time = time or datetime.now()
+        self.time = as_utc(time) if time is not None else datetime.now(timezone.utc)
 
         self.id = id if id else self.__generate_id()
 

--- a/flux/migrations/versions/0014_event_time_utc.py
+++ b/flux/migrations/versions/0014_event_time_utc.py
@@ -1,0 +1,73 @@
+"""Convert execution_events.time to a timezone-aware UTC column.
+
+Events are stamped on whichever machine creates them — the server schedules
+and claims, the worker runs tasks and ships them in checkpoints — so a naive
+timestamp left one execution's log carrying two clocks with no offset to
+reconcile them. Events are now stamped ``datetime.now(timezone.utc)``; on
+PostgreSQL a plain ``timestamp`` column would hand those back naive and every
+comparison against a fresh stamp would raise.
+
+Existing rows are pinned to UTC explicitly. Without the USING clause
+PostgreSQL reinterprets naive values through the session ``TimeZone``, which
+differs per deployment — the same rule ``ExecutionEvent`` applies in code
+(naive means UTC) has to be spelled out here or the migration's result depends
+on who runs it.
+
+SQLite is skipped: it stores datetimes as text and ignores the column's
+timezone flag entirely, so the rule is enforced on load instead.
+
+Revision ID: 0014_event_time_utc
+Revises: 0013_worker_metadata
+Create Date: 2026-08-06
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0014_event_time_utc"
+down_revision: str | None = "0013_worker_metadata"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "execution_events"
+_COLUMN = "time"
+
+
+def _is_timezone_aware(bind) -> bool:
+    column = next(
+        (c for c in sa.inspect(bind).get_columns(_TABLE) if c["name"] == _COLUMN),
+        None,
+    )
+    return bool(column and getattr(column["type"], "timezone", False))
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql" or _is_timezone_aware(bind):
+        return
+    op.alter_column(
+        _TABLE,
+        _COLUMN,
+        type_=sa.DateTime(timezone=True),
+        existing_type=sa.DateTime(),
+        existing_nullable=False,
+        postgresql_using=f"{_COLUMN} AT TIME ZONE 'UTC'",
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql" or not _is_timezone_aware(bind):
+        return
+    op.alter_column(
+        _TABLE,
+        _COLUMN,
+        type_=sa.DateTime(),
+        existing_type=sa.DateTime(timezone=True),
+        existing_nullable=False,
+        postgresql_using=f"{_COLUMN} AT TIME ZONE 'UTC'",
+    )

--- a/flux/models.py
+++ b/flux/models.py
@@ -768,7 +768,7 @@ class ExecutionEventModel(Base):
     type = Column(SqlEnum(ExecutionEventType), nullable=False)
     name = Column(String, nullable=False)
     value = Column(SignedPickleType(), nullable=True)
-    time = Column(DateTime, nullable=False)
+    time = Column(DateTime(timezone=True), nullable=False)
     subject = Column(String, nullable=True)
     execution = relationship(
         "ExecutionContextModel",

--- a/flux/server.py
+++ b/flux/server.py
@@ -510,6 +510,13 @@ class Server(
         # advanced past what `ctx` already holds. The hydrated flag (not the
         # ordinal itself) marks "seen at least once" so an execution with an
         # empty event log (ordinal None) also skips repeat hydration.
+        #
+        # Whether to *emit* the hydrated context is then decided by the last
+        # event's identity, never by its timestamp. Events are stamped on
+        # whichever machine creates them, so any backwards clock movement — a
+        # worker mid-upgrade, an NTP step — used to make every later event
+        # compare as older; since the ordinal had already advanced past it,
+        # the context was never refreshed again and the stream hung open.
         last_seen_ordinal: int | None = None
         hydrated_once = False
 
@@ -577,7 +584,7 @@ class Server(
                         if (
                             new_ctx is not None
                             and new_ctx.events
-                            and (not ctx.events or new_ctx.events[-1].time > ctx.events[-1].time)
+                            and (not ctx.events or new_ctx.events[-1].id != ctx.events[-1].id)
                         ):
                             ctx = new_ctx
                             dto = ExecutionContextDTO.from_domain(ctx)
@@ -595,7 +602,7 @@ class Server(
                     if (
                         new_ctx is not None
                         and new_ctx.events
-                        and (not ctx.events or new_ctx.events[-1].time > ctx.events[-1].time)
+                        and (not ctx.events or new_ctx.events[-1].id != ctx.events[-1].id)
                     ):
                         ctx = new_ctx
                         dto = ExecutionContextDTO.from_domain(ctx)

--- a/flux/server.py
+++ b/flux/server.py
@@ -24,7 +24,7 @@ from flux.errors import WorkflowNotFoundError
 from flux.utils import get_logger
 from flux.servers.uvicorn_server import UvicornServer
 from flux.servers.models import ExecutionContext as ExecutionContextDTO
-from flux.utils import to_json
+from flux.utils import to_wire_json
 from flux.schedule_manager import create_schedule_manager
 from flux.security.auth_service import AuthService
 from flux.security.dependencies import init_auth_service
@@ -529,7 +529,7 @@ class Server(
             dto = ExecutionContextDTO.from_domain(ctx)
             yield {
                 "event": f"{ctx.workflow_name}.execution.{ctx.state.value.lower()}",
-                "data": to_json(dto if detailed else dto.summary()),
+                "data": to_wire_json(dto if detailed else dto.summary()),
             }
         try:
             while not ctx.has_finished:
@@ -560,7 +560,7 @@ class Server(
                         for p in items:
                             yield {
                                 "event": "task.progress",
-                                "data": to_json(
+                                "data": to_wire_json(
                                     {
                                         "type": p.type.value,
                                         "source_id": p.source_id,
@@ -583,7 +583,7 @@ class Server(
                             dto = ExecutionContextDTO.from_domain(ctx)
                             yield {
                                 "event": f"{ctx.workflow_name}.execution.{ctx.state.value.lower()}",
-                                "data": to_json(dto if detailed else dto.summary()),
+                                "data": to_wire_json(dto if detailed else dto.summary()),
                             }
                 else:
                     try:
@@ -601,7 +601,7 @@ class Server(
                         dto = ExecutionContextDTO.from_domain(ctx)
                         yield {
                             "event": f"{ctx.workflow_name}.execution.{ctx.state.value.lower()}",
-                            "data": to_json(dto if detailed else dto.summary()),
+                            "data": to_wire_json(dto if detailed else dto.summary()),
                         }
         finally:
             for t in active_tasks:

--- a/flux/servers/models.py
+++ b/flux/servers/models.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from pydantic import field_validator
 
 from flux import domain
+from flux.domain.events import as_utc
 
 
 class ExecutionEvent(BaseModel):
@@ -20,9 +21,9 @@ class ExecutionEvent(BaseModel):
 
     @field_validator("time", mode="before")
     def parse_datetime(cls, value):
-        if isinstance(value, str):
-            return datetime.fromisoformat(value)
-        return value
+        # Checkpoints arriving from an older worker carry naive times; reading
+        # them as UTC keeps them comparable against the server's own stamps.
+        return as_utc(value)
 
     class Config:
         arbitrary_types_allowed = True

--- a/flux/utils.py
+++ b/flux/utils.py
@@ -167,6 +167,18 @@ def to_json(obj):
     return json.dumps(obj, indent=4, cls=FluxEncoder)
 
 
+def to_wire_json(obj):
+    """Serialize for an SSE ``data`` field: one JSON document, one line.
+
+    sse-starlette splits a payload on newlines, so the indented form shipped
+    each event as a run of ``data:`` lines. Compact JSON escapes newlines
+    inside strings, so the payload is a single line by construction — which is
+    both what line-based SSE consumers expect and ~30-50% less to send on the
+    per-progress-event hot path.
+    """
+    return json.dumps(obj, separators=(",", ":"), cls=FluxEncoder)
+
+
 def import_module(name: str) -> Any:
     return imodule(name)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.66.0"
+version = "0.66.1"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/domain/test_event_timestamps.py
+++ b/tests/flux/domain/test_event_timestamps.py
@@ -1,0 +1,92 @@
+"""Event timestamps are timezone-aware UTC at every boundary.
+
+Events are stamped on whichever machine creates them — the server stamps
+scheduling/claim events, the worker stamps workflow/task events — so a naive
+local timestamp made one execution's log unorderable whenever the two hosts
+sat in different zones (#169).
+"""
+
+from __future__ import annotations
+
+import time as time_module
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
+from flux.domain.events import ExecutionEvent
+from flux.domain.events import ExecutionEventType
+
+
+def _event(type=ExecutionEventType.WORKFLOW_STARTED, **kwargs) -> ExecutionEvent:
+    return ExecutionEvent(type=type, source_id="src", name="wf", **kwargs)
+
+
+def test_default_time_is_timezone_aware_utc():
+    event = _event()
+
+    assert event.time.tzinfo is not None
+    assert event.time.utcoffset() == timedelta(0)
+
+
+def test_default_time_is_the_current_instant():
+    before = datetime.now(timezone.utc)
+    event = _event()
+    after = datetime.now(timezone.utc)
+
+    assert before <= event.time <= after
+
+
+def test_naive_time_is_interpreted_as_utc():
+    """The one deliberate rule for the migration: naive means UTC.
+
+    Applies to rows written before this change and to older workers still
+    checkpointing naive times — both are read back as UTC rather than
+    compared against aware values (which raises TypeError).
+    """
+    event = _event(time=datetime(2026, 8, 7, 0, 57, 11))
+
+    assert event.time == datetime(2026, 8, 7, 0, 57, 11, tzinfo=timezone.utc)
+
+
+def test_aware_non_utc_time_is_converted_to_utc_preserving_the_instant():
+    minus_four = timezone(timedelta(hours=-4))
+    event = _event(time=datetime(2026, 8, 6, 20, 57, 11, tzinfo=minus_four))
+
+    assert event.time == datetime(2026, 8, 7, 0, 57, 11, tzinfo=timezone.utc)
+    assert event.time.utcoffset() == timedelta(0)
+
+
+def test_iso_string_time_is_parsed_to_aware_utc():
+    """Wire-rebuilt events (ExecutionContext.from_json) carry time as a str."""
+    event = _event(time="2026-08-07T00:57:11+00:00")
+
+    assert isinstance(event.time, datetime)
+    assert event.time == datetime(2026, 8, 7, 0, 57, 11, tzinfo=timezone.utc)
+
+
+def test_naive_iso_string_time_is_parsed_as_utc():
+    event = _event(time="2026-08-07T00:57:11")
+
+    assert event.time == datetime(2026, 8, 7, 0, 57, 11, tzinfo=timezone.utc)
+
+
+def test_default_stamp_does_not_depend_on_the_local_timezone(monkeypatch):
+    """The #169 reproduction: a UTC server and a UTC-4 worker.
+
+    The worker's WORKFLOW_STARTED genuinely happens after the server's
+    WORKFLOW_CLAIMED, but stamping with the local clock made it compare as
+    four hours older. Both stamps must land on the true instant regardless of
+    where the process runs.
+    """
+    claimed = _event(type=ExecutionEventType.WORKFLOW_CLAIMED)
+
+    monkeypatch.setenv("TZ", "America/New_York")
+    time_module.tzset()
+    try:
+        started = _event(type=ExecutionEventType.WORKFLOW_STARTED)
+    finally:
+        monkeypatch.undo()
+        time_module.tzset()
+
+    assert datetime.now(timezone.utc) - started.time < timedelta(minutes=1)
+    assert started.time > claimed.time

--- a/tests/flux/test_event_timestamp_persistence.py
+++ b/tests/flux/test_event_timestamp_persistence.py
@@ -1,0 +1,106 @@
+"""Event timestamps survive the persistence and wire round-trips as UTC.
+
+SQLite drops tzinfo on write no matter how the column is declared, so a
+freshly-stamped aware event and the same event read back would otherwise
+compare as aware-vs-naive and raise (#169).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
+from flux.domain.events import ExecutionEvent
+from flux.domain.events import ExecutionEventType
+from flux.models import ExecutionEventModel
+from flux.servers.models import ExecutionEvent as WireExecutionEvent
+
+
+def test_to_plain_reattaches_utc_when_the_row_is_naive():
+    """SQLite always hands back a naive datetime — including for rows written
+    before events became aware."""
+    model = ExecutionEventModel(
+        execution_id="exec-1",
+        source_id="src",
+        event_id="abc123",
+        type=ExecutionEventType.WORKFLOW_STARTED,
+        name="wf",
+        time=datetime(2026, 8, 7, 0, 57, 11),
+    )
+
+    event = model.to_plain()
+
+    assert event.time == datetime(2026, 8, 7, 0, 57, 11, tzinfo=timezone.utc)
+    assert event.time.utcoffset() == timedelta(0)
+
+
+def test_database_round_trip_preserves_the_instant():
+    from examples.hello_world import hello_world
+    from flux.context_managers import ContextManager
+
+    ctx = hello_world.run("Joe")
+    assert ctx.has_finished and ctx.has_succeeded
+
+    loaded = ContextManager.create().get(ctx.execution_id)
+
+    assert loaded.events
+    for event in loaded.events:
+        assert event.time.tzinfo is not None
+        assert event.time.utcoffset() == timedelta(0)
+
+    # Freshly stamped vs read back: this comparison raises TypeError the moment
+    # one side is naive.
+    assert loaded.events[-1].time < datetime.now(timezone.utc)
+
+
+def test_wire_ingest_normalizes_a_naive_checkpoint_to_utc():
+    """An older worker checkpoints naive times; the server must not store a
+    value that cannot be compared against its own aware stamps."""
+    wire = WireExecutionEvent(
+        id="abc123",
+        type="WORKFLOW_STARTED",
+        source_id="src",
+        name="wf",
+        time="2026-08-07T00:57:11",
+    )
+
+    assert wire.time == datetime(2026, 8, 7, 0, 57, 11, tzinfo=timezone.utc)
+
+
+def test_wire_ingest_converts_an_offset_checkpoint_to_utc():
+    wire = WireExecutionEvent(
+        id="abc123",
+        type="WORKFLOW_STARTED",
+        source_id="src",
+        name="wf",
+        time="2026-08-06T20:57:11-04:00",
+    )
+
+    assert wire.time == datetime(2026, 8, 7, 0, 57, 11, tzinfo=timezone.utc)
+
+
+def test_context_from_json_rebuilds_aware_times():
+    """ExecutionContext.from_json feeds ExecutionEvent the isoformat string
+    straight from the wire — the worker side of every dispatch."""
+    from flux.domain.execution_context import ExecutionContext
+
+    original = ExecutionContext(
+        workflow_id="wf-1",
+        workflow_namespace="default",
+        workflow_name="wf",
+        input=None,
+        execution_id="exec-1",
+        events=[
+            ExecutionEvent(
+                type=ExecutionEventType.WORKFLOW_STARTED,
+                source_id="src",
+                name="wf",
+                time=datetime(2026, 8, 7, 0, 57, 11, tzinfo=timezone.utc),
+            ),
+        ],
+    )
+
+    rebuilt = ExecutionContext.from_json(original.to_dict())
+
+    assert rebuilt.events[0].time == datetime(2026, 8, 7, 0, 57, 11, tzinfo=timezone.utc)

--- a/tests/flux/test_migrations.py
+++ b/tests/flux/test_migrations.py
@@ -13,7 +13,7 @@ import flux.security.models  # noqa: F401
 from flux.migrations.runner import current_revision, run_migrations
 from flux.models import Base
 
-HEAD = "0013_worker_metadata"
+HEAD = "0014_event_time_utc"
 BASELINE = "0001_baseline"
 
 # A representative index added after the original create_all schema, used to

--- a/tests/flux/test_migrations_postgresql.py
+++ b/tests/flux/test_migrations_postgresql.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import os
 import uuid
+from datetime import datetime
+from datetime import timezone
 
 import pytest
 from sqlalchemy import create_engine, inspect, text
@@ -28,7 +30,7 @@ pytestmark = [
     ),
 ]
 
-HEAD = "0013_worker_metadata"
+HEAD = "0014_event_time_utc"
 _BACKFILL_INDEX = "ix_executions_workflow_id"
 
 
@@ -91,6 +93,67 @@ def test_pg_migration_is_idempotent():
         run_migrations(engine)
         run_migrations(engine)
         assert current_revision(engine) == HEAD
+    finally:
+        engine.dispose()
+        _drop_schema(admin, schema)
+        admin.dispose()
+
+
+def test_pg_event_time_is_timestamptz_and_reinterprets_legacy_rows_as_utc():
+    """0014 converts execution_events.time to timestamptz.
+
+    PostgreSQL hands back a naive datetime from a plain ``timestamp`` column,
+    which cannot be compared against the aware stamps events now carry (#169).
+    The conversion must pin existing naive values to UTC explicitly — without a
+    USING clause PostgreSQL reinterprets them through the session TimeZone,
+    which varies by deployment.
+    """
+    engine, schema, admin = _fresh_schema_engine()
+    try:
+        Base.metadata.create_all(engine)
+        # Emulate a pre-0014 schema holding a naive timestamp.
+        with engine.begin() as conn:
+            conn.execute(
+                text("ALTER TABLE execution_events ALTER COLUMN time TYPE timestamp"),
+            )
+            # PostgreSQL enforces the workflows/executions FKs SQLite ignores.
+            conn.execute(
+                text(
+                    "INSERT INTO workflows (id, namespace, name, version, source) "
+                    "VALUES ('wf-1', 'default', 'wf', 1, '')",
+                ),
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO executions (execution_id, workflow_id, "
+                    "workflow_namespace, workflow_name, state, claim_generation) "
+                    "VALUES ('exec-1', 'wf-1', 'default', 'wf', 'COMPLETED', 0)",
+                ),
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO execution_events "
+                    "(execution_id, source_id, event_id, type, name, time) "
+                    "VALUES ('exec-1', 'src', 'abc123', 'WORKFLOW_STARTED', 'wf', "
+                    "'2026-08-07 00:57:11')",
+                ),
+            )
+
+        run_migrations(engine)
+
+        assert current_revision(engine) == HEAD
+        col = next(
+            c for c in inspect(engine).get_columns("execution_events") if c["name"] == "time"
+        )
+        assert col["type"].timezone is True, f"expected timestamptz, got {col['type']}"
+
+        # The pre-existing naive value is pinned to UTC, not to the session zone.
+        with engine.begin() as conn:
+            conn.execute(text("SET TIME ZONE 'America/New_York'"))
+            stored = conn.execute(
+                text("SELECT time FROM execution_events WHERE event_id = 'abc123'"),
+            ).scalar_one()
+        assert stored == datetime(2026, 8, 7, 0, 57, 11, tzinfo=timezone.utc)
     finally:
         engine.dispose()
         _drop_schema(admin, schema)

--- a/tests/flux/test_sse_wire_format.py
+++ b/tests/flux/test_sse_wire_format.py
@@ -1,0 +1,201 @@
+"""SSE payloads go on the wire as one JSON document per ``data:`` line.
+
+sse-starlette splits a payload on newlines, so pretty-printed JSON shipped
+every event as a run of consecutive ``data:`` lines. That is legal SSE, but
+line-based consumers — the de-facto convention for JSON-over-SSE — parse zero
+events from it, silently, and the indentation is paid per progress frame
+(#168).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime
+from datetime import timezone
+
+import pytest
+
+from flux.api.schemas import _inject_trace_context
+from flux.domain.events import ExecutionEvent
+from flux.domain.events import ExecutionEventType
+from flux.domain.events import ExecutionState
+from flux.domain.execution_context import ExecutionContext
+from flux.server import Server
+from flux.utils import to_json
+from flux.utils import to_wire_json
+
+_PAYLOAD = {
+    "workflow_name": "probe",
+    "input": {"n": 24},
+    "output": None,
+    "state": "CLAIMED",
+    "nested": {"deep": [1, 2, {"deeper": True}]},
+}
+
+
+def test_to_wire_json_is_a_single_line():
+    assert "\n" not in to_wire_json(_PAYLOAD)
+
+
+def test_to_wire_json_has_no_padding_between_tokens():
+    wire = to_wire_json(_PAYLOAD)
+    assert '"state":"CLAIMED"' in wire
+    assert ", " not in wire
+
+
+def test_to_wire_json_parses_to_the_same_object_as_the_pretty_form():
+    """Backward compatible: a spec-compliant client sees an identical object."""
+    assert json.loads(to_wire_json(_PAYLOAD)) == json.loads(to_json(_PAYLOAD))
+
+
+def test_to_wire_json_escapes_newlines_inside_strings():
+    """Compact JSON cannot contain a literal newline, so payload == one line
+    by construction and the SSE splitting path is never exercised."""
+    wire = to_wire_json({"text": "line one\nline two"})
+
+    assert "\n" not in wire
+    assert json.loads(wire)["text"] == "line one\nline two"
+
+
+def test_to_wire_json_serializes_flux_types():
+    wire = to_wire_json({"at": datetime(2026, 8, 7, tzinfo=timezone.utc)})
+
+    assert "\n" not in wire
+    assert json.loads(wire)["at"] == "2026-08-07T00:00:00+00:00"
+
+
+def test_to_json_stays_pretty_for_human_surfaces():
+    """The CLI and debug logs keep the indented form."""
+    assert "\n" in to_json(_PAYLOAD)
+
+
+def test_inject_trace_context_keeps_the_payload_on_one_line(monkeypatch):
+    monkeypatch.setattr("flux.observability.is_enabled", lambda: True)
+    monkeypatch.setattr(
+        "flux.observability.tracing.inject_trace_context",
+        lambda: {"traceparent": "00-abc-def-01"},
+    )
+
+    result = _inject_trace_context(to_wire_json(_PAYLOAD))
+
+    assert "\n" not in result
+    assert json.loads(result)["trace_context"] == {"traceparent": "00-abc-def-01"}
+
+
+class _TickingEvent(asyncio.Event):
+    async def wait(self) -> bool:
+        await asyncio.sleep(0.01)
+        return True
+
+    def clear(self) -> None:
+        pass
+
+
+class _FakeManager:
+    def __init__(self, ctx):
+        self._ctx = ctx
+
+    def last_event_ordinal(self, execution_id: str) -> int:
+        return 2
+
+    def get(self, execution_id: str):
+        return self._ctx
+
+
+@pytest.mark.asyncio
+async def test_execution_stream_frames_are_single_line():
+    stamp = datetime(2026, 8, 7, 0, 57, 11, tzinfo=timezone.utc)
+    ctx = ExecutionContext(
+        workflow_id="wf-1",
+        workflow_namespace="default",
+        workflow_name="probe",
+        input={"n": 24},
+        execution_id="exec-1",
+        state=ExecutionState.COMPLETED,
+        events=[
+            ExecutionEvent(
+                type=ExecutionEventType.WORKFLOW_COMPLETED,
+                source_id="exec-1",
+                name="probe",
+                time=stamp,
+            ),
+        ],
+    )
+
+    server = Server.__new__(Server)
+    server._execution_events = {"exec-1": _TickingEvent()}
+    server._progress_buffers = {}
+
+    frames = []
+
+    async def collect():
+        async for frame in server._stream_execution_events(
+            ctx,
+            _FakeManager(ctx),
+            detailed=True,
+            emit_initial=True,
+        ):
+            frames.append(frame)
+
+    await asyncio.wait_for(collect(), timeout=5.0)
+
+    assert frames
+    for frame in frames:
+        assert "\n" not in frame["data"], f"multi-line SSE data in {frame['event']}"
+        json.loads(frame["data"])
+
+
+@pytest.mark.asyncio
+async def test_progress_frames_are_single_line():
+    """Progress is the highest-frequency frame the server emits."""
+    stamp = datetime(2026, 8, 7, 0, 57, 11, tzinfo=timezone.utc)
+    ctx = ExecutionContext(
+        workflow_id="wf-1",
+        workflow_namespace="default",
+        workflow_name="probe",
+        input=None,
+        execution_id="exec-1",
+        state=ExecutionState.RUNNING,
+        events=[
+            ExecutionEvent(
+                type=ExecutionEventType.WORKFLOW_STARTED,
+                source_id="exec-1",
+                name="probe",
+                time=stamp,
+            ),
+        ],
+    )
+
+    buffer: asyncio.Queue = asyncio.Queue()
+    buffer.put_nowait(
+        ExecutionEvent(
+            type=ExecutionEventType.TASK_PROGRESS,
+            source_id="task-1",
+            name="step",
+            value={"pct": 50, "note": "halfway"},
+            time=stamp,
+        ),
+    )
+
+    server = Server.__new__(Server)
+    server._execution_events = {"exec-1": _TickingEvent()}
+    server._progress_buffers = {"exec-1": buffer}
+
+    frames = []
+
+    async def collect():
+        async for frame in server._stream_execution_events(
+            ctx,
+            _FakeManager(ctx),
+            detailed=False,
+        ):
+            frames.append(frame)
+            if len(frames) >= 1:
+                break
+
+    await asyncio.wait_for(collect(), timeout=5.0)
+
+    assert [f["event"] for f in frames] == ["task.progress"]
+    assert "\n" not in frames[0]["data"]
+    assert json.loads(frames[0]["data"])["value"] == {"pct": 50, "note": "halfway"}

--- a/tests/flux/test_sse_wire_format.py
+++ b/tests/flux/test_sse_wire_format.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from datetime import timezone
 
 import pytest
+from typing import Literal
 
 from flux.api.schemas import _inject_trace_context
 from flux.domain.events import ExecutionEvent
@@ -84,7 +85,7 @@ def test_inject_trace_context_keeps_the_payload_on_one_line(monkeypatch):
 
 
 class _TickingEvent(asyncio.Event):
-    async def wait(self) -> bool:
+    async def wait(self) -> Literal[True]:
         await asyncio.sleep(0.01)
         return True
 

--- a/tests/flux/test_stream_execution_events.py
+++ b/tests/flux/test_stream_execution_events.py
@@ -1,0 +1,132 @@
+"""The run/stream SSE loop must advance on log growth, not on wall clock.
+
+Gating frames on ``events[-1].time >`` wedged the stream permanently whenever
+a later event carried an earlier timestamp: the hydration ordinal had already
+moved on, so the context was never refreshed again and the loop spun until the
+client gave up (#169). Timezone skew was one way to produce that; an NTP step
+or a mid-upgrade worker are others.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
+import pytest
+from typing import Literal
+
+from flux.domain.events import ExecutionEvent
+from flux.domain.events import ExecutionEventType
+from flux.domain.events import ExecutionState
+from flux.domain.execution_context import ExecutionContext
+from flux.server import Server
+
+
+class _TickingEvent(asyncio.Event):
+    """Always ready, never latches — drives the loop without a real worker."""
+
+    async def wait(self) -> Literal[True]:
+        await asyncio.sleep(0.01)
+        return True
+
+    def clear(self) -> None:
+        pass
+
+
+class _FakeManager:
+    """Serves one hydration: the execution advances to COMPLETED exactly once."""
+
+    def __init__(self, completed: ExecutionContext):
+        self._completed = completed
+
+    def last_event_ordinal(self, execution_id: str) -> int:
+        return 2
+
+    def get(self, execution_id: str) -> ExecutionContext:
+        return self._completed
+
+
+def _ctx(state: ExecutionState, events: list[ExecutionEvent]) -> ExecutionContext:
+    return ExecutionContext(
+        workflow_id="wf-1",
+        workflow_namespace="default",
+        workflow_name="probe",
+        input=None,
+        execution_id="exec-1",
+        state=state,
+        events=events,
+    )
+
+
+def _event(type: ExecutionEventType, time: datetime) -> ExecutionEvent:
+    return ExecutionEvent(type=type, source_id="exec-1", name="probe", time=time)
+
+
+@pytest.mark.asyncio
+async def test_stream_emits_terminal_frame_when_the_clock_moves_backwards():
+    later = datetime(2026, 8, 7, 0, 57, 11, tzinfo=timezone.utc)
+    earlier = later - timedelta(hours=4)
+
+    claimed = _ctx(
+        ExecutionState.CLAIMED,
+        [_event(ExecutionEventType.WORKFLOW_CLAIMED, later)],
+    )
+    completed = _ctx(
+        ExecutionState.COMPLETED,
+        [
+            _event(ExecutionEventType.WORKFLOW_CLAIMED, later),
+            _event(ExecutionEventType.WORKFLOW_COMPLETED, earlier),
+        ],
+    )
+    assert completed.has_finished
+
+    server = Server.__new__(Server)
+    server._execution_events = {"exec-1": _TickingEvent()}
+    server._progress_buffers = {}
+
+    frames = []
+
+    async def collect():
+        async for frame in server._stream_execution_events(
+            claimed,
+            _FakeManager(completed),
+            detailed=False,
+        ):
+            frames.append(frame)
+
+    await asyncio.wait_for(collect(), timeout=5.0)
+
+    assert [f["event"] for f in frames] == ["probe.execution.completed"]
+
+
+@pytest.mark.asyncio
+async def test_stream_does_not_re_emit_an_unchanged_log():
+    """The initial frame must not be duplicated when hydration finds no new
+    events — the property the time comparison was providing."""
+    stamp = datetime(2026, 8, 7, 0, 57, 11, tzinfo=timezone.utc)
+    events = [
+        _event(ExecutionEventType.WORKFLOW_CLAIMED, stamp),
+        _event(ExecutionEventType.WORKFLOW_COMPLETED, stamp + timedelta(seconds=1)),
+    ]
+    finished = _ctx(ExecutionState.COMPLETED, events)
+
+    server = Server.__new__(Server)
+    server._execution_events = {"exec-1": _TickingEvent()}
+    server._progress_buffers = {}
+
+    frames = []
+
+    async def collect():
+        async for frame in server._stream_execution_events(
+            finished,
+            _FakeManager(finished),
+            detailed=False,
+            emit_initial=True,
+        ):
+            frames.append(frame)
+
+    await asyncio.wait_for(collect(), timeout=5.0)
+
+    assert [f["event"] for f in frames] == ["probe.execution.completed"]


### PR DESCRIPTION
Fixes #168 and #169. Both are defects in the same SSE stream, but they are independent and are separate commits.

## Why

**#169 — `run/stream` hangs whenever the worker is not in the server's timezone.**

`ExecutionEvent.time` defaulted to `datetime.now()` — naive *local*. Events are stamped on whichever machine creates them: the server stamps scheduling and claim events, the worker stamps workflow and task events and ships them in checkpoints. With the server in UTC and a worker at UTC-4, one execution's log carries two clocks and the worker's events appear to precede the execution's own scheduling by four hours.

That wedges the stream. `_stream_execution_events` emitted a frame only when the log advanced *by time*, but the hydration ordinal had already moved past the event — so after the CLAIMED frame every worker-written event compared as hours older, the context was never refreshed again, and the stream pinged forever while the execution sat COMPLETED in the database. `mode=sync` was unaffected (it polls `has_finished`), which made a clock bug look transport-specific.

Fixed at two levels, because either alone leaves a hole:

- Stamp aware UTC, with **one rule at every boundary — naive means UTC** — via `as_utc()` in the `ExecutionEvent` constructor, which every path routes through (DB load, wire ingest, `from_json` rebuilds). Python raises on naive-vs-aware comparison, so having a single rule matters more than which rule. This also fixes a latent bug: wire-rebuilt events carried `time` as a **string**, never a datetime.
- Gate stream frames on the last event's **identity** rather than its timestamp. Correct stamping removes the timezone trigger, but an NTP step or a worker mid-upgrade reproduces the identical permanent hang. Clocks no longer sit in the control path at all.

**#168 — pretty-printed payloads split every event across many `data:` lines.**

`to_json` indents with four spaces and sse-starlette splits payloads on newlines, so a small execution produced 207 `data:` lines for ~26 events. Multi-line `data` is legal SSE, but the de-facto convention for JSON-over-SSE is one document per line, and a line-based client pointed at this stream parses *zero* events — silently, because each line looks like a `data:` field yet none is valid JSON alone. `to_wire_json` is used wherever a payload becomes an SSE `data` field; `to_json` stays indented for the CLI and debug logs. Backward compatible: a spec-compliant client parses the compact payload to the identical object.

## Migration

`0014` converts `execution_events.time` to `timestamptz`. This is load-bearing on PostgreSQL, which hands back a **naive** datetime from a plain `timestamp` column — every loaded-vs-fresh comparison would raise. SQLite drops `tzinfo` whatever the column says, so the constructor rule covers it there.

Existing rows are pinned with `USING ... AT TIME ZONE 'UTC'`. Without it PostgreSQL reinterprets naive values through the session `TimeZone`, so the migration's result would vary by deployment. Rows written before this change carry local wall time with no offset left to recover; reading them as UTC keeps them orderable, which is the same rule applied in code.

## Verification

| gate | result |
|---|---|
| unit, SQLite (CI) | 3055 passed, 22 skipped |
| e2e, SQLite (CI) | 142 passed, 1 skipped |
| e2e, PostgreSQL 15 | 142 passed, 1 skipped |
| `-m postgresql` | 5 passed |
| pre-commit | all hooks pass |

Both issues' reproductions were run against a real server/worker pair on PostgreSQL with the worker in `America/New_York` (4h skew from the UTC server):

- the stream advances `CLAIMED → RUNNING → COMPLETED` and closes, where it previously stopped after CLAIMED and pinged indefinitely;
- 32 events produce **32 `data:` lines**, every one independently parseable by a line-based client, 38% smaller on the wire.

Running the *whole* unit suite against PostgreSQL yields 163 failures, but they are pre-existing and identical on `main` under a clean database — fixtures that build their own `sqlite:///` temp DB while inheriting `FLUX_DATABASE_TYPE=postgresql`. Not a supported configuration; CI runs the unit suite on SQLite.
