### PR TITLE
docs(agents): correct drifted agent instructions, adopt AGENTS.md standard

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,7 @@
           {
             "type": "command",
             "if": "Bash(git commit*)",
-            "command": "jq -r '.tool_input.command' | grep -qi 'co-authored-by' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"This repo forbids Co-Authored-By trailers (see CONTRIBUTING.md and AGENTS.md). Remove the trailer, then commit again.\"}}' || true",
+            "command": "python3 -c 'import json,sys,re\ntry:\n    c=json.load(sys.stdin).get(\"tool_input\",{}).get(\"command\",\"\")\nexcept Exception:\n    sys.exit(0)\nif re.search(r\"(?mi)^\\s*co-authored-by:\",c):\n    print(json.dumps({\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"This repo forbids Co-Authored-By trailers (see CONTRIBUTING.md and AGENTS.md). Remove the trailer, then commit again.\"}}))'",
             "statusMessage": "Checking commit trailers"
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "attribution": {
+    "commit": ""
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git commit*)",
+            "command": "jq -r '.tool_input.command' | grep -qi 'co-authored-by' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"This repo forbids Co-Authored-By trailers (see CONTRIBUTING.md and AGENTS.md). Remove the trailer, then commit again.\"}}' || true",
+            "statusMessage": "Checking commit trailers"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,8 +5,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for filing a bug. Please do **not** report security vulnerabilities here —
-        see [SECURITY.md](../blob/main/SECURITY.md) for private reporting.
+        Thanks for filing a bug. Please do **not** report security vulnerabilities here — use
+        [private reporting](https://github.com/edurdias/flux/security/advisories/new) instead
+        (see [SECURITY.md](https://github.com/edurdias/flux/blob/main/SECURITY.md)).
 
   - type: textarea
     id: what-happened

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+name: Bug report
+description: Something in Flux behaves incorrectly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Please do **not** report security vulnerabilities here —
+        see [SECURITY.md](../blob/main/SECURITY.md) for private reporting.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what did you get instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: A minimal workflow or command sequence that reproduces the problem.
+      render: python
+    validations:
+      required: true
+
+  - type: dropdown
+    id: execution-path
+    attributes:
+      label: Execution path
+      description: Which path did you hit this on?
+      options:
+        - Inline (workflow.run(...))
+        - Distributed (flux start server + flux start worker)
+        - Both
+        - Not applicable
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Flux version
+      description: "Output of `poetry run flux --version`, or the flux-core version installed."
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: "3.12.x"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: database
+    attributes:
+      label: Database
+      options:
+        - SQLite (default)
+        - PostgreSQL
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or traceback
+      description: Relevant server/worker output. Redact any secrets or tokens.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/edurdias/flux/security/advisories/new
+    about: Report privately via GitHub security advisories — never in a public issue.
+  - name: Documentation
+    url: https://github.com/edurdias/flux/tree/main/docs
+    about: Guides for core concepts, advanced features, and production deployment.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Suggest a capability or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the use case rather than a specific implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: If you have an API or decorator surface in mind, sketch it here.
+      render: python
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you have tried, and why they fall short.
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I would be willing to open a PR for this

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!--
+Contributing guide: CONTRIBUTING.md
+Architecture tour: CLAUDE.md · Agent conventions: AGENTS.md
+-->
+
+## Why
+
+<!-- What problem does this solve? Link the issue if there is one (Fixes #123). -->
+
+## What changed
+
+<!-- The shape of the change, not a file-by-file listing. -->
+
+## How it was verified
+
+<!-- Commands you ran, plus anything you exercised manually. -->
+
+- [ ] `poetry run pre-commit run --all-files`
+- [ ] `poetry run pytest tests/ --ignore=tests/e2e`
+- [ ] `poetry run pytest tests/e2e/ -m "not ollama and not network" -v`
+
+## Checklist
+
+- [ ] Version bumped in `pyproject.toml` (patch for fixes, minor for features) — **CI fails without this**
+- [ ] Tests added or updated for the new behavior
+- [ ] Docs updated (`docs/`, `README.md`, or `flux.toml` comments) if the change is user-facing
+- [ ] Alembic revision added alongside any ORM column change, with `HEAD` updated in both
+      `tests/flux/test_migrations.py` and `tests/flux/test_migrations_postgresql.py`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,129 +1,69 @@
-# Flux AI Coding Guidelines
+# Copilot instructions for Flux
 
-## Architecture Overview
+**Read [`AGENTS.md`](../AGENTS.md) first** — it is the primary, cross-tool agent contract (branch/PR
+flow, the mandatory version bump, how to extend the public surface). [`CLAUDE.md`](../CLAUDE.md) holds
+the architecture tour and the non-obvious gotchas. This file covers only what those two don't: the
+code-shaped idioms worth getting right in a completion.
 
-Flux is a distributed workflow orchestration engine with a **server-worker architecture**. The core components are:
+Do not duplicate architecture here. When something moves, `CLAUDE.md` is the file to update.
 
-- **Server** (`flux/server.py`): FastAPI-based HTTP server handling workflow execution coordination
-- **Worker** (`flux/worker.py`): Distributed execution nodes that claim and execute workflows via SSE streams
-- **ExecutionContext** (`flux/domain/execution_context.py`): Stateful workflow execution container with event tracking
-- **Task/Workflow decorators** (`flux/task.py`, `flux/workflow.py`): Core programming model for defining executable units
+## Programming model
 
-## Key Patterns
+Workflows and tasks are `async` functions. A workflow's first parameter is always
+`ctx: ExecutionContext[T]`.
 
-### 1. Task & Workflow Definition
 ```python
-@task.with_options(
-    retry_max_attempts=3,
-    timeout=30,
-    fallback=fallback_func,
-    rollback=rollback_func,
-    cache=True
-)
+@task.with_options(retry_max_attempts=3, timeout=30, fallback=fallback_func, rollback=rollback_func)
 async def my_task(param: str) -> str:
     return f"processed {param}"
+
 
 @workflow.with_options(requests=ResourceRequest(cpu=2, memory="4Gi"))
 async def my_workflow(ctx: ExecutionContext[str]) -> str:
     return await my_task(ctx.input)
 ```
 
-### 2. Execution Context Management
-- **Context is thread-local**: Use `ExecutionContext.get()` to access current context in tasks
-- **Event-driven state**: All task/workflow state changes emit `ExecutionEvent` objects
-- **Checkpointing**: Context is automatically checkpointed via `ctx.checkpoint()` for pause/resume
+Composition primitives from `flux.tasks`:
 
-### 3. Distributed Execution Pattern
-- **Worker Registration**: Workers register capabilities (CPU, memory, packages) with server
-- **Resource Matching**: Server matches workflows to workers based on `ResourceRequest` constraints
-- **SSE Communication**: Workers receive execution instructions via Server-Sent Events
-- **Base64 Encoding**: Workflow source code is base64-encoded for transport
-
-### 4. Task Composition Patterns
 ```python
-# Parallel execution
-from flux.tasks import parallel
-results = await parallel(task1(), task2(), task3())
-
-# Pipeline processing
-from flux.tasks import pipeline
-result = await pipeline(task1, task2, task3, input=data)
-
-# Task mapping
+results = await parallel(task1(), task2(), task3())   # takes awaitables
+result = await pipeline(task1, task2, task3, input=data)  # takes callables + keyword input
 results = await my_task.map(input_list)
 ```
 
-## Testing Conventions
+## Rules that completions get wrong
 
-### Example-Based Testing
-Tests live in `tests/examples/` and test actual example workflows:
+- **`ExecutionContext` is a `ContextVar`, not thread-local.** Retrieve it with
+  `await ExecutionContext.get()` inside a task — never accept it as a parameter or stash it on `self`.
+  It propagates through async context, so a completion that reaches for `threading.local` or passes
+  `ctx` down a call chain is wrong.
+- **Never read `os.environ` in feature code.** Go through
+  `Configuration.get().settings.<group>.<key>` so tests can override it.
+- **Batched work must be idempotent.** `parallel(...)`, `task.map(...)`, and an agent's tool calls in
+  one turn share a batch that can cancel stragglers; a cancelled straggler re-executes on resume.
+- **The event log is append-only.** State changes go through `ExecutionContext` methods, never by
+  mutating state directly. Events drive replay, so emitting one is a durable decision.
+- **Error handling is a chain: retry → fallback → rollback.** Don't hand-roll try/except retry loops
+  around a task; declare the options instead.
+- **Type hints are expected** on public functions, with `from __future__ import annotations` at the
+  top of the module.
+
+## Tests
+
+Inline-path tests call `.run()` synchronously and assert on context flags:
+
 ```python
 def test_should_succeed():
     ctx = my_workflow.run("input")
     assert ctx.has_finished and ctx.has_succeeded
-    return ctx
 ```
 
-### State Assertions
-Use ExecutionContext properties: `has_finished`, `has_succeeded`, `has_failed`, `is_paused`, `is_cancelled`
+Flags: `has_finished`, `has_succeeded`, `has_failed`, `is_paused`, `is_cancelled`, `is_resuming`.
+Test files must be named `test_*.py` — `name-tests-test` enforces it in pre-commit.
 
-## Development Workflows
+## Before proposing a commit
 
-### Local Development
-```bash
-# Start server
-flux start server
-
-# Start worker
-flux start worker
-
-# Run workflow
-flux workflow run my_workflow '{"input": "data"}'
-```
-
-### Configuration
-- **Config file**: `flux.toml` (TOML format)
-- **Environment-based**: Uses `pydantic-settings` for config overrides
-- **Database**: SQLite by default (`flux.db`)
-
-### CLI Commands
-- `flux workflow list` - List registered workflows
-- `flux workflow register file.py` - Register workflows from file
-- `flux workflow run name payload` - Execute workflow
-- `flux secrets set/get/list` - Manage secrets
-- `flux start server/worker/mcp` - Start different server types
-
-## Code Organization
-
-### Domain Layer (`flux/domain/`)
-- `ExecutionContext`: Core execution state container
-- `events.py`: Event types and execution states
-- `resource_request.py`: Worker resource matching logic
-
-### Infrastructure Layer
-- `context_managers.py`: Persistence layer (SQLite)
-- `catalogs.py`: Workflow registry and versioning
-- `worker_registry.py`: Worker capability tracking
-- `secret_managers.py`: Secure credential management
-
-### Task Execution
-- **Error Handling**: Automatic retry → fallback → rollback chain
-- **Timeout Management**: Per-task timeout with `asyncio.wait_for()`
-- **Caching**: Optional task result caching via `CacheManager`
-- **Secrets**: Injected via `secret_requests` parameter
-
-## Important Constraints
-
-1. **Python 3.12+ required** - Uses modern async/await patterns
-2. **SQLAlchemy models** - All persistence through SQLAlchemy ORM
-3. **Type hints mandatory** - Leverages generics for ExecutionContext typing
-4. **Async-first design** - All task/workflow functions are async
-5. **Poetry packaging** - Uses Poetry for dependency management and CLI entry points
-
-## Common Pitfalls
-
-- **Context Access**: Always use `ExecutionContext.get()` inside tasks, never pass manually
-- **Worker Matching**: ResourceRequest must match actual worker capabilities
-- **State Immutability**: Don't modify ExecutionContext state directly, use methods
-- **Event Ordering**: Events are append-only and determine execution state
-- **Base64 Encoding**: Workflow source must be base64-encoded for worker transport
+- Bump the version in `pyproject.toml` — CI rejects any PR that doesn't raise it above `main`.
+- Run `poetry run pre-commit run --all-files`; never bypass it with `--no-verify`.
+- **Do not add `Co-Authored-By:` trailers** to commits or PR descriptions.
+- Stay Python 3.12-compatible (`pyupgrade` runs `--py312-plus`); the project uses Poetry, never `uv`.

--- a/.gitignore
+++ b/.gitignore
@@ -181,7 +181,9 @@ Pipfile
 
 
 # Claude
-.claude/
+.claude/*
+# …except shared, team-wide agent config (hooks enforcing repo conventions)
+!.claude/settings.json
 .superpowers/
 
 # Worktrees

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,10 @@
-# AGENT.md
+# AGENTS.md
 
-Tool-agnostic guidance for AI coding assistants (Claude Code, Cursor, Copilot, Codex, Aider, …) working on Flux. For commands, architecture, and gotchas, read `CLAUDE.md` first — this file does not duplicate that material; it covers *how* to make changes safely.
+Tool-agnostic guidance for AI coding assistants working on Flux, following the
+[AGENTS.md](https://agents.md) convention that Codex, Cursor, Copilot, Gemini CLI, Aider, Zed and
+others read automatically. For commands, architecture, and gotchas, read `CLAUDE.md` first — this
+file does not duplicate that material; it covers *how* to make changes safely. Human contributors
+should start at `CONTRIBUTING.md`.
 
 ## Operating principles
 
@@ -13,12 +17,12 @@ Tool-agnostic guidance for AI coding assistants (Claude Code, Cursor, Copilot, C
 
 ```
 1. branch off main           – never commit directly to main
-2. understand the surface    – read the touched module + its tests + adjacent CLAUDE.md / AGENT.md
+2. understand the surface    – read the touched module + its tests + CLAUDE.md / AGENTS.md
 3. make the change           – include unit tests; add/extend e2e tests when touching server/worker/CLI
 4. bump pyproject.toml       – patch for fixes, minor for features (CI enforces this)
 5. poetry run pre-commit run --all-files
 6. poetry run pytest tests/ --ignore=tests/e2e
-7. poetry run pytest tests/e2e/ -m "not ollama"
+7. poetry run pytest tests/e2e/ -m "not ollama and not network"
 8. open a PR – describe the why, not the what
 9. respond to review – commit and push fixes before replying to comments
 ```
@@ -30,7 +34,7 @@ The version bump in step 4 is enforced by `.github/workflows/pull-request.yml::v
 - **Unit first, E2E for system behavior.** Anything that reaches across server ↔ worker, CLI ↔ server, or scheduler ↔ catalog should have an E2E test. See `tests/e2e/conftest.py` for the `cli` fixture pattern.
 - **One workflow registration per E2E test module.** Worker module-cache collisions across tests are a known footgun (commit `33c7a7b`). When E2E tests register the same workflow name from different fixture files, prefer module-scoped fixtures or distinct names.
 - **Replay determinism.** When you change task/workflow event emission, replay an existing execution (`workflow.run(execution_id=...)`) and confirm the new event log is a strict superset / consistent rewrite. Determinism tests live in `tests/examples/test_determinism.py`.
-- **Don't add tests that need network access** unless they're properly skipped when the dependency is missing (see how `@pytest.mark.ollama` is handled in `tests/e2e/conftest.py`).
+- **Don't add tests that need network access** unless they're marked `@pytest.mark.network` (CI's e2e gate deselects it) or skipped when the dependency is missing (see how `@pytest.mark.ollama` is handled in `tests/e2e/conftest.py`).
 - **Don't commit databases.** `*.db`, `*.db-wal`, `*.db-shm`, `test.db` are gitignored — verify with `git status` before staging.
 
 ## Editing the public surface
@@ -41,9 +45,10 @@ The version bump in step 4 is enforced by `.github/workflows/pull-request.yml::v
   - serialization via `flux/encoders.py` if it travels in events / requests
   - documentation in the relevant `docs/advanced-features/*.md`
 - New CLI subcommands go in `flux/cli.py`; follow the existing `--format json|simple`, `--server-url`, and Click group conventions. Add a method to `tests/e2e/conftest.py::FluxCLI` so E2E tests can drive it.
-- New HTTP endpoints in `flux/server.py` should:
+- New HTTP endpoints go in the matching `flux/api/<domain>_routes.py` mixin (**not** `flux/server.py`,
+  which only composes the mixins and owns app/middleware setup). They should:
   - declare permissions via `Depends(require_permission("..."))` (skip only with deliberate justification)
-  - accept and emit Pydantic models (don't return raw dicts)
+  - accept and emit Pydantic models from `flux/api/schemas.py` (don't return raw dicts)
   - respect the same rate-limiter / CORS / auth middleware as their neighbours
 
 ## Configuration & secrets
@@ -62,9 +67,9 @@ If your task involves *running* a workflow (rather than editing the framework):
 
 ## Documentation
 
-- `README.md` is the public face — keep examples in sync with the actual decorator surface; broken README snippets are caught by `tests/test_validate_examples.py`.
+- `README.md` is the public face — keep its snippets in sync with the actual decorator surface **by hand**. Nothing validates them: no test reads `README.md`, so a stale snippet ships silently. Re-read the code you are documenting before editing an example.
 - `docs/` is published to MkDocs (`mkdocs.yml`). Major features need an entry under `docs/advanced-features/`.
-- Internal design specs that don't ship belong under `.claude/docs/` (gitignored) — not in the repo's tracked docs.
+- Design specs for landed or in-flight features live in `docs/specs/`, named `YYYY-MM-DD-<topic>-spec.md`. Scratch notes and throwaway plans belong in `.claude/` (gitignored).
 
 ## Things to avoid
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,26 +1,34 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (claude.ai/code) working in this repository.
 
-See also `AGENT.md` for tool-agnostic agentic-development conventions (PR flow, version bump, review etiquette). This file focuses on what the project *is*; AGENT.md focuses on *how* to change it.
+Read `AGENTS.md` alongside this file: it is the shared agent contract (PR flow, version bump, how to
+edit the public surface safely). This file describes what the project *is*; `AGENTS.md` describes
+*how* to change it. Human contributors start at `CONTRIBUTING.md`.
 
 ## Project at a glance
 
-Flux (`flux-core` on PyPI) is a Python distributed workflow orchestration engine. Workflows and tasks are defined as `async` functions decorated with `@workflow` / `@task`; the runtime persists every state transition as an `ExecutionEvent`, so executions can be paused, resumed, replayed deterministically, and dispatched across worker nodes.
+Flux (`flux-core` on PyPI) is a Python distributed workflow orchestration engine. Workflows and tasks
+are `async` functions decorated with `@workflow` / `@task`; the runtime persists every state
+transition as an `ExecutionEvent`, so executions can be paused, resumed, replayed deterministically,
+and dispatched across worker nodes.
 
-- **Python 3.12+** (set in `pyproject.toml`; CI unit matrix covers 3.12–3.14). The pre-commit `pyupgrade` hook targets `--py312-plus`; new code must stay 3.12-compatible (PEP 695 syntax is fine; 3.13+ features such as PEP 696 type-parameter defaults are not).
-- **Poetry** for dependency management and the `flux` console-script entry point. `uv.lock` is gitignored — do not introduce uv.
-- **Optional extras**: `postgresql`, `observability`, `ai` (Ollama / OpenAI / Anthropic / Gemini). Default install gives SQLite + no telemetry + no LLM providers.
+- **Python 3.12+** (CI unit matrix covers 3.12–3.14). The pre-commit `pyupgrade` hook targets
+  `--py312-plus`; new code must stay 3.12-compatible (PEP 695 syntax is fine; 3.13+ features such as
+  PEP 696 type-parameter defaults are not).
+- **Poetry** for dependencies and the `flux` console-script entry point. `uv.lock` is gitignored — do
+  not introduce uv.
+- **Optional extras**: `postgresql` (psycopg v3 — psycopg2 is deliberately not used; it has no async
+  LISTEN/NOTIFY for the event-driven dispatcher), `observability`, `ai` (Ollama / OpenAI / Anthropic /
+  Gemini). Default install gives SQLite + no telemetry + no LLM providers.
 
 ## Common commands
-
-All commands are run via Poetry. The Makefile is a thin wrapper around these — prefer the explicit `poetry run …` form when in doubt.
 
 ```bash
 # Setup
 poetry install                                  # base dev environment
 poetry install --extras observability           # what CI installs for lint/unit
-poetry install --extras postgresql              # adds psycopg2
+poetry install --extras postgresql              # adds psycopg v3
 
 # Lint & format — always go through pre-commit, do NOT run ruff/mypy directly
 poetry run pre-commit run --all-files           # full sweep (matches CI)
@@ -28,13 +36,13 @@ poetry run pre-commit run --files <path>...     # single file(s)
 
 # Tests
 poetry run pytest tests/ --ignore=tests/e2e     # unit suite (what CI runs)
-poetry run pytest tests/flux/test_worker.py     # one file
 poetry run pytest tests/flux/test_worker.py::TestWorker::test_start_registers   # one test
-poetry run pytest tests/e2e/ -m "not ollama" -v # E2E (spawns server + worker)
-poe test-e2e                                    # same, via poethepoet
-poe test-e2e-no-ai                              # E2E excluding @pytest.mark.ollama
+poetry run pytest tests/e2e/ -m "not ollama and not network" -v   # E2E, as CI runs it
+poe test-e2e                                    # ALL E2E incl. ollama (needs local Ollama)
+poe test-e2e-no-ai                              # E2E minus @pytest.mark.ollama
 poetry run pytest -m postgresql                 # PostgreSQL-tagged tests
 make test-postgresql                            # full PG suite (docker-compose up + tests + down)
+FLUX_PERF=1 poetry run pytest tests/perf/       # perf suite (see tests/perf/PLAN.md)
 
 # Run a server / worker locally
 poetry run flux start server                    # FastAPI server + integrated scheduler
@@ -43,33 +51,38 @@ poetry run flux start worker my-worker --server-url http://localhost:8000 \
                               --label gpu=true  # labels enable affinity dispatch
 poetry run flux start mcp                       # MCP server exposing workflow tools
 
-# Common CLI groups (each group has --help)
-poetry run flux workflow list|register|run|show|resume|cancel|status|versions|delete
-poetry run flux execution list|show
-poetry run flux schedule create|list|show|pause|resume|history|delete
-poetry run flux secrets   set|get|list|remove
-poetry run flux config    set|get|list|remove
-poetry run flux agent     create|apply|list|show|update|delete
-poetry run flux roles | principals | auth                        # security admin
-poetry run flux server bootstrap-token                           # print the auto-generated worker token
-poetry run flux server admin-key [--rotate]                      # print/rotate the first-admin bootstrap key (#154)
+# CLI groups (each has --help)
+poetry run flux workflow|execution|worker|schedule|secrets|config|agent|db
+poetry run flux roles | principals | auth                # security admin
+poetry run flux server bootstrap-token                   # print the auto-generated worker token
+poetry run flux server admin-key [--rotate]              # print/rotate the first-admin bootstrap key
 ```
+
+Nested subgroups: `flux worker metadata …`, `flux agent session …`.
 
 ### Pytest markers (pyproject.toml)
 
 - `e2e` — autoset on everything in `tests/e2e/`; spawns real server + worker subprocesses.
-- `ollama` — requires a local Ollama install; auto-skipped in `tests/e2e/conftest.py` when `ollama list` fails.
+- `ollama` — needs a local Ollama; auto-skipped in `tests/e2e/conftest.py` when `ollama list` fails.
+- `network` — calls live external services; deselected by CI's e2e gate (rate-limit flaky).
 - `postgresql` — needs the test PG container (Make targets handle the lifecycle).
-- `integration`, `slow` — exist; rarely the primary filter.
+- `perf` — opt-in progress-streaming perf tests (`FLUX_PERF=1` or `-m perf`).
+- `integration`, `slow`, `asyncio` — exist; rarely the primary filter.
 
-## Architecture (the big picture)
+## Architecture
 
 ### The two execution paths
 
-1. **Inline** (`workflow.run("input")`) — used in `tests/examples/` and ad-hoc scripts. Runs in-process via `asyncio.run`, persists to SQLite, and *auto-registers* the workflow in the catalog on first call (`flux/workflow.py::_ensure_registered`). This auto-registration matters because PostgreSQL enforces the `executions.workflow_id` FK that SQLite ignores.
-2. **Distributed** (`flux start server` + `flux start worker`) — the production path. Server stores the catalog and execution state; workers claim executions over an SSE stream and report progress through checkpoint POSTs.
+1. **Inline** (`workflow.run("input")`) — used in `tests/examples/` and ad-hoc scripts. Runs in-process
+   via `asyncio.run`, persists to SQLite, and *auto-registers* the workflow in the catalog on first
+   call (`flux/workflow.py::_ensure_registered`). Auto-registration matters because PostgreSQL
+   enforces the `executions.workflow_id` FK that SQLite ignores.
+2. **Distributed** (`flux start server` + `flux start worker`) — the production path. Server stores the
+   catalog and execution state; workers claim executions over an SSE stream and report progress
+   through checkpoint POSTs.
 
-Both paths share the same `ExecutionContext`, event log, and checkpoint mechanism, so the same workflow code runs in either mode.
+Both share the same `ExecutionContext`, event log, and checkpoint mechanism, so the same workflow code
+runs in either mode.
 
 ### Server ↔ worker dance
 
@@ -85,113 +98,252 @@ Worker            Server
 ```
 
 Implementation hot-spots:
-- `flux/server.py` — ~4800 lines; FastAPI routes for workflows / executions / schedules / workers / admin / services. Most route handlers depend on `flux.security.dependencies.require_permission(...)`.
-- `flux/worker.py` — claim loop, checkpoint outbox, heartbeat, reconnect with exponential backoff, eviction handling.
-- `flux/runners/` — pluggable execution runners (Prefect-style). `subprocess` is the default: each execution runs in a credential-less child process (`runners/child.py`, sanitized env — no bootstrap token / `FLUX_SECURITY__*` / DB URL) streaming checkpoints/progress/secret/config/approval requests to the parent over a stdio pipe; `inprocess` runs on the worker's event loop (lowest latency — pair with transient mesh hops); `docker` (opt-in, needs `docker_image`) runs the same child protocol in a container via `docker run -i`. Workflows pin one via `@workflow.with_options(runner=...)`; workers advertise enabled runners at registration and dispatch matches on them. The workflow module cache (TTL + LRU, source-hash keyed) lives in `runners/loader.py`. Child crashes map to durability: durable → claim released for re-dispatch (replay resumes), transient → terminal FAILED. Approval rows are server-owned: workers use `GET/POST /workers/{name}/approvals/...`, only inline executions use the local DB store (`flux/approvals.py::LocalApprovalStore`).
+
+- **HTTP routes live in `flux/api/<domain>_routes.py`**, each a `*RoutesMixin` class registering
+  handlers as `@api.get/post(...)` inside a setup method. `flux/server.py` only composes those mixins
+  and owns app/middleware setup — it contains no route decorators. Most handlers depend on
+  `flux.security.dependencies.require_permission(...)`; request/response models are in
+  `flux/api/schemas.py`.
+- `flux/worker.py` — claim loop, checkpoint outbox, heartbeat, reconnect with exponential backoff,
+  eviction handling.
+- `flux/runners/` — pluggable execution runners, pinned per workflow via
+  `@workflow.with_options(runner=...)`; workers advertise enabled runners at registration and dispatch
+  matches on them. `subprocess` (default) runs each execution in a credential-less child
+  (`runners/child.py` — sanitized env: no bootstrap token, no `FLUX_SECURITY__*`, no DB URL) that
+  streams checkpoint/progress/secret/config/approval requests to the parent over a stdio pipe;
+  `inprocess` runs on the worker's event loop; `docker` runs the same child protocol via `docker run
+  -i`. The workflow module cache (TTL + LRU, source-hash keyed) is in `runners/loader.py`. Child
+  crashes map to durability: durable → claim released for re-dispatch, transient → terminal FAILED.
+  Approval rows are server-owned (`/workers/{name}/approvals/…`); only inline executions use
+  `approvals.py::LocalApprovalStore`.
 - `flux/worker_registry.py` — capability + label tracking; `WorkerInfo` is the matching unit.
-- `flux/domain/resource_request.py` — `ResourceRequest` and `matches_labels`; powers both `@workflow.with_options(requests=...)` resource matching and `affinity={...}` label matching.
-- `flux/routing.py` — **dynamic routing** (score stage of dispatch). `@workflow.with_options(routing=score(prefer(label("x") == input("y")), least(metric("m")), most(resource("f")), sticky(), least(load())))` ranks eligible workers; hard constraints still filter first. Policies are data: the factories compile to a JSON spec, `flux/catalogs.py::_extract_routing` extracts it statically (AST — unparseable policies fail registration loudly), it travels in `wf_metadata["routing"]`, and `pick_worker` evaluates it inside `next_executions_batch` (per-term 0–1 normalization across candidates, weighted sum, deterministic ties; malformed policies degrade to least-loaded). Event dispatch mode only. A policy owns its score stage — the sticky hint participates only via an explicit `sticky()` term.
-- `flux/worker_metrics.py` — built-in `flux.*` worker metrics (`WorkerMetricsCollector`): loop lag (+p95), running/slots_free, EWMA cpu / quantized memory / load_avg, failure/crash rates, executions-per-minute, duration p95, startup-overhead median, warm modules. Collected worker-side over fixed windows, published as scalars on the heartbeat pong alongside `[flux.workers] metrics_provider` output (user keys ≤32; `flux.` prefix reserved — provider keys under it are stripped; server accepts ≤64 total via `validate_worker_metrics`). Persisted change-gated to `workers.metrics`; the dispatcher reads the in-memory copy.
+- `flux/domain/resource_request.py` — `ResourceRequest` and `matches_labels`; powers both
+  `@workflow.with_options(requests=...)` and `affinity={...}` matching.
+- `flux/routing.py` — **dynamic routing**, the score stage of dispatch, ranking workers that hard
+  constraints already filtered (e.g. `routing=score(prefer(label("x") == input("y")), least(load()))`).
+  Policies are data: factories compile to a JSON spec that `catalogs.py::_extract_routing` reads
+  statically via AST (unparseable policies fail registration loudly), it travels in
+  `wf_metadata["routing"]`, and `pick_worker` evaluates it in `next_executions_batch` — per-term 0–1
+  normalization across candidates, weighted sum, deterministic ties, malformed policies degrading to
+  least-loaded. Event dispatch mode only, and a policy owns its whole score stage: the sticky hint
+  applies only via an explicit `sticky()` term.
+- `flux/worker_metrics.py` — built-in `flux.*` metrics (loop lag, slot occupancy, EWMA cpu/memory/load,
+  failure and crash rates, throughput, duration p95, warm modules), collected worker-side over fixed
+  windows and published on the heartbeat pong alongside `[flux.workers] metrics_provider` output. The
+  `flux.` prefix is reserved — provider keys under it are stripped; `validate_worker_metrics` caps user
+  keys at 32 and the total at 64. Persisted change-gated to `workers.metrics`; the dispatcher reads the
+  in-memory copy.
 
 ### Decorators and the programming model
 
-- `flux/task.py` — `task` is a class with `__call__`; `task.with_options(...)` returns a decorator that wraps a function in `task(...)`. Options: `name`, `fallback`, `rollback`, `retry_max_attempts/_delay/_backoff`, `timeout`, `secret_requests`, `config_requests`, `output_storage`, `cache`, `metadata`, `auth_exempt`, `requires_approval` (bool or runtime predicate — pauses the workflow until an operator decides via `flux execution approve|reject` or `POST /executions/{id}/approvals/{call}/{verb}`; rejection raises `ApprovalRejected` and **bypasses retry/fallback/rollback** since the body never ran; `approve --always` records a standing grant — `scope="execution"` on the approval row — so later gates on the same task name in that execution auto-approve at `register` time, each materializing an audit row naming the applied grant; `approval_target="<arg>"` additionally enables target-scoped grants — `approve --always-for-target` authorizes only calls whose declared argument resolves to the same value, fail-closed when nothing is bound, #143), `risk` (`read`/`write`/`exec`/`external`, #140 — in an agent turn only `read` runs concurrently with sibling tool calls; anything else is an ordering barrier in emission order; undeclared + `requires_approval` truthy counts as non-read), `sensitive` (#147 phase 2 — recorded args/output stored as `[REDACTED:sensitive]` and **replay re-executes the body** instead of short-circuiting, so the task must be safe to re-run; incompatible with `cache`). Agents split the old `approval_mode` into `autonomy` (strict/default/autonomous) × `approval_routing` (inline/notify) with the legacy value mapped and deprecated (#146). The error-handling chain is **retry → fallback → rollback**; each step emits its own event types.
-- `flux/workflow.py` — `workflow.with_options(...)` adds `namespace`, `requests` (ResourceRequest), `affinity` (label dict), `routing` (scoring policy from `flux/routing.py`), `schedule` (Schedule from `flux/domain/schedule.py`), plus `name`, `secret_requests`, `output_storage`. A workflow's first parameter is always `ctx: ExecutionContext[T]`; if `T` is a Pydantic `BaseModel`, the catalog publishes its JSON schema (`flux/catalogs.py::extract_workflow_input_schema`).
-- `flux/__init__.py` — installs a custom `_FluxModule` class on `sys.modules["flux"]` so that `flux.task` and `flux.workflow` resolve to the *classes* even though they're also submodules. If you import-rename anything at the top of `flux/`, exercise both `from flux import task` and `import flux.task` — the lazy/wildcard machinery is fragile.
+- `flux/task.py` — `task` is a class with `__call__`; `task.with_options(...)` returns a decorator.
+  Options: `name`, `fallback`, `rollback`, `retry_max_attempts/_delay/_backoff`, `timeout`,
+  `secret_requests`, `config_requests`, `output_storage`, `cache`, `metadata`, `auth_exempt`, plus:
+  - `requires_approval` (bool or runtime predicate) — pauses the workflow until an operator runs
+    `flux execution approve|reject` (or POSTs the equivalent). Rejection raises `ApprovalRejected` and
+    **bypasses retry/fallback/rollback**, since the body never ran. `approve --always` records a
+    standing grant (`scope="execution"`) so later gates on the same task name auto-approve at
+    `register` time, each writing an audit row naming the grant. Declaring `approval_target="<arg>"`
+    also enables `approve --always-for-target`, authorizing only calls whose declared argument
+    resolves to the same value (fail-closed when nothing is bound).
+  - `risk` (`read`/`write`/`exec`/`external`) — in an agent turn only `read` runs concurrently with
+    sibling tool calls; anything else is an ordering barrier in emission order. Undeclared plus a
+    truthy `requires_approval` counts as non-read.
+  - `sensitive` — recorded args/output stored as `[REDACTED:sensitive]`, and **replay re-executes the
+    body** instead of short-circuiting, so the task must be safe to re-run. Incompatible with `cache`.
+
+  The error-handling chain is **retry → fallback → rollback**; each step emits its own event types.
+- `flux/workflow.py` — `workflow.with_options(...)` adds `namespace`, `requests`, `affinity`,
+  `routing`, `runner`, `schedule`, plus `name`, `secret_requests`, `output_storage`. A workflow's first
+  parameter is always `ctx: ExecutionContext[T]`; if `T` is a Pydantic `BaseModel` the catalog
+  publishes its JSON schema (`catalogs.py::extract_workflow_input_schema`).
+- Agents split autonomy into `autonomy` (strict/default/autonomous) × `approval_routing`
+  (inline/notify); the legacy `approval_mode` is mapped and deprecated.
+- `flux/__init__.py` — installs a custom `_FluxModule` class on `sys.modules["flux"]` so `flux.task`
+  and `flux.workflow` resolve to the *classes* even though they're also submodules. If you
+  import-rename anything at the top of `flux/`, exercise both `from flux import task` and
+  `import flux.task` — the lazy/wildcard machinery is fragile.
 
 ### Domain core (`flux/domain/`)
 
-- `execution_context.py` — `ExecutionContext[T]` (Generic over input type). State is a `ContextVar`; tasks call `await ExecutionContext.get()` to retrieve the current context — never pass it manually. `ctx.checkpoint()` flushes events through the registered checkpoint callable (server-side: HTTP POST; inline: SQLAlchemy save).
-- `events.py` — `ExecutionState` (CREATED → SCHEDULED → CLAIMED → RUNNING → COMPLETED/FAILED/CANCELLED, with PAUSED/RESUMING/RESUME_SCHEDULED/RESUME_CLAIMED/CANCELLING intermediates) and `ExecutionEventType` (workflow + task lifecycle, plus retry/fallback/rollback variants). Convenience flags on `ExecutionContext`: `has_finished`, `has_succeeded`, `has_failed`, `is_paused`, `is_cancelled`, `is_resuming`.
-- `resource_request.py` — used by both resource matching and label affinity.
-- `schedule.py` — `cron(...)`, `interval(...)`, `once(...)` factories (each takes `overlap="skip"|"allow"` — issue #142; NULL rows from before the policy read as allow); `schedule_factory` builds them from raw config.
+- `execution_context.py` — `ExecutionContext[T]`, generic over input type. State is a `ContextVar`;
+  tasks call `await ExecutionContext.get()` — never pass it manually. `ctx.checkpoint()` flushes events
+  through the registered checkpoint callable (server-side: HTTP POST; inline: SQLAlchemy save).
+- `events.py` — `ExecutionState` (CREATED → SCHEDULED → CLAIMED → RUNNING →
+  COMPLETED/FAILED/CANCELLED, with PAUSED/RESUMING/RESUME_SCHEDULED/RESUME_CLAIMED/CANCELLING
+  intermediates) and `ExecutionEventType` (workflow + task lifecycle, plus retry/fallback/rollback
+  variants). Convenience flags: `has_finished`, `has_succeeded`, `has_failed`, `is_paused`,
+  `is_cancelled`, `is_resuming`.
+- `schedule.py` — `cron(...)`, `interval(...)`, `once(...)`, each taking `overlap="skip"|"allow"` (NULL
+  rows predating the policy read as allow); `schedule_factory` builds them from raw config.
 
 ### Persistence
 
-`flux/models.py` defines the SQLAlchemy ORM (`Base`, `WorkflowModel`, `ExecutionContextModel`, `ExecutionEventModel`, plus `RoleModel`, `APIKeyModel`, `AgentModel`, `ConfigModel`, `WorkerModel`, …). `RepositoryFactory.create_repository()` dispatches on `database_url` (`sqlite://` vs `postgresql://`); engines are cached per (repository class, URL) tuple. Schema changes go through Alembic (`flux/migrations/`, run automatically on first connect by `flux/migrations/runner.py`); add a numbered revision AND the ORM column together, and update `HEAD` in **both** `tests/flux/test_migrations.py` (its parity test compares migration output against the full metadata) and `tests/flux/test_migrations_postgresql.py` (postgresql-marked, so a stale value there only surfaces in CI's migrations-postgres job).
+`flux/models.py` defines the SQLAlchemy ORM; `RepositoryFactory.create_repository()` dispatches on
+`database_url`, and engines are cached per (repository class, URL). Schema changes go through Alembic
+(`flux/migrations/`, applied automatically on first connect by `migrations/runner.py`): add a numbered
+revision **and** the ORM column together, and update `HEAD` in **both**
+`tests/flux/test_migrations.py` (parity test against full metadata) and
+`tests/flux/test_migrations_postgresql.py` (postgresql-marked, so a stale value there only surfaces in
+CI's `migrations-postgres` job).
 
-Higher-level managers wrap the repositories:
-- `WorkflowCatalog` (`flux/catalogs.py`) — register / parse / lookup workflows; AST-based parsing of source files extracts each workflow's docstring and resource requests.
-- `ContextManager` (`flux/context_managers.py`) — execution persistence + the dispatch queries (`next_execution`, `next_resume`, `next_cancellation`) used by workers when claiming work.
-- `SecretManager` / `ConfigManager` — encrypted-at-rest blobs (PyCryptodome AES + PBKDF2). Encryption needs `flux.security.encryption.encryption_key` to be set; the shipped `flux.toml` no longer hardcodes one.
+Higher-level managers:
+
+- `WorkflowCatalog` (`flux/catalogs.py`) — register / parse / lookup; AST-based source parsing extracts
+  each workflow's docstring, resource requests, and routing policy.
+- `ContextManager` (`flux/context_managers.py`) — execution persistence plus the dispatch queries
+  (`next_execution`, `next_executions_batch`, `next_resume`, `next_cancellation`).
+- `SecretManager` / `ConfigManager` — encrypted-at-rest blobs (PyCryptodome AES + PBKDF2). Requires
+  `flux.security.encryption.encryption_key`; the shipped `flux.toml` does not hardcode one.
 
 ### Security (`flux/security/`)
 
-- Two auth layers: **OIDC** (`providers/oidc.py`) and **API keys** (`providers/api_key.py`). Both feed into a `FluxIdentity`; `AuthService` resolves it to a permission set via `RoleModel` rows. Built-in roles: `admin` (`*`), `operator`, `viewer`, `worker`.
-- **Bootstrap token** (`bootstrap_token.py`) — used once by a worker to obtain an API key + service-principal during `POST /workers/register`. If the server's `[flux.workers] bootstrap_token` is unset, one is auto-generated and persisted to `<home>/bootstrap-token` on first start; surface it via `flux server bootstrap-token`.
-- **Admin bootstrap** (`admin_bootstrap.py`, #154) — the human analog: on the first auth-enabled start with no enabled admin principal, a random admin API key is minted (hash in DB, bound to the built-in `admin` role) and the plaintext written to `<home>/admin-bootstrap-key` (0600). Init-only; `flux server admin-key [--rotate]` prints/rotates host-locally.
-- **Presentation redaction** (`redaction.py`, #147 phase 1) — execution-read API responses are scrubbed of known secret values by value identity (config `[flux.security] redact_secrets_in_responses`, default on). Presentation-boundary only: the event log and replay are untouched.
-- **Execution token** (`execution_token.py`) — short-lived JWT scoped to a single execution; used by the worker when calling back into the server during a workflow.
-- Most server routes go through `Depends(require_permission("workflow:{namespace}:{name}:run"))` etc. Permissions follow `resource:scope:scope:verb` with `*` wildcards.
+- Two auth layers: **OIDC** (`providers/oidc.py`) and **API keys** (`providers/api_key.py`), both
+  producing a `FluxIdentity` that `AuthService` resolves to a permission set via `RoleModel` rows.
+  Built-in roles: `admin` (`*`), `operator`, `viewer`, `worker`. Permissions are
+  `resource:scope:scope:verb` with `*` wildcards.
+- Two init-only bootstraps, both writing a plaintext credential to `<home>/` on first start and
+  surfaced host-locally by CLI: `bootstrap_token.py` (worker side — exchanged once at
+  `POST /workers/register` for an API key + service principal; `flux server bootstrap-token`) and
+  `admin_bootstrap.py` (human side — mints a random admin key bound to the `admin` role when no
+  enabled admin principal exists; `flux server admin-key [--rotate]`).
+- **Redaction** — `redaction.py` scrubs known secret values from execution-read API responses by value
+  identity (`[flux.security] redact_secrets_in_responses`, default on). Presentation-only; the
+  `sensitive` task option is the storage-level counterpart.
+- **Execution token** (`execution_token.py`) — short-lived JWT scoped to a single execution, used when
+  a running workflow calls back into the server.
 
 ### Tasks library (`flux/tasks/`)
 
 - `builtins.py` — `parallel`, `pipeline`, `now`, `sleep`, `uuid4`, `choice`, `randint`.
 - `graph.py` — `Graph` for DAG composition with cycle detection.
-- `pause.py` (`pause(name, until=|after=|on_complete=)` — wake conditions fire from the scheduler tick, distributed path only; issue #145), `call.py`, `progress.py`, `config_task.py`.
-- `ai/` — the agent system. `agent.py` is the user-facing `agent()` task; `agent_loop.py` is the shared tool-execution loop; provider modules (`ollama.py`, `openai.py`, `anthropic.py`, `gemini.py`) are each a `(factory, formatter)` pair conforming to the ABC in `formatter.py`. Other pieces: `agent_plan.py` (multi-step planning + replanning), `delegation.py` (sub-agents / workflow agents), `dreaming.py` (memory consolidation), `memory/`, `skills.py`, `tools/`, `tool_executor.py` (also the #140 risk partition: reads concurrent, non-reads barriers in emission order), `approval.py` (human-in-the-loop tool approval), `capabilities.py` (#141A — `resolve_capabilities("provider/model")`: curated matrix + conservative heuristics, no network; gates tool support, streaming, and parallel tool dispatch).
-- `mcp/` — MCP *client* (Flux calling external MCP servers from a workflow). The MCP *server* exposing Flux workflows is `flux/mcp_server.py` / `flux/service_mcp.py`.
+- `pause.py` — `pause(name, until=|after=|on_complete=)`; wake conditions fire from the scheduler tick,
+  distributed path only. Also `call.py`, `progress.py`, `config_task.py`.
+- `ai/` — the agent system. `agent.py` is the user-facing task, `agent_loop.py` the shared
+  tool-execution loop; provider modules (`ollama.py`, `openai.py`, `anthropic.py`, `gemini.py`) are
+  each a `(factory, formatter)` pair against the ABC in `formatter.py`. Also `agent_plan.py`,
+  `delegation.py`, `dreaming.py`, `memory/`, `skills.py`, `tools/`, `approval.py`, `tool_executor.py`
+  (owns the `risk` partition), and `capabilities.py` (`resolve_capabilities("provider/model")` —
+  curated matrix + heuristics, no network; gates tool support, streaming, parallel dispatch).
+- `mcp/` — MCP *client* (Flux calling external MCP servers). The MCP *server* exposing Flux workflows
+  is `flux/mcp_server.py` / `flux/service_mcp.py`.
 
 ### Other subsystems
 
-- `flux/agents/` — first-class **AI agent harness**: `manager.py` (CRUD), `process.py` + `session.py` (conversation lifecycle), `template.py`, `tools_resolver.py`, plus `ui/` (terminal + Textual + web) and a static `web/index.html`. Agents are stored in the `agents` table and *also* mirrored into the configs table under `agent:<name>` so workflow templates can fetch them via `get_config`.
-- `flux/service_*` modules + `flux/service_mcp.py` — **Workflow services**: a workflow can be exposed as an HTTP endpoint or MCP tool with a stable name. `service_resolver.py` handles collision detection; `service_proxy.py` provides standalone MCP endpoints with lazy discovery.
-- `flux/schedule_manager.py` — runs inside the server process; polls scheduled workflows, dispatches them, and tracks history. The scheduler tick (under the cross-replica dispatch lock) also runs the overlap-skip check (#142), the park-TTL sweep failing executions unclaimed past `executions.park_deadline` (#157), and the pause-wake pass resuming executions whose `wake_at`/`wake_on_complete` fired (#145) — wake columns are stamped atomically with the PAUSED state write in `flux/context_managers.py::_sync_wake_columns`.
-- `flux/observability/` — OpenTelemetry tracing/metrics + a Prometheus `/metrics` endpoint, gated by `[flux.observability] enabled` and the `observability` extra.
+- `flux/agents/` — first-class **AI agent harness**: `manager.py` (CRUD), `process.py` + `session.py`
+  (conversation lifecycle), `template.py`, `tools_resolver.py`, `ui/`. Agents live in the `agents`
+  table and are *also* mirrored into configs under `agent:<name>` so workflow templates can fetch them
+  via `get_config`.
+- `flux/service_*` + `flux/service_mcp.py` — **Workflow services**: expose a workflow as an HTTP
+  endpoint or MCP tool under a stable name. `service_resolver.py` handles collision detection;
+  `service_proxy.py` provides standalone MCP endpoints with lazy discovery.
+- `flux/schedule_manager.py` — runs in the server process. Under the cross-replica dispatch lock, the
+  scheduler tick polls due schedules, runs the overlap-skip check, sweeps the park-TTL (failing
+  executions unclaimed past `executions.park_deadline`), and resumes executions whose
+  `wake_at`/`wake_on_complete` fired — wake columns are stamped atomically with the PAUSED state write
+  in `context_managers.py::_sync_wake_columns`.
+- `flux/observability/` — OpenTelemetry tracing/metrics + a Prometheus `/metrics` endpoint, gated by
+  `[flux.observability] enabled` and the `observability` extra.
 
 ## Configuration
 
-Loaded by `flux/config.py` via `pydantic-settings` with this precedence (highest first):
+`flux/config.py` loads settings via `pydantic-settings`, highest precedence first:
 
-1. Environment variables prefixed `FLUX_` (nested via `__`, e.g. `FLUX_WORKERS__BOOTSTRAP_TOKEN`, `FLUX_SECURITY__ENCRYPTION__ENCRYPTION_KEY`)
-2. `flux.toml` in the project root (see the shipped file for the full surface)
+1. Environment variables prefixed `FLUX_` (nested with `__`, e.g. `FLUX_WORKERS__BOOTSTRAP_TOKEN`)
+2. `flux.toml` in the project root (the shipped file documents the full surface)
 3. `[tool.flux]` in `pyproject.toml`
 4. Defaults
 
-`Configuration.get().override(...)` is the official way to mutate config in tests; `Configuration.get().reset()` restores defaults. `tests/conftest.py` autouse-fixtures `bootstrap_token` and `encryption_key` so unit tests don't trip the missing-config errors that production now raises by design.
+`Configuration.get().override(...)` is the official way to mutate config in tests;
+`Configuration.get().reset()` restores defaults.
 
 ## Testing layout
 
-- `tests/flux/` — framework unit tests. Subdirs: `agents/`, `domain/`, `observability/`, `output_storage/`, `tasks/`. Shared fixtures in `tests/flux/fixtures/` (config, database). `tests/flux/conftest.py` adds an autouse fixture that clears `DatabaseRepository._engines` between tests.
-- `tests/examples/` — runs every example in `examples/` end-to-end through the **inline** path. Use the same pattern when adding examples: `assert ctx.has_finished and ctx.has_succeeded`.
-- `tests/e2e/` — `tests/e2e/conftest.py` is the important one: a session-scoped `cli` fixture spawns `flux start server` + `flux start worker` as subprocesses on a free port, seeds env vars (`FLUX_E2E_PORT`, `FLUX_DATABASE_URL`, `FLUX_WORKERS__BOOTSTRAP_TOKEN`, `FLUX_SECURITY__AUTH__ENABLED=false`, …), and exposes a `FluxCLI` wrapper that shells out to `poetry run flux …`. Tests register example workflows from `examples/` and `tests/e2e/fixtures/` and assert on JSON CLI output. Set `FLUX_E2E_KEEP_LOGS=1` to preserve logs at teardown.
-- `tests/security/` — auth/permissions/principals/providers; uses real OIDC mocks.
-- `tests/test_scheduling.py`, `tests/test_scheduling_examples.py`, `tests/test_validate_examples.py` — top-level cross-cutting tests.
-- `tests/conftest.py` — autouse fixture seeding the two required-but-no-longer-defaulted settings.
+- `tests/flux/` — framework unit tests (`agents/`, `domain/`, `observability/`, `output_storage/`,
+  `tasks/`). Shared fixtures in `tests/flux/fixtures/`; `tests/flux/conftest.py` autouse-clears
+  `DatabaseRepository._engines` between tests.
+- `tests/examples/` — runs every example in `examples/` through the **inline** path. Follow the same
+  pattern for new examples: `assert ctx.has_finished and ctx.has_succeeded`.
+- `tests/e2e/` — `tests/e2e/conftest.py` is the important one: a session-scoped `cli` fixture spawns
+  `flux start server` + `flux start worker` on a free port, seeds env vars (`FLUX_E2E_PORT`,
+  `FLUX_DATABASE_URL`, `FLUX_WORKERS__BOOTSTRAP_TOKEN`, `FLUX_SECURITY__AUTH__ENABLED=false`, …), and
+  exposes a `FluxCLI` wrapper shelling out to `poetry run flux …`. `FLUX_E2E_KEEP_LOGS=1` preserves
+  logs at teardown.
+- `tests/security/` — auth, permissions, principals, providers (real OIDC mocks).
+- `tests/perf/` — opt-in perf suite; see `tests/perf/PLAN.md`.
+- `tests/conftest.py` — autouse fixture seeding `bootstrap_token` and `encryption_key`, which are
+  required and no longer defaulted.
 
 ## CI gates (`.github/workflows/pull-request.yml`)
 
-Every PR must pass:
+| Job | What it runs |
+|---|---|
+| `version-check` | `pyproject.toml` version must be strictly greater than the target branch's |
+| `lint` | `pre-commit run --all-files --show-diff-on-failure` |
+| `unit` | `pytest tests/ --ignore=tests/e2e --cov=flux` on 3.12 / 3.13 / 3.14 |
+| `e2e` | `pytest tests/e2e/ -m "not ollama and not network" -v` (15-min timeout) |
+| `migrations-postgres` | PostgreSQL-only tests, incl. the migration parity check |
+| `perf-postgres` | perf suite on the `ci` profile |
 
-1. **version-check** — `pyproject.toml`'s version must be strictly greater than the target branch's. PRs that don't bump it fail. Bump the patch version for fixes, minor for features.
-2. **lint** — `poetry run pre-commit run --all-files --show-diff-on-failure`.
-3. **unit** — `poetry run pytest tests/ --ignore=tests/e2e --cov=flux …`.
-4. **e2e** — `poetry run pytest tests/e2e/ -m "not ollama" -v` (15-minute timeout).
-
-Run `pre-commit`, the unit suite, and the E2E suite locally before pushing — relying on CI for the first green is slow and the version-bump check fails fast on local mistakes too.
+Run pre-commit, the unit suite, and the E2E suite locally before pushing — the version-bump check
+fails fast, and waiting on CI for a first green is slow.
 
 ## Project-specific gotchas
 
-- **Bootstrap token + encryption key are no longer defaulted.** If you write a script or test that touches the secrets store, secret encryption, or worker auth, seed them via `Configuration.get().override(...)` or env vars (`FLUX_WORKERS__BOOTSTRAP_TOKEN`, `FLUX_SECURITY__ENCRYPTION__ENCRYPTION_KEY`). The autouse fixture in `tests/conftest.py` handles this for the standard pytest tree.
-- **`flux/__init__.py` is non-trivial.** It uses a custom module class to resolve the `flux.task`/`flux.workflow` submodule-vs-attribute collision and lazily wildcard-imports `flux.encoders`, `flux.output_storage`, `flux.secret_managers`, `flux.tasks`, `flux.catalogs`, `flux.context_managers`. New top-level exports go in `_LAZY_IMPORTS` (or `_WILDCARD_MODULES` for bulk).
-- **Workflow source travels base64-encoded** server → worker, then is `exec`-loaded under a synthetic module name (`flux_workflow__<ns>__<name>__v<version>`) cached for `module_cache_ttl` seconds. Two consequences: (a) module-cache collisions across versions are real bugs (see `33c7a7b`), (b) anything that relies on `__file__` inside a workflow module won't behave the same on a worker as it does inline.
-- **Auto-scheduling is on by default.** `@workflow.with_options(schedule=cron(...))` creates a `<workflow>_auto` schedule on registration. Disable with `[flux.scheduling] auto_schedule_enabled = false` if testing schedule semantics manually.
-- **Path-traversal guard for skills.** `flux/agents/` blocks symlinks/escapes from the configured `skills_dir`; if you add new file-loading entry points there, route them through the same helper (see commit `3d8d489`).
-- **Batched tasks must be idempotent.** `parallel(...)`, `task.map(...)`, and an agent's tool calls in one turn all run through `flux/_concurrency.py::gather_batch`, which favors durability over promptness: when any member ends the batch (pause, failure, or cancellation) the siblings get a bounded window to finish so their terminal events and rollbacks land, and stragglers past it are cancelled. A cancelled straggler re-executes on resume, so anything batched alongside work that can pause or fail needs an idempotent body.
-- **Cancellation records an audit event and compensates — replay still re-runs.** A task interrupted by `CancelledError` appends `TASK_CANCELLED` (audit-only: invisible to the replay short-circuit, same re-run semantics as a worker crash that writes nothing) and runs its declared rollback shielded against re-cancel with a `CANCELLED_ROLLBACK_TIMEOUT` bound (`flux/task.py::__handle_cancellation`, issue #149). Retry and fallback are deliberately skipped on cancel — a fallback would record a substitute `TASK_COMPLETED` that replay honors forever. Fallback preempts rollback on *failure* only.
-- **`name-tests-test --pytest-test-first`** is enabled in pre-commit. Test files must be named `test_*.py`, not `*_test.py` (excluded under `tests/*/fixtures/`).
+- **Bootstrap token + encryption key are not defaulted.** Anything touching the secrets store, secret
+  encryption, or worker auth must seed them via `Configuration.get().override(...)` or env vars
+  (`FLUX_WORKERS__BOOTSTRAP_TOKEN`, `FLUX_SECURITY__ENCRYPTION__ENCRYPTION_KEY`). The autouse fixture
+  in `tests/conftest.py` handles the standard pytest tree.
+- **`flux/__init__.py` is non-trivial.** The custom module class resolves the
+  `flux.task`/`flux.workflow` submodule-vs-attribute collision and lazily wildcard-imports
+  `flux.encoders`, `flux.output_storage`, `flux.secret_managers`, `flux.tasks`, `flux.catalogs`,
+  `flux.context_managers`. New top-level exports go in `_LAZY_IMPORTS` (or `_WILDCARD_MODULES`).
+- **Workflow source travels base64-encoded** server → worker, then is `exec`-loaded under a synthetic
+  module name (`flux_workflow__<ns>__<name>__v<version>`) cached for `module_cache_ttl` seconds. Two
+  consequences: module-cache collisions across versions are real bugs (see `33c7a7b`), and anything
+  relying on `__file__` inside a workflow module won't behave the same on a worker as inline.
+- **Auto-scheduling is on by default.** `@workflow.with_options(schedule=cron(...))` creates a
+  `<workflow>_auto` schedule at registration. Disable with `[flux.scheduling] auto_schedule_enabled =
+  false` when testing schedule semantics manually.
+- **Path-traversal guard for skills.** `flux/agents/` blocks symlinks and escapes from the configured
+  `skills_dir`; route any new file-loading entry point there through the same helper (`3d8d489`).
+- **Batched tasks must be idempotent.** `parallel(...)`, `task.map(...)`, and an agent's tool calls in
+  one turn all run through `flux/_concurrency.py::gather_batch`, which favors durability over
+  promptness: when any member ends the batch (pause, failure, cancellation) siblings get a bounded
+  window to land their terminal events and rollbacks, and stragglers past it are cancelled. A cancelled
+  straggler re-executes on resume, so anything batched alongside work that can pause or fail needs an
+  idempotent body.
+- **Cancellation records an audit event and compensates — replay still re-runs.** A task interrupted by
+  `CancelledError` appends `TASK_CANCELLED` (audit-only: invisible to the replay short-circuit, same
+  re-run semantics as a worker crash that writes nothing) and runs its declared rollback shielded
+  against re-cancel with a `CANCELLED_ROLLBACK_TIMEOUT` bound (`task.py::__handle_cancellation`). Retry
+  and fallback are deliberately skipped on cancel — a fallback would record a substitute
+  `TASK_COMPLETED` that replay honors forever. Fallback preempts rollback on *failure* only.
+- **Test files must be `test_*.py`**, not `*_test.py` — `name-tests-test --pytest-test-first` is a
+  pre-commit hook (excluded under `tests/*/fixtures/`).
+
+## Repository conventions
+
+- **Never commit directly to `main`.** Branch, then open a PR.
+- **Bump `pyproject.toml` on every PR** — patch for fixes, minor for features. CI fails without it.
+- **Do not add `Co-Authored-By:` trailers** to commits or PR descriptions on this repo.
+- **Do not bypass pre-commit** with `--no-verify`. Fix the cause or update `.pre-commit-config.yaml`
+  deliberately.
+- **Comment the *why*, not the *what*.** Reserve comments for non-obvious constraints — race fixes,
+  cross-DB quirks, security guards.
 
 ## Useful entry points when navigating
 
 | If you want… | Start here |
 |---|---|
-| All HTTP routes | `flux/server.py` (one large file, search for `@app.` decorators) |
+| An HTTP route | `flux/api/<domain>_routes.py` (workflow, execution, worker, schedule, admin, auth, rbac, service, system, dynamic) |
+| App/middleware wiring | `flux/server.py` — composes the route mixins, no routes of its own |
 | Worker claim/dispatch logic | `flux/worker.py` + `ContextManager.next_execution` in `flux/context_managers.py` |
 | Workflow-to-worker matching (hard constraints) | `flux/domain/resource_request.py` |
-| Dynamic routing / scoring policies | `flux/routing.py` + selection block in `ContextManager.next_executions_batch` |
+| Dynamic routing / scoring policies | `flux/routing.py` + the selection block in `ContextManager.next_executions_batch` |
 | Built-in worker metrics | `flux/worker_metrics.py` (collection), pong handling in `flux/api/worker_routes.py` |
-| Add a CLI command | `flux/cli.py` (Click groups: `workflow`, `execution`, `schedule`, `secrets`, `config`, `agent`, `roles`, `principals`, `auth`, `start`, `server`) |
-| Add an event type / state | `flux/domain/events.py` *and* the corresponding `ExecutionContext` method in `execution_context.py` |
-| Add a built-in task primitive | `flux/tasks/builtins.py` (re-exports via `flux/tasks/__init__.py`) |
-| Add an LLM provider | OpenAI-compatible vendors need no module: a `[flux.ai.providers.<name>]` descriptor row (or `flux/tasks/ai/providers.py::register_provider`) — #141B. Only genuinely different wire formats get a module: `flux/tasks/ai/<provider>.py`, a `(factory, formatter)` pair against `formatter.py::LLMFormatter` |
+| Add a CLI command | `flux/cli.py` (Click groups: `workflow`, `execution`, `worker`, `schedule`, `secrets`, `config`, `agent`, `db`, `start`, `server`, `roles`, `principals`, `auth`) |
+| Add an event type / state | `flux/domain/events.py` *and* the matching `ExecutionContext` method |
+| Add a built-in task primitive | `flux/tasks/builtins.py` (re-exported via `flux/tasks/__init__.py`) |
+| Add an LLM provider | OpenAI-compatible vendors need no module — add a `[flux.ai.providers.<name>]` descriptor row (or `flux/tasks/ai/providers.py::register_provider`). Only genuinely different wire formats get a module: a `(factory, formatter)` pair against `formatter.py::LLMFormatter` |
 | Add an auth provider | `flux/security/providers/` |

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,113 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a
+harassment-free experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or
+sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and
+healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the
+  experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit
+  permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior
+and will take appropriate and fair corrective action in response to any behavior that they deem
+inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits,
+code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and
+will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is
+officially representing the community in public spaces. Examples of representing our community
+include using an official email address, posting via an official social media account, or acting as
+an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community
+leaders responsible for enforcement at **edurdias@gmail.com**. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any
+incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for
+any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or
+unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the
+nature of the violation and an explanation of why the behavior was inappropriate. A public apology
+may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people
+involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified
+period of time. This includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate
+behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the
+community for a specified period of time. No public or private interaction with the people involved,
+including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including
+sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement
+of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,9 @@
 # Contributing to Flux
 
-Thanks for your interest in contributing! This guide covers the practical
-workflow. For a deeper tour of the architecture, see `CLAUDE.md` and `AGENT.md`.
+Thanks for your interest in contributing! This guide covers the practical workflow.
+
+- Architecture tour and project-specific gotchas: **`CLAUDE.md`**
+- Conventions for AI coding assistants (and the reasoning behind them): **`AGENTS.md`**
 
 ## Prerequisites
 
@@ -13,21 +15,22 @@ workflow. For a deeper tour of the architecture, see `CLAUDE.md` and `AGENT.md`.
 ```bash
 poetry install                          # base dev environment
 poetry install --extras observability   # what CI installs for lint/unit
+poetry run pre-commit install           # install the git hooks
 ```
 
 ## Development workflow
 
-1. **Branch** off `main`.
-2. **Make your change**, following the conventions already in the surrounding
-   code (naming, error handling, test style).
-3. **Bump the version** in `pyproject.toml`. CI enforces that every PR raises the
-   version above `main` — patch for fixes, minor for features.
+1. **Branch** off `main` — never commit directly to `main`.
+2. **Make your change**, following the conventions already in the surrounding code (naming, error
+   handling, test style).
+3. **Bump the version** in `pyproject.toml`. CI enforces that every PR raises the version above
+   `main` — patch for fixes, minor for features.
 4. **Run the checks locally** before pushing (CI runs the same):
 
    ```bash
-   poetry run pre-commit run --all-files            # lint + format + type check
-   poetry run pytest tests/ --ignore=tests/e2e      # unit suite
-   poetry run pytest tests/e2e/ -m "not ollama" -v  # end-to-end suite
+   poetry run pre-commit run --all-files                          # lint + format + type check
+   poetry run pytest tests/ --ignore=tests/e2e                    # unit suite
+   poetry run pytest tests/e2e/ -m "not ollama and not network" -v # end-to-end suite
    ```
 
    The `make lint`, `make format`, and `make check` targets wrap these.
@@ -36,27 +39,36 @@ poetry install --extras observability   # what CI installs for lint/unit
 
 ## Conventions
 
-- **Don't bypass pre-commit** with `--no-verify`. If a hook fails, fix the cause
-  or update `.pre-commit-config.yaml` deliberately.
+- **Don't bypass pre-commit** with `--no-verify`. If a hook fails, fix the cause or update
+  `.pre-commit-config.yaml` deliberately.
 - **Don't add `Co-Authored-By:` lines** to commits or PRs.
-- **Test files are `test_*.py`** (enforced by `name-tests-test`), except under
-  `tests/*/fixtures/`.
-- **Stay 3.12-compatible.** `pyupgrade` runs `--py312-plus`; PEP 695 syntax is
-  fine, but avoid 3.13+-only features.
-- **Comment the *why*, not the *what*.** Reserve comments for non-obvious
-  constraints (race fixes, cross-DB quirks, security guards).
+- **Test files are `test_*.py`** (enforced by `name-tests-test`), except under `tests/*/fixtures/`.
+- **Stay 3.12-compatible.** `pyupgrade` runs `--py312-plus`; PEP 695 syntax is fine, but avoid
+  3.13+-only features.
+- **Comment the *why*, not the *what*.** Reserve comments for non-obvious constraints (race fixes,
+  cross-DB quirks, security guards).
+
+`AGENTS.md` expands on these, including how to extend the `@task` / `@workflow` option surface, add
+CLI commands, and add HTTP endpoints without breaking the permission model.
 
 ## Tests
 
-- `tests/flux/` — framework unit tests.
-- `tests/examples/` — runs every example in `examples/` through the inline path.
-- `tests/e2e/` — spawns a real server + worker; the `cli` fixture in
-  `tests/e2e/conftest.py` is the canonical setup.
-- `tests/security/` — auth, permissions, providers.
+| Path | Covers |
+|---|---|
+| `tests/flux/` | framework unit tests |
+| `tests/examples/` | every example in `examples/`, via the inline path |
+| `tests/e2e/` | real server + worker; the `cli` fixture in `tests/e2e/conftest.py` is the canonical setup |
+| `tests/security/` | auth, permissions, providers |
+| `tests/perf/` | opt-in perf suite (`FLUX_PERF=1`), see `tests/perf/PLAN.md` |
 
-Markers: `e2e`, `ollama`, `postgresql`, `integration`, `slow` (see
-`pyproject.toml`).
+Markers: `e2e`, `ollama`, `network`, `postgresql`, `perf`, `integration`, `slow` — see
+`pyproject.toml` for the authoritative list.
 
 ## Reporting security issues
 
 Please follow `SECURITY.md` — do not open public issues for vulnerabilities.
+
+## Code of conduct
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). By participating, you agree to
+uphold it.

--- a/README.md
+++ b/README.md
@@ -975,7 +975,8 @@ poetry install
 
 ### Run Tests
 ```bash
-poetry run pytest
+poetry run pytest tests/ --ignore=tests/e2e                     # unit suite
+poetry run pytest tests/e2e/ -m "not ollama and not network" -v # end-to-end (spawns server + worker)
 ```
 
 ### Code Quality
@@ -1012,13 +1013,19 @@ Apache License 2.0 - See LICENSE file for details.
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit pull requests. For major changes, please open an issue first to discuss what you would like to change.
+Contributions are welcome! See **[CONTRIBUTING.md](CONTRIBUTING.md)** for setup, the development
+workflow, and project conventions. For major changes, open an issue first to discuss the direction.
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+Two things trip up most first PRs:
+
+- **Bump the version in `pyproject.toml`** — CI rejects any PR that doesn't raise it above `main`.
+- **Run the checks locally** — `pre-commit`, the unit suite, and the E2E suite all gate merges.
+
+Participation is governed by our [Code of Conduct](CODE_OF_CONDUCT.md). Security vulnerabilities go
+through [SECURITY.md](SECURITY.md), never a public issue.
+
+Working with an AI coding assistant? `AGENTS.md` and `CLAUDE.md` carry the architecture tour and the
+non-obvious constraints worth loading into context first.
 
 
 ## Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.74.4"
+version = "0.74.5"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"


### PR DESCRIPTION
## Why

Flux carries four agent-instruction files. They had drifted from the code at different rates, and the convention agents break most often lived in files no agent auto-loads.

Every claim below was verified against the codebase, not re-read from the existing text.

### The navigation entry point was wrong

`CLAUDE.md` sent agents to `flux/server.py` for "all HTTP routes", telling them to search for `@app.` decorators. Routes moved into `flux/api/*_routes.py` mixins in e399c4a; `server.py` now has **zero** route decorators and composes mixins instead. The single most-used row of the navigation table pointed at the wrong file.

### A factual error about concurrency

`.github/copilot-instructions.md` (untouched since 2025-07-17) stated *"Context is thread-local"*. It is a `ContextVar` — `flux/domain/execution_context.py:25`. That is materially misleading about async context propagation, and a completion tool would keep suggesting `threading.local` or threading `ctx` through call chains off the back of it.

### A test that doesn't exist as described

`AGENT.md` claimed broken README snippets are caught by `tests/test_validate_examples.py`. Nothing validates README — no test reads it. That file has no pytest-collectable tests (it is a `__main__` script over scheduling examples) and is referenced by no CI job, poe task, or Make target. A stale README snippet ships silently today; AGENTS.md now says so plainly.

### A rule no agent could see

The no-`Co-Authored-By` convention lived only in `AGENT.md` and `CONTRIBUTING.md`, neither of which Claude Code auto-loads. **21 of the last 100 commits on `main` carry the trailer**, including recent ones. Promoted into `CLAUDE.md` and backed by a `PreToolUse` hook plus `attribution.commit=""`, with `.claude/settings.json` un-ignored so contributors actually receive it. Prose guidance is followed inconsistently; a hook is deterministic.

### AGENT.md → AGENTS.md

The file opened by claiming coverage for "Claude Code, Cursor, Copilot, Codex, Aider" — but singular `AGENT.md` is read by none of them. `AGENTS.md` is the convention they all load, so the file now does what it always said it did. Renamed via `git mv`, history preserved.

## Other corrections

`psycopg2` → `psycopg` v3 · `poe test-e2e` does **not** equal the CI e2e command (it includes ollama) · missing `network` and `perf` markers · missing `migrations-postgres` and `perf-postgres` CI jobs · missing `worker` and `db` CLI groups · missing `tests/perf/` · e2e filter is now `not ollama and not network` · `docs/specs/` contradiction (AGENT.md said specs belong in gitignored `.claude/`; six are tracked) · all 14 issue-number references dropped from CLAUDE.md.

Also adds the missing OSS meta: `CODE_OF_CONDUCT.md`, issue and PR templates, and a README Contributing section that links `CONTRIBUTING.md` and leads with the version bump — the most common first-PR failure.

## How it was verified

- `poetry run pre-commit run --all-files` — **passed**, all 13 hooks
- Every `flux/**.py` and `tests/**` path referenced in CLAUDE.md checked to exist — no broken refs
- Every retained code sample in copilot-instructions.md checked against source: `parallel` (`builtins.py:43`), `pipeline` (`builtins.py:112`), `task.map` (`task.py:836`), `ResourceRequest` fields, and the `.run()` test pattern
- Commit-blocking hook pipe-tested against uppercase, lowercase, and clean payloads before being written to config
- `.gitignore` negation verified: `.claude/settings.json` is trackable, everything else under `.claude/` stays ignored

**Unit suite: not run to completion.** It passed 89% with zero failures, then I stopped it at ~50 minutes to avoid blocking this further. Zero Python files change here, so CI is the gate. Flagging it rather than implying a green I did not see — and a 50-minute local unit run may itself be worth a look, independent of this PR.
