### PR TITLE
fix(runners): suppress core dumps in the runner child (#177)

### DIFF
--- a/docs/advanced-features/airgapped-execution.md
+++ b/docs/advanced-features/airgapped-execution.md
@@ -18,10 +18,23 @@ else is closed.
 | Resources | memory / cpus / pids limits (required, never unlimited) |
 | Time | wall-clock ceiling; on expiry the container is killed and the execution fails terminally for both durabilities |
 | Credentials | none — the child holds no worker or fleet credentials |
+| Core dumps | the child entrypoint makes itself undumpable (`PR_SET_DUMPABLE=0`), and the profile pins the opt-out closed |
 
 The profile is emitted from code *after* any operator `extra_args`, so
 docker's last-wins flag parsing keeps it authoritative; `extra_args` that
 would re-open a closed surface are rejected at worker startup.
+
+The core-dump surface deserves a word, because no container flag covers
+it: when the host's `kernel.core_pattern` is a pipe (apport on Ubuntu,
+`systemd-coredump` on most other distros — i.e. the typical default), a
+crashing process's entire address space is handed to a collector running
+*on the host*, outside the read-only rootfs, the dropped capabilities,
+and even `RLIMIT_CORE` (which `core(5)` documents as ignored for piped
+dumps). Every runner child therefore disables dumpability in-kernel at
+startup. Setting `FLUX_CHILD_ALLOW_COREDUMP=1` in the child's environment
+re-enables dumps for debugging on the `subprocess` and plain `docker`
+runners; the airgapped profile forces the variable empty after operator
+`extra_args`, so the escape hatch does not exist on this runner.
 
 ## Enabling the runner
 

--- a/docs/advanced-features/airgapped-execution.md
+++ b/docs/advanced-features/airgapped-execution.md
@@ -18,7 +18,7 @@ else is closed.
 | Resources | memory / cpus / pids limits (required, never unlimited) |
 | Time | wall-clock ceiling; on expiry the container is killed and the execution fails terminally for both durabilities |
 | Credentials | none — the child holds no worker or fleet credentials |
-| Core dumps | the child entrypoint makes itself undumpable (`PR_SET_DUMPABLE=0`), and the profile pins the opt-out closed |
+| Core dumps | on Linux the child entrypoint makes itself undumpable (`PR_SET_DUMPABLE=0`), and the profile pins the opt-out closed |
 
 The profile is emitted from code *after* any operator `extra_args`, so
 docker's last-wins flag parsing keeps it authoritative; `extra_args` that
@@ -31,7 +31,11 @@ crashing process's entire address space is handed to a collector running
 *on the host*, outside the read-only rootfs, the dropped capabilities,
 and even `RLIMIT_CORE` (which `core(5)` documents as ignored for piped
 dumps). Every runner child therefore disables dumpability in-kernel at
-startup. Setting `FLUX_CHILD_ALLOW_COREDUMP=1` in the child's environment
+startup on Linux — where both the exposure and `prctl` exist. The call is
+skipped on other platforms, so a `subprocess` runner on macOS or Windows
+is unaffected either way.
+
+Setting `FLUX_CHILD_ALLOW_COREDUMP=1` in the child's environment
 re-enables dumps for debugging on the `subprocess` and plain `docker`
 runners; the airgapped profile forces the variable empty after operator
 `extra_args`, so the escape hatch does not exist on this runner.

--- a/flux/runners/child.py
+++ b/flux/runners/child.py
@@ -23,6 +23,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import os
 import signal
 import sys
 from typing import Any
@@ -32,6 +33,40 @@ from flux.secret_managers import SecretManager
 from flux.utils import get_logger
 
 logger = get_logger(__name__)
