### PR TITLE
fix(security): stop an execution token once its execution is terminal

### DIFF
--- a/flux/security/auth_service.py
+++ b/flux/security/auth_service.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import hashlib
 import re
 import secrets
-import time
 from datetime import datetime, timedelta, timezone
 from collections.abc import Callable
 
@@ -16,7 +15,7 @@ from flux.security.providers import AuthProvider
 from flux.security.providers.oidc import OIDCProvider
 from flux.security.providers.api_key import APIKeyProvider
 from flux.security.execution_token import ExecutionTokenProvider
-from flux.utils import get_logger
+from flux.utils import TTLCache, get_logger
 
 logger = get_logger(__name__)
 
@@ -60,40 +59,6 @@ class AuthorizationResult:
         self.missing_permissions = missing_permissions or []
 
 
-class _TTLCache:
-    """Tiny per-process TTL cache for auth resolution results.
-
-    Bounded: when full, expired entries are swept; if still full the oldest
-    insertion is dropped. No background task — expiry is checked on read.
-    """
-
-    def __init__(self, max_size: int = 4096):
-        self._data: dict[str, tuple[float, object]] = {}
-        self._max_size = max_size
-
-    def get(self, key: str) -> object | None:
-        entry = self._data.get(key)
-        if entry is None:
-            return None
-        expires_at, value = entry
-        if time.monotonic() >= expires_at:
-            self._data.pop(key, None)
-            return None
-        return value
-
-    def put(self, key: str, value: object, ttl: float) -> None:
-        if len(self._data) >= self._max_size:
-            now = time.monotonic()
-            for stale in [k for k, (exp, _) in self._data.items() if exp <= now]:
-                self._data.pop(stale, None)
-            while len(self._data) >= self._max_size:
-                self._data.pop(next(iter(self._data)), None)
-        self._data[key] = (time.monotonic() + ttl, value)
-
-    def clear(self) -> None:
-        self._data.clear()
-
-
 # A running execution calls back for a narrow set of things: running or
 # registering workflows (call_workflow, register_dynamic_workflow). Secrets,
 # configs and approvals reach it through the worker, not this token, so the
@@ -134,8 +99,8 @@ class AuthService:
         # identity, principal → permissions). Local mutations invalidate
         # immediately; other replicas converge within the TTL.
         self._resolution_cache_ttl = getattr(config, "resolution_cache_ttl", 0) or 0
-        self._identity_cache = _TTLCache()
-        self._permission_cache = _TTLCache()
+        self._identity_cache = TTLCache()
+        self._permission_cache = TTLCache()
         self._providers: list[AuthProvider] = []
 
         self._providers.append(ExecutionTokenProvider(registry=registry))

--- a/flux/security/execution_token.py
+++ b/flux/security/execution_token.py
@@ -116,8 +116,14 @@ def _execution_is_terminal(execution_id: str) -> bool:
             )
     except Exception as ex:
         # A datastore problem must not turn every running execution's
-        # callbacks into authentication failures.
-        logger.warning(f"Could not read execution state for '{execution_id}': {ex}")
+        # callbacks into authentication failures. Cache the permissive answer
+        # so an outage costs one read per TTL rather than one per request, and
+        # log the type only — driver messages carry connection details.
+        logger.warning(
+            f"Could not read execution state for '{execution_id}': {type(ex).__name__}",
+        )
+        logger.debug("Execution state read failed", exc_info=True)
+        _EXECUTION_STATE_CACHE.put(execution_id, False, _EXECUTION_STATE_CACHE_TTL)
         return False
     if state is None:
         return False

--- a/flux/security/execution_token.py
+++ b/flux/security/execution_token.py
@@ -126,6 +126,9 @@ def _execution_is_terminal(execution_id: str) -> bool:
         _EXECUTION_STATE_CACHE.put(execution_id, False, _EXECUTION_STATE_CACHE_TTL)
         return False
     if state is None:
+        # Cached like every other answer: an unknown execution id would
+        # otherwise read the row on every callback, unbounded by the TTL.
+        _EXECUTION_STATE_CACHE.put(execution_id, False, _EXECUTION_STATE_CACHE_TTL)
         return False
     terminal = getattr(state, "value", state) in _TERMINAL_STATES
     _EXECUTION_STATE_CACHE.put(execution_id, terminal, _EXECUTION_STATE_CACHE_TTL)

--- a/flux/security/execution_token.py
+++ b/flux/security/execution_token.py
@@ -8,7 +8,7 @@ import jwt
 
 from flux.security.identity import FluxIdentity
 from flux.security.providers import AuthProvider
-from flux.utils import get_logger
+from flux.utils import TTLCache, get_logger
 
 logger = get_logger(__name__)
 
