### PR TITLE
fix(ai-tools): enforce the workspace boundary per entry in grep and directory_tree

### DIFF
--- a/flux/tasks/ai/tools/directory.py
+++ b/flux/tasks/ai/tools/directory.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from flux.task import task
 
-from flux.tasks.ai.tools.system_tools import resolve_path, truncate_output
+from flux.tasks.ai.tools.system_tools import is_contained, resolve_path, truncate_output
 
 if TYPE_CHECKING:
     from flux.tasks.ai.tools.system_tools import SystemToolsConfig
@@ -65,6 +65,10 @@ def build_directory_tools(config: SystemToolsConfig) -> list[task]:
             except OSError:
                 return
             for entry in entries:
+                # is_dir() follows symlinks, so an unchecked entry lets the
+                # walk descend out of the workspace entirely.
+                if not is_contained(config, entry):
+                    continue
                 if entry.is_dir():
                     dir_count += 1
                     lines.append(f"{prefix}{entry.name}/")

--- a/flux/tasks/ai/tools/directory.py
+++ b/flux/tasks/ai/tools/directory.py
@@ -24,6 +24,11 @@ def build_directory_tools(config: SystemToolsConfig) -> list[task]:
 
         entries = []
         for entry in sorted(resolved.iterdir(), key=lambda e: e.name):
+            # Same per-entry boundary as directory_tree: is_dir() and stat()
+            # both follow symlinks, so an unchecked entry reports the type and
+            # size of a file the workspace boundary is meant to exclude.
+            if not is_contained(config, entry):
+                continue
             info: dict[str, str | int] = {"name": entry.name}
             if entry.is_dir():
                 info["type"] = "directory"

--- a/flux/tasks/ai/tools/search.py
+++ b/flux/tasks/ai/tools/search.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from flux.task import task
 
-from flux.tasks.ai.tools.system_tools import resolve_path
+from flux.tasks.ai.tools.system_tools import is_contained, resolve_path
 
 if TYPE_CHECKING:
     from flux.tasks.ai.tools.system_tools import SystemToolsConfig
@@ -85,6 +85,11 @@ def build_search_tools(config: SystemToolsConfig) -> list:
                 if include and not fnmatch.fnmatch(fname, include):
                     continue
                 fpath = os.path.join(root, fname)
+                # os.walk does not descend symlinked directories by default,
+                # but a symlink to a FILE is still listed here and open()
+                # would follow it out of the workspace.
+                if not is_contained(config, fpath):
+                    continue
                 try:
                     with open(fpath, errors="replace") as f:
                         for line_num, line in enumerate(f, 1):

--- a/flux/tasks/ai/tools/search.py
+++ b/flux/tasks/ai/tools/search.py
@@ -79,6 +79,11 @@ def build_search_tools(config: SystemToolsConfig) -> list:
         except re.error as e:
             return {"status": "error", "error": f"invalid regex: {e}"}
 
+        # Resolved, like find_files: search_root is already resolved, so
+        # relpath against the *unresolved* workspace yields a `../..` path
+        # whenever the configured workspace itself contains a symlink.
+        workspace = config.workspace.resolve()
+
         matches = []
         for root, _dirs, files in os.walk(search_root):
             for fname in sorted(files):
@@ -94,7 +99,7 @@ def build_search_tools(config: SystemToolsConfig) -> list:
                     with open(fpath, errors="replace") as f:
                         for line_num, line in enumerate(f, 1):
                             if regex.search(line):
