### PR TITLE
test(e2e): drop the gated podman worker test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.75.3"
+version = "0.75.4"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/e2e/test_airgapped_cli.py
+++ b/tests/e2e/test_airgapped_cli.py
@@ -2,14 +2,12 @@
 
 The airgapped runner can drive docker, podman, or nerdctl; anything else
 must fail the worker process fast (before it ever registers), with an
-error naming the config key. Running an actual podman/nerdctl container
-needs a container runtime and is covered by the gated integration tests
-in tests/flux/test_docker_runner.py.
+error naming the config key. Command construction, the version probe and
+its failure modes are covered per-CLI in tests/flux/test_airgapped_runner.py.
 """
 
 from __future__ import annotations
 
-import os
 import subprocess
 from pathlib import Path
 
@@ -52,28 +50,3 @@ def test_unknown_container_cli_fails_worker_startup(cli):
     assert "containerctl" in output
     # The worker never registered.
     assert all(w["name"] != "bad-cli-worker" for w in cli.worker_list())
-
-
-@pytest.mark.skipif(
-    os.environ.get("FLUX_TEST_PODMAN") != "1",
-    reason="FLUX_TEST_PODMAN=1 not set (needs a working rootless podman)",
-)
-def test_podman_worker_starts_and_registers(cli):
-    """Opt-in: with rootless podman present, a podman-backed airgapped
-    worker starts, validates the CLI, and registers."""
-    worker = cli.start_worker(
-        "podman-worker",
-        env={
-            "FLUX_WORKERS__RUNNERS": '["subprocess", "docker-airgapped"]',
-            "FLUX_WORKERS__DEFAULT_RUNNER": "subprocess",
-            "FLUX_WORKERS__DOCKER_IMAGE": os.environ.get(
-                "FLUX_TEST_DOCKER_IMAGE",
-                "flux:e2e-test",
-            ),
-            "FLUX_WORKERS__AIRGAPPED_CONTAINER_CLI": "podman",
-        },
-    )
-    try:
-        assert any(w["name"] == "podman-worker" for w in cli.worker_list())
-    finally:
-        cli.stop_worker(worker)


### PR DESCRIPTION
## Why

`test_podman_worker_starts_and_registers` was gated behind `FLUX_TEST_PODMAN=1`. **Nothing sets it** — not the workflows, not the Make targets — so the test never ran anywhere. It was the one skip in a local e2e run, which is how it surfaced.

Its only assertion was that a worker registers with `airgapped_container_cli=podman`. It never dispatched a workflow into a container, so the sole Flux behaviour behind that assertion is the startup probe — and `tests/flux/test_airgapped_runner.py` already covers, per CLI, on every push:

| Covered | Line |
|---|---|
| the probe command itself — `["podman", "version"]` | 428–433 |
| probe failure handling, podman and nerdctl | 437–451 |
| command construction — `["podman", "run", "-i"]` | 390–392 |
| kill path — `podman kill` | 424 |
| unknown CLI rejected, naming the config key | 398–399 |
| `--privileged` vetoed on nerdctl | 403 |

What the e2e added on top was "a real podman binary exits 0 for `version`" — which tests podman, not Flux.

The rejection path stays covered by `test_unknown_container_cli_fails_worker_startup` in the same file, which does run.

## Considered and rejected

Replacing it with a stub `podman` on `PATH` so it would always run. That satisfies the same probe, but it would assert what the unit tests already assert, through a slower and more indirect route.

## Verification

`tests/e2e/test_airgapped_cli.py` — 1 passed, no skips. Module docstring updated: it pointed at `test_docker_runner.py` for this coverage, which is not where it lives.