### PR TITLE
fix(api): redact secrets on every execution-read exit

### DIFF
--- a/flux/api/execution_routes.py
+++ b/flux/api/execution_routes.py
@@ -25,7 +25,7 @@ from flux.domain.events import ExecutionEvent, ExecutionEventType
 from flux.errors import ExecutionContextNotFoundError, WorkflowNotFoundError
 from flux.security.dependencies import get_identity, require_permission
 from flux.security.identity import FluxIdentity
-from flux.servers.models import ExecutionContext as ExecutionContextDTO
+from flux.servers.models import redacted_response
 from flux.utils import get_logger
 from flux.api.schemas import (
     _has_any_workflow_read,
@@ -271,8 +271,7 @@ class ExecutionRoutesMixin:
                         },
                     )
 
-                dto = ExecutionContextDTO.from_domain(ctx)
-                result = dto.summary() if not detailed else dto
+                result = await redacted_response(ctx, detailed=detailed)
 
                 logger.debug(f"Found execution {execution_id} in state: {ctx.state.value}")
                 # Presentation-boundary secret redaction (issue #147 phase 1):

--- a/flux/api/execution_routes.py
+++ b/flux/api/execution_routes.py
@@ -271,16 +271,12 @@ class ExecutionRoutesMixin:
                         },
                     )
 
+                # execution:*:read is a much wider grant than secret-read;
+                # the stored event log is untouched.
                 result = await redacted_response(ctx, detailed=detailed)
 
                 logger.debug(f"Found execution {execution_id} in state: {ctx.state.value}")
-                # Presentation-boundary secret redaction (issue #147 phase 1):
-                # the detailed DTO carries every task's recorded inputs and
-                # outputs, and execution:*:read is a much wider grant than
-                # secret-read. The stored event log is untouched.
-                from flux.security.redaction import redact_response
-
-                return await redact_response(result)
+                return result
 
             except ExecutionContextNotFoundError:
                 raise HTTPException(

--- a/flux/api/workflow_routes.py
+++ b/flux/api/workflow_routes.py
@@ -30,6 +30,7 @@ from flux.errors import (
 from flux.security.dependencies import get_identity
 from flux.security.identity import ANONYMOUS, FluxIdentity
 from flux.servers.models import ExecutionContext as ExecutionContextDTO
+from flux.servers.models import redacted_response
 from flux.utils import get_logger
 from flux.utils import to_json
 from flux.api.schemas import (
@@ -351,8 +352,7 @@ class WorkflowRoutesMixin:
                         },
                     )
 
-                dto = ExecutionContextDTO.from_domain(ctx)
-                response = dto.summary() if not detailed else dto
+                response = await redacted_response(ctx, detailed=detailed)
                 logger.debug(
                     f"Returning execution result for {ctx.execution_id} in state: {ctx.state.value}",
                 )
@@ -516,8 +516,7 @@ class WorkflowRoutesMixin:
                         },
                     )
 
-                dto = ExecutionContextDTO.from_domain(ctx)
-                response = dto.summary() if not detailed else dto
+                response = await redacted_response(ctx, detailed=detailed)
                 logger.debug(
                     f"Returning execution result for {ctx.execution_id} in state: {ctx.state.value}",
                 )
@@ -571,8 +570,7 @@ class WorkflowRoutesMixin:
                             f"workflow {namespace}/{workflow_name}."
                         ),
                     )
-                dto = ExecutionContextDTO.from_domain(context)
-                result = dto.summary() if not detailed else dto
+                result = await redacted_response(context, detailed=detailed)
                 logger.debug(f"Status for {execution_id}: {context.state.value}")
                 return result
             except ExecutionContextNotFoundError:
@@ -694,7 +692,7 @@ class WorkflowRoutesMixin:
                         self._execution_events.pop(ctx.execution_id, None)
 
                 dto = ExecutionContextDTO.from_domain(ctx)
-                result = dto.summary() if not detailed else dto
+                result = await redacted_response(ctx, detailed=detailed)
                 logger.info(
                     f"Workflow {namespace}/{workflow_name} execution {execution_id} is {dto.state}.",
                 )

--- a/flux/server.py
+++ b/flux/server.py
@@ -23,7 +23,7 @@ from flux.context_managers import ContextManager
 from flux.errors import WorkflowNotFoundError
 from flux.utils import get_logger
 from flux.servers.uvicorn_server import UvicornServer
