### PR TITLE
fix(api): scope three routes to the caller's workflow read/run boundary

### DIFF
--- a/flux/api/auth_routes.py
+++ b/flux/api/auth_routes.py
@@ -33,10 +33,26 @@ class AuthRoutesMixin:
         ):
             try:
                 catalog = WorkflowCatalog.create()
+                # This route enumerates namespaces, workflow names and the
+                # task names expanded by _collect_required_permissions, so it
+                # follows the same read boundary as /workflows and /namespaces.
+                scoped = auth_service is not None and auth_config.enabled
+                permissions: set[str] | frozenset[str] = set()
+                if scoped:
+                    permissions = await auth_service.resolve_permissions(identity)
                 if workflow:
                     from flux.catalogs import resolve_workflow_ref as _resolve_perm
 
                     _perm_ns, _perm_name = _resolve_perm(workflow)
+                    if scoped:
+                        required = f"workflow:{_perm_ns}:{_perm_name}:read"
+                        if not identity.has_permission(required, permissions):
+                            # Checked before the catalog lookup so a denial does
+                            # not distinguish "exists" from "does not exist".
+                            raise HTTPException(
+                                status_code=403,
+                                detail=f"Permission denied: requires '{required}'",
+                            )
                     wf = catalog.get(_perm_ns, _perm_name)
                     meta = wf.metadata or {} if hasattr(wf, "metadata") else {}
                     perms = [f"workflow:{wf.namespace}:{wf.name}:read"]
@@ -50,6 +66,11 @@ class AuthRoutesMixin:
                     return perms
                 result = {}
                 for wf in catalog.all():
+                    if scoped and not identity.has_permission(
+                        f"workflow:{wf.namespace}:{wf.name}:read",
+                        permissions,
+                    ):
+                        continue
                     meta = wf.metadata or {} if hasattr(wf, "metadata") else {}
                     perms = [f"workflow:{wf.namespace}:{wf.name}:read"]
                     perms.extend(
@@ -61,6 +82,8 @@ class AuthRoutesMixin:
                     )
                     result[f"{wf.namespace}/{wf.name}"] = perms
                 return result
+            except HTTPException:
+                raise
             except Exception as e:
                 raise HTTPException(status_code=500, detail=str(e))
 

--- a/flux/api/auth_routes.py
+++ b/flux/api/auth_routes.py
@@ -12,6 +12,7 @@ from fastapi import HTTPException
 from fastapi import Request
 
 from flux.catalogs import WorkflowCatalog
+from flux.errors import WorkflowNotFoundError
 from flux.security.dependencies import get_identity, require_permission
 from flux.security.identity import FluxIdentity
 
@@ -53,7 +54,15 @@ class AuthRoutesMixin:
                                 status_code=403,
                                 detail=f"Permission denied: requires '{required}'",
                             )
-                    wf = catalog.get(_perm_ns, _perm_name)
+                    try:
+                        wf = catalog.get(_perm_ns, _perm_name)
+                    except WorkflowNotFoundError:
+                        # Reached only by a caller who already holds read on
+                        # it, so 404 discloses nothing the permission did not.
+                        raise HTTPException(
+                            status_code=404,
+                            detail=f"Workflow '{workflow}' not found",
+                        ) from None
                     meta = wf.metadata or {} if hasattr(wf, "metadata") else {}
                     perms = [f"workflow:{wf.namespace}:{wf.name}:read"]
                     perms.extend(

--- a/flux/api/schedule_routes.py
+++ b/flux/api/schedule_routes.py
@@ -15,6 +15,7 @@ from fastapi import HTTPException
 
 from flux.catalogs import WorkflowCatalog
 from flux.domain.schedule import schedule_factory
+from flux.errors import WorkflowNotFoundError
 from flux.schedule_manager import create_schedule_manager
 from flux.security.dependencies import get_identity, require_permission
 from flux.security.identity import FluxIdentity
@@ -352,7 +353,10 @@ class ScheduleRoutesMixin:
                             existing_schedule.workflow_namespace,
                             existing_schedule.workflow_name,
                         )
