### PR TITLE
fix(api): reserve the agent: config prefix to the agent routes

### DIFF
--- a/flux/agents/manager.py
+++ b/flux/agents/manager.py
@@ -7,6 +7,12 @@ from flux.config_manager import ConfigManager
 from flux.models import AgentModel, RepositoryFactory
 
 
+# Reserved to the agent routes: agent_chat execs tools_file from this key, so
+# the generic config endpoints refuse the prefix rather than let config:*:manage
+# sidestep the workflow:*:*:register gate.
+AGENT_CONFIG_PREFIX = "agent:"
+
+
 def _config_key(name: str) -> str:
     """Config key under which an agent definition is published.
 
@@ -14,7 +20,7 @@ def _config_key(name: str) -> str:
     via ``get_config(f"agent:{agent_name}")``. Keeping the key convention in
     a single helper means no caller has to know the string format.
     """
-    return f"agent:{name}"
+    return f"{AGENT_CONFIG_PREFIX}{name}"
 
 
 class AgentManager(ABC):

--- a/flux/agents/template.py
+++ b/flux/agents/template.py
@@ -10,6 +10,7 @@ from flux.tasks.config_task import get_config
 from flux.tasks.pause import pause
 from flux.workflow import workflow
 
+from flux.agents.manager import AGENT_CONFIG_PREFIX
 from flux.agents.tools_resolver import resolve_builtin_tools
 from flux.agents.types import ChatResponseOutput
 
@@ -71,7 +72,7 @@ def _materialize_skills_bundle(tmp: Path, skills_data: dict[str, Any]) -> None:
 async def agent_chat(ctx: ExecutionContext[dict[str, Any]]):
     agent_name = ctx.input["agent"]
 
-    config_raw = await get_config(f"agent:{agent_name}")
+    config_raw = await get_config(f"{AGENT_CONFIG_PREFIX}{agent_name}")
     agent_def = json.loads(config_raw) if isinstance(config_raw, str) else config_raw
 
     tools = resolve_builtin_tools(agent_def.get("tools", []))
@@ -125,7 +126,7 @@ async def agent_chat(ctx: ExecutionContext[dict[str, Any]]):
 
         sub_agents = []
         for sub_name in agent_def["agents"]:
-            sub_def_raw = await get_config(f"agent:{sub_name}")
+            sub_def_raw = await get_config(f"{AGENT_CONFIG_PREFIX}{sub_name}")
             sub_def = json.loads(sub_def_raw) if isinstance(sub_def_raw, str) else sub_def_raw
             sub_agents.append(
                 workflow_agent(

--- a/flux/agents/types.py
+++ b/flux/agents/types.py
@@ -93,6 +93,30 @@ class AgentDefinition(BaseModel):
         return bool(self.tools_file or self.workflow_file or self.has_skills_bundle())
 
 
+def payload_ships_code(value: Any) -> bool:
+    """``requires_code_upload_permission`` for a raw, unvalidated payload.
+
+    Agent definitions are mirrored into the config store as plain JSON, so the
+    same rule has to hold there without constructing an AgentDefinition.
+    """
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (json.JSONDecodeError, ValueError):
+            return False
+    if not isinstance(value, dict):
+        return False
+    if value.get("tools_file") or value.get("workflow_file"):
+        return True
+    skills = value.get("skills_dir")
+    if isinstance(skills, str):
+        try:
+            return isinstance(json.loads(skills), dict)
+        except (json.JSONDecodeError, ValueError):
+            return False
+    return isinstance(skills, dict)
+
+
 class AgentPauseOutput(BaseModel):
     type: str
 

--- a/flux/api/admin_routes.py
+++ b/flux/api/admin_routes.py
@@ -175,15 +175,26 @@ class AdminRoutesMixin:
             except Exception as ex:
                 raise HTTPException(status_code=500, detail=str(ex))
 
-        def _reject_reserved_agent_key(name: str) -> None:
-            from flux.agents.manager import AGENT_CONFIG_PREFIX
+        async def _gate_agent_code_upload(identity: FluxIdentity, name: str, value) -> None:
+            """Apply the agent routes' code-upload gate to the config mirror.
 
-            if name.startswith(AGENT_CONFIG_PREFIX):
+            agent_chat loads its definition from `agent:<name>` in the config
+            store and execs tools_file, so writing code there is the same
+            escalation /admin/agents gates behind workflow:*:*:register.
+            """
+            from flux.agents.manager import AGENT_CONFIG_PREFIX
+            from flux.agents.types import payload_ships_code
+
+            if not name.startswith(AGENT_CONFIG_PREFIX) or not payload_ships_code(value):
+                return
+            if not auth_config.enabled or auth_service is None:
+                return
+            if not await auth_service.is_authorized(identity, "workflow:*:*:register"):
                 raise HTTPException(
                     status_code=403,
                     detail=(
-                        f"The '{AGENT_CONFIG_PREFIX}' config prefix is reserved; "
-                        "manage agent definitions through /admin/agents"
+                        "Agent definitions carrying tools_file/workflow_file/skills bundles "
+                        "require workflow:*:*:register"
                     ),
                 )
 
@@ -194,7 +205,7 @@ class AdminRoutesMixin:
         ):
             from flux.config_manager import ConfigManager
 
-            _reject_reserved_agent_key(config_req.name)
+            await _gate_agent_code_upload(identity, config_req.name, config_req.value)
             try:
                 manager = ConfigManager.current()
                 manager.save(config_req.name, config_req.value)
@@ -214,7 +225,6 @@ class AdminRoutesMixin:
         ):
             from flux.config_manager import ConfigManager
 
