### PR TITLE
fix(service-proxy): validate mode on the resume route

### DIFF
--- a/flux/service_proxy.py
+++ b/flux/service_proxy.py
@@ -28,6 +28,21 @@ class WorkflowRef:
     name: str
 
 
+def _is_safe_execution_id(execution_id: str) -> bool:
+    """Whether ``execution_id`` is safe to interpolate into an upstream path.
+
+    Same hazard as ``mode``: httpx collapses dot segments when merging a path
+    against ``base_url``, so a value of ``..`` walks the request off the
+    endpoint set ``proxy.resolve()`` is the allowlist for. An ASGI server
+    percent-decodes before routing, so ``%2e%2e`` arrives here as ``..``.
+    """
+    return (
+        bool(execution_id)
+        and execution_id not in (".", "..")
+        and not set("/\\") & set(execution_id)
+    )
+
+
 class StandaloneServiceProxy:
     def __init__(self, service_name: str, server_url: str, cache_ttl: int = 60):
         self.service_name = service_name
@@ -250,6 +265,8 @@ def create_standalone_app(
                 status_code=400,
                 content={"detail": "Standalone proxy only supports 'sync' and 'async' modes"},
             )
+        if not _is_safe_execution_id(execution_id):
+            return JSONResponse(status_code=400, content={"detail": "Invalid execution id"})
 
         try:
             ref = await proxy.resolve(workflow_name)
@@ -289,6 +306,9 @@ def create_standalone_app(
         workflow_name: str,
         execution_id: str,
     ):
+        if not _is_safe_execution_id(execution_id):
+            return JSONResponse(status_code=400, content={"detail": "Invalid execution id"})
+
         try:
             ref = await proxy.resolve(workflow_name)
         except KeyError as e:

--- a/flux/service_proxy.py
+++ b/flux/service_proxy.py
@@ -242,6 +242,15 @@ def create_standalone_app(
         execution_id: str,
         mode: str = Query("sync"),
     ):
+        # Interpolated into the upstream path below, and httpx normalizes `..`
+        # when merging against base_url — an unvalidated value escapes the
+        # endpoint set proxy.resolve() is the allowlist for.
+        if mode not in ("sync", "async"):
+            return JSONResponse(
+                status_code=400,
+                content={"detail": "Standalone proxy only supports 'sync' and 'async' modes"},
+            )
+
         try:
             ref = await proxy.resolve(workflow_name)
         except KeyError as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.74.10"
+version = "0.74.11"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_service_proxy.py
+++ b/tests/flux/test_service_proxy.py
@@ -83,6 +83,45 @@ class TestModeValidation:
             assert r.status_code == 400
 
 
+class TestExecutionIdValidation:
+    """``execution_id`` is interpolated into the upstream path just like
+    ``mode``. Uvicorn percent-decodes before Starlette routes, so ``%2e%2e``
+    binds ``execution_id=".."`` and httpx then collapses the dot segment when
+    merging against ``base_url`` — walking off the service's endpoint set."""
+
+    def test_status_rejects_traversal_execution_id(self):
+        app = create_standalone_app("test-svc", UNREACHABLE_SERVER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            r = client.get("/run/invoice/status/%2e%2e")
+            assert r.status_code == 400, r.text
+
+    def test_resume_rejects_traversal_execution_id(self):
+        app = create_standalone_app("test-svc", UNREACHABLE_SERVER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            r = client.post("/run/invoice/resume/%2e%2e")
+            assert r.status_code == 400, r.text
+
+    @pytest.mark.parametrize("bad", ["", ".", "..", "a/b", "a\\b"])
+    def test_guard_rejects_path_significant_ids(self, bad):
+        """Covers shapes the test client cannot route (an encoded slash 404s
+        here) but a different ASGI server may decode straight into the path
+        parameter."""
+        from flux.service_proxy import _is_safe_execution_id
+
+        assert not _is_safe_execution_id(bad)
+
+    def test_guard_accepts_ordinary_ids(self):
+        from flux.service_proxy import _is_safe_execution_id
+
+        assert _is_safe_execution_id("0f9c1e2a3b4d5e6f")
+
+    def test_ordinary_execution_id_still_reaches_the_handler(self):
+        app = create_standalone_app("test-svc", UNREACHABLE_SERVER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            r = client.get("/run/invoice/status/0f9c1e2a3b4d5e6f")
+            assert r.status_code in (404, 500, 502)
+
+
 class TestMCPRouting:
     """Verify /mcp and /.well-known/ are routed to the FastMCP app,
     not swallowed by FastAPI's routing.

--- a/tests/flux/test_service_proxy.py
+++ b/tests/flux/test_service_proxy.py
@@ -55,6 +55,34 @@ class TestWorkflowRoute:
             assert r.status_code in (404, 500, 502)
 
 
+class TestModeValidation:
+    """``mode`` is interpolated into the upstream request path, and httpx
+    normalizes ``..`` segments when merging a path against ``base_url``. An
+    unvalidated value therefore walks out of the endpoint set ``proxy.resolve()``
+    is meant to be the allowlist for, reaching arbitrary Flux API routes."""
+
+    def test_run_rejects_unknown_mode(self):
+        app = create_standalone_app("test-svc", UNREACHABLE_SERVER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            r = client.post("/run/invoice", params={"mode": "bogus"})
+            assert r.status_code == 400
+
+    def test_resume_rejects_unknown_mode(self):
+        app = create_standalone_app("test-svc", UNREACHABLE_SERVER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            r = client.post("/run/invoice/resume/exec-123", params={"mode": "bogus"})
+            assert r.status_code == 400
+
+    def test_resume_rejects_traversal_in_mode(self):
+        app = create_standalone_app("test-svc", UNREACHABLE_SERVER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            r = client.post(
+                "/run/invoice/resume/exec-123",
+                params={"mode": "../../../../../workflows/other-ns/other-wf/run/sync"},
+            )
+            assert r.status_code == 400
+
+
 class TestMCPRouting:
     """Verify /mcp and /.well-known/ are routed to the FastMCP app,
     not swallowed by FastAPI's routing.


### PR DESCRIPTION
## Why

`run_workflow` rejects a `mode` outside `("sync", "async")` before using it. `resume_workflow` did not, and interpolated the raw query parameter into the upstream path:

```
/workflows/{ns}/{name}/resume/{execution_id}/{mode}
```

`forward()` hands that path to httpx against the Flux server's `base_url`, and httpx applies RFC-3986 path normalization when merging a path with a base URL — so `..` segments collapse. A crafted `mode` walks the path back to the root and lands on an arbitrary Flux route.

That defeats what the standalone proxy is for. `proxy.resolve()` is the allowlist restricting a published service to its own endpoints, and the proxy is normally the only thing exposed while the Flux server stays on an internal network. Where the server runs with auth disabled, that allowlist is the only remaining restriction.

## Change

Validate `mode` before `resolve()`, matching the run route exactly.

## Tests

Three cases in a new `TestModeValidation`: the run route as a control (already passing), and the resume route for both an unknown mode and a traversal payload. Both resume cases fail before the fix — the traversal value reaches the forwarding call rather than being rejected.