### PR TITLE
feat(routing): gate score terms on load(), and add utilization()

### DIFF
--- a/docs/advanced-features/dynamic-routing.md
+++ b/docs/advanced-features/dynamic-routing.md
@@ -44,6 +44,7 @@ A policy is a weighted combination of terms over **selectors**:
 | `meta("key")` | server-side worker metadata (`flux worker metadata set` — admin-written, worker-unspoofable; see [Worker Affinity](worker-affinity.md#server-side-worker-metadata)) | live, re-read at dispatch |
 | `resource("field")` | `cpu_total`, `cpu_available`, `memory_total`, `memory_available`, `disk_total`, `disk_free` | registration-time snapshot (prefer `metric("flux.cpu_percent")` etc. for live values) |
 | `load()` | active executions on the worker | live, computed at dispatch |
+| `utilization()` | active executions ÷ the worker's advertised capacity | live, computed at dispatch |
 
 And four term types:
 
@@ -80,9 +81,14 @@ soft preference under `prefer(...)`:
 - `prefer(service(input("model")), weight=2)` — prefer a worker with the
   granted service socket, fall back to the rest.
 - `when(input("latency_sensitive") == "true", least(load(), weight=10))` —
-  apply a term only when the request says it matters. The condition reads
-  execution input only, never worker attributes; unresolved leaves the term
-  inactive.
+  apply a term only when the request says it matters. An `input(...)`
+  condition resolves once per execution (`==`/`!=` only); unresolved leaves
+  the term inactive.
+- `when(load() < 5, sticky(weight=3))` — apply a term only to the workers a
+  condition holds for. `meta()`, `metric()`, `load()` and `utilization()`
+  conditions are evaluated **per worker**, so this reads as "keep the
+  stickiness while the preferred worker still has room". See
+  [gating on load](#gating-on-load) below.
 
 Pair the stages for floor-plus-preference routing:
 
@@ -123,6 +129,54 @@ code runs in the dispatcher. The flip side: the policy must be declared
 with literal values (or `input(...)`); a policy the parser cannot extract
 fails registration with a clear error rather than silently routing
 differently than written.
+
+## Gating on load
+
+Normalization is relative, which makes `least(load())` sharper than it
+looks: across two workers at loads 1 and 0, the gap normalizes to a full
+1.0 — the largest value the term can take. So pairing it with a plain
+`sticky(...)` leaves only two postures, and neither is "prefer this worker
+until it fills up":
+
+| Policy | Behaviour |
+|---|---|
+| `sticky(weight=3)` | deterministic — the preferred worker wins at any load |
+| `sticky(weight=0.5)` | defeated by a **single** in-flight execution |
+
+An absolute gate gives the middle posture, because a `when()` condition on
+worker state is evaluated per candidate:
+
+```python
+routing=score(
+    when(load() < 5, sticky(weight=3)),   # stickiness, while there is room
+    least(load()),                        # otherwise spread
+)
+```
+
+`load()` is a count, so a threshold tuned for a 4-slot worker means
+something different on a 32-slot one. In a mixed fleet use the ratio:
+
+```python
+routing=score(when(utilization() < 0.8, sticky(weight=3)), least(load()))
+```
+
+`utilization()` is `load() ÷ max_concurrent_executions`. A worker that
+advertises no capacity has **no** utilization rather than zero, so it does
+not match `utilization() < 0.8` — otherwise one uncapped worker would read
+as permanently idle and collect every preference in the fleet.
+
+Note that a worker at capacity is already filtered out as a hard constraint,
+so a threshold of `1.0` gates nothing new; the useful values sit below it.
+
+Both are counted by the server from its own execution table, which is what
+makes them safe as conditions: `label()` and `resource()` are asserted by
+the worker, so gating on them would let a worker dodge or attract work, and
+they remain rejected in `when()`.
+
+Score terms only. Gating a `require(...)` term on load is refused at
+registration: skipping a hard constraint makes a worker match *more*
+easily, so it would drop the requirement on exactly the busy workers it was
+meant to steer away from.
 
 ## Built-in worker metrics
 

--- a/flux/catalogs.py
+++ b/flux/catalogs.py
@@ -745,7 +745,10 @@ class WorkflowCatalog(ABC):
             elif call_name(right) in ("meta", "metric"):
                 sel, const, op = _extract_ms_selector(right), left, _FLIPPED[op]
             else:
-                fail("one side of a when() condition must be input()/meta()/metric()")
+                fail(
+                    "one side of a when() condition must be input()/meta()/metric(); "
+                    "load()/utilization() gate score terms, so they belong in routing=score(...)",
+                )
             if not isinstance(const, ast.Constant):
                 fail("when() worker conditions compare against a literal")
             try:
@@ -853,6 +856,7 @@ class WorkflowCatalog(ABC):
             "meta": routing_dsl.meta,
             "resource": routing_dsl.resource,
             "load": routing_dsl.load,
+            "utilization": routing_dsl.utilization,
         }
 
         def extract_input_ref(ref_node: ast.AST) -> Any:
@@ -869,7 +873,7 @@ class WorkflowCatalog(ABC):
             if name is None:
                 fail(
                     f"expected label()/label_for()/metric()/meta()/meta_for()/"
-                    f"resource()/load(), got '{name}'",
+                    f"resource()/load()/utilization(), got '{name}'",
                 )
             assert isinstance(sel_node, ast.Call)
             if name in ("label_for", "meta_for"):
@@ -891,7 +895,7 @@ class WorkflowCatalog(ABC):
             if factory is None:
                 fail(
                     f"expected label()/label_for()/metric()/meta()/meta_for()/"
-                    f"resource()/load(), got '{name}'",
+                    f"resource()/load()/utilization(), got '{name}'",
                 )
             args = []
             for arg in sel_node.args:
@@ -943,11 +947,17 @@ class WorkflowCatalog(ABC):
             except ValueError as e:
                 raise SyntaxError(f"Invalid routing condition: {e}") from e
 
+        _WHEN_SELECTORS = ("meta", "metric", "load", "utilization")
+
         def _extract_ms_selector(sel_node: ast.AST) -> Any:
             name = call_name(sel_node)
-            if name not in ("meta", "metric"):
-                fail("when() worker conditions use meta() or metric()")
+            if name not in _WHEN_SELECTORS:
+                fail("when() worker conditions use meta(), metric(), load() or utilization()")
             assert isinstance(sel_node, ast.Call)
+            if name in ("load", "utilization"):
+                if sel_node.args or sel_node.keywords:
+                    fail(f"{name}() takes no arguments")
+                return routing_dsl.load() if name == "load" else routing_dsl.utilization()
             if len(sel_node.args) != 1 or not isinstance(sel_node.args[0], ast.Constant):
                 fail(f"{name}() takes a literal key")
             factory = routing_dsl.meta if name == "meta" else routing_dsl.metric
@@ -957,10 +967,10 @@ class WorkflowCatalog(ABC):
                 raise SyntaxError(f"Invalid when() selector '{name}': {e}") from e
 
         def extract_when_condition(cond_node: ast.AST) -> Any:
-            """A when() condition: input(...) (==/!= only) or a meta()/metric()
-            comparison (any op), either side."""
+            """A when() condition: input(...) (==/!= only) or a
+            meta()/metric()/load()/utilization() comparison (any op), either side."""
             if not isinstance(cond_node, ast.Compare) or len(cond_node.ops) != 1:
-                fail("when() takes an input()/meta()/metric() comparison")
+                fail("when() takes an input()/meta()/metric()/load()/utilization() comparison")
             op = _AST_OPS.get(type(cond_node.ops[0]))
             if op is None:
                 fail(f"unsupported when() operator at line {cond_node.lineno}")
@@ -975,12 +985,15 @@ class WorkflowCatalog(ABC):
                 if not isinstance(const, ast.Constant):
                     fail("when() input conditions compare against a literal")
                 return routing_dsl.InputCondition(ref, op, const.value)
-            if call_name(left) in ("meta", "metric"):
+            if call_name(left) in _WHEN_SELECTORS:
                 sel, const = _extract_ms_selector(left), right
-            elif call_name(right) in ("meta", "metric"):
+            elif call_name(right) in _WHEN_SELECTORS:
                 sel, const, op = _extract_ms_selector(right), left, _FLIPPED[op]
             else:
-                fail("one side of a when() condition must be input()/meta()/metric()")
+                fail(
+                    "one side of a when() condition must be "
+                    "input()/meta()/metric()/load()/utilization()",
+                )
             if not isinstance(const, ast.Constant):
                 fail("when() worker conditions compare against a literal")
             try:

--- a/flux/routing.py
+++ b/flux/routing.py
@@ -155,6 +155,12 @@ class Condition:
         self.value = value
 
 
+# Keyless selectors the server computes itself. Everything else in the DSL
+# reads a value the worker advertised, which is why only these are allowed to
+# gate a when() condition — a worker cannot move them to dodge or attract work.
+_SERVER_COMPUTED_SELECTORS = ("load", "utilization")
+
+
 class Selector:
     """A worker attribute usable in routing terms.
 
@@ -168,8 +174,8 @@ class Selector:
     spec: str | dict[str, Any]
 
     def __init__(self, kind: str, key: str | None = None):
-        if kind == "load":
-            self.spec = "load"
+        if kind in _SERVER_COMPUTED_SELECTORS:
+            self.spec = kind
             return
         if not key or not isinstance(key, str):
             raise ValueError(f"{kind}() requires a non-empty string key")
@@ -230,6 +236,17 @@ def resource(field: str) -> Selector:
 def load() -> Selector:
     """Active executions on the worker (built-in)."""
     return Selector("load")
+
+
+def utilization() -> Selector:
+    """Active executions as a fraction of the worker's advertised capacity.
+
+    ``load()`` is an absolute count, so a threshold tuned for a 4-slot worker
+    means something else on a 32-slot one. This is the portable form for a
+    mixed fleet. Resolves to ``None`` — matching nothing, rather than reading
+    as idle — on a worker that advertises no ``max_concurrent_executions``.
+    """
+    return Selector("utilization")
 
 
 # Resolved dynamic label keys must look like ordinary label keys: alphanumeric
@@ -562,35 +579,51 @@ def when(condition: Any, term: Condition | dict) -> dict:
     """Apply ``term`` only when ``condition`` holds.
 
     The condition may be ``input(...)`` (requester intent, per-execution,
-    ``==``/``!=`` only) or a ``meta(...)``/``metric(...)`` comparison (dynamic
-    worker state, per-worker, any operator). ``label()``/``resource()``/
-    ``load()`` are not valid conditions — label is static capability (gating a
-    hard constraint on a worker-set label invites a self-dodge), and
-    resource/load are not conditionable state here.
+    ``==``/``!=`` only), a ``meta(...)``/``metric(...)`` comparison (dynamic
+    worker state, per-worker, any operator), or — in the score stage only —
+    ``load()``/``utilization()``.
+
+    ``label()`` and ``resource()`` are not valid conditions: their values are
+    worker-asserted with no server-side counterpart, so gating on them invites
+    a self-dodge. ``load()`` and ``utilization()`` are counted by the server
+    from its own execution table, which is what makes them safe here.
 
     Valid in both stages: wrapping a require match term it gates a
     ``require(...)`` term; wrapping a ``prefer()``/``least()``/``most()``/
     ``sticky()`` term it gates a ``score(...)`` term.
     """
+    is_score_term = isinstance(term, dict) and term.get("kind") in _SCORE_TERM_KINDS
     if isinstance(condition, InputCondition):
         cond_spec = {"input": condition.ref.path, "op": condition.op, "value": condition.value}
     elif isinstance(condition, Condition):
         spec = condition.selector.spec
-        if not (isinstance(spec, str) and (spec.startswith("meta:") or spec.startswith("metric:"))):
+        server_computed = spec in _SERVER_COMPUTED_SELECTORS
+        if not (
+            isinstance(spec, str)
+            and (spec.startswith("meta:") or spec.startswith("metric:") or server_computed)
+        ):
             raise ValueError(
-                "when() worker conditions use meta() or metric() (dynamic worker state); "
-                "label()/resource()/load() are not valid when() conditions",
+                "when() worker conditions use meta(), metric(), load() or utilization(); "
+                "label()/resource() are not valid when() conditions",
+            )
+        if server_computed and not is_score_term:
+            # Skipping a require term makes a worker match MORE easily, so a
+            # load-gated hard constraint would drop its requirement on exactly
+            # the busy workers it was meant to steer away from.
+            raise ValueError(
+                f"{spec}() gates score terms only — prefer()/least()/most()/sticky(); "
+                "it cannot gate a require() term",
             )
         if isinstance(condition.value, dict) and "$input" in condition.value:
             raise ValueError("when() conditions compare against a constant, not input(...)")
         cond_spec = {"selector": spec, "op": condition.op, "value": condition.value}
     else:
         raise ValueError(
-            "when() condition must be input(...), meta(...), or metric(...) compared "
-            f"against a constant, got: {type(condition).__name__}",
+            "when() condition must be input(...), meta(...), metric(...), load() or "
+            f"utilization() compared against a constant, got: {type(condition).__name__}",
         )
-    if isinstance(term, dict) and term.get("kind") in _SCORE_TERM_KINDS:
-        then = dict(term)
+    if is_score_term:
+        then = dict(term)  # type: ignore[arg-type]
     else:
         then = _compile_match(term, "when()")
     return {"kind": "when", "if": cond_spec, "then": then}
@@ -697,9 +730,24 @@ def _resolve_input_path(input_value: Any, path: str) -> Any:
     return current
 
 
+def _worker_utilization(worker: WorkerInfo, loads: dict[str, int]) -> float | None:
+    """Active executions over advertised capacity, or None when unlimited.
+
+    None rather than 0.0 on purpose: a worker that advertises no capacity is
+    unknown, not idle, and reading it as idle would make one legacy worker
+    look permanently free and collect every preference in the fleet.
+    """
+    cap = getattr(worker, "max_concurrent_executions", None)
+    if not cap:
+        return None
+    return loads.get(worker.name, 0) / cap
+
+
 def _selector_value(worker: WorkerInfo, selector: str, loads: dict[str, int]) -> Any:
     if selector == "load":
         return loads.get(worker.name, 0)
+    if selector == "utilization":
+        return _worker_utilization(worker, loads)
     kind, _, key = selector.partition(":")
     if kind == "label":
         return (worker.labels or {}).get(key)
@@ -802,6 +850,7 @@ def pick_worker(
                         worker_metadata=getattr(w, "metadata", None) or {},
                         worker_metrics=getattr(w, "metrics", None) or {},
                         loads=loads,
+                        worker=w,
                         has_worker=True,
                     )
                     if isinstance(a, str):
@@ -1030,6 +1079,7 @@ def _when_condition_active(
     worker_metadata: dict[str, Any] | None = None,
     worker_metrics: dict[str, Any] | None = None,
     loads: dict[str, int] | None = None,
+    worker: WorkerInfo | None = None,
     has_worker: bool = False,
 ) -> bool | str | None:
     """Whether a when-term's condition holds. Returns True/False, a string for a
@@ -1056,10 +1106,22 @@ def _when_condition_active(
         selector, op = cond.get("selector"), cond.get("op")
         if (
             not isinstance(selector, str)
-            or not (selector.startswith("meta:") or selector.startswith("metric:"))
+            or not (
+                selector.startswith("meta:")
+                or selector.startswith("metric:")
+                or selector in _SERVER_COMPUTED_SELECTORS
+            )
             or op not in _OPS
         ):
             return f"malformed affinity when-condition: {cond!r}"
+        if selector in _SERVER_COMPUTED_SELECTORS:
+            # when() confines these to the score stage, which always passes a
+            # worker. Reaching here without one means hand-written metadata put
+            # the condition in a require() expression — diagnose it so the
+            # execution fails loudly instead of matching nobody and parking.
+            if worker is None:
+                return f"{selector}() gates score terms only: {cond!r}"
+            return _compare(_selector_value(worker, selector, loads or {}), op, cond.get("value"))
         if not has_worker:
             return None  # fleet-dependent; not evaluable in diagnostic context
         kind, _, key = selector.partition(":")

--- a/flux/routing.py
+++ b/flux/routing.py
@@ -155,10 +155,11 @@ class Condition:
         self.value = value
 
 
-# Keyless selectors the server computes itself. Everything else in the DSL
-# reads a value the worker advertised, which is why only these are allowed to
-# gate a when() condition — a worker cannot move them to dodge or attract work.
-_SERVER_COMPUTED_SELECTORS = ("load", "utilization")
+# The only selectors a when() condition may gate on. Both resolve from the
+# server's own execution count rather than a worker-supplied value — utilization
+# also divides by the worker's advertised capacity, but _has_free_slot already
+# trusts that number as a hard admission gate, so it grants no new leverage.
+_SERVER_EVALUATED_SELECTORS = ("load", "utilization")
 
 
 class Selector:
@@ -174,7 +175,7 @@ class Selector:
     spec: str | dict[str, Any]
 
     def __init__(self, kind: str, key: str | None = None):
-        if kind in _SERVER_COMPUTED_SELECTORS:
+        if kind in _SERVER_EVALUATED_SELECTORS:
             self.spec = kind
             return
         if not key or not isinstance(key, str):
@@ -585,8 +586,9 @@ def when(condition: Any, term: Condition | dict) -> dict:
 
     ``label()`` and ``resource()`` are not valid conditions: their values are
     worker-asserted with no server-side counterpart, so gating on them invites
-    a self-dodge. ``load()`` and ``utilization()`` are counted by the server
-    from its own execution table, which is what makes them safe here.
+    a self-dodge. ``load()`` is counted by the server from its own execution
+    table; ``utilization()`` divides that count by the worker's advertised
+    capacity, which dispatch already trusts as a hard admission gate.
 
     Valid in both stages: wrapping a require match term it gates a
     ``require(...)`` term; wrapping a ``prefer()``/``least()``/``most()``/
@@ -597,7 +599,7 @@ def when(condition: Any, term: Condition | dict) -> dict:
         cond_spec = {"input": condition.ref.path, "op": condition.op, "value": condition.value}
     elif isinstance(condition, Condition):
         spec = condition.selector.spec
-        server_computed = spec in _SERVER_COMPUTED_SELECTORS
+        server_computed = spec in _SERVER_EVALUATED_SELECTORS
         if not (
             isinstance(spec, str)
             and (spec.startswith("meta:") or spec.startswith("metric:") or server_computed)
@@ -1109,12 +1111,12 @@ def _when_condition_active(
             or not (
                 selector.startswith("meta:")
                 or selector.startswith("metric:")
-                or selector in _SERVER_COMPUTED_SELECTORS
+                or selector in _SERVER_EVALUATED_SELECTORS
             )
             or op not in _OPS
         ):
             return f"malformed affinity when-condition: {cond!r}"
-        if selector in _SERVER_COMPUTED_SELECTORS:
+        if selector in _SERVER_EVALUATED_SELECTORS:
             # when() confines these to the score stage, which always passes a
             # worker. Reaching here without one means hand-written metadata put
             # the condition in a require() expression — diagnose it so the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.77.0"
+version = "0.78.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_routing.py
+++ b/tests/flux/test_routing.py
@@ -613,3 +613,141 @@ class TestWhenWorkerState:
         winner = pick_worker([busy, idle], policy, loads={})
 
         assert winner.name == "idle"
+
+
+class TestWhenServerComputedLoad:
+    """when() gating on load()/utilization(): the server counts both from its
+    own execution table, so a worker cannot move them to dodge or attract work
+    — which is what separates them from the worker-asserted label()/resource().
+    """
+
+    def _capped(self, name: str, cap: int | None) -> WorkerInfo:
+        return WorkerInfo(name=name, max_concurrent_executions=cap)
+
+    def test_load_gate_keeps_stickiness_until_the_worker_is_busy(self):
+        """The motivating case (#204): plain sticky() is either deterministic
+        (weight > 1 wins at any load) or defeated by a single execution
+        (weight < 1, because least() normalizes to a full 1.0 gap over two
+        workers). An absolute gate gives the middle posture."""
+        from flux.routing import when
+
+        a, b = _worker("a"), _worker("b")
+        policy = score(when(load() < 5, sticky(weight=3)), least(load()))
+
+        # One execution in flight: 'a' keeps its bonus.
+        assert pick_worker([a, b], policy, loads={"a": 1, "b": 0}, preferred="a") is a
+        # Past the gate: the bonus is gone and least(load()) decides.
+        assert pick_worker([a, b], policy, loads={"a": 6, "b": 0}, preferred="a") is b
+
+    def test_bare_sticky_cannot_express_that(self):
+        """Documents why the gate is needed rather than a weight tweak."""
+        a, b = _worker("a"), _worker("b")
+        loads = {"a": 6, "b": 0}
+
+        # Deterministic: wins even at load 6.
+        assert (
+            pick_worker([a, b], score(sticky(weight=3), least(load())), loads=loads, preferred="a")
+            is a
+        )
+        # Defeated by a single execution: 'a' at load 1 already loses.
+        assert (
+            pick_worker(
+                [a, b],
+                score(sticky(weight=0.5), least(load())),
+                loads={"a": 1, "b": 0},
+                preferred="a",
+            )
+            is b
+        )
+
+    def test_reversed_comparison(self):
+        from flux.routing import when
+
+        a, b = _worker("a"), _worker("b")
+        policy = score(when(5 > load(), sticky(weight=3)), least(load()))
+        assert pick_worker([a, b], policy, loads={"a": 1, "b": 0}, preferred="a") is a
+        assert pick_worker([a, b], policy, loads={"a": 6, "b": 0}, preferred="a") is b
+
+    def test_utilization_is_load_over_advertised_capacity(self):
+        """Same load, different capacity, opposite verdicts — which is the
+        whole point: an absolute count cannot tell these two apart."""
+        from flux.routing import utilization, when
+
+        other = self._capped("other", 32)
+        loads = {"preferred": 3, "other": 0}
+        policy = score(when(utilization() < 0.5, sticky(weight=3)), least(load()))
+
+        # 3 of 32 slots: still roomy, so the bonus holds and beats least(load).
+        roomy = self._capped("preferred", 32)
+        assert pick_worker([roomy, other], policy, loads=loads, preferred="preferred") is roomy
+
+        # The same 3 executions on a 4-slot worker: over the gate, bonus gone.
+        cramped = self._capped("preferred", 4)
+        assert pick_worker([cramped, other], policy, loads=loads, preferred="preferred") is other
+
+    def test_least_utilization_ranks_a_mixed_fleet_by_headroom(self):
+        from flux.routing import utilization
+
+        small = self._capped("small", 4)
+        big = self._capped("big", 32)
+        loads = {"small": 3, "big": 8}
+
+        # By count 'small' looks emptier; by headroom 'big' plainly is.
+        assert pick_worker([small, big], score(least(load())), loads=loads) is small
+        assert pick_worker([small, big], score(least(utilization())), loads=loads) is big
+
+    def test_unlimited_capacity_is_unknown_not_idle(self):
+        """A worker advertising no capacity must not read as 0% utilized, or
+        one legacy worker collects every preference in the fleet."""
+        from flux.routing import utilization, when
+
+        legacy = self._capped("legacy", None)
+        known = self._capped("known", 8)
+        policy = score(when(utilization() < 0.9, sticky(weight=3)), least(load()))
+
+        # 'legacy' carries the heavier load, so it wins only if it wrongly
+        # reads as 0% utilized and collects the bonus.
+        loads = {"legacy": 5, "known": 4}
+        assert pick_worker([legacy, known], policy, loads=loads, preferred="legacy") is known
+
+    def test_gating_a_require_term_is_rejected(self):
+        """Skipping a require term makes a worker match MORE easily, so a
+        load-gated hard constraint would drop its requirement on exactly the
+        busy workers it was meant to steer away from."""
+        from flux.routing import utilization, when
+
+        with pytest.raises(ValueError, match="score terms only"):
+            when(load() < 5, label("gpu") == "true")
+        with pytest.raises(ValueError, match="score terms only"):
+            when(utilization() < 0.5, label("gpu") == "true")
+
+    def test_worker_asserted_selectors_are_still_rejected(self):
+        from flux.routing import when
+
+        with pytest.raises(ValueError, match="not valid when"):
+            when(label("region") == "eu", sticky(weight=2))
+        with pytest.raises(ValueError, match="not valid when"):
+            when(resource("memory_available") > 1000, sticky(weight=2))
+
+    def test_condition_still_compares_against_a_constant(self):
+        from flux.routing import when
+
+        with pytest.raises(ValueError, match="constant"):
+            when(load() < input_ref("max"), sticky(weight=2))
+
+    def test_hand_written_require_metadata_fails_loudly(self):
+        """when() refuses to build one, so this shape only reaches the server
+        as hand-written metadata. It must diagnose as a terminal error rather
+        than match no worker and park the execution forever."""
+        from flux.routing import require_diagnostic, require_matches
+
+        terms = [
+            {
+                "kind": "when",
+                "if": {"selector": "load", "op": "<", "value": 5},
+                "then": {"kind": "match", "selector": "label:gpu", "op": "==", "value": "true"},
+            },
+        ]
+
+        assert require_diagnostic(terms, None) is not None
+        assert require_matches(terms, {"gpu": "true"}, None, loads={"w": 0}) is False

--- a/tests/flux/test_routing_catalog.py
+++ b/tests/flux/test_routing_catalog.py
@@ -244,3 +244,40 @@ async def routed(ctx):
             },
         },
     ]
