### PR TITLE
chore(agents): forbid all AI attribution, not just Co-Authored-By

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "attribution": {
-    "commit": ""
+    "commit": "",
+    "pr": ""
   },
   "hooks": {
     "PreToolUse": [
@@ -13,6 +14,12 @@
             "if": "Bash(git commit*)",
             "command": "python3 -c 'import json,sys,re\ntry:\n    c=json.load(sys.stdin).get(\"tool_input\",{}).get(\"command\",\"\")\nexcept Exception:\n    sys.exit(0)\nif re.search(r\"(?mi)^\\s*co-authored-by:\",c):\n    print(json.dumps({\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"This repo forbids Co-Authored-By trailers (see CONTRIBUTING.md and AGENTS.md). Remove the trailer, then commit again.\"}}))'",
             "statusMessage": "Checking commit trailers"
+          },
+          {
+            "type": "command",
+            "if": "Bash(gh pr *)",
+            "command": "python3 -c 'import json,sys,re\ntry:\n    c=json.load(sys.stdin).get(\"tool_input\",{}).get(\"command\",\"\")\nexcept Exception:\n    sys.exit(0)\nif re.search(r\"(?mi)^\\s*co-authored-by:|🤖\\s*generated with|generated with \\[claude code\\]\\(\",c):\n    print(json.dumps({\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"This repo forbids AI attribution in PR bodies (see CONTRIBUTING.md and AGENTS.md). Remove the trailer/footer, then retry.\"}}))'",
+            "statusMessage": "Checking PR body for attribution"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,7 @@
           {
             "type": "command",
             "if": "Bash(gh pr *)",
-            "command": "python3 -c 'import json,sys,re\ntry:\n    c=json.load(sys.stdin).get(\"tool_input\",{}).get(\"command\",\"\")\nexcept Exception:\n    sys.exit(0)\nif re.search(r\"(?mi)^\\s*co-authored-by:|🤖\\s*generated with|generated with \\[claude code\\]\\(\",c):\n    print(json.dumps({\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"This repo forbids AI attribution in PR bodies (see CONTRIBUTING.md and AGENTS.md). Remove the trailer/footer, then retry.\"}}))'",
+            "command": "python3 -c 'import json,sys,re\ntry:\n    c=json.load(sys.stdin).get(\"tool_input\",{}).get(\"command\",\"\")\nexcept Exception:\n    sys.exit(0)\nif re.search(r\"(?mi)^\\s*co-authored-by:|^\\s*🤖|^\\s*generated with \\[[^\\]]*\\]\\(https?://\",c):\n    print(json.dumps({\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"This repo forbids AI attribution in PR bodies (see CONTRIBUTING.md and AGENTS.md). Remove the trailer/footer, then retry.\"}}))'",
             "statusMessage": "Checking PR body for attribution"
           }
         ]

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,5 +65,6 @@ Test files must be named `test_*.py` — `name-tests-test` enforces it in pre-co
 
 - Bump the version in `pyproject.toml` — CI rejects any PR that doesn't raise it above `main`.
 - Run `poetry run pre-commit run --all-files`; never bypass it with `--no-verify`.
-- **Do not add `Co-Authored-By:` trailers** to commits or PR descriptions.
+- **Do not add AI attribution** to commits or PR descriptions — no `Co-Authored-By:` trailers,
+  no "Generated with" footers, no tool bylines.
 - Stay Python 3.12-compatible (`pyupgrade` runs `--py312-plus`); the project uses Poetry, never `uv`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ If your task involves *running* a workflow (rather than editing the framework):
 
 ## Things to avoid
 
-- **Don't add `Co-Authored-By:` lines** to commits or PR descriptions on this repo.
+- **Don't add AI attribution** to commits or PR descriptions: no `Co-Authored-By:` lines, no "Generated with" footers, no tool bylines. Describing the convention in prose is fine; emitting it is not.
 - **Don't bypass pre-commit** with `--no-verify`. If a hook fails, fix the underlying issue or update the hook config in `.pre-commit-config.yaml` deliberately.
 - **Don't raise or lower the Python floor casually.** The project supports Python 3.12+ (CI tests 3.12-3.14); the `pyupgrade` hook runs `--py312-plus`. New code must stay 3.12-compatible -- don't use 3.13+ features.
 - **Don't introduce `uv`.** The repo uses Poetry exclusively; `uv.lock` is gitignored to keep this unambiguous.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,7 +326,8 @@ fails fast, and waiting on CI for a first green is slow.
 
 - **Never commit directly to `main`.** Branch, then open a PR.
 - **Bump `pyproject.toml` on every PR** — patch for fixes, minor for features. CI fails without it.
-- **Do not add `Co-Authored-By:` trailers** to commits or PR descriptions on this repo.
+- **No AI attribution in commits or PR descriptions.** No `Co-Authored-By:` trailers, no
+  "Generated with" footers, no tool bylines — in the message body or the PR description.
 - **Do not bypass pre-commit** with `--no-verify`. Fix the cause or update `.pre-commit-config.yaml`
   deliberately.
 - **Comment the *why*, not the *what*.** Reserve comments for non-obvious constraints — race fixes,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,8 @@ poetry run pre-commit install           # install the git hooks
 
 - **Don't bypass pre-commit** with `--no-verify`. If a hook fails, fix the cause or update
   `.pre-commit-config.yaml` deliberately.
-- **Don't add `Co-Authored-By:` lines** to commits or PRs.
+- **Don't add AI attribution** to commits or PRs — no `Co-Authored-By:` lines, no
+  "Generated with" footers, no tool bylines.
 - **Test files are `test_*.py`** (enforced by `name-tests-test`), except under `tests/*/fixtures/`.
 - **Stay 3.12-compatible.** `pyupgrade` runs `--py312-plus`; PEP 695 syntax is fine, but avoid
   3.13+-only features.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.74.5"
+version = "0.74.7"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"


### PR DESCRIPTION
## Why

The rule named one form of attribution:

> Don't add `Co-Authored-By:` lines to commits or PR descriptions

So it read as a ban on that specific trailer rather than on tool bylines generally. #175 and #176 both carried a "Generated with [Claude Code]" footer while satisfying the rule *as written* — the footer was never mentioned. I left `attribution.pr` unset in #175 on that same narrow reading, which is what let it through twice.

The convention was always about not signing this project's history with tool bylines. All four instruction files now say that, so the letter matches the intent.

## What changed

- **Wording** broadened in `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`, and `.github/copilot-instructions.md`: no `Co-Authored-By:` trailers, no "Generated with" footers, no tool bylines. Prose *describing* the convention stays explicitly fine — only emitting it is not.
- **`attribution.pr: ""`** alongside the existing `commit` setting.
- **A second hook on `Bash(gh pr *)`**, so the PR path is enforced the way the commit path already is.

## Matching emitted attribution, not mentions of it

Attribution is emitted on its own line; prose embeds it mid-sentence. Every branch of the pattern is anchored to a line start, and the footer branch additionally requires a URL.

I got this wrong on the first pass. The initial pattern matched the footer anywhere in the command, so this PR's own body tripped it — the section you are reading quotes the link form, and quoting it contained it. That is the same false-positive class as the commit hook's original `grep -i`, and my claim that the pattern avoided it was wrong when written. Fixed in efa8486 and regression-tested against this PR's real body.

Verified against both hooks run from the stored config:

| input | result |
|---|---|
| footer with emoji, own line | deny |
| footer without emoji, own line | deny |
| `Co-Authored-By:` trailer | deny |
| this PR's actual body (quotes the footer) | allow |
| body discussing the rule, naming Claude Code | allow |
| ordinary PR body | allow |
| malformed stdin | allow, exit 0 |
| this PR's body **plus** a real appended footer | deny |

`pre-commit --all-files` passes.

## Merge order

Version is 0.74.7 against `main` at 0.74.5, so this can merge whenever. If it lands **before** #176 (0.74.6), that PR will need a re-bump to clear the gate — merging #176 first avoids the extra round trip.

## Already done

The footers are already stripped from the #175 and #176 bodies, so nothing outstanding there.
