### PR TITLE
fix(security): mint the bootstrap admin principal as service_account

### DIFF
--- a/flux/security/admin_bootstrap.py
+++ b/flux/security/admin_bootstrap.py
@@ -86,12 +86,25 @@ async def _mint(
     """
     principal = registry.find(ADMIN_SUBJECT, ADMIN_ISSUER)
     if principal is None:
+        # service_account, not user: the API-key provider only authenticates
+        # service accounts (an API key is a machine credential), and this
+        # principal exists solely to hold the bootstrap key — a user-typed
+        # principal here mints a key that can never authenticate (issue #170).
         principal = registry.create(
-            type="user",
+            type="service_account",
             subject=ADMIN_SUBJECT,
             external_issuer=ADMIN_ISSUER,
             display_name="Bootstrap admin",
             metadata={"via": "admin-bootstrap"},
+        )
+    elif principal.type != "service_account":
+        # Repair a principal seeded by the #154 implementation that minted
+        # dead keys: rotating (or re-minting) heals the deployment in place.
+        registry.set_type(principal.id, "service_account")
+        logger.warning(
+            "Repaired bootstrap admin principal '%s': type changed to "
+            "'service_account' so its API key can authenticate (issue #170)",
+            ADMIN_SUBJECT,
         )
     registry.assign_role(principal.id, ADMIN_ROLE, assigned_by="admin-bootstrap")
 

--- a/flux/security/admin_bootstrap.py
+++ b/flux/security/admin_bootstrap.py
@@ -19,6 +19,11 @@ token and kubeadm):
   bootstrap principal after creating real admins retires it for good.
 - **Rotatable** via ``flux server admin-key --rotate``.
 - **Bound to the built-in admin role**, not a bespoke grant.
+- **Typed ``service_account``** (issue #170). API keys are a machine
+  credential throughout: ``POST /admin/principals/{subject}/keys`` refuses
+  to mint one for a ``user``-typed principal and ``APIKeyProvider`` refuses
+  to accept one, so a ``user``-typed bootstrap principal produces a key no
+  enabled provider will ever honour.
 """
 
 from __future__ import annotations
@@ -33,7 +38,7 @@ from flux.security.bootstrap_token import write as _write_file
 
 if TYPE_CHECKING:
     from flux.security.auth_service import AuthService
-    from flux.security.principals import PrincipalRegistry
+    from flux.security.principals import PrincipalModel, PrincipalRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +47,9 @@ ADMIN_SUBJECT = "admin"
 ADMIN_ISSUER = "flux"
 ADMIN_KEY_NAME = "bootstrap"
 ADMIN_ROLE = "admin"
+# The credential is machine-held and delivered as an API key, so the
+# principal has to be the type API keys are issued to (issue #170).
+ADMIN_PRINCIPAL_TYPE = "service_account"
 
 
 def read_persisted(home: str | Path) -> str | None:
@@ -73,6 +81,35 @@ def has_admin_principal(session_factory: Callable) -> bool:
         session.close()
 
 
+def _normalize_principal_type(registry: PrincipalRegistry) -> PrincipalModel | None:
+    """Return the bootstrap principal, re-typing a pre-#170 ``user`` row.
+
+    Deployments seeded by the original #154 implementation hold a
+    ``user``-typed bootstrap principal whose key no provider accepts. That
+    principal still carries the admin role, so ``has_admin_principal``
+    suppresses re-seeding and the operator stays locked out — which is why
+    this runs on the plain startup path too, not only when minting.
+
+    Scoped to the ``(admin, flux)`` identity this module already claims and
+    reuses; no other principal is touched. The stored key is deliberately
+    left alone, so the operator's existing copy starts working instead of
+    being replaced by one they would have to go and fetch.
+    """
+    principal = registry.find(ADMIN_SUBJECT, ADMIN_ISSUER)
+    if principal is not None and principal.type != ADMIN_PRINCIPAL_TYPE:
+        registry.set_type(principal.id, ADMIN_PRINCIPAL_TYPE)
+        logger.warning(
+            "Repaired bootstrap admin principal '%s': type '%s' -> '%s'. Its "
+            "API key could not authenticate before this (issue #170); the key "
+            "at <home>/%s is now accepted.",
+            ADMIN_SUBJECT,
+            principal.type,
+            ADMIN_PRINCIPAL_TYPE,
+            ADMIN_KEY_FILENAME,
+        )
+    return principal
+
+
 async def _mint(
     auth_service: AuthService,
     registry: PrincipalRegistry,
@@ -80,31 +117,22 @@ async def _mint(
 ) -> str:
     """Create/repair the bootstrap admin principal and mint a fresh key.
 
-    Idempotent against partial prior runs: an existing principal is reused,
-    the role grant is re-asserted, and a stale key of the same name is
-    revoked before the new one is created.
+    Idempotent against partial prior runs: an existing principal is reused
+    (and re-typed if it predates #170), the role grant is re-asserted, and a
+    stale key of the same name is revoked before the new one is created.
     """
-    principal = registry.find(ADMIN_SUBJECT, ADMIN_ISSUER)
+    principal = _normalize_principal_type(registry)
     if principal is None:
         # service_account, not user: the API-key provider only authenticates
         # service accounts (an API key is a machine credential), and this
         # principal exists solely to hold the bootstrap key — a user-typed
         # principal here mints a key that can never authenticate (issue #170).
         principal = registry.create(
-            type="service_account",
+            type=ADMIN_PRINCIPAL_TYPE,
             subject=ADMIN_SUBJECT,
             external_issuer=ADMIN_ISSUER,
             display_name="Bootstrap admin",
             metadata={"via": "admin-bootstrap"},
-        )
-    elif principal.type != "service_account":
-        # Repair a principal seeded by the #154 implementation that minted
-        # dead keys: rotating (or re-minting) heals the deployment in place.
-        registry.set_type(principal.id, "service_account")
-        logger.warning(
-            "Repaired bootstrap admin principal '%s': type changed to "
-            "'service_account' so its API key can authenticate (issue #170)",
-            ADMIN_SUBJECT,
         )
     registry.assign_role(principal.id, ADMIN_ROLE, assigned_by="admin-bootstrap")
 
@@ -128,7 +156,12 @@ async def ensure_admin_key(
     Returns the plaintext key when one was minted this call, else None.
     Called from the server's lifespan startup hook when auth is enabled —
     after ``seed_built_in_roles``, so the admin role row exists.
+
+    Repairs a pre-#170 bootstrap principal on the way through. That is the
+    only path which heals an already-seeded deployment: nothing is minted
+    there, the key the operator already holds simply becomes usable.
     """
+    _normalize_principal_type(registry)
     if has_admin_principal(session_factory):
         return None
     key = await _mint(auth_service, registry, home)

--- a/flux/security/principals.py
+++ b/flux/security/principals.py
@@ -182,6 +182,26 @@ class PrincipalRegistry:
         finally:
             session.close()
 
+    def set_type(self, principal_id: str, type: str) -> None:
+        """Change a principal's type.
+
+        Exists for the admin-bootstrap repair path (issue #170): a bootstrap
+        principal minted as 'user' holds an API key the api-key provider will
+        never accept, and healing it requires flipping the type in place.
+        """
+        session = self._session_factory()
+        try:
+            principal = session.query(PrincipalModel).filter_by(id=principal_id).first()
+            if principal is None:
+                raise ValueError(f"Principal '{principal_id}' not found")
+            principal.type = type
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
     def set_enabled(self, principal_id: str, enabled: bool) -> None:
         session = self._session_factory()
         try:

--- a/flux/security/principals.py
+++ b/flux/security/principals.py
@@ -195,6 +195,9 @@ class PrincipalRegistry:
             if principal is None:
                 raise ValueError(f"Principal '{principal_id}' not found")
             principal.type = type
+            # Stamped like every other operator mutation, so a repaired
+            # principal is distinguishable from an untouched one in an audit.
+            principal.updated_at = datetime.now(timezone.utc)
             session.commit()
         except Exception:
             session.rollback()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.74.2"
+version = "0.74.3"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/security/test_admin_bootstrap.py
+++ b/tests/security/test_admin_bootstrap.py
@@ -217,3 +217,67 @@ class TestRotate:
         principal = registry.find(admin_bootstrap.ADMIN_SUBJECT, admin_bootstrap.ADMIN_ISSUER)
         assert "admin" in registry.get_roles(principal.id)
         assert admin_bootstrap.read_persisted(tmp_path) == key
+
+
+class TestBootstrapKeyAuthenticates:
+    """Issue #170: the seeding test and the provider test each passed alone
+    while the minted key could never authenticate — the bootstrap principal
+    was 'user'-typed and the api-key provider only accepts service accounts.
+    These tests drive the bootstrap key through the *real* provider."""
+
+    async def test_bootstrap_key_authenticates_through_api_key_provider(
+        self,
+        auth_service,
+        registry,
+        session_factory,
+        tmp_path,
+    ):
+        from flux.security.providers.api_key import APIKeyProvider
+
+        key = await admin_bootstrap.ensure_admin_key(
+            auth_service,
+            registry,
+            session_factory,
+            tmp_path,
+        )
+        assert key is not None
+
+        identity = await APIKeyProvider(session_factory, registry=registry).authenticate(key)
+        assert identity is not None, "bootstrap key must authenticate through the real provider"
+        assert identity.subject == admin_bootstrap.ADMIN_SUBJECT
+        assert "admin" in identity.roles
+
+        principal = registry.find(admin_bootstrap.ADMIN_SUBJECT, admin_bootstrap.ADMIN_ISSUER)
+        assert principal.type == "service_account"
+
+    async def test_rotate_repairs_user_typed_principal_from_broken_deployment(
+        self,
+        auth_service,
+        registry,
+        session_factory,
+        tmp_path,
+    ):
+        """A deployment seeded by the pre-#170 implementation holds a
+        'user'-typed bootstrap principal with a dead key; rotating must flip
+        the type and mint a key that authenticates."""
+        from flux.security.providers.api_key import APIKeyProvider
+
+        broken = registry.create(
+            type="user",
+            subject=admin_bootstrap.ADMIN_SUBJECT,
+            external_issuer=admin_bootstrap.ADMIN_ISSUER,
+        )
+        registry.assign_role(broken.id, admin_bootstrap.ADMIN_ROLE, assigned_by="test")
+        dead_key = await auth_service.create_api_key(broken.id, admin_bootstrap.ADMIN_KEY_NAME)
+        provider = APIKeyProvider(session_factory, registry=registry)
+        assert await provider.authenticate(dead_key) is None  # the #170 symptom
+
+        fresh = await admin_bootstrap.rotate(auth_service, registry, tmp_path)
+        identity = await provider.authenticate(fresh)
+        assert identity is not None and "admin" in identity.roles
+        assert (
+            registry.find(admin_bootstrap.ADMIN_SUBJECT, admin_bootstrap.ADMIN_ISSUER).type
+            == "service_account"
+        )
+        # The dead key was revoked, not left as a second credential.
+        assert await provider.authenticate(dead_key) is None

--- a/tests/security/test_admin_bootstrap.py
+++ b/tests/security/test_admin_bootstrap.py
@@ -48,6 +48,31 @@ def auth_service(session_factory, registry):
     return service
 
 
+@pytest.fixture
+def enabled_auth_service(session_factory, registry):
+    """An ``AuthService`` wired the way the server wires it with the API-key
+    provider on — the configuration the bootstrap key is minted for."""
+    from flux.security.config import APIKeyAuthConfig, AuthConfig
+
+    service = AuthService(
+        config=AuthConfig(enabled=True, api_keys=APIKeyAuthConfig(enabled=True)),
+        session_factory=session_factory,
+        registry=registry,
+    )
+    service.seed_built_in_roles()
+    return service
+
+
+@pytest.fixture
+def api_key_provider(session_factory, registry):
+    """The real provider, not a stand-in — issue #170 is precisely the case
+    where the seeding test and the provider test each passed alone while the
+    credential they agree on could never authenticate."""
+    from flux.security.providers.api_key import APIKeyProvider
+
+    return APIKeyProvider(session_factory=session_factory, registry=registry)
+
+
 def _key_rows(session_factory, principal_id):
     from flux.security.models import APIKeyModel
 
@@ -281,3 +306,114 @@ class TestBootstrapKeyAuthenticates:
         )
         # The dead key was revoked, not left as a second credential.
         assert await provider.authenticate(dead_key) is None
+
+    async def test_key_resolves_to_admin_permissions_through_auth_service(
+        self,
+        enabled_auth_service,
+        registry,
+        session_factory,
+        tmp_path,
+    ):
+        """The issue's repro end to end: mint, then present the key the way a
+        request does. Goes through the whole provider chain and on into
+        permission resolution, so a key that authenticates but resolves to no
+        permissions would fail here too."""
+        key = await admin_bootstrap.ensure_admin_key(
+            enabled_auth_service,
+            registry,
+            session_factory,
+            tmp_path,
+        )
+
+        identity = await enabled_auth_service.authenticate(key)
+        permissions = await enabled_auth_service.resolve_permissions(identity)
+
+        assert identity.subject == admin_bootstrap.ADMIN_SUBJECT
+        assert "*" in permissions
+
+
+class TestStartupHealsBrokenDeployment:
+    """Repair has to reach the *startup* path, not just rotation.
+
+    A deployment seeded before #170 holds a broken principal that still
+    carries the admin role, so ``has_admin_principal`` is satisfied and
+    ``ensure_admin_key`` returns before it would ever mint. Unless the repair
+    runs ahead of that guard, restarting the server changes nothing and the
+    operator has to diagnose the 401s and rotate by hand.
+    """
+
+    async def _seed_pre_fix_deployment(self, auth_service, registry):
+        principal = registry.create(
+            type="user",
+            subject=admin_bootstrap.ADMIN_SUBJECT,
+            external_issuer=admin_bootstrap.ADMIN_ISSUER,
+            display_name="Bootstrap admin",
+            metadata={"via": "admin-bootstrap"},
+        )
+        registry.assign_role(principal.id, admin_bootstrap.ADMIN_ROLE, assigned_by="test")
+        key = await auth_service.create_api_key(principal.id, admin_bootstrap.ADMIN_KEY_NAME)
+        return principal, key
+
+    async def test_restart_makes_the_existing_key_work(
+        self,
+        auth_service,
+        registry,
+        session_factory,
+        api_key_provider,
+        tmp_path,
+    ):
+        _, key = await self._seed_pre_fix_deployment(auth_service, registry)
+        assert await api_key_provider.authenticate(key) is None, (
+            "guard for the bug being fixed: the pre-#170 credential is rejected"
+        )
+
+        # Exactly what the server's lifespan hook calls on every start.
+        seeded = await admin_bootstrap.ensure_admin_key(
+            auth_service,
+            registry,
+            session_factory,
+            tmp_path,
+        )
+
+        assert seeded is None, "an admin already exists — seeding stays init-only"
+        identity = await api_key_provider.authenticate(key)
+        assert identity is not None, "restarting the server must heal the deployment"
+        assert admin_bootstrap.ADMIN_ROLE in identity.roles
+
+    async def test_repair_does_not_remint(
+        self,
+        auth_service,
+        registry,
+        session_factory,
+        tmp_path,
+    ):
+        """The plaintext only exists in the operator's copy of the file, so
+        minting a replacement would invalidate it for no reason."""
+        principal, key = await self._seed_pre_fix_deployment(auth_service, registry)
+        before = _key_rows(session_factory, principal.id)[0].key_hash
+
+        await admin_bootstrap.ensure_admin_key(auth_service, registry, session_factory, tmp_path)
+
+        rows = _key_rows(session_factory, principal.id)
+        assert len(rows) == 1
+        assert rows[0].key_hash == before == hashlib.sha256(key.encode()).hexdigest()
+
+    async def test_repair_leaves_other_user_principals_alone(
+        self,
+        auth_service,
+        registry,
+        session_factory,
+        tmp_path,
+    ):
+        """Only the bootstrap identity is re-typed. An OIDC-provisioned human
+        stays a ``user``, so a static API key can never be minted for them."""
+        human = registry.create(
+            type="user",
+            subject="ops@example.com",
+            external_issuer="https://idp.example.com",
+        )
+        registry.assign_role(human.id, admin_bootstrap.ADMIN_ROLE)
+
+        await admin_bootstrap.ensure_admin_key(auth_service, registry, session_factory, tmp_path)
+
+        assert registry.get(human.id).type == "user"


### PR DESCRIPTION
Closes #170

## What

The #154 first-admin bootstrap minted its principal as `type="user"`, but the API-key provider only authenticates `service_account` principals — an API key is a machine credential. So the bootstrap admin key could never authenticate: every request got a 401 that read as a bad token rather than a type mismatch, and the exact auth-off bootstrap hole #154 exists to close stayed open.

## Fix

- **Mint as `service_account`** — the truthful type for a principal that exists solely to hold a machine-held key, with a comment in `_mint` explaining why the type is load-bearing.
- **Repair broken deployments in place**: `_mint` now flips a pre-existing `user`-typed bootstrap principal to `service_account` (new `PrincipalRegistry.set_type`, scoped to this repair path), so a deployment seeded by the old implementation heals with `flux server admin-key --rotate` — no manual `UPDATE principals ...` needed. The repair logs a warning naming what changed and why.
- The API-key provider's `service_account` gate is deliberately untouched — it's the right posture for machine credentials. (That the admin API can still mint dead-shaped keys for `user`-typed principals is a separate UX question, noted here for the record.)

## The regression test the issue asked for

The seeding test and the provider test each passed alone while the composed path was broken. `TestBootstrapKeyAuthenticates` drives the bootstrap key through the **real** `APIKeyProvider`:

- `test_bootstrap_key_authenticates_through_api_key_provider` — seed via `ensure_admin_key`, authenticate the plaintext key, assert the identity carries the admin role and the principal is `service_account`.
- `test_rotate_repairs_user_typed_principal_from_broken_deployment` — reproduces the #170 shape exactly (user-typed principal, dead key 401s through the provider), rotates, asserts the fresh key authenticates, the type is repaired, and the dead key stays revoked.

## Validation

- `pre-commit run --all-files` — clean
- Security suite — 446 passed; full unit suite — 3272 passed, 22 skipped
- E2E (`-m "not ollama"`) — 139 passed, 2 skipped; the two `github_stars` failures are the known sandbox limitation (api.github.com unreachable), unrelated

Version bumped 0.74.2 → 0.74.3.
