### PR TITLE
fix(security): bind worker join tokens to a subject (#174)

### DIFF
--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -61,14 +61,25 @@ review (`docs/production-readiness-review.md`).
    (`FLUX_WORKERS__BOOTSTRAP_TOKEN`), store it in your secret manager, and
    rotate it deliberately — rotation invalidates the whole fleet's ability
    to re-register until workers get the new value.
-10. **Prefer one-time join tokens.** Instead of sharing the fleet secret with
-    every new worker, mint a single-use, short-lived token per registration:
-    `flux server join-token` (or `POST /admin/workers/join-tokens` with
-    `admin:workers:manage`). The plaintext is shown once and stored hashed;
-    it is consumed atomically on first use and expires after
+10. **Prefer one-time join tokens, bound to a worker name.** Instead of sharing
+    the fleet secret with every new worker, mint a single-use, short-lived
+    token per registration: `flux server join-token --subject <worker-name>`
+    (or `POST /admin/workers/join-tokens` with `admin:workers:manage` and a
+    `subject` in the body). The plaintext is shown once and stored hashed; it
+    is consumed atomically on first use and expires after
     `[flux.workers] join_token_ttl` (default 3600s). Once the fleet has
     migrated, set `[flux.workers] bootstrap_token_enabled = false` so the
     shared secret stops being a registration credential.
+
+    Always pass `--subject`. A token minted without one is **unbound**: it
+    authorizes registration under *any* worker name, and registering an
+    existing name revokes that worker's API keys and issues fresh ones to the
+    caller. An unbound token in the wrong hands is therefore enough to evict a
+    running worker and inherit the admin-written metadata attached to its
+    name. Binding is verified when the token is claimed, and a mismatched name
+    does not consume the token, so a wrong guess cannot burn a legitimate
+    worker's credential. Tokens minted before this check existed have no
+    subject and stay unbound — re-mint them.
 11. **Request body cap.** The server rejects request bodies over
     `server_max_body_size` (default 64 MiB) with 413 — declared or streamed.
     Raise it only if your workflows legitimately ship larger inputs/outputs

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -112,6 +112,10 @@ class WorkerRoutesMixin:
             The plaintext is returned exactly once; only its hash is stored.
             Hand it to one new worker as its registration Bearer token — it
             is consumed on first use and expires after the TTL.
+
+            Pass ``subject`` to bind the token to a single worker name so it
+            cannot register under any other identity. Omitting it mints an
+            unbound token, which any name may claim.
             """
             from flux.security import join_tokens
 
@@ -121,9 +125,16 @@ class WorkerRoutesMixin:
                 # None means "not provided" — an explicit 0 must reach mint()
                 # and be rejected there, not silently become the default.
                 ttl = workers_config.join_token_ttl if raw_ttl is None else int(raw_ttl)
+                raw_subject = (body or {}).get("subject")
+                # A blank string reads as intent to bind that never took
+                # effect; refuse it rather than mint an unbound token.
+                if raw_subject is not None and not str(raw_subject).strip():
+                    raise ValueError("subject must not be blank")
+                subject = str(raw_subject).strip() if raw_subject is not None else None
                 token, expires_at = await asyncio.to_thread(
                     join_tokens.mint,
                     ttl,
+                    subject=subject,
                     created_by=identity.subject,
                 )
             except (TypeError, ValueError) as e:
@@ -133,6 +144,7 @@ class WorkerRoutesMixin:
             return {
                 "token": token,
                 "expires_at": expires_at.replace(tzinfo=_tz.utc).isoformat(),
+                "subject": subject,
             }
 
         def _apply_worker_metadata(name: str, metadata: dict) -> dict:

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -126,11 +126,18 @@ class WorkerRoutesMixin:
                 # and be rejected there, not silently become the default.
                 ttl = workers_config.join_token_ttl if raw_ttl is None else int(raw_ttl)
                 raw_subject = (body or {}).get("subject")
-                # A blank string reads as intent to bind that never took
-                # effect; refuse it rather than mint an unbound token.
-                if raw_subject is not None and not str(raw_subject).strip():
+                # subject decides which identity the token authorizes, so it is
+                # validated rather than coerced: str() would render {"a": 1} as
+                # its Python repr and bind the token to a name no worker can
+                # present, which an operator would read as a successful bind.
+                # JSON null keeps meaning "not provided", matching an omitted
+                # field; a blank string is intent to bind that never took
+                # effect, so it is refused instead of minting an unbound token.
+                if raw_subject is not None and not isinstance(raw_subject, str):
+                    raise ValueError("subject must be a string")
+                if raw_subject is not None and not raw_subject.strip():
                     raise ValueError("subject must not be blank")
-                subject = str(raw_subject).strip() if raw_subject is not None else None
+                subject = raw_subject.strip() if raw_subject is not None else None
                 token, expires_at = await asyncio.to_thread(
                     join_tokens.mint,
                     ttl,

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -1529,7 +1529,12 @@ def server_group():
     default=None,
     help="Token lifetime in seconds (default: [flux.workers] join_token_ttl, 3600).",
 )
-def server_join_token(ttl_seconds: int | None):
+@click.option(
+    "--subject",
+    default=None,
+    help="Bind the token to this worker name; it will not register under any other.",
+)
+def server_join_token(ttl_seconds: int | None, subject: str | None):
     """Mint a one-time worker join token (printed once, stored hashed).
 
     Hand the token to exactly one new worker as its registration credential
@@ -1537,6 +1542,9 @@ def server_join_token(ttl_seconds: int | None):
     and expires after the TTL. Runs against the server's database — execute
     on the server host. Once the fleet has migrated, disable the shared
     secret with [flux.workers] bootstrap_token_enabled = false.
+
+    Prefer --subject: an unbound token registers under any name, and taking
+    over an existing name revokes that worker's keys.
     """
     from flux.config import Configuration
     from flux.security import join_tokens
@@ -1544,8 +1552,14 @@ def server_join_token(ttl_seconds: int | None):
     settings = Configuration.get().settings
     # --ttl 0 must surface mint()'s ValueError, not silently use the default.
     ttl = settings.workers.join_token_ttl if ttl_seconds is None else ttl_seconds
+    if subject is not None and not subject.strip():
+        raise click.ClickException("--subject must not be blank")
     try:
-        token, expires_at = join_tokens.mint(ttl, created_by="cli")
+        token, expires_at = join_tokens.mint(
+            ttl,
+            subject=subject.strip() if subject else None,
+            created_by="cli",
+        )
     except ValueError as e:
         raise click.ClickException(str(e))
     from datetime import timezone as _tz

--- a/flux/migrations/versions/0021_join_token_subject.py
+++ b/flux/migrations/versions/0021_join_token_subject.py
@@ -1,0 +1,46 @@
+"""Add worker_join_tokens.subject to bind a token to one worker name.
+
+A join token recorded the name that consumed it but never checked it, so any
+live token authorized registration under any name. Because registering an
+existing name revokes the incumbent's API keys and issues a fresh one to the
+caller, a holder of their own token could evict another worker and inherit the
+admin-written metadata attached to its subject — the exact guarantee that
+metadata is meant to provide.
+
+The column is nullable and needs no backfill: NULL means unbound, which is how
+every token minted before this revision behaves, so tokens already in flight
+during an upgrade still work.
+
+Revision ID: 0021_join_token_subject
+Revises: 0020_event_time_utc
+Create Date: 2026-08-08
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0021_join_token_subject"
+down_revision: str | None = "0020_event_time_utc"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "worker_join_tokens"
+_COLUMN = "subject"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    if _COLUMN not in existing:
+        op.add_column(_TABLE, sa.Column(_COLUMN, sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    if _COLUMN in existing:
+        op.drop_column(_TABLE, _COLUMN)

--- a/flux/security/join_tokens.py
+++ b/flux/security/join_tokens.py
@@ -18,7 +18,7 @@ import secrets
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
-from sqlalchemy import Column, DateTime, String
+from sqlalchemy import Column, DateTime, String, or_
 
 from flux.models import Base, RepositoryFactory
 
@@ -40,16 +40,28 @@ class WorkerJoinTokenModel(Base):
     used_at = Column(DateTime, nullable=True)
     used_by = Column(String, nullable=True)
     created_by = Column(String, nullable=True)
+    # The worker name this token authorizes. NULL means unbound: any name may
+    # claim it, which is how tokens minted before binding existed behave.
+    subject = Column(String, nullable=True)
 
 
 def _hash(token: str) -> str:
     return hashlib.sha256(token.encode()).hexdigest()
 
 
-def mint(ttl_seconds: int, *, created_by: str | None = None) -> tuple[str, datetime]:
+def mint(
+    ttl_seconds: int,
+    *,
+    subject: str | None = None,
+    created_by: str | None = None,
+) -> tuple[str, datetime]:
     """Create a join token; returns (plaintext, expires_at).
 
     The plaintext is never stored — surface it to the caller once.
+
+    ``subject`` binds the token to one worker name, so it cannot be used to
+    register under a different identity. Leaving it unset keeps the older
+    unbound behaviour, where any name may claim the token.
     """
     if ttl_seconds <= 0:
         raise ValueError("ttl_seconds must be positive")
@@ -62,6 +74,7 @@ def mint(ttl_seconds: int, *, created_by: str | None = None) -> tuple[str, datet
                 token_hash=_hash(token),
                 expires_at=expires_at,
                 created_by=created_by,
+                subject=subject,
             ),
         )
         session.commit()
@@ -71,9 +84,14 @@ def mint(ttl_seconds: int, *, created_by: str | None = None) -> tuple[str, datet
 def claim(token: str, worker_name: str) -> bool:
     """Atomically consume a live join token for a registering worker.
 
-    Returns True when this call claimed the token; a used, expired, or
-    unknown token returns False. Single UPDATE statement, so two racing
-    registrations cannot both succeed.
+    Returns True when this call claimed the token; a used, expired, unknown,
+    or wrongly-addressed token returns False. Single UPDATE statement, so two
+    racing registrations cannot both succeed.
+
+    A token minted with a ``subject`` only claims for that worker name. The
+    check rides in the UPDATE's WHERE clause rather than a prior SELECT, so a
+    mismatched name matches no row: the attempt neither succeeds nor consumes
+    the token, leaving the legitimate worker's credential live.
     """
     if not token:
         return False
@@ -86,6 +104,10 @@ def claim(token: str, worker_name: str) -> bool:
                 WorkerJoinTokenModel.token_hash == _hash(token),
                 WorkerJoinTokenModel.used_at.is_(None),
                 WorkerJoinTokenModel.expires_at > now,
+                or_(
+                    WorkerJoinTokenModel.subject.is_(None),
+                    WorkerJoinTokenModel.subject == worker_name,
+                ),
             )
             .update(
                 {"used_at": now, "used_by": worker_name},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.74.5"
+version = "0.74.6"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_migrations.py
+++ b/tests/flux/test_migrations.py
@@ -13,7 +13,7 @@ import flux.security.models  # noqa: F401
 from flux.migrations.runner import current_revision, run_migrations
 from flux.models import Base
 
-HEAD = "0020_event_time_utc"
+HEAD = "0021_join_token_subject"
 BASELINE = "0001_baseline"
 
 # A representative index added after the original create_all schema, used to

--- a/tests/flux/test_migrations_postgresql.py
+++ b/tests/flux/test_migrations_postgresql.py
@@ -30,7 +30,7 @@ pytestmark = [
     ),
 ]
 
-HEAD = "0020_event_time_utc"
+HEAD = "0021_join_token_subject"
 _BACKFILL_INDEX = "ix_executions_workflow_id"
 
 

--- a/tests/security/test_join_tokens_and_body_limit.py
+++ b/tests/security/test_join_tokens_and_body_limit.py
@@ -142,6 +142,51 @@ class TestJoinTokenLifecycle:
         assert join_tokens.purge_expired(older_than_seconds=86400) == 1
 
 
+class TestSubjectBinding:
+    """A token minted for one worker must not authorize another (#174).
+
+    Without binding, any live token authorizes registration under any name,
+    and the registration path revokes the incumbent's API keys — so a holder
+    of their own token can evict a worker and inherit admin-written metadata
+    attached to its subject.
+    """
+
+    def test_bound_token_rejects_a_different_worker(self, make_client):
+        make_client()
+        token, _ = join_tokens.mint(3600, subject="worker-a")
+        assert join_tokens.claim(token, "worker-b") is False
+
+    def test_bound_token_accepts_its_own_worker(self, make_client):
+        make_client()
+        token, _ = join_tokens.mint(3600, subject="worker-a")
+        assert join_tokens.claim(token, "worker-a") is True
+
+    def test_rejected_claim_does_not_consume_the_token(self, make_client):
+        """A failed claim must leave the token live, or an attacker who
+        guesses wrong burns a legitimate worker's credential."""
+        make_client()
+        token, _ = join_tokens.mint(3600, subject="worker-a")
+        assert join_tokens.claim(token, "worker-b") is False
+        assert join_tokens.claim(token, "worker-a") is True
+
+    def test_unbound_token_still_claims_for_any_worker(self, make_client):
+        """Rows minted before binding existed have a NULL subject and must
+        keep working, so an upgrade does not strand a mid-flight token."""
+        make_client()
+        token, _ = join_tokens.mint(3600)
+        assert join_tokens.claim(token, "any-worker") is True
+
+    def test_registration_rejects_token_bound_to_another_worker(self, make_client):
+        client = make_client()
+        token, _ = join_tokens.mint(3600, subject="worker-a")
+
+        impostor = _register(client, "worker-b", token)
+        assert impostor.status_code == 403, impostor.text
+
+        legitimate = _register(client, "worker-a", token)
+        assert legitimate.status_code == 200, legitimate.text
+
+
 class TestMintRoute:
     def test_explicit_zero_ttl_is_rejected(self, make_client):
         """ttl_seconds: 0 must be a 400 from mint(), not silently replaced
@@ -155,6 +200,32 @@ class TestMintRoute:
         resp = client.post("/admin/workers/join-tokens", json={})
         assert resp.status_code == 200, resp.text
         assert resp.json()["token"]
+
+    def test_minted_subject_binds_the_token(self, make_client):
+        """Binding is only reachable if the operator-facing route exposes it;
+        otherwise every token minted through the API stays unbound."""
+        client = make_client()
+        resp = client.post("/admin/workers/join-tokens", json={"subject": "worker-a"})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["subject"] == "worker-a"
+
+        token = resp.json()["token"]
+        assert join_tokens.claim(token, "worker-b") is False
+        assert join_tokens.claim(token, "worker-a") is True
+
+    def test_omitted_subject_mints_an_unbound_token(self, make_client):
+        client = make_client()
+        resp = client.post("/admin/workers/join-tokens", json={})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["subject"] is None
+        assert join_tokens.claim(resp.json()["token"], "any-worker") is True
+
+    def test_blank_subject_is_rejected(self, make_client):
+        """An empty string must not silently mint an unbound token when the
+        operator's intent was clearly to bind one."""
+        client = make_client()
+        resp = client.post("/admin/workers/join-tokens", json={"subject": "   "})
+        assert resp.status_code == 400, resp.text
 
 
 class TestRegistrationCredentials:
@@ -192,6 +263,37 @@ class TestRegistrationCredentials:
         client = make_client()
         resp = _register(client, "worker-bad", "not-a-real-token")
         assert resp.status_code == 403, resp.text
+
+
+class TestJoinTokenCLI:
+    """`flux server join-token` is the documented way to mint, so it has to
+    reach the binding too — otherwise operators keep minting unbound tokens.
+    Asserts against a real claim, not a call-args mock."""
+
+    def test_subject_option_binds_the_token(self, make_client):
+        from click.testing import CliRunner
+
+        from flux.cli import cli
+
+        make_client()  # initializes the DB schema on the temp database
+        result = CliRunner().invoke(cli, ["server", "join-token", "--subject", "worker-a"])
+        assert result.exit_code == 0, result.output
+
+        token = result.stdout.strip().splitlines()[0]
+        assert join_tokens.claim(token, "worker-b") is False
+        assert join_tokens.claim(token, "worker-a") is True
+
+    def test_without_subject_mints_an_unbound_token(self, make_client):
+        from click.testing import CliRunner
+
+        from flux.cli import cli
+
+        make_client()
+        result = CliRunner().invoke(cli, ["server", "join-token"])
+        assert result.exit_code == 0, result.output
+
+        token = result.stdout.strip().splitlines()[0]
+        assert join_tokens.claim(token, "any-worker") is True
 
 
 class TestBodySizeLimit:

--- a/tests/security/test_join_tokens_and_body_limit.py
+++ b/tests/security/test_join_tokens_and_body_limit.py
@@ -227,6 +227,23 @@ class TestMintRoute:
         resp = client.post("/admin/workers/join-tokens", json={"subject": "   "})
         assert resp.status_code == 400, resp.text
 
+    @pytest.mark.parametrize("value", [123, True, {"a": 1}, ["worker-a"], 1.5])
+    def test_non_string_subject_is_rejected(self, make_client, value):
+        """subject decides which identity a token authorizes, so a non-string
+        must be refused rather than coerced. str() would turn {"a": 1} into
+        the Python repr "{'a': 1}" and bind the token to a name no worker can
+        ever present — an operator would read the 200 as a successful bind."""
+        client = make_client()
+        resp = client.post("/admin/workers/join-tokens", json={"subject": value})
+        assert resp.status_code == 400, resp.text
+
+    def test_null_subject_mints_unbound(self, make_client):
+        """JSON null reads as 'not provided', matching an omitted field."""
+        client = make_client()
+        resp = client.post("/admin/workers/join-tokens", json={"subject": None})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["subject"] is None
+
 
 class TestRegistrationCredentials:
     def test_join_token_registers_and_is_consumed(self, make_client):


### PR DESCRIPTION
Fixes #174.

## Why

`claim()` matched a token on hash and liveness alone. The registering worker's name went into `used_by` but was never verified, and `mint()` stored nothing about who the token was for — so **any live join token authorized registration under any name**.

That is an identity takeover, not just a scoping gap. Registering a name whose principal already exists revokes the incumbent's API keys and issues a fresh key to the caller, while preserving admin-written worker metadata. An operator holding a token of their own — the normal case, since tokens are minted per attach — could evict a running worker and inherit the metadata attached to its subject. That inverts the guarantee metadata exists to provide. Worker names are frequently derivable from operational surfaces, so name secrecy was never a sound defence.

Verified present on `main` before changing anything:

| | |
|---|---|
| `join_tokens.py:83-94` | filters on `token_hash`, `used_at IS NULL`, `expires_at > now` — no name check |
| `join_tokens.py:49` | `mint(ttl_seconds, *, created_by)` — no way to express an intended holder |
| `api/worker_routes.py:335-346` | `revoke_all_api_keys()` then `create_api_key()`, returned as `session_token` |

## What changed

Tokens carry an optional `subject`, checked at claim. Three properties worth calling out:

- **The check rides in the UPDATE's WHERE clause**, not a preceding SELECT. A mismatched name matches no row, so the attempt neither succeeds *nor consumes the token* — a wrong guess cannot burn a legitimate worker's credential. The atomicity that stops two racing registrations from sharing a token is untouched.
- **NULL means unbound**, so tokens minted before this revision keep working and an upgrade strands nothing mid-flight. Migration `0021` is additive with no backfill.
- **Both operator paths expose it** — `flux server join-token --subject` and a `subject` field on `POST /admin/workers/join-tokens`. A fix reachable from neither would leave every token unbound in practice, which is why the CLI and route are in scope rather than a follow-up. Blank subjects are rejected rather than silently minting an unbound token.

## Deliberately not addressed

The issue also suggests requiring a valid existing key to re-register a known principal. That is independent of token binding and can break legitimate worker recovery, so it wants its own change and its own decision. Happy to take it separately.

Note the shared bootstrap token still registers under any name — that is inherent to a fleet-wide master secret, and the issue's own guidance is to migrate off it via `bootstrap_token_enabled = false`. This PR closes the join-token vector; it does not change what the bootstrap token is.

## How it was verified

Written test-first: each test was watched failing for the right reason before any implementation. The first failure was `TypeError: mint() got an unexpected keyword argument 'subject'`, the route tests failed on an unbound token claiming under the wrong name, and the CLI test on `No such option '--subject'`.

Ten new tests: the takeover attempt, the rightful claim, non-consumption on mismatch, unbound backward compatibility, the end-to-end registration path returning 403 for a token bound elsewhere, both mint surfaces, and blank-subject rejection. The CLI tests assert against a real `claim()` on a real database rather than mock call-args.

Also reproduced the issue's attack directly against the patched code — claim as the victim's name returns `False`, the rightful owner still claims, and a legacy unbound token still works.

| suite | result |
|---|---|
| `tests/security/` | 460 passed |
| join-token file | 25 passed (10 new) |
| `test_migrations.py` | 8 passed |
| `test_cli.py` / `test_cli_server.py` | 37 / 14 passed |
| `pre-commit --all-files` | passed |

`HEAD` updated in both `test_migrations.py` and `test_migrations_postgresql.py`. The full unit suite is CI's gate — it takes ~50 min locally versus ~7 in CI, so I ran the affected suites rather than block on it.
