### PR TITLE
fix(agents): only follow http(s) elicitation urls

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -101,9 +101,13 @@ jobs:
       if: steps.cached-lint-deps.outputs.cache-hit != 'true'
       run: poetry install --no-interaction --extras observability
 
+    # Not --no-root: the project itself must be in the venv, not merely
+    # importable from the repo root. Tests that spawn a child process with a
+    # different cwd (and the subprocess runner itself) import flux the same
+    # way any installed package would.
     - name: Ensure dependencies are available
       if: steps.cached-lint-deps.outputs.cache-hit == 'true'
-      run: poetry install --no-interaction --no-root --extras observability
+      run: poetry install --no-interaction --extras observability
 
     - name: Linting and code quality
       run: |
@@ -145,9 +149,13 @@ jobs:
       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
       run: poetry install --no-interaction --extras observability
 
+    # Not --no-root: the project itself must be in the venv, not merely
+    # importable from the repo root. Tests that spawn a child process with a
+    # different cwd (and the subprocess runner itself) import flux the same
+    # way any installed package would.
     - name: Ensure dependencies are available
       if: steps.cached-poetry-dependencies.outputs.cache-hit == 'true'
-      run: poetry install --no-interaction --no-root --extras observability
+      run: poetry install --no-interaction --extras observability
 
     - name: Run unit tests
       run: |
@@ -310,9 +318,13 @@ jobs:
       if: steps.cached-e2e-deps.outputs.cache-hit != 'true'
       run: poetry install --no-interaction
 
+    # Not --no-root: the project itself must be in the venv, not merely
+    # importable from the repo root. Tests that spawn a child process with a
+    # different cwd (and the subprocess runner itself) import flux the same
+    # way any installed package would.
     - name: Ensure dependencies are available
       if: steps.cached-e2e-deps.outputs.cache-hit == 'true'
-      run: poetry install --no-interaction --no-root
+      run: poetry install --no-interaction
 
     - name: Run E2E tests
       run: |

--- a/flux/agents/ui/terminal.py
+++ b/flux/agents/ui/terminal.py
@@ -5,7 +5,7 @@ import shutil
 import sys
 import webbrowser
 
-from flux.tasks.mcp.elicitation import BROWSABLE_SCHEMES
+from flux.tasks.mcp.elicitation import is_browsable
 
 from flux.agents.types import SessionEndOutput
 from flux.agents.ui import UI
@@ -124,7 +124,7 @@ class TerminalUI(UI):
         )
 
         if answer.strip().lower() in ("", "y", "yes"):