+
+
+def test_load_and_utilization_when_conditions_extracted():
+    source = b"""
+from flux import workflow
+from flux.routing import score, sticky, least, when, load, utilization
+
+
+@workflow.with_options(
+    routing=score(
+        when(load() < 5, sticky(weight=3)),
+        when(utilization() < 0.8, sticky(weight=2)),
+        least(utilization()),
+    ),
+)
+async def routed(ctx):
+    return 1
+"""
+    routing = (_parse(source)[0].metadata or {})["routing"]
+
+    assert routing["terms"][0]["if"] == {"selector": "load", "op": "<", "value": 5}
+    assert routing["terms"][1]["if"] == {"selector": "utilization", "op": "<", "value": 0.8}
+    assert routing["terms"][2] == {"kind": "least", "selector": "utilization", "weight": 1.0}
+
+
+def test_load_gated_require_term_fails_registration():
+    source = b"""
+from flux import workflow
+from flux.routing import require, when, load, label
+
+
+@workflow.with_options(affinity=require(when(load() < 5, label("gpu") == "true")))
+async def routed(ctx):
+    return 1
+"""
+    with pytest.raises(SyntaxError, match="input\\(\\)/meta\\(\\)/metric\\(\\)"):
+        _parse(source)


### PR DESCRIPTION
Closes #204.

