### PR TITLE
fix(security): scope an execution token to what an execution needs

### DIFF
--- a/flux/security/auth_service.py
+++ b/flux/security/auth_service.py
@@ -94,6 +94,32 @@ class _TTLCache:
         self._data.clear()
 
 
+# A running execution calls back for a narrow set of things: running or
+# registering workflows (call_workflow, register_dynamic_workflow). Secrets,
+# configs and approvals reach it through the worker, not this token, so the
+# admin, rbac, schedule, service, worker, config and secret families are
+# unreachable with an execution token however privileged the triggering
+# principal is.
+EXECUTION_TOKEN_RESOURCES = ("workflow", "execution")
+
+
+def scope_to_execution(permissions: frozenset[str]) -> frozenset[str]:
+    """Intersect a principal's permissions with what an execution needs.
+
+    Fail-closed: a resource family that is not listed is dropped, so a new
+    one is unreachable until it is added deliberately.
+    """
+    scoped: set[str] = set()
+    for perm in permissions:
+        head, _, rest = perm.partition(":")
+        if head == "*":
+            # A blanket grant becomes the allowed families, never everything.
+            scoped.update(f"{r}:{rest}" if rest else f"{r}:*" for r in EXECUTION_TOKEN_RESOURCES)
+        elif head in EXECUTION_TOKEN_RESOURCES:
+            scoped.add(perm)
+    return frozenset(scoped)
+
+
 class AuthService:
     def __init__(
         self,
@@ -164,6 +190,18 @@ class AuthService:
         return f"identity:{provider}:{identity.subject}:{','.join(sorted(identity.roles))}"
 
     async def resolve_permissions(self, identity: FluxIdentity) -> frozenset[str]:
+        resolved = await self._resolve_principal_permissions(identity)
+        # Scoped on the way out, never cached: the cache key is the principal,
+        # which an execution token shares with that principal's other
+        # credentials, so caching the narrowed set would starve them.
+        if (identity.metadata or {}).get("token_type") == "execution":
+            return scope_to_execution(resolved)
+        return resolved
+
+    async def _resolve_principal_permissions(
+        self,
+        identity: FluxIdentity,
+    ) -> frozenset[str]:
         cache_key = None
         if self._resolution_cache_ttl > 0:
             cache_key = self._permission_cache_key(identity)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.74.18"
+version = "0.74.19"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/security/test_execution_token_scope.py
+++ b/tests/security/test_execution_token_scope.py
@@ -1,0 +1,117 @@
+"""An execution token carries the triggering principal's identity, but not
+its full authority.
+
+The token is handed to workflow code — stored on the execution row, forwarded
+into the runner child, exposed as ``ctx.exec_token`` and
+``FluxClient.for_current_execution()`` — so whatever it can reach, a workflow
+author can reach. It needs to run and register workflows; it never needs the
+admin, rbac, schedule, service, worker, config or secret families.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from flux.security.auth_service import AuthService, scope_to_execution
+from flux.security.config import AuthConfig
+from flux.security.identity import FluxIdentity
+from flux.security.models import Base, RoleModel
+
+
+class TestScopeToExecution:
+    def test_blanket_grant_becomes_the_allowed_families(self):
+        scoped = scope_to_execution(frozenset({"*"}))
+        assert scoped == {"workflow:*", "execution:*"}
+        # The point: admin is no longer reachable.
+        assert not FluxIdentity(subject="s").has_permission("admin:secrets:read", scoped)
+        assert not FluxIdentity(subject="s").has_permission("admin:principals:manage", scoped)
+
+    def test_out_of_family_permissions_are_dropped(self):
+        scoped = scope_to_execution(
+            frozenset(
+                {
+                    "workflow:*:*:register",
+                    "workflow:*:*:run",
+                    "execution:*:read",
+                    "schedule:*",
+                    "config:*:manage",
+                    "admin:workers:manage",
+                    "service:*:manage",
+                    "worker:*:*",
+                },
+            ),
+        )
+        assert scoped == {"workflow:*:*:register", "workflow:*:*:run", "execution:*:read"}
+
+    def test_wildcard_resource_is_narrowed_not_dropped(self):
+        assert scope_to_execution(frozenset({"*:*:read"})) == {
+            "workflow:*:read",
+            "execution:*:read",
+        }
+
+    def test_scoped_permissions_still_authorize_the_real_calls(self):
+        """call_workflow and register_dynamic_workflow must keep working."""
+        identity = FluxIdentity(subject="s")
+        scoped = scope_to_execution(frozenset({"*"}))
+        assert identity.has_permission("workflow:default:report:run", scoped)
+        assert identity.has_permission("workflow:dyn-abc:generated:register", scoped)
+        assert identity.has_permission("workflow:default:report:task:load:execute", scoped)
+
+
+@pytest.fixture
+def session_factory(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'exec_scope.db'}")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+def _auth(session_factory) -> AuthService:
+    return AuthService(config=AuthConfig(), session_factory=session_factory)
+
+
+def _identity(roles: set[str], *, execution: bool) -> FluxIdentity:
+    metadata = {"token_type": "execution", "exec_id": "e1"} if execution else {}
+    return FluxIdentity(subject="svc", roles=frozenset(roles), metadata=metadata)
+
+
+async def test_execution_token_cannot_reach_admin(session_factory):
+    with session_factory() as s:
+        s.add(RoleModel(name="privileged", permissions=["*"]))
+        s.commit()
+
+    auth = _auth(session_factory)
+    perms = await auth.resolve_permissions(_identity({"privileged"}, execution=True))
+
+    identity = FluxIdentity(subject="svc")
+    assert not identity.has_permission("admin:secrets:read", perms)
+    assert not identity.has_permission("schedule:*:manage", perms)
+    assert identity.has_permission("workflow:default:report:run", perms)
+
+
+async def test_ordinary_identity_is_unchanged(session_factory):
+    with session_factory() as s:
+        s.add(RoleModel(name="privileged", permissions=["*"]))
+        s.commit()
+
+    auth = _auth(session_factory)
+    perms = await auth.resolve_permissions(_identity({"privileged"}, execution=False))
+    assert FluxIdentity(subject="svc").has_permission("admin:secrets:read", perms)
+
+
+async def test_scoping_does_not_poison_the_shared_cache(session_factory):
+    """resolve_permissions caches on the principal, which an execution token
+    shares with that principal's other credentials — so the narrowed set must
+    never be what gets cached."""
+    with session_factory() as s:
+        s.add(RoleModel(name="privileged", permissions=["*"]))
+        s.commit()
+
+    auth = _auth(session_factory)
+    scoped = await auth.resolve_permissions(_identity({"privileged"}, execution=True))
+    full = await auth.resolve_permissions(_identity({"privileged"}, execution=False))
+
+    identity = FluxIdentity(subject="svc")
+    assert not identity.has_permission("admin:secrets:read", scoped)
+    assert identity.has_permission("admin:secrets:read", full)


### PR DESCRIPTION
## Why

`ExecutionTokenProvider` mints a token carrying `exec_id` and `scope`, and then `authenticate()` throws that scoping away: it resolves the referenced principal's **full role set** and files the claims into `metadata` as inert data. `AuthService.resolve_permissions` keys off `metadata["principal_id"]` and never reads them.

Exactly one route inspects the claims (`execution_routes.py:804`, which checks `token_type` and `exec_id` itself and does not go through `require_permission`). Every other route gated by `require_permission` accepted the token as an ordinary bearer credential for the triggering principal.

That matters because the token is handed to workflow code **by design** — stored on the execution row, shipped in the dispatch payload, forwarded into the otherwise credential-less runner child, and exposed as `ctx.exec_token` plus the public helper `FluxClient.for_current_execution()`. So whatever it reaches, a workflow author reaches.

Measured against a principal holding `*`:

```
                          before    after
admin:secrets:read         True     False
admin:principals:manage    True     False
schedule:*:manage          True     False
workflow:default:r:run     True     True
```

## The change

Permissions are intersected with the families a running execution actually calls back for. I derived those from the consumers rather than guessing: `flux/tasks/call.py` (`call_workflow`), `flux/tasks/dynamic.py` (`register_dynamic_workflow`), and the task-authorize callback in `flux/task.py`. Secrets, configs and approvals reach the child through the **worker**, not this token, so those families are dropped.

Two details worth review:

- **A blanket `*` becomes `workflow:*`/`execution:*`, not everything.** A bare family name would match nothing given the wildcard semantics (`_wildcard_match` requires equal segment counts unless the pattern ends in `*`), so the expansion has to add the terminal wildcard.
- **The filter is applied on the way out of `resolve_permissions`, not inside it.** The permission cache keys on `principal:{principal_id}`, which an execution token *shares* with that principal's other credentials — caching the narrowed set would starve them. The existing body is now `_resolve_principal_permissions` and the cache still holds the unscoped set.

Fail-closed: a resource family that is not listed is unreachable until added deliberately.

## Tests

`tests/security/test_execution_token_scope.py` — the unit behaviour of the intersection (blanket grant, out-of-family drops, wildcard-resource narrowing), that the scoped set still authorizes the real calls, and specifically that scoping does not poison the shared cache.

## Verification note

Local full-suite runs are currently unreliable on my machine (repeated SIGSEGV/SIGILL inside `libpython3.12.so`, unrelated to this change). A targeted 35-test subset passes and pre-commit is clean; **CI is the verification of record for this PR.**

## Follow-ups, already agreed

- An explicit impersonation permission for `run_as_service_account` — a caller can otherwise bind a more privileged SA, and `workflow:*` necessarily stays in this allowlist, so `call_workflow` under that SA remains an escalation this PR does not close.
- Rejecting the token once its execution is terminal (the TTL default is 86400s).