### PR TITLE
feat(security)!: require impersonation rights to bind a schedule's service account

### DIFF
--- a/docs/advanced-features/authentication.md
+++ b/docs/advanced-features/authentication.md
@@ -382,8 +382,8 @@ flux principals revoke-key <subject> --key-name <name>
 | `POST` | `/executions/{id}/authorize/{task}` | exec_token (internal) |
 | `GET` | `/schedules` | `schedule:*:read` |
 | `POST` | `/schedules` | `schedule:*:manage` + `principal:{sa}:impersonate` |
-| `PUT` | `/schedules/{name}` | `schedule:*:manage` (+ `principal:{sa}:impersonate` to rebind) |
-| `DELETE` | `/schedules/{name}` | `schedule:*:manage` |
+| `PUT` | `/schedules/{id_or_name}` | `schedule:*:manage` (+ `principal:{sa}:impersonate` to rebind) |
+| `DELETE` | `/schedules/{id_or_name}` | `schedule:*:manage` |
 | `GET` | `/admin/secrets` | `admin:secrets:manage` |
 | `PUT` | `/admin/secrets/{name}` | `admin:secrets:manage` |
 | `DELETE` | `/admin/secrets/{name}` | `admin:secrets:manage` |

--- a/docs/advanced-features/authentication.md
+++ b/docs/advanced-features/authentication.md
@@ -127,9 +127,28 @@ Other resources remain 3-segment (`resource:name:action`).
 | `workflow:billing:invoice:run` | Run `invoice` in `billing` |
 | `workflow:billing:*` | Any action on any workflow in `billing` |
 | `schedule:*:manage` | Create, update, delete any schedule |
+| `principal:payroll-sa:impersonate` | Bind a schedule to the `payroll-sa` service account |
+| `principal:*:impersonate` | Bind a schedule to any service account |
 | `admin:secrets:manage` | Create and delete secrets |
 | `admin:roles:manage` | Manage roles |
 | `admin:principals:manage` | Manage principals and API keys |
+
+### Running a schedule as a service account
+
+A schedule stores `run_as_service_account`, and at trigger time the workflow
+runs with **that account's** roles rather than the creator's. Choosing it is
+therefore impersonation, and needs `principal:{subject}:impersonate` in
+addition to `schedule:*:manage`.
+
+```bash
+flux roles update release-manager \
+  --add-permissions "principal:deploy-sa:impersonate"
+```
+
+Grant `principal:*:impersonate` to allow any service account. No built-in role
+carries it except `admin` (through its `*`), so an `operator` upgrading from
+before this was enforced must be granted it explicitly before it can create or
+rebind schedules.
 
 **Wildcard rules:**
 
@@ -362,8 +381,8 @@ flux principals revoke-key <subject> --key-name <name>
 | `POST` | `/executions/{id}/cancel` | `workflow:*:*:run` |
 | `POST` | `/executions/{id}/authorize/{task}` | exec_token (internal) |
 | `GET` | `/schedules` | `schedule:*:read` |
-| `POST` | `/schedules` | `schedule:*:manage` |
-| `PUT` | `/schedules/{name}` | `schedule:*:manage` |
+| `POST` | `/schedules` | `schedule:*:manage` + `principal:{sa}:impersonate` |
+| `PUT` | `/schedules/{name}` | `schedule:*:manage` (+ `principal:{sa}:impersonate` to rebind) |
 | `DELETE` | `/schedules/{name}` | `schedule:*:manage` |
 | `GET` | `/admin/secrets` | `admin:secrets:manage` |
 | `PUT` | `/admin/secrets/{name}` | `admin:secrets:manage` |

--- a/flux/api/schedule_routes.py
+++ b/flux/api/schedule_routes.py
@@ -100,6 +100,20 @@ class ScheduleRoutesMixin:
 
             return None
 
+        async def _require_impersonation(identity: FluxIdentity, subject: str) -> None:
+            """Binding a schedule to a service account is impersonation: the
+            workflow runs under that account's roles at trigger time, so
+            schedule:*:manage alone must not choose which identity it runs as.
+            """
+            if not auth_config.enabled or auth_service is None:
+                return
+            required = f"principal:{subject}:impersonate"
+            if not await auth_service.is_authorized(identity, required):
+                raise HTTPException(
+                    status_code=403,
+                    detail=f"Permission denied: requires '{required}'",
+                )
+
         @api.post("/schedules", response_model=ScheduleResponse)
         async def create_schedule(
             request: ScheduleRequest,
@@ -128,6 +142,7 @@ class ScheduleRoutesMixin:
                             status_code=400,
                             detail=f"Service account '{request.run_as_service_account}' not found",
                         )