+
+_PR_SET_DUMPABLE = 4  # prctl(2)
+
+
+def _suppress_core_dumps() -> None:
+    """Make this process undumpable so a crash cannot hand its memory to a
+    host-side core collector.
+
+    When ``kernel.core_pattern`` starts with ``|`` (apport, systemd-coredump —
+    the default on typical hosts), the kernel pipes a crashing process's whole
+    address space to a handler running on the HOST, in the host's namespaces.
+    No container flag stops that path, and ``core(5)`` documents that
+    ``RLIMIT_CORE`` is ignored for piped dumps — ``PR_SET_DUMPABLE`` is the
+    only mitigation that works from inside, and it does not survive execve,
+    so it must run here in the entrypoint rather than in the launcher.
+
+    ``FLUX_CHILD_ALLOW_COREDUMP=1`` opts back into dumpable children for
+    debugging; the airgapped profile forces the variable empty after operator
+    args so the opt-out is unavailable there.
+    """
+    if os.environ.get("FLUX_CHILD_ALLOW_COREDUMP", "").strip().lower() in ("1", "true", "yes"):
+        logger.info("FLUX_CHILD_ALLOW_COREDUMP is set; leaving the runner child dumpable")
+        return
+    if not sys.platform.startswith("linux"):
+        return
+    try:
+        import ctypes
+
+        libc = ctypes.CDLL(None, use_errno=True)
+        if libc.prctl(_PR_SET_DUMPABLE, 0, 0, 0, 0) != 0:
+            errno = ctypes.get_errno()
+            raise OSError(errno, os.strerror(errno))
+    except Exception as e:
+        logger.warning(f"Could not disable core dumps for the runner child: {e}")
 
 
 class _FrameIO:
@@ -283,6 +318,9 @@ async def _run(request: dict) -> int:
 def main() -> int:
     # Stdout carries frames; force every log record to stderr.
     logging.basicConfig(stream=sys.stderr, force=True)
+    # Before the stdio protocol starts: once the request frame arrives this
+    # process holds workflow data a crash must not leak (issue #177).
+    _suppress_core_dumps()
 
     line = sys.stdin.readline()
     if not line:

--- a/flux/runners/docker.py
+++ b/flux/runners/docker.py
@@ -528,6 +528,16 @@ class AirgappedDockerRunner(DockerRunner):
             "--cpus",
             str(self._airgapped_cpus),
         ]
+        # A crash must not hand the sandbox's memory to a host-side core
+        # collector: with a piped kernel.core_pattern (apport,
+        # systemd-coredump — the default on typical hosts) the dump handler
+        # runs on the HOST, outside every flag above, and core(5) documents
+        # that RLIMIT_CORE does not apply to piped dumps. The child entrypoint
+        # suppresses dumps in-kernel via PR_SET_DUMPABLE; forcing its opt-out
+        # variable empty here — after extra_args, so last-wins parsing keeps
+        # it authoritative — makes the debugging escape hatch unavailable on
+        # this profile (issue #177).
+        args += ["--env", "FLUX_CHILD_ALLOW_COREDUMP="]
         # Named capability knobs. Emitted here — not accepted in extra_args —
         # so each grant is explicit config; read-only is forced on mounts no
         # matter what the entry said.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.74.7"
+version = "0.74.8"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_airgapped_runner.py
+++ b/tests/flux/test_airgapped_runner.py
@@ -59,6 +59,21 @@ class TestLockedProfile:
         assert command.count("--cpus") == 1
         assert "--network" not in command  # only the fused --network=none form
 
+    def test_coredump_optout_forced_closed(self):
+        """The profile pins FLUX_CHILD_ALLOW_COREDUMP empty so the child's
+        PR_SET_DUMPABLE seal cannot be defeated (issue #177)."""
+        command = make_runner()._build_command("c")
+        assert "--env FLUX_CHILD_ALLOW_COREDUMP=" in " ".join(command)
+
+    def test_coredump_optout_wins_over_operator_env(self):
+        """--env is deliberately not vetoed, so the profile's empty value must
+        land after an operator's — docker env parsing is last-wins."""
+        runner = make_runner(extra_args=["--env", "FLUX_CHILD_ALLOW_COREDUMP=1"])
+        command = runner._build_command("c")
+        operator_at = command.index("FLUX_CHILD_ALLOW_COREDUMP=1")
+        profile_at = command.index("FLUX_CHILD_ALLOW_COREDUMP=")
+        assert operator_at < profile_at
+
     def test_configured_limits_flow_into_profile(self):
         runner = make_runner(memory="1g", cpus=2.0, pids_limit=64, tmp_size="16m")
         joined = " ".join(runner._build_command("c"))