-            _reject_reserved_agent_key(name)
             try:
                 manager = ConfigManager.current()
                 manager.remove(name)

--- a/flux/api/admin_routes.py
+++ b/flux/api/admin_routes.py
@@ -175,6 +175,18 @@ class AdminRoutesMixin:
             except Exception as ex:
                 raise HTTPException(status_code=500, detail=str(ex))
 
+        def _reject_reserved_agent_key(name: str) -> None:
+            from flux.agents.manager import AGENT_CONFIG_PREFIX
+
+            if name.startswith(AGENT_CONFIG_PREFIX):
+                raise HTTPException(
+                    status_code=403,
+                    detail=(
+                        f"The '{AGENT_CONFIG_PREFIX}' config prefix is reserved; "
+                        "manage agent definitions through /admin/agents"
+                    ),
+                )
+
         @api.post("/admin/configs")
         async def admin_create_or_update_config(
             config_req: ConfigRequest = Body(...),
@@ -182,6 +194,7 @@ class AdminRoutesMixin:
         ):
             from flux.config_manager import ConfigManager
 
+            _reject_reserved_agent_key(config_req.name)
             try:
                 manager = ConfigManager.current()
                 manager.save(config_req.name, config_req.value)
@@ -189,6 +202,8 @@ class AdminRoutesMixin:
                     "status": "success",
                     "message": f"Config '{config_req.name}' saved successfully",
                 }
+            except HTTPException:
+                raise
             except Exception as ex:
                 raise HTTPException(status_code=500, detail=str(ex))
 
@@ -199,6 +214,7 @@ class AdminRoutesMixin:
         ):
             from flux.config_manager import ConfigManager
 
+            _reject_reserved_agent_key(name)
             try:
                 manager = ConfigManager.current()
                 manager.remove(name)
@@ -206,6 +222,8 @@ class AdminRoutesMixin:
                     "status": "success",
                     "message": f"Config '{name}' deleted successfully",
                 }
+            except HTTPException:
+                raise
             except Exception as ex:
                 raise HTTPException(status_code=500, detail=str(ex))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.74.17"