-                    except Exception:
+                    except WorkflowNotFoundError:
+                        # Only a genuinely absent workflow is a 409; a DB or
+                        # catalog failure must surface as a 500 rather than be
+                        # reported as "not in the catalog".
                         workflow_def = None
                     if workflow_def is None:
                         raise HTTPException(
@@ -476,7 +480,10 @@ class ScheduleRoutesMixin:
                             schedule.workflow_namespace,
                             schedule.workflow_name,
                         )
-                    except Exception:
+                    except WorkflowNotFoundError:
+                        # Only a genuinely absent workflow is a 409; a DB or
+                        # catalog failure must surface as a 500 rather than be
+                        # reported as "not in the catalog".
                         workflow_def = None
                     if workflow_def is None:
                         raise HTTPException(

--- a/flux/api/schedule_routes.py
+++ b/flux/api/schedule_routes.py
@@ -420,6 +420,20 @@ class ScheduleRoutesMixin:
                         detail=f"Schedule '{schedule_id}' not found",
                     )
 
+                # Pausing only stops execution, so it takes the read boundary
+                # get_schedule uses rather than full run authorization —
+                # stopping a runaway schedule should not require the right to
+                # run its workflow.
+                if auth_service is not None and auth_config.enabled:
+                    required = (
+                        f"workflow:{schedule.workflow_namespace}:{schedule.workflow_name}:read"
+                    )
+                    if not await auth_service.is_authorized(identity, required):
+                        raise HTTPException(
+                            status_code=403,
+                            detail=f"Permission denied: requires '{required}'",
+                        )
+
                 # Now pause using the actual ID
                 schedule = schedule_manager.pause_schedule(schedule.id)
 
@@ -450,6 +464,43 @@ class ScheduleRoutesMixin:
                         status_code=404,
                         detail=f"Schedule '{schedule_id}' not found",
                     )
+
+                # Resuming makes the workflow fire under the bound service
+                # account again, so it takes the same run authorization as
+                # create/update rather than the lighter read boundary — an
+                # operator's deliberate pause would otherwise be the only
+                # thing standing between schedule:*:manage and the SA's roles.
+                if auth_config.enabled and auth_service is not None:
+                    try:
+                        workflow_def = WorkflowCatalog.create().get(
+                            schedule.workflow_namespace,
+                            schedule.workflow_name,
+                        )
+                    except Exception:
+                        workflow_def = None
+                    if workflow_def is None:
+                        raise HTTPException(
+                            status_code=409,
+                            detail=(
+                                f"Cannot resume schedule: workflow "
+                                f"'{schedule.workflow_namespace}/"
+                                f"{schedule.workflow_name}' is not in the catalog"
+                            ),
+                        )
+                    auth_result = await auth_service.authorize(
+                        identity,
+                        schedule.workflow_namespace,
+                        schedule.workflow_name,
+                        workflow_def.metadata or {},
+                    )
+                    if not auth_result.ok:
+                        raise HTTPException(
+                            status_code=403,
+                            detail={
+                                "error": "forbidden",
+                                "missing_permissions": auth_result.missing_permissions,
+                            },
+                        )
 
                 # Now resume using the actual ID
                 schedule = schedule_manager.resume_schedule(schedule.id)

--- a/flux/api/schedule_routes.py
+++ b/flux/api/schedule_routes.py
@@ -336,17 +336,17 @@ class ScheduleRoutesMixin:
                         detail=f"Schedule '{schedule_id}' not found",
                     )
 