--- a/tests/flux/test_runners.py
+++ b/tests/flux/test_runners.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import sys
 import textwrap
 from unittest.mock import AsyncMock, MagicMock
 
@@ -214,6 +215,83 @@ class TestChildEnvironment:
 
         assert result.has_finished and not result.has_failed
         assert result.output == [None, None, "visible"]
+
+
+class TestCoreDumpSuppression:
+    """The child seals itself against core dumps at startup (issue #177):
+    PR_SET_DUMPABLE=0 is the only mitigation that also covers piped
+    kernel.core_pattern handlers, and it does not survive execve, so it must
+    run inside the entrypoint. Real-prctl tests run in a fresh subprocess —
+    making the pytest process itself undumpable would be a side effect."""
+
+    PROBE = textwrap.dedent(
+        """
+        import ctypes
+        from flux.runners.child import _suppress_core_dumps
+        _suppress_core_dumps()
+        print(ctypes.CDLL(None).prctl(3, 0, 0, 0, 0))  # PR_GET_DUMPABLE
+        """,
+    )
+
+    def _probe_dumpable(self, monkeypatch, allow_coredump: str | None) -> str:
+        import os
+        import subprocess
+        import sys
+
+        monkeypatch.delenv("FLUX_CHILD_ALLOW_COREDUMP", raising=False)
+        if allow_coredump is not None:
+            monkeypatch.setenv("FLUX_CHILD_ALLOW_COREDUMP", allow_coredump)
+        result = subprocess.run(
+            [sys.executable, "-c", self.PROBE],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=os.environ.copy(),
+        )
+        assert result.returncode == 0, result.stderr
+        # flux's logger may write to stdout in the probe; the prctl value is
+        # whatever printed last.
+        return result.stdout.strip().splitlines()[-1]
+
+    @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="prctl is Linux-only")
+    def test_child_becomes_undumpable(self, monkeypatch):
+        assert self._probe_dumpable(monkeypatch, allow_coredump=None) == "0"
+
+    @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="prctl is Linux-only")
+    def test_optout_leaves_child_dumpable(self, monkeypatch):
+        assert self._probe_dumpable(monkeypatch, allow_coredump="1") == "1"
+
+    @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="prctl is Linux-only")
+    def test_empty_optout_still_seals(self, monkeypatch):
+        """The airgapped profile forces the variable EMPTY (last-wins --env);
+        empty must mean sealed, not opted out."""
+        assert self._probe_dumpable(monkeypatch, allow_coredump="") == "0"
+
+    def test_non_linux_degrades_quietly(self, monkeypatch):
+        from flux.runners import child
+
+        monkeypatch.delenv("FLUX_CHILD_ALLOW_COREDUMP", raising=False)
+        monkeypatch.setattr(child.sys, "platform", "darwin")
+        called = []
+        monkeypatch.setattr(
+            "ctypes.CDLL",
+            lambda *a, **k: called.append(a) or MagicMock(),
+        )
+        child._suppress_core_dumps()
+        assert called == []
+
+    def test_prctl_failure_is_a_warning_not_a_crash(self, monkeypatch, caplog):
+        from flux.runners import child
+
+        monkeypatch.delenv("FLUX_CHILD_ALLOW_COREDUMP", raising=False)
+        monkeypatch.setattr(child.sys, "platform", "linux")
+        monkeypatch.setattr(
+            "ctypes.CDLL",
+            MagicMock(side_effect=OSError("no libc here")),
+        )
+        with caplog.at_level("WARNING"):
+            child._suppress_core_dumps()
+        assert any("core dumps" in r.message for r in caplog.records)
 
 
 class TestApprovalRpcRelay:


### PR DESCRIPTION
## Why

Fixes #177.

`AirgappedDockerRunner` is documented as a locked profile for untrusted workflows whose "only capability channel is the stdio protocol to the parent worker". Core dumps sat outside that boundary.

