### PR TITLE
ci: install the project itself on the cache-hit path

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -101,9 +101,13 @@ jobs:
       if: steps.cached-lint-deps.outputs.cache-hit != 'true'
       run: poetry install --no-interaction --extras observability
 
+    # Not --no-root: the project itself must be in the venv, not merely
+    # importable from the repo root. Tests that spawn a child process with a
+    # different cwd (and the subprocess runner itself) import flux the same
+    # way any installed package would.
     - name: Ensure dependencies are available
       if: steps.cached-lint-deps.outputs.cache-hit == 'true'
-      run: poetry install --no-interaction --no-root --extras observability
+      run: poetry install --no-interaction --extras observability
 
     - name: Linting and code quality
       run: |
@@ -145,9 +149,13 @@ jobs:
       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
       run: poetry install --no-interaction --extras observability
 
+    # Not --no-root: the project itself must be in the venv, not merely
+    # importable from the repo root. Tests that spawn a child process with a
+    # different cwd (and the subprocess runner itself) import flux the same
+    # way any installed package would.
     - name: Ensure dependencies are available
       if: steps.cached-poetry-dependencies.outputs.cache-hit == 'true'
-      run: poetry install --no-interaction --no-root --extras observability
+      run: poetry install --no-interaction --extras observability
 
     - name: Run unit tests
       run: |
@@ -310,9 +318,13 @@ jobs:
       if: steps.cached-e2e-deps.outputs.cache-hit != 'true'
       run: poetry install --no-interaction
 
+    # Not --no-root: the project itself must be in the venv, not merely
+    # importable from the repo root. Tests that spawn a child process with a
+    # different cwd (and the subprocess runner itself) import flux the same
+    # way any installed package would.
     - name: Ensure dependencies are available
       if: steps.cached-e2e-deps.outputs.cache-hit == 'true'
-      run: poetry install --no-interaction --no-root
+      run: poetry install --no-interaction
 
     - name: Run E2E tests
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.75.0"
+version = "0.75.2"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"


### PR DESCRIPTION
## Why

The cache-hit install branch used `--no-root`:

```yaml
- name: Ensure dependencies are available
  if: steps.cached-poetry-dependencies.outputs.cache-hit == 'true'
  run: poetry install --no-interaction --no-root --extras observability
```

So on a cache hit the venv had every dependency but **not `flux` itself**. Most tests never noticed, because pytest runs from the repo root and imports it from the working directory.

`tests/flux/test_task_id_cross_process_replay.py` does notice. It spawns a child with `cwd=str(tmp_path)`, so that child imports `flux` the way any installed package would — and got:

```
ModuleNotFoundError: No module named 'flux'
```

Confirmed from the failing job's log: `Cache restored successfully` → `poetry install --no-interaction --no-root --extras observability`. The test passes locally, where the project *is* installed.

So whether this test passed depended on cache state, not on the code under test. It's the only test that would catch a genuine cross-process import regression, and it was a coin flip.

## The change

Drop `--no-root` from all three cache-hit paths (lint, unit, e2e). `poetry install` is idempotent, so installing the root into a warm venv costs almost nothing, and the distinction the two steps were drawing doesn't survive contact with this failure mode.

This also aligns CI with a developer's environment, where `poetry install` installs the project — which is *why* the test passes locally and failed in CI.

## Note

Found while diagnosing a failure on #198. That failure was not caused by #198's changes (MCP elicitation, two UI modules, an HTML file); it was this. #198 needs a rebase once this lands.