+                    await _require_impersonation(identity, request.run_as_service_account)
 
                 # Get workflow from catalog to ensure it exists
                 from flux.catalogs import resolve_workflow_ref as _resolve_ref
@@ -326,6 +341,7 @@ class ScheduleRoutesMixin:
                             status_code=400,
                             detail=f"Service account '{request.run_as_service_account}' not found",
                         )
+                    await _require_impersonation(identity, request.run_as_service_account)
 
                 schedule_manager = create_schedule_manager()
 

--- a/flux/api/schedule_routes.py
+++ b/flux/api/schedule_routes.py
@@ -100,6 +100,28 @@ class ScheduleRoutesMixin:
 
             return None
 
+        def _resolve_service_account(subject: str):
+            """A service account, not merely a principal that exists.
+
+            run_as_service_account promises the workflow runs as a service
+            account; binding a user principal or a disabled one would be
+            honoured at trigger time and surprise the operator.
+            """
+            sa = None
+            if auth_service is not None and auth_service.principal_registry is not None:
+                sa = auth_service.principal_registry.find(subject, "flux")
+            if sa is None or getattr(sa, "type", None) != "service_account":
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Service account '{subject}' not found",
+                )
+            if not getattr(sa, "enabled", True):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Service account '{subject}' is disabled",
+                )
+            return sa
+
         async def _require_impersonation(identity: FluxIdentity, subject: str) -> None:
             """Binding a schedule to a service account is impersonation: the
             workflow runs under that account's roles at trigger time, so
@@ -131,17 +153,7 @@ class ScheduleRoutesMixin:
                             status_code=400,
                             detail="run_as_service_account is required when auth is enabled",
                         )
-                    sa = None
-                    if auth_service.principal_registry is not None:
-                        sa = auth_service.principal_registry.find(
-                            request.run_as_service_account,
-                            "flux",
-                        )
-                    if sa is None:
-                        raise HTTPException(
-                            status_code=400,
-                            detail=f"Service account '{request.run_as_service_account}' not found",
-                        )
+                    _resolve_service_account(request.run_as_service_account)
                     await _require_impersonation(identity, request.run_as_service_account)
 
                 # Get workflow from catalog to ensure it exists
@@ -329,20 +341,6 @@ class ScheduleRoutesMixin:
             try:
                 logger.info(f"Updating schedule '{schedule_id}'")
 
-                if auth_config.enabled and request.run_as_service_account is not None:
-                    sa = None
-                    if auth_service.principal_registry is not None:
-                        sa = auth_service.principal_registry.find(
-                            request.run_as_service_account,
-                            "flux",
-                        )
-                    if sa is None:
-                        raise HTTPException(
-                            status_code=400,
-                            detail=f"Service account '{request.run_as_service_account}' not found",
-                        )
-                    await _require_impersonation(identity, request.run_as_service_account)
-
                 schedule_manager = create_schedule_manager()
 
                 # Resolve by ID or name
@@ -352,6 +350,18 @@ class ScheduleRoutesMixin:
                         status_code=404,
                         detail=f"Schedule '{schedule_id}' not found",
                     )
+
+                # Only an actual rebind is impersonation. A client sending a
+                # full representation re-sends the current account, and must
+                # not need the grant to edit a description.
+                requested_sa = request.run_as_service_account
+                if (
+                    auth_config.enabled
+                    and requested_sa is not None
+                    and requested_sa != existing_schedule.run_as_service_account
+                ):
+                    _resolve_service_account(requested_sa)
+                    await _require_impersonation(identity, requested_sa)
 
                 # Every update is subject to the same escalation guard as
                 # create: the caller must be authorized to run the schedule's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.74.20"
+version = "0.75.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/security/test_schedule_execution_authz.py
+++ b/tests/security/test_schedule_execution_authz.py
@@ -668,3 +668,57 @@ def test_schedule_update_rebind_requires_impersonate(client):
             json={"run_as_service_account": f"target-sa-{suffix}"},
         )
     assert resp.status_code == 403, resp.text
+
+
+def test_update_resending_the_same_service_account_is_not_a_rebind(client):
+    """A client sending a full representation re-sends the current account.
+    That is not impersonation and must not need the grant."""
+    from flux.domain.schedule import schedule_factory
+    from flux.schedule_manager import create_schedule_manager
+
+    suffix = uuid.uuid4().hex[:6]
+    wf_id = _seed_workflow("default", f"steady_{suffix}")
+    _seed_service_account(f"steady-sa-{suffix}")
+
+    schedule_model = create_schedule_manager().create_schedule(
+        workflow_id=wf_id,
+        workflow_namespace="default",
+        workflow_name=f"steady_{suffix}",
+        name=f"steady-sched-{suffix}",
+        schedule=schedule_factory({"type": "interval", "interval_seconds": 3600}),
+        run_as_service_account=f"steady-sa-{suffix}",
+    )
+
+    _seed_role(
+        f"steady_{suffix}",
+        ["schedule:*:manage", f"workflow:default:steady_{suffix}:*"],
+    )
+    identity = FluxIdentity(subject="dev", roles=frozenset({f"steady_{suffix}"}))
+
+    with _auth_as(identity):
+        resp = client.put(
+            f"/schedules/{schedule_model.id}",
+            headers=_headers(),
+            json={
+                "description": "same account, new description",
+                "run_as_service_account": f"steady-sa-{suffix}",
+            },
+        )
+    assert resp.status_code == 200, resp.text
+
+
+def test_update_of_missing_schedule_is_404_not_403(client):
+    """The schedule is resolved before impersonation is enforced, so a bad id
+    reports 404 rather than leaking a permission error for a row that is not
+    there."""
+    suffix = uuid.uuid4().hex[:6]
+    _seed_role(f"missing_{suffix}", ["schedule:*:manage"])
+    identity = FluxIdentity(subject="dev", roles=frozenset({f"missing_{suffix}"}))
+
+    with _auth_as(identity):
+        resp = client.put(
+            "/schedules/00000000000000000000000000000000",
+            headers=_headers(),
+            json={"run_as_service_account": f"nobody-{suffix}"},
+        )
+    assert resp.status_code == 404, resp.text

--- a/tests/security/test_schedule_execution_authz.py
+++ b/tests/security/test_schedule_execution_authz.py
@@ -186,7 +186,11 @@ def test_schedule_create_allows_caller_who_can_run_workflow(client):
     _seed_service_account(f"deploy-sa-{suffix}")
     _seed_role(
         f"sched_run_{suffix}",
-        ["schedule:*:manage", f"workflow:default:deploy_{suffix}:*"],
+        [
+            "schedule:*:manage",
+            f"workflow:default:deploy_{suffix}:*",
+            f"principal:deploy-sa-{suffix}:impersonate",
+        ],
     )
     identity = FluxIdentity(subject="release-manager", roles=frozenset({f"sched_run_{suffix}"}))
 
@@ -476,7 +480,12 @@ def test_schedule_update_sa_rebind_fails_closed_when_workflow_unregistered(clien
         run_as_service_account=f"sa-x-{suffix}",
     )
 
-    _seed_role(f"full_{suffix}", ["schedule:*:manage", "workflow:*:*:*"])
+    # Impersonation is granted so the request reaches the catalog check this
+    # test is about, rather than stopping at the earlier 403.
+    _seed_role(
+        f"full_{suffix}",
+        ["schedule:*:manage", "workflow:*:*:*", f"principal:sa-x-{suffix}:impersonate"],
+    )
     identity = FluxIdentity(subject="operator", roles=frozenset({f"full_{suffix}"}))
 
     with _auth_as(identity):
@@ -566,4 +575,96 @@ def test_executions_list_no_workflow_read_at_all_is_403(client):
     with _auth_as(identity):
         resp = client.get("/executions", headers=_headers())
 
+    assert resp.status_code == 403, resp.text
+
+
+def test_schedule_create_denies_binding_a_service_account_without_impersonate(client):
+    """schedule:*:manage plus the right to run the workflow is not enough: the
+    schedule runs under the SA's roles, so binding one is impersonation."""
+    suffix = uuid.uuid4().hex[:6]
+    _seed_workflow("default", f"batch_{suffix}")
+    _seed_service_account(f"privileged-sa-{suffix}")
+    _seed_role(
+        f"no_imp_{suffix}",
+        ["schedule:*:manage", f"workflow:default:batch_{suffix}:*"],
+    )
+    identity = FluxIdentity(subject="dev", roles=frozenset({f"no_imp_{suffix}"}))
+
+    with _auth_as(identity):
+        resp = client.post(
+            "/schedules",
+            headers=_headers(),
+            json={
+                "workflow_name": f"batch_{suffix}",
+                "workflow_namespace": "default",
+                "name": f"nightly-imp-{suffix}",
+                "schedule_config": {"type": "interval", "interval_seconds": 3600},
+                "run_as_service_account": f"privileged-sa-{suffix}",
+            },
+        )
+    assert resp.status_code == 403, resp.text
+
+
+def test_impersonate_grant_is_per_subject(client):
+    """A grant for one service account must not authorize another."""
+    suffix = uuid.uuid4().hex[:6]
+    _seed_workflow("default", f"job_{suffix}")
+    _seed_service_account(f"allowed-sa-{suffix}")
+    _seed_service_account(f"other-sa-{suffix}")
+    _seed_role(
+        f"one_sa_{suffix}",
+        [
+            "schedule:*:manage",
+            f"workflow:default:job_{suffix}:*",
+            f"principal:allowed-sa-{suffix}:impersonate",
+        ],
+    )
+    identity = FluxIdentity(subject="dev", roles=frozenset({f"one_sa_{suffix}"}))
+
+    def _create(sa: str, name: str):
+        return client.post(
+            "/schedules",
+            headers=_headers(),
+            json={
+                "workflow_name": f"job_{suffix}",
+                "workflow_namespace": "default",
+                "name": name,
+                "schedule_config": {"type": "interval", "interval_seconds": 3600},
+                "run_as_service_account": sa,
+            },
+        )
+
+    with _auth_as(identity):
+        assert _create(f"allowed-sa-{suffix}", f"ok-{suffix}").status_code == 200
+        assert _create(f"other-sa-{suffix}", f"nope-{suffix}").status_code == 403
+
+
+def test_schedule_update_rebind_requires_impersonate(client):
+    from flux.domain.schedule import schedule_factory
+    from flux.schedule_manager import create_schedule_manager
+
+    suffix = uuid.uuid4().hex[:6]
+    wf_id = _seed_workflow("default", f"rebind_{suffix}")
+    _seed_service_account(f"target-sa-{suffix}")
+
+    schedule_model = create_schedule_manager().create_schedule(
+        workflow_id=wf_id,
+        workflow_namespace="default",
+        workflow_name=f"rebind_{suffix}",
+        name=f"rebind-sched-{suffix}",
+        schedule=schedule_factory({"type": "interval", "interval_seconds": 3600}),
+    )
+
+    _seed_role(
+        f"rebind_{suffix}",
+        ["schedule:*:manage", f"workflow:default:rebind_{suffix}:*"],
+    )
+    identity = FluxIdentity(subject="dev", roles=frozenset({f"rebind_{suffix}"}))
+
+    with _auth_as(identity):
+        resp = client.put(
+            f"/schedules/{schedule_model.id}",
+            headers=_headers(),
+            json={"run_as_service_account": f"target-sa-{suffix}"},
+        )
     assert resp.status_code == 403, resp.text