When the host's `kernel.core_pattern` begins with `|` — apport on Ubuntu, `systemd-coredump` on most other distros, i.e. the default on a typical host — the kernel pipes a crashing process's entire address space to a handler running **on the host, in the host's namespaces**. None of the profile's flags (`--network=none`, `--read-only`, `--cap-drop=ALL`, `--security-opt=no-new-privileges`, the pids/memory/cpu limits) touch that path: nothing is written through the container's filesystem and the container issues no syscall. For a profile built to run code you don't trust over data you don't want leaked, an ordinary crash was enough to hand that data to a host-side collector — no adversary required.

The obvious mitigation doesn't work. `core(5)` states that `RLIMIT_CORE` is ignored for dumps piped to a program, so adding `--ulimit core=0` would look like a fix while changing nothing on exactly the hosts where it matters. And `PR_SET_DUMPABLE` does not survive `execve`, so the runner cannot set it from the outside — a `preexec_fn` is reset by the container's exec.

## What changed

The container entrypoint is ours, so the seal goes there.

- **`flux/runners/child.py`** — `_suppress_core_dumps()` calls `prctl(PR_SET_DUMPABLE, 0)` at startup in `main()`, before the stdio protocol delivers any workflow data. This suppresses the dump in-kernel for the whole child, piped handler included, independent of host configuration and with no new container flags. It is Linux-gated (where both the exposure and `prctl` exist) and returns early elsewhere; a `prctl` failure logs a warning rather than taking down the child.
- **Debugging escape hatch** — `FLUX_CHILD_ALLOW_COREDUMP=1` keeps the child dumpable on the `subprocess` and plain `docker` runners, since an undumpable child is also undebuggable.
- **`flux/runners/docker.py`** — `AirgappedDockerRunner._locked_args()` emits `--env FLUX_CHILD_ALLOW_COREDUMP=`, pinning the opt-out closed. It lands after operator `extra_args`, so docker's last-wins env parsing keeps the profile authoritative — the same structural approach `_locked_args()` already uses to refuse re-opened surfaces. `--env` stays un-vetoed (operators legitimately set `TZ` and friends), so ordering is what enforces this rather than a veto entry.
- **Docs** — `docs/advanced-features/airgapped-execution.md` gains a Core dumps row in the locked-profile table plus the piped-`core_pattern` rationale, the Linux scope, and the opt-out's availability per runner.

## How it was verified

New tests in `tests/flux/test_runners.py::TestCoreDumpSuppression` exercise the real `prctl` in a fresh subprocess (making the pytest process itself undumpable would be a side effect): sealed by default, opt-out honored, and empty-value-still-seals — that last one is what the airgapped `--env` override depends on. Non-Linux and `prctl`-failure paths are covered with mocks. `tests/flux/test_airgapped_runner.py::TestLockedProfile` adds the emission test and an ordering test proving the profile's empty value lands after an operator's `FLUX_CHILD_ALLOW_COREDUMP=1`.

- [x] `poetry run pre-commit run --all-files` — all hooks pass
- [x] `poetry run pytest tests/ --ignore=tests/e2e` — 3283 passed, 22 skipped
- [ ] `poetry run pytest tests/e2e/ -m "not ollama and not network" -v` — left to CI. Locally the suite ran green apart from the two `network`-marked GitHub-API tests in `tests/e2e/test_subflows.py`, which this sandbox cannot reach and which CI deselects anyway.

Container-level verification of the fix (a real crash under a piped `core_pattern`) needs a Docker host and is not something the unit suite can assert; the mitigation itself is verified directly by reading back `PR_GET_DUMPABLE` in a real process.

## Checklist

- [x] Version bumped in `pyproject.toml` — 0.74.8, patch for a fix. Skips 0.74.7, which #178 held; now that #178 has merged, this branch is rebased on it and still clears the gate without a re-bump.
- [x] Tests added or updated for the new behavior
- [x] Docs updated (`docs/advanced-features/airgapped-execution.md`)
- [x] No ORM column change, so no Alembic revision needed