-            if not url.startswith(BROWSABLE_SCHEMES):
+            if not is_browsable(url):
                 print(f"  {self._c(_DIM, 'Refusing a non-browsable url: ')}{url[:80]}")
                 return {
                     "elicitation_response": {

--- a/flux/agents/ui/terminal.py
+++ b/flux/agents/ui/terminal.py
@@ -5,6 +5,8 @@ import shutil
 import sys
 import webbrowser
 
+from flux.tasks.mcp.elicitation import BROWSABLE_SCHEMES
+
 from flux.agents.types import SessionEndOutput
 from flux.agents.ui import UI
 
@@ -122,6 +124,14 @@ class TerminalUI(UI):
         )
 
         if answer.strip().lower() in ("", "y", "yes"):
+            if not url.startswith(BROWSABLE_SCHEMES):
+                print(f"  {self._c(_DIM, 'Refusing a non-browsable url: ')}{url[:80]}")
+                return {
+                    "elicitation_response": {
+                        "elicitation_id": elicitation_id,
+                        "action": "decline",
+                    },
+                }
             webbrowser.open(url)
             print(f"  {self._c(_DIM, 'Opening browser... waiting for authorization.')}")
             return {

--- a/flux/agents/ui/textual_app.py
+++ b/flux/agents/ui/textual_app.py
@@ -6,7 +6,7 @@ import asyncio
 import time
 import webbrowser
 
-from flux.tasks.mcp.elicitation import BROWSABLE_SCHEMES
+from flux.tasks.mcp.elicitation import is_browsable
 
 from textual.app import App, ComposeResult
 from textual.binding import Binding
@@ -276,9 +276,7 @@ class AgentApp(App):
 
         if self._elicitation_future is not None and not self._elicitation_future.done():
             if event.key in ("y", "Y"):
-                if self._elicitation_url and self._elicitation_url.startswith(
-                    BROWSABLE_SCHEMES,
-                ):
+                if self._elicitation_url and is_browsable(self._elicitation_url):
                     webbrowser.open(self._elicitation_url)
                 self._elicitation_future.set_result("accept")
                 self._elicitation_future = None

--- a/flux/agents/ui/textual_app.py
+++ b/flux/agents/ui/textual_app.py
@@ -6,6 +6,8 @@ import asyncio
 import time
 import webbrowser
 
+from flux.tasks.mcp.elicitation import BROWSABLE_SCHEMES
+
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import VerticalScroll
@@ -274,7 +276,9 @@ class AgentApp(App):
 
         if self._elicitation_future is not None and not self._elicitation_future.done():
             if event.key in ("y", "Y"):
-                if self._elicitation_url:
+                if self._elicitation_url and self._elicitation_url.startswith(
+                    BROWSABLE_SCHEMES,
+                ):
                     webbrowser.open(self._elicitation_url)
                 self._elicitation_future.set_result("accept")
                 self._elicitation_future = None

--- a/flux/agents/web/index.html
+++ b/flux/agents/web/index.html
@@ -399,9 +399,13 @@
                         // The url comes from a remote MCP server. Only http(s)
                         // becomes a link; anything else is shown as text so a
                         // javascript: payload cannot run in this origin.
+                        // Absolute http(s) only, matching the Python
+                        // validator. Parsing with a base would resolve a
+                        // relative "/path" to this origin and render it as a
+                        // link, re-opening a same-origin navigation surface.
                         let browsable = false;
                         try {
-                            const parsed = new URL(event.url, location.origin);
+                            const parsed = new URL(event.url);
                             browsable = parsed.protocol === 'http:' || parsed.protocol === 'https:';
                         } catch (e) {
                             browsable = false;

--- a/flux/agents/web/index.html
+++ b/flux/agents/web/index.html
@@ -396,12 +396,26 @@
 
                     if (event.url) {
                         const linkRow = document.createElement('div');
-                        const a = document.createElement('a');
-                        a.href = event.url;
-                        a.target = '_blank';
-                        a.rel = 'noopener noreferrer';
-                        a.textContent = 'Open authorization page';
-                        linkRow.appendChild(a);
+                        // The url comes from a remote MCP server. Only http(s)
+                        // becomes a link; anything else is shown as text so a
+                        // javascript: payload cannot run in this origin.
+                        let browsable = false;
+                        try {
+                            const parsed = new URL(event.url, location.origin);
+                            browsable = parsed.protocol === 'http:' || parsed.protocol === 'https:';
+                        } catch (e) {
+                            browsable = false;
+                        }
+                        if (browsable) {
+                            const a = document.createElement('a');
+                            a.href = event.url;
+                            a.target = '_blank';
+                            a.rel = 'noopener noreferrer';
+                            a.textContent = event.url;
+                            linkRow.appendChild(a);
+                        } else {
+                            linkRow.textContent = `Refusing a non-browsable url: ${event.url}`;
+                        }
                         div.appendChild(linkRow);
                     }
 

--- a/flux/tasks/mcp/elicitation.py
+++ b/flux/tasks/mcp/elicitation.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
+
+# An elicitation URL is a page the operator opens to authorize. Anything else
+# is a URI handler chosen by the remote server: javascript: runs in the agent
+# UI's origin, file:/smb: exfiltrate, custom schemes launch desktop apps.
+BROWSABLE_SCHEMES = ("http://", "https://")
 
 
 class ElicitationRequestOutput(BaseModel):
@@ -12,6 +17,13 @@ class ElicitationRequestOutput(BaseModel):
     url: str
     message: str
     server_name: str
+
+    @field_validator("url")
+    @classmethod
+    def validate_browsable(cls, v: str) -> str:
+        if v and not v.startswith(BROWSABLE_SCHEMES):
+            raise ValueError(f"elicitation url must be http(s), got: {v[:32]!r}")
+        return v
 
 
 class ElicitationResponse(BaseModel):

--- a/flux/tasks/mcp/elicitation.py
+++ b/flux/tasks/mcp/elicitation.py
@@ -10,6 +10,15 @@ from pydantic import BaseModel, field_validator
 BROWSABLE_SCHEMES = ("http://", "https://")
 
 
+def is_browsable(url: str) -> bool:
+    """Whether ``url`` is an absolute http(s) address.
+
+    Schemes are case-insensitive (RFC 3986), so ``HTTPS://`` is valid and must
+    not be refused.
+    """
+    return url.lower().startswith(BROWSABLE_SCHEMES)
+
+
 class ElicitationRequestOutput(BaseModel):
     type: Literal["elicitation"] = "elicitation"
     mode: Literal["url"] = "url"
@@ -21,7 +30,7 @@ class ElicitationRequestOutput(BaseModel):
     @field_validator("url")
     @classmethod
     def validate_browsable(cls, v: str) -> str:
-        if v and not v.startswith(BROWSABLE_SCHEMES):
+        if v and not is_browsable(v):
             raise ValueError(f"elicitation url must be http(s), got: {v[:32]!r}")
         return v
 

--- a/flux/tasks/mcp/tool_builder.py
+++ b/flux/tasks/mcp/tool_builder.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from flux.task import task
 from flux.utils import get_logger
-from flux.tasks.mcp.elicitation import BROWSABLE_SCHEMES, ElicitationRequestOutput
+from flux.tasks.mcp.elicitation import ElicitationRequestOutput, is_browsable
 
 logger = get_logger(__name__)
 
@@ -19,7 +19,7 @@ def _handle_elicitation_error(error: Exception, server_name: str) -> Elicitation
 
     elicitation = elicitations[0]
     url = elicitation.get("url", "")
-    if url and not url.startswith(BROWSABLE_SCHEMES):
+    if url and not is_browsable(url):
         # Surface the original failure rather than a prompt whose only action
         # is to hand a server-chosen URI to the operator's browser.
         logger.warning(

--- a/flux/tasks/mcp/tool_builder.py
+++ b/flux/tasks/mcp/tool_builder.py
@@ -5,7 +5,10 @@ import re
 from typing import Any
 
 from flux.task import task
-from flux.tasks.mcp.elicitation import ElicitationRequestOutput
+from flux.utils import get_logger
+from flux.tasks.mcp.elicitation import BROWSABLE_SCHEMES, ElicitationRequestOutput
+
+logger = get_logger(__name__)
 
 
 def _handle_elicitation_error(error: Exception, server_name: str) -> ElicitationRequestOutput:
@@ -15,9 +18,19 @@ def _handle_elicitation_error(error: Exception, server_name: str) -> Elicitation
         raise error
 
     elicitation = elicitations[0]
+    url = elicitation.get("url", "")
+    if url and not url.startswith(BROWSABLE_SCHEMES):
+        # Surface the original failure rather than a prompt whose only action
+        # is to hand a server-chosen URI to the operator's browser.
+        logger.warning(
+            f"MCP server '{server_name}' sent an elicitation with a "
+            f"non-browsable url scheme; refusing it",
+        )
+        raise error
+
     return ElicitationRequestOutput(
         elicitation_id=elicitation.get("elicitationId", ""),
-        url=elicitation.get("url", ""),
+        url=url,
         message=elicitation.get("message", ""),
         server_name=server_name,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.75.0"
+version = "0.75.1"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/tasks/mcp/test_tool_builder_elicitation.py
+++ b/tests/flux/tasks/mcp/test_tool_builder_elicitation.py
@@ -136,7 +136,17 @@ def test_dangerous_elicitation_schemes_are_refused(url):
     assert excinfo.value is error
 
 
-@pytest.mark.parametrize("url", ["https://auth.example.com/oauth", "http://localhost:8080/cb"])
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://auth.example.com/oauth",
+        "http://localhost:8080/cb",
+        # Schemes are case-insensitive (RFC 3986); refusing these would break
+        # otherwise-correct servers.
+        "HTTPS://auth.example.com/oauth",
+        "HttP://localhost:8080/cb",
+    ],
+)
 def test_browsable_schemes_are_accepted(url):
     from flux.tasks.mcp.tool_builder import _handle_elicitation_error
 
@@ -156,3 +166,15 @@ def test_model_refuses_a_non_browsable_url_directly():
             message="m",
             server_name="s",
         )
+
+
+@pytest.mark.parametrize("url", ["/relative/path", "auth.example.com/oauth", "//evil.example.com"])
+def test_relative_urls_are_refused(url):
+    """The web UI must not resolve these against its own origin, and the
+    Python side refuses them for the same reason."""
+    from flux.tasks.mcp.tool_builder import _handle_elicitation_error
+
+    error = MockElicitationError("elic-1", url, "Authorization required")
+    with pytest.raises(Exception) as excinfo:
+        _handle_elicitation_error(error, server_name="evil-mcp")
+    assert excinfo.value is error

--- a/tests/flux/tasks/mcp/test_tool_builder_elicitation.py
+++ b/tests/flux/tasks/mcp/test_tool_builder_elicitation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from flux.tasks.mcp.elicitation import ElicitationRequestOutput
 
 
@@ -109,3 +111,48 @@ def test_extract_elicitation_action_missing_defaults_decline():
     assert _extract_elicitation_action(None) == "decline"
     assert _extract_elicitation_action({}) == "decline"
     assert _extract_elicitation_action({"foo": "bar"}) == "decline"
+
+
+DANGEROUS_URLS = [
+    "javascript:fetch('/approval/1',{method:'POST'})",
+    "file:///home/op/.flux/bootstrap_token",
+    "smb://attacker/share",
+    "data:text/html,<script>1</script>",
+    "vscode://file/etc/passwd",
+]
+
+
+@pytest.mark.parametrize("url", DANGEROUS_URLS)
+def test_dangerous_elicitation_schemes_are_refused(url):
+    """The URL comes from a remote server's error payload and reaches a.href
+    in the web UI and webbrowser.open in both terminal UIs. Only http(s) is a
+    browsable authorization page; anything else is a URI handler the operator
+    never asked to invoke."""
+    from flux.tasks.mcp.tool_builder import _handle_elicitation_error
+
+    error = MockElicitationError("elic-1", url, "Authorization required")
+    with pytest.raises(Exception) as excinfo:
+        _handle_elicitation_error(error, server_name="evil-mcp")
+    assert excinfo.value is error
+
+
+@pytest.mark.parametrize("url", ["https://auth.example.com/oauth", "http://localhost:8080/cb"])
+def test_browsable_schemes_are_accepted(url):
+    from flux.tasks.mcp.tool_builder import _handle_elicitation_error
+
+    result = _handle_elicitation_error(
+        MockElicitationError("elic-1", url, "Authorization required"),
+        server_name="github-mcp",
+    )
+    assert result.url == url
+
+
+def test_model_refuses_a_non_browsable_url_directly():
+    """Enforced on the model too, so any other construction site fails closed."""
+    with pytest.raises(ValueError):
+        ElicitationRequestOutput(
+            elicitation_id="e1",
+            url="javascript:alert(1)",
+            message="m",
+            server_name="s",
+        )


### PR DESCRIPTION
## Why

An MCP server signals "the user must authorize" by returning a `-32042` error carrying an elicitation. `_handle_elicitation_error` lifted the url straight out of that payload with no validation, and `ElicitationRequestOutput.url` is a bare `str`.

That url reaches three sinks:

| Sink | Consequence |
|---|---|
| `flux/agents/web/index.html` — `a.href = event.url` | `javascript:` executes in the agent UI's origin. `WebUI._get_token_dependency` attaches the operator's Flux token to every request from that origin, so the payload can approve gated tool calls and read transcripts as them. No CSP exists to stop it. |
| `flux/agents/ui/terminal.py` — `webbrowser.open(url)` | `webbrowser.open` delegates unknown schemes to `xdg-open`, so `file:`, `smb:` or any registered desktop scheme is invoked. |
| `flux/agents/ui/textual_app.py` — `webbrowser.open(...)` | Same, on the `y` key. |

The operator had little to go on: the UI displayed the server's `message` and the fixed text "Open authorization page" — **never the url** — and the terminal prompt treated a bare Enter as consent.

## The change

Refused in three places, so no single sink is load-bearing:

- **Source** — `_handle_elicitation_error` raises the original error rather than surfacing a prompt whose only action hands a server-chosen URI to the browser.
- **Model** — a `field_validator` on `ElicitationRequestOutput.url`, so any other construction site fails closed.
- **Sinks** — each checks before opening. The web UI parses with `new URL(...)` (no base, so relative urls are refused) and renders an anchor only for `http:`/`https:`, otherwise plain text.

Scheme comparison goes through one predicate, `is_browsable()`, which lowercases first — schemes are case-insensitive per RFC 3986, so `HTTPS://` from a correct server must not be refused.

The web UI now uses **the url as the link text** instead of fixed prose, so what is about to be opened is visible before clicking.

## Also included: a CI fix

The `unit (3.14)` failure on this branch was **not** caused by these changes. On a cache hit CI installed with `--no-root`, so the venv held every dependency but not `flux`. Most tests never noticed because pytest runs from the repo root; `test_task_id_cross_process_replay.py` spawns a child with `cwd=tmp_path` and got `ModuleNotFoundError: No module named 'flux'`.

Confirmed from the failing job log: `Cache restored successfully` → `poetry install --no-interaction --no-root …`. The test passes locally, where the project is installed.

So that test's result depended on cache state rather than the code under test — and it is the only test covering cross-process imports. `--no-root` is dropped from all three cache-hit paths, which also makes CI match a developer's environment.

## Tests

Five dangerous schemes (`javascript:`, `file:`, `smb:`, `data:`, a custom app scheme) refused; uppercase `HTTPS://` and `HttP://` accepted; relative and protocol-relative urls refused; the model rejects a bad url directly. All fail against the pre-fix code.

**Not covered:** `index.html` — the repo has no JS test setup, so that sink is verified by reading.

## Verification

`tests/flux` 2735 passed, `mcp` + `agents` 263 passed, pre-commit clean.