### PR TITLE
fix(task): redact sensitive output on the retry-success path

### DIFF
--- a/flux/task.py
+++ b/flux/task.py
@@ -1343,7 +1343,7 @@ class task:
                             "max_attempts": self.retry_max_attempts,
                             "current_delay": current_delay,
                             "backoff": self.retry_backoff,
-                            "output": self.output_storage.store(task_id, output),
+                            "output": self._stored_output(task_id, output),
                         },
                     ),
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.74.9"
+version = "0.74.10"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_sensitive_output.py
+++ b/tests/flux/test_sensitive_output.py
@@ -89,6 +89,29 @@ class TestStorageRedaction:
         [completed] = _events(ctx, ExecutionEventType.TASK_COMPLETED, "flaky_mint")
         assert _stored(flaky_mint, completed) == REDACTED_SENSITIVE
 
+    def test_retry_output_of_sensitive_task_redacted(self, isolated_db):
+        attempts = {"n": 0}
+
+        @task_decorator.with_options(sensitive=True, retry_max_attempts=2, retry_delay=0)
+        async def retried_mint() -> str:
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise ValueError("transient mint failure")
+            return "sk-retry-secret"
+
+        @workflow
+        async def wf(ctx: ExecutionContext):
+            return len(await retried_mint())
+
+        ctx = wf.run()
+        assert ctx.has_succeeded
+        assert ctx.output == len("sk-retry-secret")
+        [retried] = _events(ctx, ExecutionEventType.TASK_RETRY_COMPLETED, "retried_mint")
+        assert retried_mint.output_storage.retrieve(retried.value["output"]) == REDACTED_SENSITIVE
+        [completed] = _events(ctx, ExecutionEventType.TASK_COMPLETED, "retried_mint")
+        assert _stored(retried_mint, completed) == REDACTED_SENSITIVE
+        assert "sk-retry-secret" not in str(ctx.to_dict())
+
 
 class TestReplaySemantics:
     def test_sensitive_task_reexecutes_on_replay(self, isolated_db):


### PR DESCRIPTION
## Why

`sensitive=True` exists to keep a task's return value out of the event log — the docs describe that value as a credential. Every terminal event routes its output through `_stored_output()`, which substitutes the redaction marker: `TASK_COMPLETED`, `TASK_FALLBACK_COMPLETED`, `TASK_ROLLBACK_COMPLETED`.

`TASK_RETRY_COMPLETED` called `output_storage.store()` directly, so any sensitive task with `retry_max_attempts > 0` that succeeded on a retry persisted the real value.

Both events are flushed by the same checkpoint, so the later redacted `TASK_COMPLETED` does not overwrite it. The raw credential stays in the log, readable by any principal holding `execution:*:read` — the built-in `viewer` role, which carries no secret permission. `redaction.py` cannot cover it either: that layer redacts by value identity against the `SecretManager` store, and a runtime-minted credential was never in that store.

Nothing forbids combining `sensitive` with `retry`, unlike `sensitive` + `cache`, so the combination is reachable by design.

## Change

One line: route the retry-success output through `_stored_output()` like every other terminal event.

## Tests

Adds `test_retry_output_of_sensitive_task_redacted`, mirroring the existing fallback coverage. Confirmed it fails before the fix with the raw value present in the event, and passes after.