-                # Rebinding the service account is subject to the same
-                # escalation guard as create: the caller must be authorized
-                # to run the schedule's workflow themselves. A failed catalog
-                # lookup fails CLOSED — authorizing against empty metadata
-                # would silently drop the per-task and nested-workflow
-                # permission requirements derived from it.
-                if (
-                    auth_config.enabled
-                    and auth_service is not None
-                    and request.run_as_service_account is not None
-                ):
+                # Every update is subject to the same escalation guard as
+                # create: the caller must be authorized to run the schedule's
+                # workflow themselves. This cannot be conditional on the
+                # service account being rebound — rewriting schedule_config or
+                # input_data alone re-aims the schedule's EXISTING service
+                # account at attacker-chosen input on an attacker-chosen
+                # cadence, which is the same escalation by another route. A
+                # failed catalog lookup fails CLOSED — authorizing against
+                # empty metadata would silently drop the per-task and
+                # nested-workflow permission requirements derived from it.
+                if auth_config.enabled and auth_service is not None:
                     try:
                         workflow_def = WorkflowCatalog.create().get(
                             existing_schedule.workflow_namespace,
@@ -358,7 +358,7 @@ class ScheduleRoutesMixin:
                         raise HTTPException(
                             status_code=409,
                             detail=(
-                                f"Cannot rebind service account: workflow "
+                                f"Cannot update schedule: workflow "
                                 f"'{existing_schedule.workflow_namespace}/"
                                 f"{existing_schedule.workflow_name}' is not in the catalog"
                             ),
@@ -530,6 +530,19 @@ class ScheduleRoutesMixin:
                         status_code=404,
                         detail=f"Schedule '{schedule_id}' not found",
                     )
+
+                # History carries execution ids, states and error strings for
+                # the bound workflow, so it follows the same read boundary as
+                # GET /schedules/{id} rather than the flat schedule:*:read.
+                if auth_service is not None and auth_config.enabled:
+                    required = (
+                        f"workflow:{schedule.workflow_namespace}:{schedule.workflow_name}:read"
+                    )
+                    if not await auth_service.is_authorized(identity, required):
+                        raise HTTPException(
+                            status_code=403,
+                            detail=f"Permission denied: requires '{required}'",
+                        )
 
                 # Get execution history
                 entries, total = schedule_manager.get_schedule_history(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.74.11"
+version = "0.74.12"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/security/test_schedule_execution_authz.py
+++ b/tests/security/test_schedule_execution_authz.py
@@ -261,6 +261,13 @@ def test_schedule_update_denies_retarget_without_workflow_run(client):
         run_as_service_account=f"payroll-sa-{suffix}",
     )
 
+    before = {
+        "input_data": schedule_model.input_data,
+        "interval": schedule_model.schedule_config.interval,
+        "next_run_at": schedule_model.next_run_at,
+        "run_as_service_account": schedule_model.run_as_service_account,
+    }
+
     _seed_role(f"sched_only_cfg_{suffix}", ["schedule:*:manage"])
     identity = FluxIdentity(subject="intruder", roles=frozenset({f"sched_only_cfg_{suffix}"}))
 
@@ -275,9 +282,12 @@ def test_schedule_update_denies_retarget_without_workflow_run(client):
         )
     assert resp.status_code == 403, resp.text
 
-    # The stored schedule is untouched.
+    # The stored schedule is untouched — not merely free of the payload.
     reloaded = manager.get_schedule(schedule_model.id)
-    assert reloaded.input_data != {"amount": 1000000, "account": "attacker"}
+    assert reloaded.input_data == before["input_data"]
+    assert reloaded.schedule_config.interval == before["interval"]
+    assert reloaded.next_run_at == before["next_run_at"]
+    assert reloaded.run_as_service_account == before["run_as_service_account"]
 
 
 def test_schedule_update_allows_retarget_for_caller_who_can_run_workflow(client):

--- a/tests/security/test_schedule_execution_authz.py
+++ b/tests/security/test_schedule_execution_authz.py
@@ -239,6 +239,158 @@ def test_schedule_update_denies_sa_rebind_without_workflow_run(client):
     assert resp.status_code == 403, resp.text
 
 
