### PR TITLE
fix(runners): bind relayed child operations to the dispatched execution

### DIFF
--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -842,6 +842,17 @@ class WorkerRoutesMixin:
                 self._verify_worker_identity(identity, name)
                 self._worker_last_pong[name] = time.monotonic()
 
+                # _verify_worker_identity only proves the caller is this
+                # worker, not that this worker owns the execution it is
+                # writing to. The body carries its own execution_id, so
+                # without both checks a worker can write to any execution.
+                if context.execution_id != execution_id:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Checkpoint body does not match the execution in the path",
+                    )
+                self._verify_worker_owns_execution(name, execution_id)
+
                 context_manager = ContextManager.create()
                 domain_ctx = context.to_domain()
 
@@ -967,6 +978,7 @@ class WorkerRoutesMixin:
             from flux.approvals import ApprovalManager, ApprovalSnapshot
 
             self._verify_worker_identity(identity, name)
+            self._verify_worker_owns_execution(name, execution_id)
             row = await asyncio.to_thread(
                 lambda: ApprovalManager().get_by_call(execution_id, task_call_id),
             )
@@ -993,6 +1005,7 @@ class WorkerRoutesMixin:
             checkpoint path.
             """
             self._verify_worker_identity(identity, name)
+            self._verify_worker_owns_execution(name, execution_id)
             task_call_id = payload.get("task_call_id")
             task_name = payload.get("task_name")
             target_value = payload.get("target_value") or None

--- a/flux/runners/subprocess_runner.py
+++ b/flux/runners/subprocess_runner.py
@@ -149,13 +149,20 @@ class SubprocessRunner(Runner):
 
             async for frame in self._frames(proc):
                 kind = frame.get("type")
+                # The child's stdout is the frame channel, so workflow code can
+                # emit a frame naming any execution. Every relayed operation is
+                # bound to the execution actually dispatched; a frame claiming a
+                # different one is dropped rather than trusted or rewritten,
+                # since its events and state belong to that other execution.
+                if kind in ("checkpoint", "result") and not self._owns_frame(frame, execution_id):
+                    continue
                 if kind == "checkpoint":
                     last_ctx = self._rebuild(frame, hooks)
                     await hooks.checkpoint(last_ctx)
                 elif kind == "progress":
                     if hooks.progress:
                         hooks.progress(
-                            frame["execution_id"],
+                            execution_id,
                             frame["task_id"],
                             frame["task_name"],
                             frame["value"],
@@ -167,7 +174,7 @@ class SubprocessRunner(Runner):
                     "approval_register_request",
                 ):
                     task = asyncio.create_task(
-                        self._serve_rpc(proc, frame, hooks, stdin_lock),
+                        self._serve_rpc(proc, frame, hooks, stdin_lock, execution_id),
                     )
                     rpc_tasks.add(task)
                     task.add_done_callback(rpc_tasks.discard)
@@ -222,6 +229,18 @@ class SubprocessRunner(Runner):
             except json.JSONDecodeError:
                 logger.warning("Dropping malformed frame from runner child")
 
+    @staticmethod
+    def _owns_frame(frame: dict, execution_id: str) -> bool:
+        """Whether a context-bearing frame names the dispatched execution."""
+        claimed = (frame.get("context") or {}).get("execution_id")
+        if claimed == execution_id:
+            return True
+        logger.error(
+            f"Runner child for {execution_id} emitted a {frame.get('type')} frame "
+            f"naming execution {claimed!r}; dropping it",
+        )
+        return False
+
     def _rebuild(self, frame: dict, hooks: RunnerHooks) -> ExecutionContext:
         from flux.domain.execution_context import ExecutionContext
 
@@ -230,10 +249,17 @@ class SubprocessRunner(Runner):
             ctx.mark_transient()
         return ctx
 
-    async def _serve_rpc(self, proc, frame: dict, hooks: RunnerHooks, stdin_lock: asyncio.Lock):
+    async def _serve_rpc(
+        self,
+        proc,
+        frame: dict,
+        hooks: RunnerHooks,
+        stdin_lock: asyncio.Lock,
+        execution_id: str,
+    ):
         response: dict[str, Any] = {"type": "rpc_response", "id": frame["id"]}
         try:
-            response["values"] = await self._resolve_rpc(frame, hooks)
+            response["values"] = await self._resolve_rpc(frame, hooks, execution_id)
         except Exception as e:
             response["error"] = str(e)
         try:
@@ -243,7 +269,16 @@ class SubprocessRunner(Runner):
         except (ConnectionError, RuntimeError):
             logger.debug("Runner child went away before its RPC response was written")
 
-    async def _resolve_rpc(self, frame: dict, hooks: RunnerHooks) -> dict[str, Any]:
+    async def _resolve_rpc(
+        self,
+        frame: dict,
+        hooks: RunnerHooks,
+        execution_id: str,
+    ) -> dict[str, Any]:
+        # execution_id is the parent's, never the frame's. get_secrets is
+        # already bound this way — the parent closed over the real id when it
+        # built the hook — and the approval hooks now match, so a child cannot
+        # read or register approvals against an execution it was not given.
         kind = frame["type"]
         if kind == "secrets_request":
             return await hooks.get_secrets(frame.get("names") or [])
@@ -253,7 +288,7 @@ class SubprocessRunner(Runner):
             if hooks.get_approval is None:
                 raise RuntimeError("Approval lookups are not available for this execution")
             approval = await hooks.get_approval(
-                frame["execution_id"],
+                execution_id,
                 frame["task_call_id"],
             )
             return {"approval": approval}
@@ -261,7 +296,7 @@ class SubprocessRunner(Runner):
             if hooks.register_approval is None:
                 raise RuntimeError("Approval registration is not available for this execution")
             return await hooks.register_approval(
-                frame["execution_id"],
+                execution_id,
                 {
                     "task_call_id": frame["task_call_id"],
                     "task_name": frame["task_name"],

--- a/flux/server.py
+++ b/flux/server.py
@@ -353,10 +353,14 @@ class Server(
         the credential — the pattern ``workers_secrets_batch`` already applies.
         """
         from flux.context_managers import ContextManager