@@ -91,6 +91,41 @@ def mint_execution_token(
     return jwt.encode(payload, secret, algorithm="HS256")
 
 
+# Terminal executions must stop authorizing callbacks: the token's TTL is a
+# ceiling (86400s by default), not a lifetime, and the work it was minted for
+# is over. Cached briefly so a chatty workflow does not read the row per call —
+# the trade is that a token keeps working for a few seconds past completion.
+_TERMINAL_STATES = frozenset({"COMPLETED", "FAILED", "CANCELLED"})
+_EXECUTION_STATE_CACHE = TTLCache()
+_EXECUTION_STATE_CACHE_TTL = 5.0
+
+
+def _execution_is_terminal(execution_id: str) -> bool:
+    cached = _EXECUTION_STATE_CACHE.get(execution_id)
+    if cached is not None:
+        return bool(cached)
+    try:
+        from flux.models import ExecutionContextModel, RepositoryFactory
+
+        repo = RepositoryFactory.create_repository()
+        with repo.session() as session:
+            state = (
+                session.query(ExecutionContextModel.state)
+                .filter(ExecutionContextModel.execution_id == execution_id)
+                .scalar()
+            )
+    except Exception as ex:
+        # A datastore problem must not turn every running execution's
+        # callbacks into authentication failures.
+        logger.warning(f"Could not read execution state for '{execution_id}': {ex}")
+        return False
+    if state is None:
+        return False
+    terminal = getattr(state, "value", state) in _TERMINAL_STATES
+    _EXECUTION_STATE_CACHE.put(execution_id, terminal, _EXECUTION_STATE_CACHE_TTL)
+    return terminal
+
+
 class ExecutionTokenProvider(AuthProvider):
     def __init__(self, registry=None):
         self._registry = registry
@@ -112,6 +147,10 @@ class ExecutionTokenProvider(AuthProvider):
             subject = payload["sub"]
             principal_issuer = payload["principal_issuer"]
             exec_id = payload["exec_id"]
+
+            if _execution_is_terminal(exec_id):
+                logger.debug(f"Execution token refused: execution '{exec_id}' is terminal")
+                return None
 
             if self._registry is not None:
                 principal = self._registry.find(subject, principal_issuer)

--- a/flux/utils.py
+++ b/flux/utils.py
@@ -433,7 +433,7 @@ def parse_iso8601_duration(s: str) -> timedelta:
 
 
 class TTLCache:
-    """Tiny per-process TTL cache for auth resolution results.
+    """Tiny per-process TTL cache.
 
     Bounded: when full, expired entries are swept; if still full the oldest
     insertion is dropped. No background task — expiry is checked on read.

--- a/flux/utils.py
+++ b/flux/utils.py
@@ -22,6 +22,8 @@ from types import GeneratorType
 from typing import Any
 from collections.abc import Callable
 
+from time import monotonic
+
 from flux.errors import ExecutionError
 
 
@@ -428,3 +430,37 @@ def parse_iso8601_duration(s: str) -> timedelta:
     if days == 0 and hours == 0 and minutes == 0 and seconds == 0:
         raise ValueError(f"Invalid ISO-8601 duration: {s}")
     return timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
+
+
+class TTLCache:
+    """Tiny per-process TTL cache for auth resolution results.
+
+    Bounded: when full, expired entries are swept; if still full the oldest
+    insertion is dropped. No background task — expiry is checked on read.
+    """
+
+    def __init__(self, max_size: int = 4096):
+        self._data: dict[str, tuple[float, object]] = {}
+        self._max_size = max_size
+
+    def get(self, key: str) -> object | None:
+        entry = self._data.get(key)
+        if entry is None:
+            return None
+        expires_at, value = entry
+        if monotonic() >= expires_at:
+            self._data.pop(key, None)
+            return None
+        return value
+
+    def put(self, key: str, value: object, ttl: float) -> None:
+        if len(self._data) >= self._max_size:
+            now = monotonic()
+            for stale in [k for k, (exp, _) in self._data.items() if exp <= now]:
+                self._data.pop(stale, None)
+            while len(self._data) >= self._max_size:
+                self._data.pop(next(iter(self._data)), None)
+        self._data[key] = (monotonic() + ttl, value)
+
+    def clear(self) -> None:
+        self._data.clear()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.74.19"
+version = "0.74.20"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/security/test_execution_token.py
+++ b/tests/security/test_execution_token.py
@@ -360,3 +360,100 @@ class TestExecutionTokenSecret:
                 et._get_execution_token_secret()
         finally:
             Configuration.get().reset()
+
+
+class TestTerminalExecutionRejection:
+    """A token outlives the work it was minted for: the TTL default is 24h and
+    nothing invalidated it on completion. Terminal means the token stops."""
+
+    SECRET = "test-secret-for-unit-tests-only"
+
+    @pytest.fixture(autouse=True)
+    def patch_secret(self, monkeypatch):
+        monkeypatch.setenv("FLUX_EXECUTION_TOKEN_SECRET", self.SECRET)
+
+    @pytest.fixture
+    def db(self, tmp_path, monkeypatch):
+        from flux.config import Configuration
+        from flux.models import DatabaseRepository
+        from flux.security.execution_token import _EXECUTION_STATE_CACHE
+
+        monkeypatch.setenv("FLUX_DATABASE_URL", f"sqlite:///{tmp_path / 'tok.db'}")
+        Configuration._instance = None  # type: ignore[attr-defined]
+        Configuration._config = None  # type: ignore[attr-defined]
+        DatabaseRepository._engines.clear()
+        Configuration.get().override(database_url=f"sqlite:///{tmp_path / 'tok.db'}")
+        _EXECUTION_STATE_CACHE.clear()
+        yield
+        Configuration._instance = None  # type: ignore[attr-defined]
+        Configuration._config = None  # type: ignore[attr-defined]
+        DatabaseRepository._engines.clear()
+        _EXECUTION_STATE_CACHE.clear()
+
+    @pytest.fixture
+    def provider(self):
+        from unittest.mock import MagicMock
+
+        from flux.security.execution_token import ExecutionTokenProvider
+        from flux.security.principals import PrincipalModel, PrincipalRegistry
+
+        registry = MagicMock(spec=PrincipalRegistry)
+        principal = MagicMock(spec=PrincipalModel)
+        principal.id = "p1"
+        principal.enabled = True
+        registry.find.return_value = principal
+        registry.get_roles.return_value = ["operator"]
+        return ExecutionTokenProvider(registry=registry)
+
+    def _seed(self, execution_id: str, state) -> None:
+        from flux import ExecutionContext
+        from flux.context_managers import ContextManager
+        from flux.models import ExecutionContextModel
+        from flux.unit_of_work import UnitOfWork
+
+        ctx: ExecutionContext = ExecutionContext(
+            workflow_id="default/release",
+            workflow_namespace="default",
+            workflow_name="release",
+            input=None,
+            execution_id=execution_id,
+        )
+        ContextManager.create().save(ctx)
+        with UnitOfWork() as uow:
+            uow.session.get(ExecutionContextModel, execution_id).state = state
+            uow.commit()
+
+    def _token(self, execution_id: str) -> str:
+        return mint_execution_token(
+            subject="alice@acme.com",
+            principal_issuer="flux",
+            execution_id=execution_id,
+            on_behalf_of="alice@acme.com",
+            ttl_seconds=600,
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("state", ["COMPLETED", "FAILED", "CANCELLED"])
+    async def test_terminal_execution_rejects_the_token(self, provider, db, state):
+        from flux.domain import ExecutionState
+
+        eid = f"exec-term-{state.lower()}"
+        self._seed(eid, ExecutionState(state))
+        assert await provider.authenticate(self._token(eid)) is None
+
+    @pytest.mark.asyncio
+    async def test_running_execution_still_authenticates(self, provider, db):
+        from flux.domain import ExecutionState
+
+        eid = "exec-running"
+        self._seed(eid, ExecutionState.RUNNING)
+        identity = await provider.authenticate(self._token(eid))
+        assert identity is not None
+        assert identity.metadata["exec_id"] == eid
+
+    @pytest.mark.asyncio
+    async def test_unknown_execution_is_not_rejected(self, provider, db):
+        """Deliberate: only a row that exists and is terminal stops the token.
+        Failing closed on a missing or unreadable row would turn a datastore
+        problem into an authentication outage for every running execution."""
+        assert await provider.authenticate(self._token("exec-never-existed")) is not None


### PR DESCRIPTION
## Why

The execution token is described as short-lived and scoped to one execution. Its TTL is a **ceiling** — 86400 seconds by default (`execution_token.py:18`) — and nothing invalidated it when the execution finished. Exactly one route checked execution state; every route gated by `require_permission` accepted the token until expiry.

Since the token is handed to workflow code by design, that meant a credential for the triggering principal that outlived the work it was minted for by up to a day.

Follows #194, which bounded *what* the token can reach; this bounds *how long*.

## The change

`ExecutionTokenProvider.authenticate` refuses a token whose execution is `COMPLETED`, `FAILED` or `CANCELLED`. The check runs before the principal lookup, so a dead token costs one indexed read rather than a registry round-trip.

The state is read as a single column rather than via `ContextManager.get`, which would materialize the whole context — including the `SignedPickleType` input/output columns — on an authentication path.

Cached for 5s so a workflow making many calls doesn't read the row each time. The deliberate trade: a token keeps working for a few seconds past completion.

## Two judgement calls worth reviewing

- **A missing or unreadable row is permitted, not refused.** Failing closed there would turn a datastore hiccup into an authentication outage for every running execution. It would also have broken the provider's existing tests, which run with no database — worth noticing rather than "fixing", since it says the check must not assume one.
- **`TTLCache` moved from `auth_service` to `utils`.** `auth_service` already imports `execution_token`, so borrowing the cache the other way would have been circular. `utils` binds `time` from `datetime`, so `monotonic` is imported directly rather than as `time.monotonic`.

## Tests

`TestTerminalExecutionRejection` — each terminal state refuses the token (parametrized), a `RUNNING` execution still authenticates, and an unknown execution is deliberately still permitted.

## Verification note

Local full-suite runs remain unreliable here (SIGSEGV inside `libpython3.12.so`, unrelated to this change). A 59-test targeted batch covering the token, scope and auth-cache paths passes, and pre-commit is clean. **CI is the verification of record.**