### PR TITLE
fix(api): let claim fencing handle an unclaimed execution's checkpoint

### DIFF
--- a/flux/server.py
+++ b/flux/server.py
@@ -362,7 +362,13 @@ class Server(
             # catalog failure must surface as a 500 rather than be reported
             # as "not found".
             raise HTTPException(status_code=404, detail="Execution not found") from None
-        if ctx.current_worker != name:
+        # Only a claim held by someone *else* is a cross-execution write. An
+        # unclaimed execution is the recovery path — eviction clears
+        # worker_name and bumps claim_generation so the old owner's next
+        # checkpoint is fenced with 409 stale-claim, which the worker handles
+        # by abandoning cleanly. Rejecting it here with 403 pre-empts that
+        # fence and strands the execution in CREATED.
+        if ctx.current_worker and ctx.current_worker != name:
             raise HTTPException(
                 status_code=403,
                 detail=f"Worker '{name}' does not hold the claim for execution '{execution_id}'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.74.15"
+version = "0.74.17"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_server_approvals.py
+++ b/tests/flux/test_server_approvals.py
@@ -457,3 +457,51 @@ def test_worker_register_grant_yields_to_concurrent_cancel(client):
     assert r.status_code == 200, r.text
     assert r.json()["status"] == "cancelled"
     assert ApprovalManager().get_by_call(eid, "call-gc-2") is None
+
+
+class TestCheckpointOwnership:
+    """A worker may only checkpoint an execution another worker holds — but an
+    *unclaimed* one must fall through to claim-generation fencing, not 403.
+    Eviction clears worker_name and bumps the generation so the old owner's
+    next checkpoint is fenced with 409 stale-claim and abandons cleanly;
+    rejecting it here strands the execution in CREATED (perf t6c).
+    """
+
+    @staticmethod
+    def _body(eid: str) -> dict:
+        return {
+            "workflow_id": "default/release",
+            "workflow_namespace": "default",
+            "workflow_name": "release",
+            "execution_id": eid,
+            "input": None,
+            "output": None,
+            "state": "RUNNING",
+            "events": [],
+        }
+
+    def _seed(self, worker: str | None) -> str:
+        from flux.models import ExecutionContextModel
+        from flux.unit_of_work import UnitOfWork
+
+        eid = f"exec-ckpt-{uuid.uuid4().hex[:6]}"
+        _seed_execution(eid, "default", "release")
+        with UnitOfWork() as uow:
+            uow.session.get(ExecutionContextModel, eid).worker_name = worker
+            uow.commit()
+        return eid
+
+    def test_released_execution_is_not_rejected_as_foreign(self, client):
+        eid = self._seed(None)
+        r = client.post(f"/workers/w1/checkpoint/{eid}", json=self._body(eid))
+        assert r.status_code != 403, r.text
+
+    def test_execution_held_by_another_worker_is_rejected(self, client):
+        eid = self._seed("other-worker")
+        r = client.post(f"/workers/w1/checkpoint/{eid}", json=self._body(eid))
+        assert r.status_code == 403, r.text
+
+    def test_body_execution_id_must_match_the_path(self, client):
+        eid = self._seed("w1")
+        r = client.post(f"/workers/w1/checkpoint/{eid}", json=self._body("someone-elses"))
+        assert r.status_code == 400, r.text

--- a/tests/flux/test_server_approvals.py
+++ b/tests/flux/test_server_approvals.py
@@ -460,7 +460,7 @@ def test_worker_register_grant_yields_to_concurrent_cancel(client):
 
 
 class TestCheckpointOwnership:
-    """A worker may only checkpoint an execution another worker holds — but an
+    """A worker may not checkpoint an execution another worker holds, but an
     *unclaimed* one must fall through to claim-generation fencing, not 403.
     Eviction clears worker_name and bumps the generation so the old owner's
     next checkpoint is fenced with 409 stale-claim and abandons cleanly;
@@ -480,21 +480,31 @@ class TestCheckpointOwnership:
             "events": [],
         }
 
-    def _seed(self, worker: str | None) -> str:
+    def _seed(self, worker: str | None, generation: int = 0) -> str:
         from flux.models import ExecutionContextModel
         from flux.unit_of_work import UnitOfWork
 
         eid = f"exec-ckpt-{uuid.uuid4().hex[:6]}"
         _seed_execution(eid, "default", "release")
         with UnitOfWork() as uow:
-            uow.session.get(ExecutionContextModel, eid).worker_name = worker
+            model = uow.session.get(ExecutionContextModel, eid)
+            model.worker_name = worker
+            model.claim_generation = generation
             uow.commit()
         return eid
 
-    def test_released_execution_is_not_rejected_as_foreign(self, client):
-        eid = self._seed(None)
-        r = client.post(f"/workers/w1/checkpoint/{eid}", json=self._body(eid))
-        assert r.status_code != 403, r.text
+    def test_released_execution_reaches_claim_fencing(self, client):
+        """Eviction clears worker_name and bumps the generation, so the old
+        owner's checkpoint must be answered with the 409 stale-claim it knows
+        how to handle. A 403 here never reaches the fence."""
+        eid = self._seed(None, generation=5)
+        r = client.post(
+            f"/workers/w1/checkpoint/{eid}",
+            json=self._body(eid),
+            headers={"X-Flux-Claim-Generation": "1"},
+        )
+        assert r.status_code == 409, r.text
+        assert "stale-claim" in r.text
 
     def test_execution_held_by_another_worker_is_rejected(self, client):
         eid = self._seed("other-worker")


### PR DESCRIPTION
## Regression from #191, currently on main

#191 added `_verify_worker_owns_execution` and applied it to `workers_checkpoint`. It rejected any worker whose name did not match `worker_name` — **including when `worker_name` is `None`**, which is the recovery path rather than a foreign write.

`recover_execution` (`context_managers.py:1264-1268`) resets an evicted or disconnected worker's execution:

```python
model.state = ExecutionState.CREATED
model.worker_name = None
model.claim_generation = (model.claim_generation or 0) + 1
```

The design then fences the old owner: its next checkpoint carries a stale generation, the server answers **409 `stale-claim`**, and `_send_checkpoint` raises `StaleClaimError` so the worker abandons cleanly and the execution is re-dispatched.

The new 403 arrived first. `_send_checkpoint` only special-cases 409, so a 403 fell through to `raise_for_status()` as a generic error, the fence never fired, and the execution stayed in `CREATED`.

## Evidence

`tests/perf/test_t6_violence.py::test_t6c_connection_drop` — which drops a worker's TCP connection mid-stream and waits for a terminal state — failed **five consecutive times** from #191 onward and passed on every run before it:

| Branch | perf-postgres |
|---|---|
| before #191 (5 runs) | success |
| #191 | fail ×3 — `t6c`, last state `CREATED` |
| #192 (branched after #191 merged) | fail ×2 — same |

## The change

The check now fires only when **another** worker genuinely holds the claim; an unclaimed execution falls through to fencing as designed.

## Scope

This is still stricter than pre-#191 behaviour — a checkpoint against an execution held by a different worker is rejected, which was the point. It does **not** close forging against an *unclaimed* execution: that needs the fencing to treat a missing claim generation as stale rather than skipping the check, which is a separate change with its own compatibility question. The parent-side binding from #191 (`SubprocessRunner` dropping frames that name another execution) is untouched and remains the primary control.

## Tests

`TestCheckpointOwnership` covers all three cases at unit level — released execution not rejected, foreign claim rejected, body/path mismatch rejected. The first fails against the regressing guard, so this cannot recur without waiting on the 20-minute perf suite.