+        from flux.errors import ExecutionContextNotFoundError
 
         try:
             ctx = ContextManager.create().get(execution_id)
-        except Exception:
+        except ExecutionContextNotFoundError:
+            # Only a genuinely absent execution is a 404; a database or
+            # catalog failure must surface as a 500 rather than be reported
+            # as "not found".
             raise HTTPException(status_code=404, detail="Execution not found") from None
         if ctx.current_worker != name:
             raise HTTPException(

--- a/flux/server.py
+++ b/flux/server.py
@@ -344,6 +344,26 @@ class Server(
                 f"but accessing endpoint for '{name}'",
             )
 
+    def _verify_worker_owns_execution(self, name: str, execution_id: str) -> None:
+        """Reject a worker acting on an execution it does not hold the claim for.
+
+        ``_verify_worker_identity`` proves only that the caller is the worker
+        it claims to be. Routes that act on a specific execution need this in
+        addition, because the execution is named by the request rather than by
+        the credential — the pattern ``workers_secrets_batch`` already applies.
+        """
+        from flux.context_managers import ContextManager
+
+        try:
+            ctx = ContextManager.create().get(execution_id)
+        except Exception:
+            raise HTTPException(status_code=404, detail="Execution not found") from None
+        if ctx.current_worker != name:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Worker '{name}' does not hold the claim for execution '{execution_id}'",
+            )
+
     def _get_version(self) -> str:
         import importlib.metadata
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.74.14"
+version = "0.74.15"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_runners.py
+++ b/tests/flux/test_runners.py
@@ -321,6 +321,7 @@ class TestApprovalRpcRelay:
         got = await runner._resolve_rpc(
             {"type": "approval_get_request", "execution_id": "e1", "task_call_id": "c1"},
             hooks,
+            "e1",
         )
         assert got == {"approval": {"id": "a1", "status": "pending"}}
 
@@ -332,6 +333,7 @@ class TestApprovalRpcRelay:
                 "task_name": "deploy",
             },
             hooks,
+            "e1",
         )
         assert registered == {"status": "created"}
 
@@ -339,7 +341,7 @@ class TestApprovalRpcRelay:
     async def test_resolve_rpc_rejects_unknown_frames(self):
         runner = SubprocessRunner(term_grace=5)
         with pytest.raises(RuntimeError, match="Unknown RPC frame"):
-            await runner._resolve_rpc({"type": "bogus_request", "id": 1}, make_hooks())
+            await runner._resolve_rpc({"type": "bogus_request", "id": 1}, make_hooks(), "e1")
 
 
 class TestCrashDurabilityMapping:
@@ -483,3 +485,81 @@ async def isolated_wf(ctx: ExecutionContext[str]):
             payload = server._build_dispatch_payload(ctx)
 
         assert payload.get("runner") == "subprocess"