-from flux.servers.models import ExecutionContext as ExecutionContextDTO
+from flux.servers.models import redacted_response
 from flux.utils import to_wire_json
 from flux.schedule_manager import create_schedule_manager
 from flux.security.auth_service import AuthService
@@ -565,10 +565,9 @@ class Server(
             # Emit the current state immediately so a consumer attaching after
             # the execution already finished still receives the terminal
             # frame — the loop below exits at once when ctx.has_finished.
-            dto = ExecutionContextDTO.from_domain(ctx)
             yield {
                 "event": f"{ctx.workflow_name}.execution.{ctx.state.value.lower()}",
-                "data": to_wire_json(dto if detailed else dto.summary()),
+                "data": to_wire_json(await redacted_response(ctx, detailed=detailed)),
             }
         try:
             while not ctx.has_finished:
@@ -619,10 +618,11 @@ class Server(
                             and (not ctx.events or new_ctx.events[-1].id != ctx.events[-1].id)
                         ):
                             ctx = new_ctx
-                            dto = ExecutionContextDTO.from_domain(ctx)
                             yield {
                                 "event": f"{ctx.workflow_name}.execution.{ctx.state.value.lower()}",
-                                "data": to_wire_json(dto if detailed else dto.summary()),
+                                "data": to_wire_json(
+                                    await redacted_response(ctx, detailed=detailed),
+                                ),
                             }
                 else:
                     try:
@@ -637,10 +637,9 @@ class Server(
                         and (not ctx.events or new_ctx.events[-1].id != ctx.events[-1].id)
                     ):
                         ctx = new_ctx
-                        dto = ExecutionContextDTO.from_domain(ctx)
                         yield {
                             "event": f"{ctx.workflow_name}.execution.{ctx.state.value.lower()}",
-                            "data": to_wire_json(dto if detailed else dto.summary()),
+                            "data": to_wire_json(await redacted_response(ctx, detailed=detailed)),
                         }
         finally:
             for t in active_tasks:

--- a/flux/servers/models.py
+++ b/flux/servers/models.py
@@ -123,12 +123,11 @@ class ExecutionContext(BaseModel):
         return cls(**data)
 
 
-async def redacted_response(ctx, *, detailed: bool):
+async def redacted_response(ctx: domain.ExecutionContext, *, detailed: bool) -> Any:
     """An execution's wire form with known secret values scrubbed.
 
-    Redaction is a property of every execution-read response, not of the one
-    handler that remembered to call it — task outputs are persisted verbatim,
-    so any exit returning this DTO can carry a secret.
+    Task outputs are persisted verbatim, so any exit returning this DTO can
+    carry a secret.
     """
     from flux.security.redaction import redact_response
 

--- a/flux/servers/models.py
+++ b/flux/servers/models.py
@@ -121,3 +121,16 @@ class ExecutionContext(BaseModel):
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ExecutionContext:
         return cls(**data)
+
+
+async def redacted_response(ctx, *, detailed: bool):
+    """An execution's wire form with known secret values scrubbed.
+
+    Redaction is a property of every execution-read response, not of the one
+    handler that remembered to call it — task outputs are persisted verbatim,
+    so any exit returning this DTO can carry a secret.
+    """
+    from flux.security.redaction import redact_response
+
+    dto = ExecutionContext.from_domain(ctx)
+    return await redact_response(dto if detailed else dto.summary())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.75.1"
+version = "0.75.2"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/security/test_redaction_routes.py
+++ b/tests/security/test_redaction_routes.py
@@ -1,0 +1,167 @@
+"""Redaction is a property of execution-read responses, not of one handler.
+
+``redact_response`` was applied on two exits of ``GET /executions/{id}`` and
+nowhere else, so the same DTO left unredacted through the SSE stream and the
+workflow status routes — reachable with the same ``execution:*:read`` grant
+that the redacted path requires.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+SECRET_VALUE = "sk-live-do-not-leak-0123456789"
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "redaction_routes.db"
+    monkeypatch.setenv("FLUX_DATABASE_URL", f"sqlite:///{db_path}")
+
+    from flux.config import Configuration
+    from flux.models import DatabaseRepository
+
+    Configuration._instance = None  # type: ignore[attr-defined]
+    Configuration._config = None  # type: ignore[attr-defined]
+    DatabaseRepository._engines.clear()
+    # Resetting Configuration discards what tests/conftest.py seeds, and this
+    # module is one of the few that actually encrypts a secret.
+    Configuration.get().override(
+        database_url=f"sqlite:///{db_path}",
+        workers={"bootstrap_token": "test-bootstrap-token"},
+        security={"encryption": {"encryption_key": "test-encryption-key"}},
+    )
+
+    from flux.server import Server
+
+    server = Server("127.0.0.1", 0)
+    yield TestClient(server._create_api())
+
+    Configuration._instance = None  # type: ignore[attr-defined]
+    Configuration._config = None  # type: ignore[attr-defined]
+    DatabaseRepository._engines.clear()
+
+
+@pytest.fixture
+def leaked_execution(client):
+    """An execution whose output embeds a value the secret store knows.
+
+    This is the case redaction.py exists for: a task returned something with a
+    secret in it, and the value is now in the event log.
+    """
+    from flux.secret_managers import SecretManager
+    from flux.security import redaction
+
+    suffix = uuid.uuid4().hex[:6]
+    name = f"leaky_{suffix}"
+    eid = f"exec-leak-{suffix}"
+
+    SecretManager.current().save(f"LEAK_KEY_{suffix}", SECRET_VALUE)
+
+    from flux import ExecutionContext
+    from flux.context_managers import ContextManager
+    from flux.models import RepositoryFactory, WorkflowModel
+
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        session.add(
+            WorkflowModel(
+                id=f"default/{name}",
+                name=name,
+                version=1,
+                imports=[],
+                source=b"async def p(ctx): pass",
+                namespace="default",
+            ),
+        )
+        session.commit()
+
+    ctx: ExecutionContext = ExecutionContext(
+        workflow_id=f"default/{name}",
+        workflow_namespace="default",
+        workflow_name=name,
+        input=None,
+        execution_id=eid,
+    )
+    # Through the domain API: has_finished is derived from a WORKFLOW_COMPLETED
+    # event rather than the state column, and the SSE stream only ends once it
+    # is true — poking the row directly hangs the stream forever.
+    ctx.start(eid)
+    ctx.complete(eid, {"token": SECRET_VALUE})
+    ContextManager.create().save(ctx)
+
+    # The value cache is process-global and may predate the save above.
+    redaction._cache = None
+
+    try:
+        yield name, eid
+    finally:
+        SecretManager.current().remove(f"LEAK_KEY_{suffix}")
+
+
+def test_detailed_execution_read_is_redacted(client, leaked_execution):
+    """Control: the exit that already called redact_response."""
+    _name, eid = leaked_execution
+    r = client.get(f"/executions/{eid}", params={"detailed": "true"})
+    assert r.status_code == 200, r.text
+    assert SECRET_VALUE not in r.text
+
+
+def test_stream_mode_is_redacted(client, leaked_execution):
+    """Same endpoint, same permission, one query parameter apart."""
+    _name, eid = leaked_execution
+    with client.stream(
+        "GET",
+        f"/executions/{eid}",
+        params={"detailed": "true", "mode": "stream"},
+    ) as r:
+        body = "".join(chunk for chunk in r.iter_text())
+    assert SECRET_VALUE not in body
+
+
+def test_workflow_status_is_redacted(client, leaked_execution):
+    name, eid = leaked_execution
+    r = client.get(f"/workflows/default/{name}/status/{eid}", params={"detailed": "true"})
+    assert r.status_code == 200, r.text
+    assert SECRET_VALUE not in r.text
+
+
+def test_redaction_does_not_mangle_ordinary_output(client):
+    """The marker must not appear where there is nothing to redact."""
+    from flux import ExecutionContext
+    from flux.context_managers import ContextManager
+    from flux.models import RepositoryFactory, WorkflowModel
+
+    suffix = uuid.uuid4().hex[:6]
+    name, eid = f"plain_{suffix}", f"exec-plain-{suffix}"
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        session.add(
+            WorkflowModel(
+                id=f"default/{name}",
+                name=name,
+                version=1,
+                imports=[],
+                source=b"async def p(ctx): pass",
+                namespace="default",
+            ),
+        )
+        session.commit()
+    ctx: ExecutionContext = ExecutionContext(
+        workflow_id=f"default/{name}",
+        workflow_namespace="default",
+        workflow_name=name,
+        input=None,
+        execution_id=eid,
+    )
+    ctx.start(eid)
+    ctx.complete(eid, {"result": "ordinary value"})
+    ContextManager.create().save(ctx)
+
+    r = client.get(f"/executions/{eid}", params={"detailed": "true"})
+    assert r.status_code == 200, r.text
+    assert json.loads(r.text)["output"]["result"] == "ordinary value"

--- a/tests/security/test_redaction_routes.py
+++ b/tests/security/test_redaction_routes.py
@@ -28,8 +28,7 @@ def client(tmp_path, monkeypatch):
     Configuration._instance = None  # type: ignore[attr-defined]
     Configuration._config = None  # type: ignore[attr-defined]
     DatabaseRepository._engines.clear()
-    # Resetting Configuration discards what tests/conftest.py seeds, and this
-    # module is one of the few that actually encrypts a secret.
+    # The reset above discards what tests/conftest.py seeds.
     Configuration.get().override(
         database_url=f"sqlite:///{db_path}",
         workers={"bootstrap_token": "test-bootstrap-token"},
@@ -87,9 +86,8 @@ def leaked_execution(client):
         input=None,
         execution_id=eid,
     )
-    # Through the domain API: has_finished is derived from a WORKFLOW_COMPLETED
-    # event rather than the state column, and the SSE stream only ends once it
-    # is true — poking the row directly hangs the stream forever.
+    # has_finished comes from the WORKFLOW_COMPLETED event, not the state
+    # column; setting the column alone hangs the SSE stream forever.
     ctx.start(eid)
     ctx.complete(eid, {"token": SECRET_VALUE})
     ContextManager.create().save(ctx)
@@ -119,8 +117,11 @@ def test_stream_mode_is_redacted(client, leaked_execution):
         f"/executions/{eid}",
         params={"detailed": "true", "mode": "stream"},
     ) as r:
+        # An error response would also lack the secret.
+        assert r.status_code == 200
         body = "".join(chunk for chunk in r.iter_text())
     assert SECRET_VALUE not in body
+    assert eid in body, "the stream should have emitted the execution's frame"
 
 
 def test_workflow_status_is_redacted(client, leaked_execution):


### PR DESCRIPTION
## Why

`redact_response` was called from exactly two places, both inside `GET /executions/{id}`:

```
flux/api/execution_routes.py:231   summary fast path
flux/api/execution_routes.py:284   detailed sync path
```

The same `ExecutionContextDTO` left unredacted through four other exits:

| Exit | Note |
|---|---|
| `GET /executions/{id}?mode=stream` | **Same endpoint, same `execution:*:read` dependency**, one query parameter apart. `emit_initial=True`, so the first frame carries the terminal context — this works on long-finished executions. |
| `POST /workflows/{ns}/{name}/run/{mode}` | sync exit |
| `POST /workflows/{ns}/{name}/resume/...` | sync exit |
| `GET /workflows/{ns}/{name}/status/{id}` | |

`redaction.py` exists because task outputs are persisted verbatim, and execution reads are visible to every holder of `execution:*:read` — a far wider grant than secret-read. So redaction is a property of the payload, not of the handler that remembered to call it.

## The change

`servers.models.redacted_response(ctx, *, detailed)` builds the DTO and redacts in one step; every exit goes through it.

**Deliberately not a response middleware.** `GET /admin/secrets/{name}` returns a secret value *by design*, so a blanket rule needs an exemption list — and that fails in the worse direction: forget an entry and you break a working endpoint, or worse, someone adds an exemption that silently disables redaction elsewhere. Scoping to the execution DTO keeps the rule where the hazard is.

Cost is negligible: `collect_secret_values` is already TTL-cached, so extra exits don't decrypt the store per request.

## Tests

`tests/security/test_redaction_routes.py` drives the actual routes, which the existing coverage did not — it was unit-level on `redact_values`, which is precisely why four leaking exits went unnoticed. Covers the redacted control, the SSE stream, workflow status, and that ordinary output is not mangled. The stream and status tests fail against pre-fix code with the secret visible in the body.

One fixture detail worth noting: the execution is completed through the domain API (`ctx.start` / `ctx.complete`) rather than by setting the state column, because `has_finished` is derived from a `WORKFLOW_COMPLETED` event — setting the column alone leaves the SSE stream waiting forever.

## Verification

`tests/security` + `tests/flux` — 3241 passed, pre-commit clean.