## The problem

`score(sticky(...), least(load()))` offers only two postures, and neither is "prefer this worker until it fills up".

`least()` normalizes each term 0–1 across the eligible set, so over two workers at loads `{1, 0}` the gap is exactly `1.0` — the largest value the term can take. A single in-flight execution therefore produces the maximum possible penalty:

| Policy | Behaviour |
|---|---|
| `sticky(weight=3)` | deterministic — the preferred worker wins at any load |
| `sticky(weight=0.5)` | defeated by one in-flight execution |

In a pool of one it is worse: `hi == lo`, so `least()` returns `0.5` for everyone and cannot discriminate at all.

## The change

`when()` already evaluates worker-state conditions per candidate to build `applies_to`, so allowing `load()` there expresses the missing posture with no new evaluation machinery:

```python
routing=score(
    when(load() < 5, sticky(weight=3)),   # stickiness, while there is room
    least(load()),                        # otherwise spread
)
```

Preferred over a `sticky(max_load=N)` parameter because it generalizes to `prefer()`/`least()`/`most()` instead of duplicating, sticky-only, a condition the DSL nearly expressed already.

### Why `load()` and not `label()`

`load()` is a `COUNT(*)` the server runs over its own execution table (`context_managers.py::_worker_load_map`). The worker never asserts it, so the self-dodge rationale that justifies rejecting `label()`/`resource()` in `when()` does not apply. Those stay rejected; the old error message lumped all three together and now explains the split by who computes the value.

