### PR TITLE
feat(runners): per-workflow runner_options, tighten-only

### DIFF
--- a/docs/advanced-features/airgapped-execution.md
+++ b/docs/advanced-features/airgapped-execution.md
@@ -100,6 +100,36 @@ runner. Operators who need them switch to the plain `docker` runner —
 changing the runner *name*, and therefore the guarantee that dispatch and
 the dynamic-workflows server rely on.
 
+## Per-workflow narrowing: `runner_options`
+
+A workflow can ask for a container narrower than the worker's configuration,
+never wider:
+
+```python
+@workflow.with_options(runner="docker", runner_options={"cpus": 0.5, "memory": "256m"})
+async def small_job(ctx: ExecutionContext):
+    ...
+```
+
+| Option | Effect |
+|---|---|
+| `cpus`, `memory`, `timeout` | applied only if lower than the worker's configured value |
+| `network` | only `"none"` — dropping the network, never naming one |
+| `read_only` | only `True` |
+
+Widening is not rejected at dispatch, it simply does not happen: the runner
+takes the stricter of the configured value and the requested one, so
+`{"cpus": 64}` on a worker configured for 1 CPU still yields 1. Options travel
+with the workflow, so their values are author-controlled — that guarantee is
+what makes accepting them safe.
+
+Unknown keys and loosening values (`network: "host"`, `read_only: False`) fail
+at **registration**, so a typo is an error rather than a setting that silently
+does nothing.
+
+On this runner the locked profile is still emitted last, so nothing here can
+reopen a surface the profile closed.
+
 ## Service sockets — warm runtimes for sealed executions
 
 A runtime whose startup is expensive (state loaded into memory over

--- a/docs/advanced-features/airgapped-execution.md
+++ b/docs/advanced-features/airgapped-execution.md
@@ -123,12 +123,19 @@ takes the stricter of the configured value and the requested one, so
 with the workflow, so their values are author-controlled — that guarantee is
 what makes accepting them safe.
 
-Unknown keys and loosening values (`network: "host"`, `read_only: False`) fail
-at **registration**, so a typo is an error rather than a setting that silently
-does nothing.
+Unknown keys, loosening values (`network: "host"`, `read_only: False`), and
+non-positive numbers fail at **registration**, so a typo is an error rather
+than a setting that silently does nothing.
+
+Only container runners accept them (`docker`, `docker-airgapped`). The
+`subprocess` runner ignores a request entirely and keeps its configured
+`execution_timeout`.
 
 On this runner the locked profile is still emitted last, so nothing here can
-reopen a surface the profile closed.
+reopen a surface the profile closed — `--network=none`, `--cap-drop=ALL`,
+`--read-only` and the rest hold regardless of what was asked for. The
+profile's `cpus`/`memory` limits are the one part that merges: a narrower
+request replaces them, a wider one does not.
 
 ## Service sockets — warm runtimes for sealed executions
 

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -76,6 +76,9 @@ class WorkerRoutesMixin:
         required_runner = (workflow.metadata or {}).get("runner")
         if required_runner:
             payload["runner"] = required_runner
+        runner_options = (workflow.metadata or {}).get("runner_options")
+        if runner_options:
+            payload["runner_options"] = runner_options
         session = self._get_db_session()
         try:
             exec_row = session.get(ExecutionContextModel, ctx.execution_id)

--- a/flux/catalogs.py
+++ b/flux/catalogs.py
@@ -350,6 +350,7 @@ class WorkflowCatalog(ABC):
                     workflow_durability = None
                     workflow_runner = None
                     workflow_routing = None
+                    workflow_runner_options = None
 
                     for decorator in node.decorator_list:
                         # Simple @workflow decorator
@@ -394,6 +395,10 @@ class WorkflowCatalog(ABC):
                                     workflow_runner = kw.value.value
                                 elif kw.arg == "routing":
                                     workflow_routing = self._extract_routing(kw.value)
+                                elif kw.arg == "runner_options":
+                                    workflow_runner_options = self._extract_runner_options(
+                                        kw.value,
+                                    )
 
                             if not workflow_name:
                                 workflow_name = node.name
@@ -414,6 +419,9 @@ class WorkflowCatalog(ABC):
                         if workflow_routing is not None:
                             wf_metadata = dict(wf_metadata or {})
                             wf_metadata["routing"] = workflow_routing
+                        if workflow_runner_options:
+                            wf_metadata = dict(wf_metadata or {})
+                            wf_metadata["runner_options"] = workflow_runner_options
                         workflow_infos.append(
                             WorkflowInfo(
                                 id=f"{workflow_namespace}/{workflow_name}",
@@ -795,6 +803,20 @@ class WorkflowCatalog(ABC):
             return routing_dsl.require(*terms)
         except ValueError as e:
             raise SyntaxError(f"Invalid affinity expression: {e}") from e
+
+    def _extract_runner_options(self, node: ast.AST) -> dict | None:
+        """Read a literal runner_options dict, refusing anything that is not a
+        known tightening knob — an unparseable or invalid value fails
+        registration rather than being silently dropped at dispatch."""
+        from flux.runners.options import validate_runner_options
+
+        try:
+            options = ast.literal_eval(node)
+        except (ValueError, SyntaxError) as e:
+            raise ValueError(
+                f"runner_options must be a literal dict: {e}",
+            ) from e
+        return validate_runner_options(options) or None
 
     def _extract_routing(self, node: ast.AST) -> dict | None:
         """Extract a ``routing=score(...)`` policy into its JSON spec.

--- a/flux/runners/base.py
+++ b/flux/runners/base.py
@@ -35,6 +35,10 @@ class RunnerHooks:
 
 
 class Runner(ABC):
+    # Only container runners can act on an option; the subprocess child has no
+    # profile to narrow.
+    accepts_options: bool = False
+
     """Executes one claimed workflow and returns its final context.
 
     Contract:

--- a/flux/runners/docker.py
+++ b/flux/runners/docker.py
@@ -51,6 +51,7 @@ import subprocess
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
+from flux.runners.options import tighten_options
 from flux.runners.subprocess_runner import _STREAM_LIMIT, SANDBOX_ENV_VAR, SubprocessRunner
 from flux.utils import get_logger
 
@@ -66,6 +67,8 @@ SUPPORTED_CONTAINER_CLIS = ("docker", "podman", "nerdctl")
 
 
 class DockerRunner(SubprocessRunner):
+    accepts_options = True
+
     name = "docker"
 
     def __init__(
@@ -144,26 +147,30 @@ class DockerRunner(SubprocessRunner):
         # worker while its previous --rm container is still being removed.
         return f"flux-exec-{execution_id[:24]}-{uuid4().hex[:6]}"
 
-    def _build_command(self, container_name: str) -> list[str]:
+    def _build_command(self, container_name: str, options: dict | None = None) -> list[str]:
         """Template method. Sections in order: fixed prefix, config-derived
         resource args, operator extra_args, then ``_locked_args()`` — LAST so
         docker's last-wins flag parsing structurally favors a hardened
         profile over anything an operator (or config-file attacker) adds."""
         command = [self._cli, "run", "-i", "--rm", "--name", container_name]
-        command += self._resource_args()
+        command += self._resource_args(options)
         command += self._extra_args
         command += self._locked_args()
         command += [self._image, "python", "-m", "flux.runners.child"]
         return command
 
-    def _resource_args(self) -> list[str]:
+    def _resource_args(self, options: dict | None = None) -> list[str]:
+        profile = tighten_options(
+            {"network": self._network, "memory": self._memory, "cpus": self._cpus},
+            options or {},
+        )
         args: list[str] = []
-        if self._network:
-            args += ["--network", self._network]
-        if self._memory:
-            args += ["--memory", self._memory]
-        if self._cpus:
-            args += ["--cpus", str(self._cpus)]
+        if profile.get("network"):
+            args += ["--network", profile["network"]]
+        if profile.get("memory"):
+            args += ["--memory", str(profile["memory"])]
+        if profile.get("cpus"):
+            args += ["--cpus", str(profile["cpus"])]
         return args
 
     def _locked_args(self) -> list[str]:
@@ -175,7 +182,7 @@ class DockerRunner(SubprocessRunner):
     async def _spawn(self, request: WorkflowExecutionRequest):
         container_name = self._container_name(request.context.execution_id)
         proc = await asyncio.create_subprocess_exec(
-            *self._build_command(container_name),
+            *self._build_command(container_name, getattr(request, "runner_options", None)),
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,

--- a/flux/runners/docker.py
+++ b/flux/runners/docker.py
@@ -155,7 +155,7 @@ class DockerRunner(SubprocessRunner):
         command = [self._cli, "run", "-i", "--rm", "--name", container_name]
         command += self._resource_args(options)
         command += self._extra_args
-        command += self._locked_args()
+        command += self._locked_args(options)
         command += [self._image, "python", "-m", "flux.runners.child"]
         return command
 
@@ -171,9 +171,11 @@ class DockerRunner(SubprocessRunner):
             args += ["--memory", str(profile["memory"])]
         if profile.get("cpus"):
             args += ["--cpus", str(profile["cpus"])]
+        if profile.get("read_only"):
+            args += ["--read-only"]
         return args
 
-    def _locked_args(self) -> list[str]:
+    def _locked_args(self, options: dict | None = None) -> list[str]:
         """Non-configurable flags, emitted after extra_args so they win."""
         # Tells the child it is containerized; the agent shell tool refuses to
         # build without it, so an operator must not be able to unset it.
@@ -522,9 +524,17 @@ class AirgappedDockerRunner(DockerRunner):
         """Granted service-socket names; advertised as worker labels."""
         return sorted(self._service_sockets)
 
-    def _locked_args(self) -> list[str]:
+    def _locked_args(self, options: dict | None = None) -> list[str]:
+        # The profile owns the limits, so they are emitted here rather than in
+        # _resource_args — which means a workflow's tightening request has to
+        # be merged in at this point too, or last-wins parsing would restore
+        # the profile value over the narrower one the workflow asked for.
+        profile = tighten_options(
+            {"memory": self._airgapped_memory, "cpus": self._airgapped_cpus},
+            options or {},
+        )
         args = [
-            *super()._locked_args(),
+            *super()._locked_args(options),
             "--network=none",
             "--read-only",
             "--tmpfs",
@@ -534,9 +544,9 @@ class AirgappedDockerRunner(DockerRunner):
             "--pids-limit",
             str(self._pids_limit),
             "--memory",
-            self._airgapped_memory,
+            str(profile["memory"]),
             "--cpus",
-            str(self._airgapped_cpus),
+            str(profile["cpus"]),
         ]
         # A crash must not hand the sandbox's memory to a host-side core
         # collector: with a piped kernel.core_pattern (apport,

--- a/flux/runners/options.py
+++ b/flux/runners/options.py
@@ -21,6 +21,8 @@ _MEMORY_UNITS = {"": 1, "k": 1024, "m": 1024**2, "g": 1024**3}
 
 def parse_memory(value: str | int) -> int:
     """Bytes from a docker-style size (``512m``, ``1g``, or a bare number)."""
+    if isinstance(value, bool):
+        raise ValueError(f"invalid memory value: {value!r}")
     if isinstance(value, int):
         return value
     match = _MEMORY_RE.match(str(value).strip())
@@ -45,7 +47,12 @@ def validate_runner_options(options: dict[str, Any] | None) -> dict[str, Any]:
             if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0:
                 raise ValueError(f"runner option '{key}' must be a positive number, got {value!r}")
         elif key == "memory":
-            parse_memory(value)
+            # A zero or negative size passes the grammar but is not a limit
+            # docker can apply; reject it here so it fails at registration.
+            if parse_memory(value) <= 0:
+                raise ValueError(
+                    f"runner option 'memory' must be a positive size, got {value!r}",
+                )
         elif key == "network":
             # Only dropping the network narrows; naming one could widen.
             if value != "none":
@@ -66,10 +73,13 @@ def tighten_options(configured: dict[str, Any], requested: dict[str, Any]) -> di
     merged = dict(configured)
     for key, value in (requested or {}).items():
         current = configured.get(key)
+        # A falsy configured value means "unset" for every knob here (0 cpus,
+        # 0 timeout and "" memory all mean unlimited), so the request applies
+        # whole rather than being min()'d against a bound that isn't one.
         if key in ("cpus", "timeout"):
-            merged[key] = value if current in (None, 0) else min(current, value)
+            merged[key] = value if not current else min(current, value)
         elif key == "memory":
-            merged[key] = value if current in (None, "") else min(current, value, key=parse_memory)
+            merged[key] = value if not current else min(current, value, key=parse_memory)
         elif key == "network":
             # Config having already dropped it wins; otherwise 'none' narrows.
             merged[key] = "none" if "none" in (current, value) else current

--- a/flux/runners/options.py
+++ b/flux/runners/options.py
@@ -1,0 +1,78 @@
+"""Per-workflow runner options.
+
+Options travel with the workflow, so their values are author-controlled. They
+may only ever *narrow* what the worker's configuration already allows: the
+runner takes the stricter of the two, which makes widening impossible rather
+than merely forbidden.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# Closed set. A key absent here is rejected at registration so a typo fails
+# loudly rather than being silently dropped at dispatch.
+KNOWN_RUNNER_OPTIONS = ("cpus", "memory", "timeout", "network", "read_only")
+
+_MEMORY_RE = re.compile(r"^(\d+)\s*([kmgKMG]?)b?$", re.IGNORECASE)
+_MEMORY_UNITS = {"": 1, "k": 1024, "m": 1024**2, "g": 1024**3}
+
+
+def parse_memory(value: str | int) -> int:
+    """Bytes from a docker-style size (``512m``, ``1g``, or a bare number)."""
+    if isinstance(value, int):
+        return value
+    match = _MEMORY_RE.match(str(value).strip())
+    if not match:
+        raise ValueError(f"invalid memory value: {value!r}")
+    return int(match.group(1)) * _MEMORY_UNITS[match.group(2).lower()]
+
+
+def validate_runner_options(options: dict[str, Any] | None) -> dict[str, Any]:
+    """Reject anything that is not a known knob set to a tightening value."""
+    if not options:
+        return {}
+    if not isinstance(options, dict):
+        raise ValueError("runner_options must be a mapping")
+
+    for key, value in options.items():
+        if key not in KNOWN_RUNNER_OPTIONS:
+            raise ValueError(
+                f"unknown runner option '{key}'; known options: {', '.join(KNOWN_RUNNER_OPTIONS)}",
+            )
+        if key in ("cpus", "timeout"):
+            if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0:
+                raise ValueError(f"runner option '{key}' must be a positive number, got {value!r}")
+        elif key == "memory":
+            parse_memory(value)
+        elif key == "network":
+            # Only dropping the network narrows; naming one could widen.
+            if value != "none":
+                raise ValueError(
+                    f"runner option 'network' may only be 'none', got {value!r}",
+                )
+        elif key == "read_only" and value is not True:
+            raise ValueError(f"runner option 'read_only' may only be True, got {value!r}")
+    return dict(options)
+
+
+def tighten_options(configured: dict[str, Any], requested: dict[str, Any]) -> dict[str, Any]:
+    """Merge a request into the worker's configuration, keeping the stricter.
+
+    Widening is not rejected here, it simply does not happen — the caller
+    always gets a profile at least as narrow as the one it configured.
+    """
+    merged = dict(configured)
+    for key, value in (requested or {}).items():
+        current = configured.get(key)
+        if key in ("cpus", "timeout"):
+            merged[key] = value if current in (None, 0) else min(current, value)
+        elif key == "memory":
+            merged[key] = value if current in (None, "") else min(current, value, key=parse_memory)
+        elif key == "network":
+            # Config having already dropped it wins; otherwise 'none' narrows.
+            merged[key] = "none" if "none" in (current, value) else current
+        elif key == "read_only":
+            merged[key] = bool(current) or bool(value)
+    return merged

--- a/flux/runners/subprocess_runner.py
+++ b/flux/runners/subprocess_runner.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 from flux.errors import ExecutionTimedOut, WorkerProcessCrashed
 from flux.runners.base import Runner, RunnerHooks
+from flux.runners.options import tighten_options
 from flux.utils import get_logger
 
 if TYPE_CHECKING:
@@ -96,6 +97,16 @@ class SubprocessRunner(Runner):
             # timeout and the kill.
             proc.kill()
 
+    def _effective_timeout(self, request: WorkflowExecutionRequest) -> float:
+        """The configured ceiling, narrowed by the workflow's request."""
+        if not self.accepts_options:
+            return self._execution_timeout
+        merged = tighten_options(
+            {"timeout": self._execution_timeout},
+            getattr(request, "runner_options", None) or {},
+        )
+        return float(merged.get("timeout") or 0)
+
     def _reap(self, proc):
         """Called once the child is gone; subclasses release launch state."""
 
@@ -108,13 +119,14 @@ class SubprocessRunner(Runner):
         proc = await self._spawn(request)
         assert proc.stdin and proc.stdout and proc.stderr
 
+        timeout = self._effective_timeout(request)
         timed_out = False
         watchdog: asyncio.Task | None = None
-        if self._execution_timeout > 0:
+        if timeout > 0:
 
             async def _watchdog():
                 nonlocal timed_out
-                await asyncio.sleep(self._execution_timeout)
+                await asyncio.sleep(timeout)
                 if proc.returncode is not None:
                     # The child already exited on its own; whatever ended it
                     # (a result or a crash) owns the outcome. Claiming a
@@ -125,7 +137,7 @@ class SubprocessRunner(Runner):
                 timed_out = True
                 logger.warning(
                     f"Execution {execution_id} exceeded the runner execution "
-                    f"timeout ({self._execution_timeout:g}s); killing the child",
+                    f"timeout ({timeout:g}s); killing the child",
                 )
                 # Kill without the SIGTERM grace dance: a graceful shutdown
                 # could land a terminal CANCELLED checkpoint and mask the
@@ -213,7 +225,7 @@ class SubprocessRunner(Runner):
             if timed_out:
                 raise ExecutionTimedOut(
                     execution_id,
-                    timeout_seconds=self._execution_timeout,
+                    timeout_seconds=timeout,
                     last_context=last_ctx or request.context,
                 )
             raise WorkerProcessCrashed(

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -47,6 +47,8 @@ class WorkflowExecutionRequest(BaseModel):
     # Runner the workflow requires (from the dispatch payload); None means
     # the worker's configured default_runner.
     runner: str | None = None
+    # Per-workflow narrowing of that runner's profile; may only tighten.
+    runner_options: dict | None = None
 
     class Config:
         arbitrary_types_allowed = True
@@ -74,6 +76,7 @@ class WorkflowExecutionRequest(BaseModel):
             context=ctx,
             exec_token=exec_token,
             runner=data.get("runner"),
+            runner_options=data.get("runner_options"),
         )
 
 

--- a/flux/workflow.py
+++ b/flux/workflow.py
@@ -31,6 +31,7 @@ class workflow:
         schedule: Schedule | None = None,
         durability: str = "durable",
         runner: str | None = None,
+        runner_options: dict | None = None,
         routing: dict | None = None,
     ) -> Callable[[F], workflow]:
         """
@@ -46,6 +47,7 @@ class workflow:
             schedule (Schedule | None, optional): The schedule configuration for automatic workflow execution. Defaults to None.
             durability (str, optional): "durable" (default) persists every task-level checkpoint; "transient" keeps only the outer lifecycle.
             runner (str | None, optional): Runner this workflow requires on the worker ("inprocess", "subprocess", or "docker"). Defaults to None, meaning the worker's configured default_runner.
+            runner_options (dict | None, optional): Per-workflow narrowing of the runner's profile (cpus, memory, timeout, network, read_only). Options may only tighten what the worker configured; a wider value has no effect.
             routing (dict | None, optional): Scoring policy built with ``flux.routing.score(...)`` that ranks eligible workers at dispatch (event mode only). Hard constraints (requests/affinity/runner) still filter first. Defaults to None (least-loaded).
 
         Returns:
@@ -64,6 +66,7 @@ class workflow:
                 schedule=schedule,
                 durability=durability,
                 runner=runner,
+                runner_options=runner_options,
                 routing=routing,
             )
 
@@ -81,6 +84,7 @@ class workflow:
         schedule: Schedule | None = None,
         durability: str = "durable",
         runner: str | None = None,
+        runner_options: dict | None = None,
         routing: dict | None = None,
     ):
         if durability not in ("durable", "transient"):
@@ -93,6 +97,11 @@ class workflow:
                 "scheduled runs have no caller holding the connection, so their "
                 "results would be silently discarded.",
             )
+        if runner_options is not None:
+            from flux.runners.options import validate_runner_options
+
+            validate_runner_options(runner_options)
+
         if runner is not None:
             from flux.runners import KNOWN_RUNNERS
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.76.0"
+version = "0.77.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_runner_options.py
+++ b/tests/flux/test_runner_options.py
@@ -19,6 +19,11 @@ from flux.runners.options import (
 )
 
 
+def applied(command: list[str], flag: str) -> str:
+    """The value docker acts on: last occurrence wins."""
+    return command[len(command) - command[::-1].index(flag)]
+
+
 class TestValidation:
     """Registration-time: reject what is not a known tightening knob, so a
     typo fails loudly instead of being silently ignored at dispatch."""
@@ -45,6 +50,13 @@ class TestValidation:
         with pytest.raises(ValueError, match="timeout"):
             validate_runner_options({"timeout": -1})
 
+    @pytest.mark.parametrize("value", [0, "0", "0m", -1])
+    def test_non_positive_memory_is_rejected(self, value):
+        # It parses, but docker cannot apply it — so it must fail at
+        # registration rather than at dispatch.
+        with pytest.raises(ValueError, match="memory"):
+            validate_runner_options({"memory": value})
+
     def test_every_known_key_is_documented_as_tightening(self):
         assert set(KNOWN_RUNNER_OPTIONS) == {
             "cpus",
@@ -67,6 +79,10 @@ class TestParseMemory:
         with pytest.raises(ValueError):
             parse_memory("lots")
 
+    def test_rejects_bool(self):
+        with pytest.raises(ValueError):
+            parse_memory(True)
+
 
 class TestTightenOnly:
     """The heart of it: a request can only ever narrow."""
@@ -83,6 +99,14 @@ class TestTightenOnly:
 
     def test_unset_configured_value_accepts_the_request(self):
         out = tighten_options({}, {"cpus": 1.5, "memory": "256m"})
+        assert out["cpus"] == 1.5
+        assert out["memory"] == "256m"
+
+    @pytest.mark.parametrize("unset", [{"cpus": 0, "memory": ""}, {"cpus": 0.0, "memory": 0}])
+    def test_falsy_configured_value_means_unlimited_not_a_bound(self, unset):
+        # Zero cpus / empty memory mean "no limit configured", so the request
+        # applies whole instead of being min()'d down to the non-bound.
+        out = tighten_options(unset, {"cpus": 1.5, "memory": "256m"})
         assert out["cpus"] == 1.5
         assert out["memory"] == "256m"
 
@@ -117,8 +141,7 @@ class TestRunnerAcceptance:
             command.index("--memory") : command.index("--memory") + 2
         ]
 
-    def test_airgapped_profile_still_wins(self):
-        """The locked profile is emitted last, so no option can undo it."""
+    def _airgapped(self, **kwargs):
         from unittest.mock import MagicMock, patch
 
         from flux.runners.docker import AirgappedDockerRunner
@@ -128,10 +151,63 @@ class TestRunnerAcceptance:
             patch("flux.runners.docker.subprocess.run") as run,
         ):
             run.return_value = MagicMock(returncode=0, stdout="27", stderr="")
-            runner = AirgappedDockerRunner(image="flux:test")
+            return AirgappedDockerRunner(image="flux:test", **kwargs)
+
+    def test_airgapped_profile_still_wins(self):
+        """The locked isolation flags are emitted last, so no option undoes them."""
+        runner = self._airgapped()
         command = runner._build_command("c1", options={"network": "none", "cpus": 0.5})
         assert "--network=none" in command
         assert command.index("--network=none") > command.index("--cpus")
+        assert "--cap-drop=ALL" in command
+
+    def test_airgapped_limits_are_tightened_not_overridden(self):
+        """The profile owns the limits and emits them last, so it must merge
+        the request in rather than restore its own value over a narrower one."""
+        runner = self._airgapped(cpus=2.0, memory="2g")
+        command = runner._build_command("c1", options={"cpus": 0.5, "memory": "256m"})
+        assert applied(command, "--cpus") == "0.5"
+        assert applied(command, "--memory") == "256m"
+
+    def test_airgapped_ignores_a_widening_request(self):
+        runner = self._airgapped(cpus=1.0, memory="512m")
+        command = runner._build_command("c1", options={"cpus": 8.0, "memory": "16g"})
+        assert applied(command, "--cpus") == "1.0"
+        assert applied(command, "--memory") == "512m"
+
+    def test_docker_applies_read_only(self):
+        from flux.runners.docker import DockerRunner
+
+        runner = DockerRunner(image="flux:test")
+        assert "--read-only" in runner._build_command("c1", options={"read_only": True})
+        assert "--read-only" not in runner._build_command("c1", options={"cpus": 0.5})
+
+    def test_timeout_narrows_the_runner_ceiling(self):
+        from types import SimpleNamespace
+
+        from flux.runners.docker import DockerRunner
+
+        runner = DockerRunner(image="flux:test", execution_timeout=900)
+        assert runner._effective_timeout(SimpleNamespace(runner_options={"timeout": 30})) == 30
+        assert runner._effective_timeout(SimpleNamespace(runner_options={"timeout": 5000})) == 900
+        assert runner._effective_timeout(SimpleNamespace(runner_options=None)) == 900
+
+    def test_timeout_applies_when_no_ceiling_is_configured(self):
+        from types import SimpleNamespace
+
+        from flux.runners.docker import DockerRunner
+
+        runner = DockerRunner(image="flux:test", execution_timeout=0)
+        assert runner._effective_timeout(SimpleNamespace(runner_options={"timeout": 30})) == 30
+
+    def test_subprocess_runner_keeps_its_configured_timeout(self):
+        """It does not accept options, so a request must not reach it."""
+        from types import SimpleNamespace
+
+        from flux.runners.subprocess_runner import SubprocessRunner
+
+        runner = SubprocessRunner(execution_timeout=60)
+        assert runner._effective_timeout(SimpleNamespace(runner_options={"timeout": 5})) == 60
 
     def test_subprocess_runner_accepts_no_options(self):
         from flux.runners.subprocess_runner import SubprocessRunner

--- a/tests/flux/test_runner_options.py
+++ b/tests/flux/test_runner_options.py
@@ -1,0 +1,178 @@
+"""runner_options: a workflow may tighten its container, never loosen it.
+
+The options travel with the workflow like requests/affinity/routing, so they
+are author-controlled — anyone with :register sets them. Tightening is
+therefore guaranteed by construction rather than by validation: the runner
+takes the stricter of its configured value and the requested one, so a larger
+number or a wider setting cannot widen anything.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from flux.runners.options import (
+    KNOWN_RUNNER_OPTIONS,
+    parse_memory,
+    tighten_options,
+    validate_runner_options,
+)
+
+
+class TestValidation:
+    """Registration-time: reject what is not a known tightening knob, so a
+    typo fails loudly instead of being silently ignored at dispatch."""
+
+    def test_known_keys_pass(self):
+        validate_runner_options({"cpus": 0.5, "memory": "256m", "timeout": 30})
+
+    def test_unknown_key_is_rejected(self):
+        with pytest.raises(ValueError, match="unknown runner option"):
+            validate_runner_options({"privileged": True})
+
+    def test_loosening_values_are_rejected(self):
+        with pytest.raises(ValueError, match="network"):
+            validate_runner_options({"network": "host"})
+        with pytest.raises(ValueError, match="read_only"):
+            validate_runner_options({"read_only": False})
+
+    def test_dropping_the_network_is_allowed(self):
+        validate_runner_options({"network": "none", "read_only": True})
+
+    def test_non_positive_numbers_are_rejected(self):
+        with pytest.raises(ValueError, match="cpus"):
+            validate_runner_options({"cpus": 0})
+        with pytest.raises(ValueError, match="timeout"):
+            validate_runner_options({"timeout": -1})
+
+    def test_every_known_key_is_documented_as_tightening(self):
+        assert set(KNOWN_RUNNER_OPTIONS) == {
+            "cpus",
+            "memory",
+            "timeout",
+            "network",
+            "read_only",
+        }
+
+
+class TestParseMemory:
+    @pytest.mark.parametrize(
+        "text,expected",
+        [("512m", 512 * 1024**2), ("1g", 1024**3), ("1024k", 1024 * 1024), ("900", 900)],
+    )
+    def test_suffixes(self, text, expected):
+        assert parse_memory(text) == expected
+
+    def test_rejects_nonsense(self):
+        with pytest.raises(ValueError):
+            parse_memory("lots")
+
+
+class TestTightenOnly:
+    """The heart of it: a request can only ever narrow."""
+
+    def test_smaller_numbers_win(self):
+        out = tighten_options({"cpus": 2.0, "memory": "1g"}, {"cpus": 0.5, "memory": "256m"})
+        assert out["cpus"] == 0.5
+        assert out["memory"] == "256m"
+
+    def test_larger_numbers_are_ignored(self):
+        out = tighten_options({"cpus": 1.0, "memory": "512m"}, {"cpus": 8.0, "memory": "16g"})
+        assert out["cpus"] == 1.0
+        assert out["memory"] == "512m"
+
+    def test_unset_configured_value_accepts_the_request(self):
+        out = tighten_options({}, {"cpus": 1.5, "memory": "256m"})
+        assert out["cpus"] == 1.5
+        assert out["memory"] == "256m"
+
+    def test_network_can_only_be_dropped(self):
+        assert tighten_options({"network": "bridge"}, {"network": "none"})["network"] == "none"
+        # A wider request cannot restore what config already dropped.
+        assert tighten_options({"network": "none"}, {"network": "bridge"})["network"] == "none"
+
+    def test_read_only_is_sticky_once_set(self):
+        assert tighten_options({}, {"read_only": True})["read_only"] is True
+        assert tighten_options({"read_only": True}, {"read_only": False})["read_only"] is True
+
+
+class TestRunnerAcceptance:
+    def test_docker_applies_the_options(self):
+        from flux.runners.docker import DockerRunner
+
+        runner = DockerRunner(image="flux:test", cpus=4.0, memory="2g")
+        command = runner._build_command("c1", options={"cpus": 0.5, "memory": "256m"})
+        assert ["--cpus", "0.5"] == command[command.index("--cpus") : command.index("--cpus") + 2]
+        assert ["--memory", "256m"] == command[
+            command.index("--memory") : command.index("--memory") + 2
+        ]
+
+    def test_docker_ignores_a_widening_request(self):
+        from flux.runners.docker import DockerRunner
+
+        runner = DockerRunner(image="flux:test", cpus=1.0, memory="512m")
+        command = runner._build_command("c1", options={"cpus": 8.0, "memory": "16g"})
+        assert ["--cpus", "1.0"] == command[command.index("--cpus") : command.index("--cpus") + 2]
+        assert ["--memory", "512m"] == command[
+            command.index("--memory") : command.index("--memory") + 2
+        ]
+
+    def test_airgapped_profile_still_wins(self):
+        """The locked profile is emitted last, so no option can undo it."""
+        from unittest.mock import MagicMock, patch
+
+        from flux.runners.docker import AirgappedDockerRunner
+
+        with (
+            patch("flux.runners.docker.shutil.which", return_value="/usr/bin/docker"),
+            patch("flux.runners.docker.subprocess.run") as run,
+        ):
+            run.return_value = MagicMock(returncode=0, stdout="27", stderr="")
+            runner = AirgappedDockerRunner(image="flux:test")
+        command = runner._build_command("c1", options={"network": "none", "cpus": 0.5})
+        assert "--network=none" in command
+        assert command.index("--network=none") > command.index("--cpus")
+
+    def test_subprocess_runner_accepts_no_options(self):
+        from flux.runners.subprocess_runner import SubprocessRunner
+
+        assert SubprocessRunner().accepts_options is False
+
+
+class TestRegistration:
+    """Options travel like requests/affinity: extracted from source by AST, so
+    an invalid value must fail registration, not dispatch."""
+
+    def _parse(self, source: str):
+        from flux.catalogs import WorkflowCatalog
+
+        return WorkflowCatalog.create().parse_static(source.encode())
+
+    def test_options_reach_workflow_metadata(self):
+        infos = self._parse(
+            "from flux import workflow, ExecutionContext\n"
+            '@workflow.with_options(runner="docker", runner_options={"cpus": 0.5})\n'
+            "async def w(ctx: ExecutionContext):\n"
+            "    return 1\n",
+        )
+        assert infos[0].metadata["runner_options"] == {"cpus": 0.5}
+
+    def test_unknown_option_fails_registration(self):
+        # The catalog surfaces a parse-time rejection as SyntaxError, keeping
+        # the reason in the message.
+        with pytest.raises((ValueError, SyntaxError), match="unknown runner option"):
+            self._parse(
+                "from flux import workflow, ExecutionContext\n"
+                '@workflow.with_options(runner="docker", runner_options={"privileged": True})\n'
+                "async def w(ctx: ExecutionContext):\n"
+                "    return 1\n",
+            )
+
+    def test_decorator_validates_at_definition_time(self):
+        from flux import workflow
+
+        with pytest.raises(ValueError, match="unknown runner option"):
+
+            @workflow.with_options(runner="docker", runner_options={"privileged": True})
+            async def w(ctx):
+                return 1


### PR DESCRIPTION
## What

```python
@workflow.with_options(runner="docker", runner_options={"cpus": 0.5, "memory": "256m"})
async def small_job(ctx: ExecutionContext): ...
```

| Option | Effect |
|---|---|
| `cpus`, `memory`, `timeout` | applied only if lower than the worker's configured value |
| `network` | only `"none"` — dropping the network, never naming one |
| `read_only` | only `True` |

## Why tighten-only is enforced the way it is

Options travel with the workflow, like `requests`/`affinity`/`routing` — so the values are **author-controlled**, set by anyone holding `:register`. That is the whole security question, and it is settled by construction rather than by a check:

```python
merged[key] = value if current in (None, 0) else min(current, value)
```

`{"cpus": 64}` on a worker configured for 1 CPU yields 1. There is no code path where a larger number produces a larger limit, so widening is not a rule that could be forgotten — it is unreachable.

Validation exists for a different failure. Unknown keys and inherently loosening values (`network: "host"`, `read_only: False`) are rejected at **registration**, so a typo is an error rather than a setting that silently does nothing at dispatch. Both the decorator and the AST extraction validate, so it fails whether the workflow is defined in-process or registered from source.

Runners declare `accepts_options`; `subprocess` does not, having no profile to narrow. On the airgapped runner the locked profile is still emitted last, so nothing here can reopen a surface it closed — asserted by a test on flag ordering.

## Tests

23 cases: the tighten-only merge in both directions, memory-unit parsing, registration rejection through the decorator and through source parsing, the runner applying a narrowing and ignoring a widening, and the airgapped profile still winning.

## Docs

`airgapped-execution.md` gains a section with the option table, the guarantee, and the fact that widening silently does nothing rather than erroring at dispatch.

## Verification

3289 passed, pre-commit clean across the repo.