### PR TITLE
docs: correct the SSE buffering rationale after #168 (#180)

### DIFF
--- a/flux/agents/flux_client.py
+++ b/flux/agents/flux_client.py
@@ -17,8 +17,9 @@ async def _iter_sse_data_frames(lines: AsyncIterable[str]) -> AsyncIterator[dict
     """Yield one decoded JSON object per SSE ``data:`` frame.
 
     Per the SSE spec a single event may span multiple ``data:`` lines; the
-    receiver joins them with ``\\n``. A blank line terminates the event. Flux
-    streams pretty-printed JSON, so buffering is required; parsing each line
+    receiver joins them with ``\\n``. A blank line terminates the event.
+    Buffering is therefore required in general, and specifically for servers
+    before 0.74.4, which pretty-printed payloads (#168) — parsing each line
     individually produces ``Expecting property name`` errors on ``data: {``.
     """
     buf: list[str] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.74.8"
+version = "0.74.9"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.74.7"
+version = "0.74.8"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/e2e/test_agent_harness_ollama.py
+++ b/tests/e2e/test_agent_harness_ollama.py
@@ -67,8 +67,11 @@ async def _agent_server(
 async def _read_sse_events(response: httpx.Response):
     """Parse SSE events from an httpx streaming response.
 
-    Yields ``(kind, payload)`` tuples. Handles Flux's multi-line ``data:``
-    frames (JSON pretty-printed with indent).
+    Yields ``(kind, payload)`` tuples. Buffers until the blank line that ends
+    an event, since the SSE spec lets one event span multiple ``data:`` lines
+    — as servers before 0.74.4 did, having pretty-printed their payloads
+    (#168). Current servers send one compact line per event; the buffering
+    handles both.
     """
     buffer: list[str] = []
     async for line in response.aiter_lines():

--- a/tests/flux/agents/test_flux_client.py
+++ b/tests/flux/agents/test_flux_client.py
@@ -80,7 +80,13 @@ async def test_start_agent_posts_body_unwrapped():
 
 @pytest.mark.asyncio
 async def test_start_agent_buffers_multiline_sse_frames():
-    """Regression: a single SSE frame can span multiple ``data:`` lines (pretty-printed JSON)."""
+    """Regression: a single SSE frame can span multiple ``data:`` lines.
+
+    The fixture below is what a pre-0.74.4 server sent (#168). Current servers
+    send one compact line per event, so this case is no longer reachable from
+    our own server — it stays because the SSE spec permits it and because a
+    current client must keep talking to older servers in the field.
+    """
     client = FluxClient(server_url="http://test", token="t")
 
     multi_line_sse = (


### PR DESCRIPTION
Fixes #180.

## Why

`_iter_sse_data_frames` justified its buffering with "Flux streams pretty-printed JSON". That stopped being true in the release the docstring now sits in — #168 (`cfc24bd`) made `to_wire_json` compact via `separators=(",", ":")`, so the server emits one line per event.

The buffering itself is correct and stays. The risk is entirely in the stale reason: someone checks the justification against the wire, finds it false, and deletes the buffering as obsolete — which breaks the client against every pre-0.74.4 server still in the field, and against any spec-compliant server that splits a frame across `data:` lines.

## The grep turned up a second instance

The issue suggested checking for the same claim elsewhere. Four hits; two were wrong, two were already right:

| location | verdict |
|---|---|
| `flux/agents/flux_client.py:21` | **stale** — the reported one |
| `tests/e2e/test_agent_harness_ollama.py:71` | **stale** — described Flux's frames as multi-line pretty-printed, as current behaviour |
| `tests/flux/test_sse_wire_format.py:3` | correct — describes the pre-#168 state in past tense, as motivation |
| `tests/flux/test_sse_wire_format.py:70` | correct — covers `to_json`, which is still indented by design |

I left the two accurate ones alone rather than rewrite for consistency's sake.

Also clarified the multi-line regression test in `test_flux_client.py`. It is no longer reachable from our own server, which makes it exactly the kind of test someone deletes as dead; the docstring now says why it stays — it is what a pre-0.74.4 server sent, and the SSE spec permits it regardless of how any server serializes.

## Verification

Comments only, no behaviour change — so there is nothing new to test, and I did not invent a test that asserts on docstring text. What matters is that the described behaviour still holds: `tests/flux/agents/test_flux_client.py` and `tests/flux/test_sse_wire_format.py` pass unchanged (20 passed), covering both the multi-line buffering path and the compact-wire guarantee.

`pre-commit --all-files` passes.