### PR TITLE
fix(server): classify anonymous state-change by route, not by verb

### DIFF
--- a/flux/server.py
+++ b/flux/server.py
@@ -1436,7 +1436,7 @@ class Server(
         def _is_state_changing(method: str, path: str) -> bool:
             if method in _MUTATING_METHODS:
                 return True
-            return method == "GET" and any(p.match(path) for p in _MUTATING_GETS)
+            return method in ("GET", "HEAD") and any(p.match(path) for p in _MUTATING_GETS)
 
         @api.middleware("http")
         async def _enforce_anonymous_policy(request: Request, call_next):

--- a/flux/server.py
+++ b/flux/server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 import time
 from typing import Any
 from collections.abc import AsyncIterator
@@ -1425,6 +1426,18 @@ class Server(
 
         _MUTATING_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 
+        # GET routes that change state, which the verb alone does not reveal.
+        # A new one must be added here or it is anonymously reachable.
+        _MUTATING_GETS = (
+            re.compile(r"^/workflows/[^/]+/[^/]+/cancel/[^/]+/?$"),
+            re.compile(r"^/workers/[^/]+/connect/?$"),
+        )
+
+        def _is_state_changing(method: str, path: str) -> bool:
+            if method in _MUTATING_METHODS:
+                return True
+            return method == "GET" and any(p.match(path) for p in _MUTATING_GETS)
+
         @api.middleware("http")
         async def _enforce_anonymous_policy(request: Request, call_next):
             # Secure default: when authentication is disabled, refuse anonymous
@@ -1435,7 +1448,7 @@ class Server(
             if (
                 not auth.enabled
                 and not auth.allow_anonymous
-                and request.method in _MUTATING_METHODS
+                and _is_state_changing(request.method, request.url.path)
             ):
                 return JSONResponse(
                     status_code=401,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.75.2"
+version = "0.75.3"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/security/test_anonymous_mutation.py
+++ b/tests/security/test_anonymous_mutation.py
@@ -1,0 +1,123 @@
+"""Anonymous state-change is classified by what a route does, not its verb.
+
+With auth disabled and allow_anonymous unset — the shipped default — the
+middleware refuses anonymous mutating requests. It inferred "mutating" from
+the HTTP method, so a GET that changes state slipped through: cancel commits
+start_cancel and voids pending approvals, and the worker connect route bumps
+a connection generation and marks the worker online.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "anon_mutation.db"
+    monkeypatch.setenv("FLUX_DATABASE_URL", f"sqlite:///{db_path}")
+
+    from flux.config import Configuration
+    from flux.models import DatabaseRepository
+
+    Configuration._instance = None  # type: ignore[attr-defined]
+    Configuration._config = None  # type: ignore[attr-defined]
+    DatabaseRepository._engines.clear()
+    Configuration.get().override(
+        database_url=f"sqlite:///{db_path}",
+        workers={"bootstrap_token": "test-bootstrap-token"},
+        security={
+            "encryption": {"encryption_key": "test-encryption-key"},
+            # tests/conftest.py permits anonymous mutations for convenience;
+            # this module is the one exercising the deny path.
+            "auth": {"allow_anonymous": False},
+        },
+    )
+
+    from flux.server import Server
+
+    server = Server("127.0.0.1", 0)
+    yield TestClient(server._create_api(), raise_server_exceptions=False)
+
+    Configuration._instance = None  # type: ignore[attr-defined]
+    Configuration._config = None  # type: ignore[attr-defined]
+    DatabaseRepository._engines.clear()
+
+
+def _seed(namespace: str, name: str) -> str:
+    from flux import ExecutionContext
+    from flux.context_managers import ContextManager
+    from flux.models import RepositoryFactory, WorkflowModel
+
+    eid = f"exec-{uuid.uuid4().hex[:8]}"
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        session.add(
+            WorkflowModel(
+                id=f"{namespace}/{name}",
+                name=name,
+                version=1,
+                imports=[],
+                source=b"async def p(ctx): pass",
+                namespace=namespace,
+            ),
+        )
+        session.commit()
+    ctx: ExecutionContext = ExecutionContext(
+        workflow_id=f"{namespace}/{name}",
+        workflow_namespace=namespace,
+        workflow_name=name,
+        input=None,
+        execution_id=eid,
+    )
+    ContextManager.create().save(ctx)
+    return eid
+
+
+def test_anonymous_post_is_refused(client):
+    """Control: the verb-based rule already covers this."""
+    r = client.post("/workflows/default/anything/run/sync", json={})
+    assert r.status_code == 401, r.text
+
+
+def test_anonymous_cancel_is_refused(client):
+    """A GET that commits start_cancel and voids pending approvals."""
+    suffix = uuid.uuid4().hex[:6]
+    name = f"cancelme_{suffix}"
+    eid = _seed("default", name)
+
+    r = client.get(f"/workflows/default/{name}/cancel/{eid}")
+    assert r.status_code == 401, r.text
+
+
+def test_anonymous_worker_connect_is_refused(client):
+    """A GET that bumps the connection generation and marks a worker online."""
+    r = client.get("/workers/some-worker/connect")
+    assert r.status_code == 401, r.text
+
+
+def test_anonymous_reads_still_work(client):
+    """The guard must not turn into a blanket deny."""
+    assert client.get("/workflows").status_code == 200
+    assert client.get("/executions").status_code == 200
+
+
+def test_allow_anonymous_permits_the_mutating_get(client):
+    """The opt-out still applies to the newly classified routes."""
+    from flux.config import Configuration
+
+    suffix = uuid.uuid4().hex[:6]
+    name = f"allowme_{suffix}"
+    eid = _seed("default", name)
+
+    settings = Configuration.get().settings
+    original = settings.security.auth.allow_anonymous
+    settings.security.auth.allow_anonymous = True
+    try:
+        r = client.get(f"/workflows/default/{name}/cancel/{eid}")
+        assert r.status_code != 401, r.text
+    finally:
+        settings.security.auth.allow_anonymous = original

--- a/tests/security/test_anonymous_mutation.py
+++ b/tests/security/test_anonymous_mutation.py
@@ -121,3 +121,24 @@ def test_allow_anonymous_permits_the_mutating_get(client):
         assert r.status_code != 401, r.text
     finally:
         settings.security.auth.allow_anonymous = original
+
+
+def test_anonymous_head_cancel_does_not_reach_the_handler(client):
+    """FastAPI's APIRoute does not add HEAD to a GET route (bare Starlette
+    Route does), so this is 405 today. Asserted anyway: if HEAD ever becomes
+    routable, it must not be a way around the guard."""
+    suffix = uuid.uuid4().hex[:6]
+    name = f"headcancel_{suffix}"
+    eid = _seed("default", name)
+
+    r = client.head(f"/workflows/default/{name}/cancel/{eid}")
+    assert r.status_code in (401, 405), r.status_code
+
+    from flux.context_managers import ContextManager
+
+    assert ContextManager.create().get(eid).state.value != "CANCELLING"
+
+
+def test_anonymous_head_worker_connect_does_not_reach_the_handler(client):
+    r = client.head("/workers/some-worker/connect")
+    assert r.status_code in (401, 405), r.status_code


### PR DESCRIPTION
## Why

`_enforce_anonymous_policy` exists to refuse anonymous state-changing requests when auth is disabled and `allow_anonymous` is unset — **both default to false**, so this is the shipped configuration, and `ANONYMOUS` carries the `admin` role, meaning per-route checks pass.

It inferred "state-changing" from the HTTP method:

```python
if not auth.enabled and not auth.allow_anonymous and request.method in _MUTATING_METHODS:
```

Two GET routes change state and slipped through:

| Route | What it does |
|---|---|
| `GET /workflows/{ns}/{name}/cancel/{id}` | `ctx.start_cancel()`, `manager.save()`, and `ApprovalManager().cancel_pending_for_execution()` |
| `GET /workers/{name}/connect` | bumps the connection generation, sets `status = "online"` |

So an unauthenticated caller could cancel every running execution and void its pending approvals, while the equivalent `POST` returned 401.

## The change

The middleware asks whether the *route* changes state rather than whether the *verb* usually does. Mutating GETs are listed explicitly, so adding another one is a deliberate act rather than something the middleware silently fails to notice.

**Verbs are unchanged.** Moving cancel to `POST` would be REST-correct but breaks every existing client — `cli.py`, `client.py` and `mcp_server.py` all use GET, as would any external caller — and it fixes one instance rather than the class, since the middleware would still be inferring from the verb.

## Tests

`tests/security/test_anonymous_mutation.py`, with `allow_anonymous` explicitly false (the repo's conftest permits it for convenience, so this module opts back into the deny path). Covers the POST control, both mutating GETs, that ordinary reads still work, and that the `allow_anonymous` opt-out still applies to the newly classified routes.

Against pre-fix code the cancel test returns **200 with `state: CANCELLING`** — the execution really was cancelled anonymously.

## Verification

`tests/security` + `tests/flux` — 3246 passed. E2E running (this touches middleware on shared paths). Pre-commit clean.