-                                rel = os.path.relpath(fpath, config.workspace)
+                                rel = os.path.relpath(fpath, workspace)
                                 matches.append(
                                     {
                                         "file": rel,

--- a/flux/tasks/ai/tools/system_tools.py
+++ b/flux/tasks/ai/tools/system_tools.py
@@ -35,6 +35,20 @@ def resolve_path(config: SystemToolsConfig, path: str) -> Path:
     return resolved
 
 
+def is_contained(config: SystemToolsConfig, path: Path | str) -> bool:
+    """Whether ``path`` resolves inside the workspace.
+
+    Tools that walk the tree need this per entry, not just per root:
+    ``resolve_path`` validates the path it is handed, but a symlink *inside*
+    the workspace resolves outside it, so a walk reaches files the boundary is
+    meant to exclude.
+    """
+    try:
+        return Path(path).resolve().is_relative_to(config.workspace.resolve())
+    except OSError:
+        return False
+
+
 def truncate_output(text: str, max_chars: int) -> tuple[str, bool]:
     if len(text) <= max_chars:
         return text, False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.74.12"
+version = "0.74.13"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/tasks/ai/tools/test_path_validation.py
+++ b/tests/flux/tasks/ai/tools/test_path_validation.py
@@ -147,3 +147,38 @@ class TestSymlinkContainment:
 
         assert result["status"] == "ok"
         assert [m["file"] for m in result["matches"]] == ["own.txt"]
+
+    async def test_list_directory_hides_entries_that_escape(self, config):
+        """``is_dir()``/``stat()`` follow symlinks here too: without the same
+        per-entry check the listing reports the type and size of files outside
+        the workspace."""
+        from flux.tasks.ai.tools.directory import build_directory_tools
+
+        tools = self._tools(build_directory_tools, config)
+        result = await self._call(tools["list_directory"], "")
+
+        assert result["status"] == "ok"
+        assert [e["name"] for e in result["entries"]] == ["own.txt"]
+
+    async def test_grep_paths_are_relative_when_workspace_is_symlinked(self, tmp_path):
+        """A workspace path that itself contains a symlink (``/tmp`` on macOS,
+        a symlinked checkout) must still yield paths relative to it — the walk
+        starts from the *resolved* root, so relpath needs the resolved base."""
+        from flux.tasks.ai.tools.search import build_search_tools
+
+        real = tmp_path / "real_ws"
+        real.mkdir()
+        (real / "own.txt").write_text("nothing interesting\n")
+        linked = tmp_path / "linked_ws"
+        linked.symlink_to(real)
+
+        config = SystemToolsConfig(
+            workspace=linked,
+            timeout=30,
+            blocklist=[],
+            max_output_chars=100_000,
+        )
+        tools = self._tools(build_search_tools, config)
+        result = await self._call(tools["grep"], "nothing interesting")
+
+        assert [m["file"] for m in result["matches"]] == ["own.txt"]

--- a/tests/flux/tasks/ai/tools/test_path_validation.py
+++ b/tests/flux/tasks/ai/tools/test_path_validation.py
@@ -75,3 +75,75 @@ def test_symlink_escape_rejected(config, tmp_path):
         pytest.skip("symlinks not supported")
     with pytest.raises(ValueError, match="path escapes workspace boundary"):
         resolve_path(config, "sneaky_link")
+
+
+class TestSymlinkContainment:
+    """``resolve_path`` validates only the path it is handed. Tools that walk
+    the tree must re-check each entry they reach, because a symlink inside the
+    workspace resolves outside it — ``find_files`` and ``read_file`` do, so
+    ``grep`` and ``directory_tree`` must not be the way out."""
+
+    @pytest.fixture
+    def config(self, tmp_path):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secrets.env").write_text("API_TOKEN=sk-not-yours\n")
+
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        (ws / "own.txt").write_text("nothing interesting\n")
+        (ws / "link.env").symlink_to(outside / "secrets.env")
+        (ws / "dirlink").symlink_to(outside)
+        return SystemToolsConfig(
+            workspace=ws,
+            timeout=30,
+            blocklist=[],
+            max_output_chars=100_000,
+        )
+
+    @staticmethod
+    async def _call(tool, *args):
+        from flux.domain.execution_context import ExecutionContext
+
+        ctx = ExecutionContext(
+            workflow_id="test",
+            workflow_namespace="default",
+            workflow_name="test",
+        )
+        token = ExecutionContext.set(ctx)
+        try:
+            return await tool(*args)
+        finally:
+            ExecutionContext.reset(token)
+
+    @staticmethod
+    def _tools(builder, config):
+        return {t.func.__name__: t for t in builder(config)}
+
+    async def test_grep_does_not_follow_symlink_out_of_workspace(self, config):
+        from flux.tasks.ai.tools.search import build_search_tools
+
+        tools = self._tools(build_search_tools, config)
+        result = await self._call(tools["grep"], "API_TOKEN")
+
+        assert result["status"] == "ok"
+        assert result["matches"] == []
+        assert "sk-not-yours" not in str(result)
+
+    async def test_directory_tree_does_not_descend_symlinked_dir(self, config):
+        from flux.tasks.ai.tools.directory import build_directory_tools
+
+        tools = self._tools(build_directory_tools, config)
+        result = await self._call(tools["directory_tree"], "")
+
+        assert result["status"] == "ok"
+        assert "secrets.env" not in result["tree"]
+
+    async def test_grep_still_reads_real_workspace_files(self, config):
+        from flux.tasks.ai.tools.search import build_search_tools
+
+        tools = self._tools(build_search_tools, config)
+        result = await self._call(tools["grep"], "nothing interesting")
+
+        assert result["status"] == "ok"
+        assert [m["file"] for m in result["matches"]] == ["own.txt"]

--- a/tests/flux/tasks/ai/tools/test_path_validation.py
+++ b/tests/flux/tasks/ai/tools/test_path_validation.py
@@ -92,8 +92,11 @@ class TestSymlinkContainment:
         ws = tmp_path / "ws"
         ws.mkdir()
         (ws / "own.txt").write_text("nothing interesting\n")
-        (ws / "link.env").symlink_to(outside / "secrets.env")
-        (ws / "dirlink").symlink_to(outside)
+        try:
+            (ws / "link.env").symlink_to(outside / "secrets.env")
+            (ws / "dirlink").symlink_to(outside, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlinks not supported")
         return SystemToolsConfig(
             workspace=ws,
             timeout=30,
@@ -170,7 +173,10 @@ class TestSymlinkContainment:
         real.mkdir()
         (real / "own.txt").write_text("nothing interesting\n")
         linked = tmp_path / "linked_ws"
-        linked.symlink_to(real)
+        try:
+            linked.symlink_to(real, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlinks not supported")
 
         config = SystemToolsConfig(
             workspace=linked,


### PR DESCRIPTION
## Why

`resolve_path` validates the path it is handed, which is enough for the tools that touch one path. It is not enough for the two that walk a tree: a symlink *inside* the workspace resolves outside it, and neither re-checked the entries it reached.

- **`grep`** opened every file `os.walk` listed. `os.walk` does not descend symlinked directories by default, but a symlink to a **file** is still classified into `files`, so `open()` followed it out of the workspace.
- **`directory_tree`** decided recursion with `entry.is_dir()`, which follows symlinks, so it walked symlinked directories and printed their contents.

The result was a boundary that held for `read_file` and for `find_files` (which already re-checks each match) and leaked through the other two. `read_file("link.env")` refuses with `path escapes workspace boundary` while `grep` returned that same file's contents verbatim — and a tool result is fed back to the model and stored in working memory.

This needs no `shell` in the toolset. `tools: [files, search, directory]` is enough, and real workspaces routinely contain symlinks: `.venv/bin`, `node_modules/.bin`, mounted-secret links.

## Change

Adds `is_contained()` next to `resolve_path` in `system_tools.py` so the check has one home and future tree-walking tools don't have to rediscover it. Containment is by resolution rather than by rejecting symlinks outright, so a link pointing inside the workspace still works.

## Tests

New `TestSymlinkContainment` covering both tools against a workspace holding a symlinked file and a symlinked directory, plus a control asserting `grep` still reads genuine workspace files. Both containment tests fail before the fix — `grep` returns the out-of-workspace contents and `directory_tree` lists the outside directory.