+
+
+class TestChildExecutionBinding:
+    """The child's stdout IS the frame channel, so workflow code can emit a
+    frame naming any execution it likes. The parent must bind every relayed
+    operation to the execution it actually dispatched, never to what the
+    frame claims."""
+
+    @pytest.mark.asyncio
+    async def test_forged_checkpoint_cannot_target_another_execution(self):
+        source = """
+            import json
+            from flux import task, workflow, ExecutionContext
+
+            @workflow
+            async def forger(ctx: ExecutionContext):
+                print(json.dumps({
+                    "type": "checkpoint",
+                    "transient": False,
+                    "context": {
+                        "workflow_id": "victim/deploy",
+                        "workflow_namespace": "victim",
+                        "workflow_name": "deploy",
+                        "execution_id": "VICTIM-EXECUTION",
+                        "input": None,
+                        "output": {"owned": True},
+                        "state": "COMPLETED",
+                        "events": [],
+                    },
+                }), flush=True)
+                return "done"
+        """
+        checkpoints: list = []
+        request = make_request(source, "forger")
+        runner = SubprocessRunner(term_grace=5)
+
+        await runner.execute(request, make_hooks(checkpoints=checkpoints))
+
+        targeted = {c.execution_id for c in checkpoints}
+        assert "VICTIM-EXECUTION" not in targeted, (
+            f"a forged frame reached the checkpoint hook: {targeted}"
+        )
+        assert targeted <= {request.context.execution_id}
+
+    @pytest.mark.asyncio
+    async def test_approval_rpcs_ignore_the_execution_id_in_the_frame(self):
+        runner = SubprocessRunner(term_grace=5)
+        hooks = make_hooks()
+        seen: list = []
+
+        async def get_approval(execution_id, task_call_id):
+            seen.append(("get", execution_id))
+            return None
+
+        async def register_approval(execution_id, payload):
+            seen.append(("register", execution_id))
+            return {"status": "created"}
+
+        hooks.get_approval = get_approval
+        hooks.register_approval = register_approval
+
+        await runner._resolve_rpc(
+            {"type": "approval_get_request", "execution_id": "VICTIM", "task_call_id": "c1"},
+            hooks,
+            "MINE",
+        )
+        await runner._resolve_rpc(
+            {
+                "type": "approval_register_request",
+                "execution_id": "VICTIM",
+                "task_call_id": "c1",
+                "task_name": "deploy",
+            },
+            hooks,
+            "MINE",
+        )
+
+        assert seen == [("get", "MINE"), ("register", "MINE")]

--- a/tests/flux/test_server_approvals.py
+++ b/tests/flux/test_server_approvals.py
@@ -76,6 +76,7 @@ def _seed_execution(execution_id: str, namespace: str, workflow_name: str) -> No
         execution_id=execution_id,
     )
     ContextManager.create().save(ctx)
+    _claim_execution(execution_id)
 
 
 def test_get_approvals_lists_pending(client):
@@ -369,6 +370,22 @@ def test_cancel_marks_pending_approvals_cancelled(client):
 # ---------------------------------------------------------------------------
 # Worker-side approval registration (POST /workers/{name}/approvals/{eid})
 # ---------------------------------------------------------------------------
+
+
+def _claim_execution(execution_id: str, worker: str = "w1") -> None:
+    """Mark the execution as held by `worker`.
+
+    The worker-facing approval routes require the caller to hold the claim,
+    matching /workers/{name}/secrets/batch — a worker only registers or reads
+    approvals for executions dispatched to it.
+    """
+    from flux.models import ExecutionContextModel
+    from flux.unit_of_work import UnitOfWork
+
+    with UnitOfWork() as uow:
+        model = uow.session.get(ExecutionContextModel, execution_id)
+        model.worker_name = worker
+        uow.commit()
 
 
 def _set_execution_state(execution_id: str, state) -> None:


### PR DESCRIPTION
## Why

The runner child names the execution in its own frames, and the parent took that at face value:

- `checkpoint` and `result` frames were rebuilt from `frame["context"]`;
- `progress` used `frame["execution_id"]`;
- both approval RPCs passed `frame["execution_id"]` through to the hooks.

Only `secrets_request` was bound parent-side — the hook closes over the real id, which is why it reads `hooks.get_secrets(frame.get("names"))` with no id from the frame at all. The approval RPCs sit three lines away and did not.

`request.context.execution_id` was available throughout; it was used only for logging.

## The change

**Parent side.** Context-bearing frames that do not name the dispatched execution are dropped, and the parent's own `execution_id` is passed to the approval hooks and the progress hook. Dropped rather than rewritten: such a frame carries another execution's events and state, so adopting it under the correct id would corrupt that execution rather than correct the frame.

**Server side.** `workers_checkpoint`, `workers_approval_get` and `workers_approval_register` acted on an execution named by the request while verifying only that the caller was the worker it claimed to be. `workers_checkpoint` also trusted the body's `execution_id` over the path's. All three now go through `_verify_worker_owns_execution`, the check `/workers/{name}/secrets/batch` has always applied. Both halves matter independently — the parent fix alone would leave the server trusting any worker's word.

## Tests

Two new cases in `TestChildExecutionBinding`. The first runs a real child through `SubprocessRunner.execute` and asserts no foreign execution reaches the checkpoint hook; it fails against the pre-fix code. The second asserts the approval RPCs use the bound id and ignore the frame's.

Fixtures in `test_server_approvals` seeded executions without a claim and then called worker routes as `w1`, which no real worker does — they now set `worker_name`, matching how the secrets route already constrains its callers.

`DockerRunner` inherits this path, so both container runners are covered.

## Merge order

Versioned 0.74.15. Land after #186 (0.74.13) and #190 (0.74.14).