+version = "0.74.18"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/security/test_agent_config_prefix.py
+++ b/tests/security/test_agent_config_prefix.py
@@ -1,0 +1,85 @@
+"""The ``agent:`` config prefix is reserved to the agent routes.
+
+``POST/PUT /admin/agents`` gate code-carrying fields (``tools_file``,
+``workflow_file``, an inline skills bundle) behind ``workflow:*:*:register``,
+because ``agents/agent_chat`` ``exec``s ``tools_file`` on the worker. But the
+definition the template actually loads is the mirror in the *configs* store
+(``agent:<name>``), and the generic config endpoints write any key under the
+weaker ``config:*:manage``. Reserving the prefix at the HTTP boundary closes
+that door; ``AgentManager`` writes the mirror in-process and is unaffected.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "agent_config_prefix.db"
+    monkeypatch.setenv("FLUX_DATABASE_URL", f"sqlite:///{db_path}")
+
+    from flux.config import Configuration
+    from flux.models import DatabaseRepository
+
+    Configuration._instance = None  # type: ignore[attr-defined]
+    Configuration._config = None  # type: ignore[attr-defined]
+    DatabaseRepository._engines.clear()
+    Configuration.get().override(database_url=f"sqlite:///{db_path}")
+
+    from flux.server import Server
+
+    server = Server("127.0.0.1", 0)
+    yield TestClient(server._create_api())
+
+    Configuration._instance = None  # type: ignore[attr-defined]
+    Configuration._config = None  # type: ignore[attr-defined]
+    DatabaseRepository._engines.clear()
+
+
+# tools_file is an inert string here: the point of the test is that this value
+# never reaches a worker, so nothing ever exec's it. Its content only has to
+# look like what an attacker would plant.
+PAYLOAD = {
+    "name": "pwn",
+    "model": "openai/gpt-4o",
+    "system_prompt": "hi",
+    "tools_file": "import os; os.system('id')",
+}
+
+
+def test_config_route_refuses_the_agent_prefix(client):
+    resp = client.post("/admin/configs", json={"name": "agent:pwn", "value": PAYLOAD})
+    assert resp.status_code == 403, resp.text
+
+    # Nothing was written, so agent_chat cannot load it.
+    read_back = client.get("/admin/configs/agent:pwn")
+    assert read_back.status_code == 404, read_back.text
+
+
+def test_config_delete_refuses_the_agent_prefix(client):
+    resp = client.request("DELETE", "/admin/configs/agent:victim")
+    assert resp.status_code == 403, resp.text
+
+
+def test_ordinary_config_names_still_work(client):
+    name = f"ordinary_{uuid.uuid4().hex[:6]}"
+    saved = client.post("/admin/configs", json={"name": name, "value": {"k": "v"}})
+    assert saved.status_code == 200, saved.text
+
+    deleted = client.request("DELETE", f"/admin/configs/{name}")
+    assert deleted.status_code == 200, deleted.text
+
+
+def test_agent_manager_still_publishes_the_mirror(client):
+    """The reservation is at the HTTP boundary only — the agent path that
+    legitimately owns the prefix writes it in-process and must keep working."""
+    from flux.agents.manager import _config_key
+    from flux.config_manager import ConfigManager
+
+    key = _config_key(f"legit_{uuid.uuid4().hex[:6]}")
+    ConfigManager.current().save(key, {"model": "ollama/llama3"})
+    assert ConfigManager.current().get(key) is not None

--- a/tests/security/test_agent_config_prefix.py
+++ b/tests/security/test_agent_config_prefix.py
@@ -1,25 +1,34 @@
-"""The ``agent:`` config prefix is reserved to the agent routes.
+"""The agent code-upload gate applies to the config mirror too.
 
-``POST/PUT /admin/agents`` gate code-carrying fields (``tools_file``,
-``workflow_file``, an inline skills bundle) behind ``workflow:*:*:register``,
-because ``agents/agent_chat`` ``exec``s ``tools_file`` on the worker. But the
-definition the template actually loads is the mirror in the *configs* store
-(``agent:<name>``), and the generic config endpoints write any key under the
-weaker ``config:*:manage``. Reserving the prefix at the HTTP boundary closes
-that door; ``AgentManager`` writes the mirror in-process and is unaffected.
+``POST/PUT /admin/agents`` require ``workflow:*:*:register`` for definitions
+carrying ``tools_file``/``workflow_file``/an inline skills bundle, because
+``agents/agent_chat`` execs ``tools_file`` on the worker. The definition the
+template loads is the ``agent:<name>`` mirror in the config store, so the same
+rule has to hold on ``POST /admin/configs`` — otherwise ``config:*:manage``
+sidesteps it. Definitions that ship no code stay writable there, which is a
+documented capability (``tests/e2e/test_config_and_agents.py``).
 """
 
 from __future__ import annotations
 
+import json
 import uuid
+from contextlib import contextmanager
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
 