+def test_schedule_update_denies_retarget_without_workflow_run(client):
+    """Escalation through PUT does not require touching run_as_service_account.
+    Rewriting schedule_config/input_data alone re-aims the schedule's EXISTING
+    privileged SA at attacker-chosen input on an attacker-chosen cadence, so
+    the guard cannot be conditional on the SA being rebound."""
+    from flux.domain.schedule import schedule_factory
+    from flux.schedule_manager import create_schedule_manager
+
+    suffix = uuid.uuid4().hex[:6]
+    wf_id = _seed_workflow("default", f"payroll_{suffix}")
+    _seed_service_account(f"payroll-sa-{suffix}")
+
+    manager = create_schedule_manager()
+    schedule_model = manager.create_schedule(
+        workflow_id=wf_id,
+        workflow_namespace="default",
+        workflow_name=f"payroll_{suffix}",
+        name=f"payroll-auto-{suffix}",
+        schedule=schedule_factory({"type": "interval", "interval_seconds": 3600}),
+        run_as_service_account=f"payroll-sa-{suffix}",
+    )
+
+    _seed_role(f"sched_only_cfg_{suffix}", ["schedule:*:manage"])
+    identity = FluxIdentity(subject="intruder", roles=frozenset({f"sched_only_cfg_{suffix}"}))
+
+    with _auth_as(identity):
+        resp = client.put(
+            f"/schedules/{schedule_model.id}",
+            headers=_headers(),
+            json={
+                "schedule_config": {"type": "interval", "interval_seconds": 10},
+                "input_data": {"amount": 1000000, "account": "attacker"},
+            },
+        )
+    assert resp.status_code == 403, resp.text
+
+    # The stored schedule is untouched.
+    reloaded = manager.get_schedule(schedule_model.id)
+    assert reloaded.input_data != {"amount": 1000000, "account": "attacker"}
+
+
+def test_schedule_update_allows_retarget_for_caller_who_can_run_workflow(client):
+    """The guard must not block a caller who is authorized to run the
+    workflow — otherwise legitimate schedule edits break."""
+    from flux.domain.schedule import schedule_factory
+    from flux.schedule_manager import create_schedule_manager
+
+    suffix = uuid.uuid4().hex[:6]
+    wf_id = _seed_workflow("default", f"report_{suffix}")
+
+    manager = create_schedule_manager()
+    schedule_model = manager.create_schedule(
+        workflow_id=wf_id,
+        workflow_namespace="default",
+        workflow_name=f"report_{suffix}",
+        name=f"report-auto-{suffix}",
+        schedule=schedule_factory({"type": "interval", "interval_seconds": 3600}),
+    )
+
+    _seed_role(
+        f"sched_run_upd_{suffix}",
+        ["schedule:*:manage", f"workflow:default:report_{suffix}:*"],
+    )
+    identity = FluxIdentity(subject="owner", roles=frozenset({f"sched_run_upd_{suffix}"}))
+
+    with _auth_as(identity):
+        resp = client.put(
+            f"/schedules/{schedule_model.id}",
+            headers=_headers(),
+            json={"schedule_config": {"type": "interval", "interval_seconds": 60}},
+        )
+    assert resp.status_code == 200, resp.text
+
+
+def test_auth_permissions_lists_only_readable_workflows(client):
+    """`/auth/permissions` enumerates namespaces, workflow names and each
+    workflow's task names. Its siblings (`/workflows`, `/namespaces`) filter
+    that inventory on workflow read; this route must too."""
+    suffix = uuid.uuid4().hex[:6]
+    _seed_workflow("default", f"visible_{suffix}")
+    _seed_workflow("default", f"hidden_{suffix}")
+
+    _seed_role(f"one_wf_{suffix}", [f"workflow:default:visible_{suffix}:read"])
+    identity = FluxIdentity(subject="tenant", roles=frozenset({f"one_wf_{suffix}"}))
+
+    with _auth_as(identity):
+        resp = client.get("/auth/permissions", headers=_headers())
+    assert resp.status_code == 200, resp.text
+    listed = resp.json()
+    assert f"default/visible_{suffix}" in listed
+    assert f"default/hidden_{suffix}" not in listed
+
+
+def test_auth_permissions_single_workflow_requires_read(client):
+    suffix = uuid.uuid4().hex[:6]
+    _seed_workflow("default", f"secret_{suffix}")
+
+    _seed_role(f"no_wf_{suffix}", ["execution:*:read"])
+    identity = FluxIdentity(subject="tenant", roles=frozenset({f"no_wf_{suffix}"}))
+
+    with _auth_as(identity):
+        resp = client.get(
+            "/auth/permissions",
+            params={"workflow": f"default/secret_{suffix}"},
+            headers=_headers(),
+        )
+    assert resp.status_code == 403, resp.text
+
+
+def _seed_schedule(suffix: str, workflow_name: str):
+    from flux.domain.schedule import schedule_factory
+    from flux.schedule_manager import create_schedule_manager
+
+    wf_id = _seed_workflow("default", workflow_name)
+    return create_schedule_manager().create_schedule(
+        workflow_id=wf_id,
+        workflow_namespace="default",
+        workflow_name=workflow_name,
+        name=f"hist-{suffix}",
+        schedule=schedule_factory({"type": "interval", "interval_seconds": 3600}),
+    )
+
+
+def test_schedule_history_denies_reader_without_workflow_read(client):
+    """`get_schedule` scopes to the bound workflow; history exposes the same
+    workflow's execution ids, states and error strings, so it must scope too."""
+    suffix = uuid.uuid4().hex[:6]
+    schedule_model = _seed_schedule(suffix, f"finance_{suffix}")
+
+    _seed_role(f"sched_read_{suffix}", ["schedule:*:read"])
+    identity = FluxIdentity(subject="nosy", roles=frozenset({f"sched_read_{suffix}"}))
+
+    with _auth_as(identity):
+        resp = client.get(f"/schedules/{schedule_model.id}/history", headers=_headers())
+    assert resp.status_code == 403, resp.text
+
+
+def test_schedule_history_allows_reader_with_workflow_read(client):
+    suffix = uuid.uuid4().hex[:6]
+    schedule_model = _seed_schedule(suffix, f"ledger_{suffix}")
+
+    _seed_role(
+        f"sched_read_ok_{suffix}",
+        ["schedule:*:read", f"workflow:default:ledger_{suffix}:read"],
+    )
+    identity = FluxIdentity(subject="owner", roles=frozenset({f"sched_read_ok_{suffix}"}))
+
+    with _auth_as(identity):
+        resp = client.get(f"/schedules/{schedule_model.id}/history", headers=_headers())
+    assert resp.status_code == 200, resp.text
+
+
 def test_schedule_update_sa_rebind_fails_closed_when_workflow_unregistered(client):
     """If the schedule's workflow is gone from the catalog, the rebind guard
     cannot derive task-level permission requirements — it must refuse rather

--- a/tests/security/test_schedule_execution_authz.py
+++ b/tests/security/test_schedule_execution_authz.py
@@ -362,6 +362,59 @@ def _seed_schedule(suffix: str, workflow_name: str):
     )
 
 
+def test_schedule_resume_denies_caller_who_cannot_run_workflow(client):
+    """Resuming makes the workflow fire under the bound service account on its
+    configured cadence. Blocking the rewrite but not the resume would leave the
+    escalation reachable — an operator's deliberate pause is the only thing
+    standing between the attacker and the privileged run."""
+    from flux.schedule_manager import create_schedule_manager
+
+    suffix = uuid.uuid4().hex[:6]
+    schedule_model = _seed_schedule(suffix, f"payout_{suffix}")
+    manager = create_schedule_manager()
+    manager.pause_schedule(schedule_model.id)
+
+    _seed_role(f"sched_resume_{suffix}", ["schedule:*:manage"])
+    identity = FluxIdentity(subject="intruder", roles=frozenset({f"sched_resume_{suffix}"}))
+
+    with _auth_as(identity):
+        resp = client.post(f"/schedules/{schedule_model.id}/resume", headers=_headers())
+    assert resp.status_code == 403, resp.text
+
+
+def test_schedule_resume_allows_caller_who_can_run_workflow(client):
+    from flux.schedule_manager import create_schedule_manager
+
+    suffix = uuid.uuid4().hex[:6]
+    schedule_model = _seed_schedule(suffix, f"batch_{suffix}")
+    manager = create_schedule_manager()
+    manager.pause_schedule(schedule_model.id)
+
+    _seed_role(
+        f"sched_resume_ok_{suffix}",
+        ["schedule:*:manage", f"workflow:default:batch_{suffix}:*"],
+    )
+    identity = FluxIdentity(subject="owner", roles=frozenset({f"sched_resume_ok_{suffix}"}))
+
+    with _auth_as(identity):
+        resp = client.post(f"/schedules/{schedule_model.id}/resume", headers=_headers())
+    assert resp.status_code == 200, resp.text
+
+
+def test_schedule_pause_denies_caller_without_workflow_read(client):
+    """Pausing only stops execution, so it takes the lighter read boundary that
+    get_schedule uses rather than full run authorization."""
+    suffix = uuid.uuid4().hex[:6]
+    schedule_model = _seed_schedule(suffix, f"nightly_{suffix}")
+
+    _seed_role(f"sched_pause_{suffix}", ["schedule:*:manage"])
+    identity = FluxIdentity(subject="intruder", roles=frozenset({f"sched_pause_{suffix}"}))
+
+    with _auth_as(identity):
+        resp = client.post(f"/schedules/{schedule_model.id}/pause", headers=_headers())
+    assert resp.status_code == 403, resp.text
+
+
 def test_schedule_history_denies_reader_without_workflow_read(client):
     """`get_schedule` scopes to the bound workflow; history exposes the same
     workflow's execution ids, states and error strings, so it must scope too."""