### PR DESCRIPTION
## ⚠️ Breaking change

Creating a schedule with `run_as_service_account`, or rebinding one, now requires **`principal:{subject}:impersonate`** alongside `schedule:*:manage`.

**No built-in role carries it** except `admin` (through its `*`). An `operator` upgrading from an earlier version cannot create or rebind schedules until granted it:

```bash
flux roles update operator --add-permissions "principal:*:impersonate"   # old behaviour
flux roles update release-manager --add-permissions "principal:deploy-sa:impersonate"
```

That default was a deliberate choice: granting it to `operator` automatically would have preserved compatibility but left the control inert for the role most deployments actually use.

## Why

A schedule stores `run_as_service_account`, and at trigger time the workflow runs with **that account's** roles rather than the creator's. `create_schedule` validated only that the account *existed*, so `schedule:*:manage` was enough to choose which identity your work ran as.

The existing guard — the caller must be able to run the scheduled workflow — doesn't cover this. It says nothing about what that workflow reaches once running, and after #194 `workflow:*` necessarily remains in an execution token's allowlist, so a scheduled workflow can still `call_workflow` under the bound account's authority. #194's advisory names this as its open limit; this closes it.

## Design

The permission is **per-subject**, not a blanket flag: `principal:payroll-sa:impersonate` authorizes that account and no other, so a role can be granted exactly the identities it should run as. `principal:*:impersonate` restores prior behaviour for anyone who wants it.

Chosen over a subset rule (caller must already hold everything the account holds), which would have refused the common and legitimate case of a least-privileged human driving a scoped automation identity — with a 403 whose remedy is "widen the human's role", the opposite of what you want.

## Tests

Three new cases: binding without the grant is refused, a grant for one account does not authorize another, and rebinding on `PUT` is gated too.

One pre-existing test needed the grant added — `test_schedule_update_sa_rebind_fails_closed_when_workflow_unregistered` exists to prove the *catalog* fail-closed returns 409, and the caller now has to be authorized enough to reach that check. Its intent is unchanged.

## Docs

`docs/advanced-features/authentication.md`: the permission table, the endpoint table, and a section explaining the impersonation model and the upgrade step.

## Verification note

Local full-suite runs remain unreliable on my machine (SIGSEGV inside `libpython3.12.so`, unrelated). The affected files pass (20 + 7) and pre-commit is clean; **CI is the verification of record.**