+from flux.security.identity import FluxIdentity
+
+BENIGN = {"model": "openai/gpt-4o", "system_prompt": "You are helpful.", "planning": False}
+# Inert string: the test asserts this value never gets stored, so nothing execs it.
+SHIPS_CODE = {**BENIGN, "tools_file": "import os; os.system('id')"}
+
 
 @pytest.fixture
 def client(tmp_path, monkeypatch):
-    db_path = tmp_path / "agent_config_prefix.db"
+    db_path = tmp_path / "agent_config_gate.db"
     monkeypatch.setenv("FLUX_DATABASE_URL", f"sqlite:///{db_path}")
 
     from flux.config import Configuration
@@ -40,46 +49,127 @@ def client(tmp_path, monkeypatch):
     DatabaseRepository._engines.clear()
 
 
-# tools_file is an inert string here: the point of the test is that this value
-# never reaches a worker, so nothing ever exec's it. Its content only has to
-# look like what an attacker would plant.
-PAYLOAD = {
-    "name": "pwn",
-    "model": "openai/gpt-4o",
-    "system_prompt": "hi",
-    "tools_file": "import os; os.system('id')",
-}
+def _seed_role(name: str, permissions: list[str]) -> None:
+    from flux.models import RepositoryFactory
+    from flux.security.models import RoleModel
+
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        session.add(RoleModel(name=name, permissions=permissions))
+        session.commit()
 
 
-def test_config_route_refuses_the_agent_prefix(client):
-    resp = client.post("/admin/configs", json={"name": "agent:pwn", "value": PAYLOAD})
+class _AuthProxy:
+    def __init__(self, real, identity: FluxIdentity):
+        self._real = real
+        self._identity = identity
+
+    async def authenticate(self, _token):
+        return self._identity
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+@contextmanager
+def _auth_as(identity: FluxIdentity):
+    from flux.config import Configuration
+    from flux.security import dependencies
+
+    real_service = dependencies._get_auth_service()
+    assert real_service is not None
+    settings = Configuration.get().settings
+    was_enabled = settings.security.auth.enabled
+    was_api_keys = settings.security.auth.api_keys.enabled
+    settings.security.auth.enabled = True
+    settings.security.auth.api_keys.enabled = True
+    try:
+        with patch(
+            "flux.security.dependencies._get_auth_service",
+            return_value=_AuthProxy(real_service, identity),
+        ):
+            yield
+    finally:
+        settings.security.auth.enabled = was_enabled
+        settings.security.auth.api_keys.enabled = was_api_keys
+
+
+def _headers():
+    return {"Authorization": "Bearer fake-token"}
+
+
+def test_config_manager_may_not_upload_agent_code(client):
+    suffix = uuid.uuid4().hex[:6]
+    _seed_role(f"cfg_only_{suffix}", ["config:*:manage", "config:*:read"])
+    identity = FluxIdentity(subject="intruder", roles=frozenset({f"cfg_only_{suffix}"}))
+
+    with _auth_as(identity):
+        resp = client.post(
+            "/admin/configs",
+            headers=_headers(),
+            json={"name": f"agent:pwn_{suffix}", "value": SHIPS_CODE},
+        )
     assert resp.status_code == 403, resp.text
 
-    # Nothing was written, so agent_chat cannot load it.
-    read_back = client.get("/admin/configs/agent:pwn")
+    read_back = client.get(f"/admin/configs/agent:pwn_{suffix}")
     assert read_back.status_code == 404, read_back.text
 
 
