### PR TITLE
ci: cancel superseded pull-request runs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,6 +5,16 @@ on:
     branches: [ main ]
   workflow_dispatch:  # Allow manual triggering
 
+# Force-pushing a PR (a rebase onto main, a review fix) otherwise leaves the
+# superseded run going: it keeps a 15-minute e2e and the postgres jobs busy for
+# a commit nobody will merge, and reports its result against a PR whose head has
+# already moved — which reads as a failure on the current code. Keyed on the PR
+# number so branches never cancel each other, and falling back to the ref for
+# workflow_dispatch, where there is no PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   version-check:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.74.13"
+version = "0.74.14"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"


### PR DESCRIPTION
## Why

Force-pushing a PR (rebasing onto main, pushing a review fix) leaves the superseded run executing. Two consequences, both seen today while rebasing the security fixes through four merges:

- It burns a 15-minute `e2e` plus `perf-postgres` and `migrations-postgres` on a commit that will never merge.
- It reports its result against a PR whose head has already moved, so a stale failure looks like a failure on the current code. That cost real time on #186: an `e2e` failure surfaced against a commit that had been superseded twenty minutes earlier, and disentangling it from a genuine intermittent took a detour.

## The change

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

Keyed on the **PR number**, deliberately not `github.head_ref`. `head_ref` is attacker-controllable and is the usual injection vector in this idiom; it would also let two branches with a colliding name cancel each other's runs, which is worse than the problem being fixed. The fallback to `github.ref` covers `workflow_dispatch`, where there is no PR.

## Note on merge order

Versioned 0.74.14, so this needs to land **after** #186 (0.74.13). `version-check` reads `origin/main` at run time, so merging this first would fail that PR.