### PR DESCRIPTION
## Why

Three routes granted more than their permission implies.

### `PUT /schedules/{id}`

`create_schedule` refuses a caller who cannot run the target workflow, with a comment explaining why: the schedule later runs that workflow under a service account's roles, so `schedule:*:manage` alone must not buy work the caller could never run themselves.

`update_schedule` applied that guard only when `run_as_service_account` was being rebound. But rewriting `schedule_config` and `input_data` alone re-aims the schedule's **existing** service account at attacker-chosen input on an attacker-chosen cadence — the same escalation, reached without touching the SA field. The guard is now unconditional, matching create.

### `GET /schedules/{id}/history`

Gated on the flat `schedule:*:read`, while `GET /schedules/{id}` scopes to the bound workflow. History carries execution ids, states and error strings for that workflow, so it now follows the same boundary. Note `_resolve_schedule_id_or_name` also resolves by name and auto-created schedules are deterministically `<workflow>_auto`, so no id enumeration was needed to reach it.

### `GET /auth/permissions`

No filtering at all, while its siblings `/workflows` and `/namespaces` both filter on workflow read. It returns every namespace and workflow name plus the task names and nested workflows expanded by `_collect_required_permissions`.

Now filtered on the list branch and gated on the single-workflow branch — the latter checked *before* the catalog lookup, so a denial does not reveal whether the workflow exists.

## Note

The handler also needed an `except HTTPException: raise` passthrough. Its bare `except Exception` was turning the new 403 into a 500; the test caught it.

## Tests

Five new cases in `tests/security/test_schedule_execution_authz.py`, each paired with an allow-case so the guards don't over-block. All fail before the fix.