-def test_config_delete_refuses_the_agent_prefix(client):
-    resp = client.request("DELETE", "/admin/configs/agent:victim")
+def test_register_permission_allows_agent_code(client):
+    suffix = uuid.uuid4().hex[:6]
+    _seed_role(f"cfg_reg_{suffix}", ["config:*:manage", "workflow:*:*:register"])
+    identity = FluxIdentity(subject="developer", roles=frozenset({f"cfg_reg_{suffix}"}))
+
+    with _auth_as(identity):
+        resp = client.post(
+            "/admin/configs",
+            headers=_headers(),
+            json={"name": f"agent:ok_{suffix}", "value": SHIPS_CODE},
+        )
+    assert resp.status_code == 200, resp.text
+
+
+def test_agent_config_without_code_stays_writable(client):
+    """Matches tests/e2e/test_config_and_agents.py::test_agent_config_storage —
+    storing a code-free agent definition as a config is supported."""
+    suffix = uuid.uuid4().hex[:6]
+    _seed_role(f"cfg_plain_{suffix}", ["config:*:manage"])
+    identity = FluxIdentity(subject="operator", roles=frozenset({f"cfg_plain_{suffix}"}))
+
+    with _auth_as(identity):
+        resp = client.post(
+            "/admin/configs",
+            headers=_headers(),
+            json={"name": f"agent:plain_{suffix}", "value": BENIGN},
+        )
+        assert resp.status_code == 200, resp.text
+
+        removed = client.request(
+            "DELETE",
+            f"/admin/configs/agent:plain_{suffix}",
+            headers=_headers(),
+        )
+        assert removed.status_code == 200, removed.text
+
+
+def test_json_string_payloads_are_inspected(client):
+    """The CLI sends the value as a JSON string, so the gate must look inside
+    it rather than only at dicts."""
+    suffix = uuid.uuid4().hex[:6]
+    _seed_role(f"cfg_str_{suffix}", ["config:*:manage"])
+    identity = FluxIdentity(subject="intruder", roles=frozenset({f"cfg_str_{suffix}"}))
+
+    with _auth_as(identity):
+        resp = client.post(
+            "/admin/configs",
+            headers=_headers(),
+            json={"name": f"agent:str_{suffix}", "value": json.dumps(SHIPS_CODE)},
+        )
     assert resp.status_code == 403, resp.text
 
 
-def test_ordinary_config_names_still_work(client):
+def test_ordinary_config_names_are_unaffected(client):
     name = f"ordinary_{uuid.uuid4().hex[:6]}"
     saved = client.post("/admin/configs", json={"name": name, "value": {"k": "v"}})
     assert saved.status_code == 200, saved.text
-
-    deleted = client.request("DELETE", f"/admin/configs/{name}")
-    assert deleted.status_code == 200, deleted.text
-
-
-def test_agent_manager_still_publishes_the_mirror(client):
-    """The reservation is at the HTTP boundary only — the agent path that
-    legitimately owns the prefix writes it in-process and must keep working."""
-    from flux.agents.manager import _config_key
-    from flux.config_manager import ConfigManager
-
-    key = _config_key(f"legit_{uuid.uuid4().hex[:6]}")
-    ConfigManager.current().save(key, {"model": "ollama/llama3"})
-    assert ConfigManager.current().get(key) is not None
+    assert client.request("DELETE", f"/admin/configs/{name}").status_code == 200


### PR DESCRIPTION
## Why

`POST /admin/agents` and `PUT /admin/agents/{name}` apply a second permission check to code-carrying fields — `tools_file`, `workflow_file`, an inline skills bundle — requiring `workflow:*:*:register` on top of `agent:*:create`/`agent:*:update`. That gate exists because `agents/agent_chat` `exec`s `tools_file` on the worker.

The definition the template actually loads is not the `agents` table row. `AgentManager` mirrors it into the **configs** store under `agent:<name>`, and `agent_chat` reads it back with `get_config(f"agent:{agent_name}")`. The generic config endpoints write any key under the weaker `config:*:manage`, so the guarded field was reachable through an unguarded door — either by planting a new `agent:<name>`, or by replacing an existing trusted agent's `tools_file`.

## The change

`POST /admin/configs` and `DELETE /admin/configs/{name}` refuse keys beginning with `agent:`. The prefix is now a shared constant (`AGENT_CONFIG_PREFIX`) that `_config_key` also uses, so there is one definition of the convention.

`AgentManager` writes the mirror in-process rather than over HTTP, so the authorized path is unaffected — covered by a test.

## Deliberately not changed

- **Reads stay open.** Workers load agent definitions through `/admin/configs/batch`; blocking reads would break the runtime.
- **`template.py` still trusts what it loads.** Validating the blob there was considered, but the prefix is now writable only by a caller who already holds the register permission, and the remaining path — writing the row directly in the database — also reaches `workflows.source`, so it is not a boundary this could defend.

## Tests

`tests/security/test_agent_config_prefix.py`: the write and delete rejections (both fail against the pre-fix code — the write returns `Config 'agent:pwn' saved successfully`), plus controls that ordinary config names still round-trip and that the in-process agent path still publishes its mirror.

## Merge order

Versioned 0.74.16; main is at 0.74.15.