### `utilization()`

`load()` is a count, so `load() < 5` means something different on a 4-slot worker than a 32-slot one — in a mixed fleet the threshold has to be tuned to the smallest, wasting the large ones. `utilization()` is `load() / max_concurrent_executions`, computed server-side from data already held (`WorkerInfo.max_concurrent_executions`, which `_has_free_slot` already trusts for the *hard* admission gate).

Capacity is worker-advertised, but this adds no attack surface: inflating it is the same lever a worker already has against `_has_free_slot`, the stricter consumer.

A worker advertising no capacity resolves to `None`, not `0.0`, so it does not match `utilization() < 0.8`. Reading it as idle would make one uncapped worker look permanently free and collect every preference in the fleet. This follows the existing convention (`_selector_value` returns `None` for absent values). The asymmetry against `_has_free_slot`, which fails *open* for unknown capacity, is deliberate: refusing to dispatch strands work, refusing to prefer costs only a preference.

### Score stage only

Skipping a `require` term makes a worker match *more* easily, so a load-gated hard constraint would drop its requirement on exactly the busy workers it was meant to steer away from. Rejected at registration by both `when()` and the affinity AST extractor, and diagnosed as a terminal dispatch error (rather than parking forever) if it arrives as hand-written metadata.

## Tests

`tests/flux/test_routing.py::TestWhenServerComputedLoad` — the motivating case, a test documenting why bare `sticky()` cannot express it, reversed comparisons, capacity resolution, `least(utilization())` ranking a mixed fleet by headroom, the unlimited-capacity case, and every rejection path. Plus AST round-trip and require-stage rejection in `test_routing_catalog.py`.

## Docs

`docs/advanced-features/dynamic-routing.md` gains a "Gating on load" section, the `utilization()` selector row, and a corrected `when()` bullet — the old one claimed the condition "reads execution input only, never worker attributes", which stopped being true when `meta()`/`metric()` conditions landed.

