### PR TITLE
feat(routing): bind an execution to one worker via X-Flux-Require-Worker

### DIFF
--- a/docs/advanced-features/authentication.md
+++ b/docs/advanced-features/authentication.md
@@ -405,6 +405,16 @@ flux principals revoke-key <subject> --key-name <name>
 | `POST` | `/workers/{name}/checkpoint/{id}` | `worker:*:*` |
 | `POST` | `/workers/{name}/progress/{id}` | `worker:*:*` |
 
+Binding an execution to a named worker with the `X-Flux-Require-Worker`
+header additionally requires `worker:{name}:target` on top of the workflow's
+run permission — it concentrates load on one node and compels that node to
+run the code, which running the workflow alone does not authorize. The grant
+is per worker, so `worker:build-7:target` does not permit binding to another.
+`worker:*:*` (held by the `worker` role, and by `admin` via `*`) satisfies it
+for any worker. The advisory `X-Flux-Preferred-Worker` needs no grant: it
+cannot force placement. See
+[Dynamic Routing](dynamic-routing.md#binding-an-execution-to-one-worker).
+
 ### Worker bootstrap token
 
 `POST /workers/register` is gated by a long-lived shared secret rather than the auth-service permission system. Resolution order on the server:

--- a/docs/advanced-features/dynamic-routing.md
+++ b/docs/advanced-features/dynamic-routing.md
@@ -280,8 +280,9 @@ curl -X POST localhost:8000/workflows/default/verify/run/async \
 
 | | `X-Flux-Preferred-Worker` | `X-Flux-Require-Worker` |
 |---|---|---|
-| Unavailable worker | falls back | parks, never falls back |
+| Busy or offline worker | falls back | parks, never falls back |
 | Invalid value | dropped | rejected (400) |
+| Unknown worker name | dropped | rejected (400) |
 | Permission | none beyond run | `worker:{name}:target` |
 
 It is a **header, not a policy term**, on purpose: `affinity=` is declared in
@@ -289,19 +290,35 @@ workflow source and fixed at registration, but "run *this* execution on
 worker-7" is decided per call. A `require()` term that applied only when a
 header happened to be present would not be a hard constraint at all.
 
-Sending both headers is a 400 — one is advisory and one binding, so honouring
-either silently would be an ambiguity the caller cannot see.
+If both headers are sent the binding wins and the hint is ignored — a binding
+leaves one eligible worker, so the hint has nothing left to order. (It is not
+an error because `FluxClient.for_current_execution()` attaches the hint
+automatically inside a running workflow, so rejecting would break the very
+case this feature exists for.)
 
-**It parks rather than falling back.** If the named worker is unknown,
-offline, or fails the workflow's own `affinity`/`requests`, the execution
-stays unclaimed. That is the existing no-match path, so it is bounded by the
-park TTL (`park_ttl`) and then failed terminally with a `ParkTimeoutError`
-naming the worker it was bound to. The failure is visible; a silent
-reassignment would not be.
+The name must belong to a worker that has registered at least once; an
+unknown name is a 400 rather than an execution that can only park. Binding to
+a **registered but currently offline** worker is fine and parks until it
+returns.
+
+**It parks rather than falling back.** If the named worker is offline or
+fails the workflow's own `affinity`/`requests`, the execution stays
+unclaimed. Whether that park ever ends is governed by `park_ttl`, which
+**defaults to `0` — park indefinitely**. Set a non-zero `[flux.workers]
+park_ttl` (or pass `?park_ttl=` per run) if you want a bound execution to
+fail terminally with a `ParkTimeoutError` naming the worker instead of
+waiting forever.
 
 Because the binding is a filter on the execution row rather than a score, it
 holds in **both** dispatch modes — unlike the advisory hint, which is
-event-mode only — and it is re-applied when a paused execution resumes.
+event-mode only — and it is re-applied when a paused execution resumes. It is
+enforced on the claim endpoint too, so a worker cannot take a bound execution
+by claiming it directly.
+
+One gap to know about: if a bound execution is paused and its worker is then
+evicted, it waits in `RESUMING` for that worker to come back, and the
+park-TTL sweep does not cover that state (it sweeps unclaimed executions
+only). Such a row waits indefinitely rather than failing.
 
 The workflow's own constraints still apply on top: the named worker must also
 satisfy `affinity=`/`requests`. A `routing=score(...)` policy then ranks a

--- a/docs/advanced-features/dynamic-routing.md
+++ b/docs/advanced-features/dynamic-routing.md
@@ -262,3 +262,52 @@ prefer that worker when eligible — keeping mesh hops on warm module caches.
 A workflow **with** a policy takes full ownership of the score stage;
 include `sticky(weight=...)` to blend the hint into your ranking, or omit
 it to override the hint entirely.
+
+## Binding an execution to one worker
+
+The hint above is advisory: dispatch silently places the execution elsewhere
+when the named worker is busy or gone. That is wrong whenever the execution
+is a check *on* a worker — verification, an A/B against one instance,
+reproducing a fault on a suspect node — because falling back is
+indistinguishable from success at the client.
+
+`X-Flux-Require-Worker` is the binding counterpart:
+
+```bash
+curl -X POST localhost:8000/workflows/default/verify/run/async \
+     -H "X-Flux-Require-Worker: worker-7"
+```
+
+| | `X-Flux-Preferred-Worker` | `X-Flux-Require-Worker` |
+|---|---|---|
+| Unavailable worker | falls back | parks, never falls back |
+| Invalid value | dropped | rejected (400) |
+| Permission | none beyond run | `worker:{name}:target` |
+
+It is a **header, not a policy term**, on purpose: `affinity=` is declared in
+workflow source and fixed at registration, but "run *this* execution on
+worker-7" is decided per call. A `require()` term that applied only when a
+header happened to be present would not be a hard constraint at all.
+
+Sending both headers is a 400 — one is advisory and one binding, so honouring
+either silently would be an ambiguity the caller cannot see.
+
+**It parks rather than falling back.** If the named worker is unknown,
+offline, or fails the workflow's own `affinity`/`requests`, the execution
+stays unclaimed. That is the existing no-match path, so it is bounded by the
+park TTL (`park_ttl`) and then failed terminally with a `ParkTimeoutError`
+naming the worker it was bound to. The failure is visible; a silent
+reassignment would not be.
+
+Because the binding is a filter on the execution row rather than a score, it
+holds in **both** dispatch modes — unlike the advisory hint, which is
+event-mode only — and it is re-applied when a paused execution resumes.
+
+The workflow's own constraints still apply on top: the named worker must also
+satisfy `affinity=`/`requests`. A `routing=score(...)` policy then ranks a
+single survivor, so `sticky()` alongside a binding header is redundant rather
+than contradictory.
+
+The directive never reaches the worker. It arrives as a header, lives on the
+execution row, and is absent from the context serialized to the worker — so a
+workflow that checks a worker cannot tip it off, which is the point.

--- a/flux/api/workflow_routes.py
+++ b/flux/api/workflow_routes.py
@@ -237,18 +237,6 @@ class WorkflowRoutesMixin:
                             },
                         )
 
-                # Checked on the raw headers: one is advisory and one binding,
-                # so silently honouring either is an ambiguity the caller
-                # cannot see. Rejecting is the only unsurprising answer.
-                if preferred_worker is not None and required_worker is not None:
-                    raise HTTPException(
-                        status_code=400,
-                        detail=(
-                            "X-Flux-Preferred-Worker and X-Flux-Require-Worker are "
-                            "mutually exclusive (advisory vs binding)"
-                        ),
-                    )
-
                 # The sticky-routing hint is caller-supplied header input:
                 # bound and sanitize before it reaches the database. Invalid
                 # values are dropped, not rejected — it is only a hint.
@@ -280,6 +268,27 @@ class WorkflowRoutesMixin:
                                 status_code=403,
                                 detail=f"Permission denied: requires '{needed}'",
                             )
+                    # Registered, not necessarily online: binding to a worker
+                    # that is currently down is legitimate (it parks until the
+                    # worker returns), but a name no worker ever had can only
+                    # park forever, and park_ttl defaults to no bound.
+                    from flux.worker_registry import WorkerRegistry
+
+                    try:
+                        WorkerRegistry.create().get(required_worker)
+                    except WorkerNotFoundError:
+                        raise HTTPException(
+                            status_code=400,
+                            detail=(
+                                f"X-Flux-Require-Worker names an unknown worker "
+                                f"'{required_worker}'; it has never registered"
+                            ),
+                        )
+                    # A binding leaves one eligible worker, so the hint has
+                    # nothing to order. Dropped rather than rejected because
+                    # FluxClient.for_current_execution() injects it as a
+                    # client-level default.
+                    preferred_worker = None
 
                 # Per-run park-TTL override (issue #157): bounds how long this
                 # execution may wait unclaimed. None defers to the server

--- a/flux/api/workflow_routes.py
+++ b/flux/api/workflow_routes.py
@@ -201,6 +201,7 @@ class WorkflowRoutesMixin:
             version: int | None = None,
             park_ttl: int | None = None,
             preferred_worker: str | None = Header(None, alias="X-Flux-Preferred-Worker"),
+            required_worker: str | None = Header(None, alias="X-Flux-Require-Worker"),
             identity: FluxIdentity = Depends(get_identity),
         ):
             try:
@@ -236,6 +237,18 @@ class WorkflowRoutesMixin:
                             },
                         )
 
+                # Checked on the raw headers: one is advisory and one binding,
+                # so silently honouring either is an ambiguity the caller
+                # cannot see. Rejecting is the only unsurprising answer.
+                if preferred_worker is not None and required_worker is not None:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=(
+                            "X-Flux-Preferred-Worker and X-Flux-Require-Worker are "
+                            "mutually exclusive (advisory vs binding)"
+                        ),
+                    )
+
                 # The sticky-routing hint is caller-supplied header input:
                 # bound and sanitize before it reaches the database. Invalid
                 # values are dropped, not rejected — it is only a hint.
@@ -243,6 +256,30 @@ class WorkflowRoutesMixin:
                     preferred_worker = preferred_worker.strip()
                     if not preferred_worker or len(preferred_worker) > 256:
                         preferred_worker = None
+
+                # The binding header takes the opposite policy (issue #187):
+                # dropping a malformed value would dispatch the execution
+                # anywhere, which is indistinguishable from having honoured it.
+                if required_worker is not None:
+                    required_worker = required_worker.strip()
+                    if not required_worker or len(required_worker) > 256:
+                        raise HTTPException(
+                            status_code=400,
+                            detail=(
+                                "X-Flux-Require-Worker must be a non-empty worker name "
+                                "of at most 256 characters"
+                            ),
+                        )
+                    # Pinning work to a named node concentrates load there and
+                    # compels that node to run the code, so it needs a
+                    # worker-scoped grant on top of the run permission.
+                    if auth_service is not None and auth_config.enabled:
+                        needed = f"worker:{required_worker}:target"
+                        if not await auth_service.is_authorized(identity, needed):
+                            raise HTTPException(
+                                status_code=403,
+                                detail=f"Permission denied: requires '{needed}'",
+                            )
 
                 # Per-run park-TTL override (issue #157): bounds how long this
                 # execution may wait unclaimed. None defers to the server
@@ -259,6 +296,7 @@ class WorkflowRoutesMixin:
                     input,
                     version,
                     preferred_worker=preferred_worker,
+                    required_worker=required_worker,
                     park_ttl=park_ttl,
                 )
                 manager = ContextManager.create()

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -1042,8 +1042,11 @@ class DatabaseContextManager(ContextManager):
                     w
                     for w in workers
                     if self._has_free_slot(w, loads)
-                    and self._worker_matches_workflow(w, workflow, model.input)
+                    # Name check before the matcher: a bound execution has at
+                    # most one candidate, so evaluating affinity/requests for
+                    # the rest of the fleet is work whose result is discarded.
                     and (not model.required_worker or w.name == model.required_worker)
+                    and self._worker_matches_workflow(w, workflow, model.input)
                 ]
                 if not eligible:
                     continue
@@ -1164,8 +1167,8 @@ class DatabaseContextManager(ContextManager):
                         w
                         for w in workers
                         if self._has_free_slot(w, loads)
-                        and self._worker_matches_workflow(w, workflow, model.input)
                         and (not model.required_worker or w.name == model.required_worker)
+                        and self._worker_matches_workflow(w, workflow, model.input)
                     ]
                     if not eligible:
                         continue

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -70,6 +70,7 @@ class ContextManager(ABC):
         *,
         uow: UnitOfWork | None = None,
         preferred_worker: str | None = None,
+        required_worker: str | None = None,
         park_ttl: int | None = None,
     ) -> ExecutionContext:  # pragma: no cover
         raise NotImplementedError()
@@ -81,6 +82,7 @@ class ContextManager(ABC):
         *,
         uow: UnitOfWork | None = None,
         preferred_worker: str | None = None,
+        required_worker: str | None = None,
         park_ttl: int | None = None,
     ) -> bool:  # pragma: no cover
         """Like ``save`` but report whether the state write was applied.
@@ -349,9 +351,16 @@ class DatabaseContextManager(ContextManager):
         *,
         uow: UnitOfWork | None = None,
         preferred_worker: str | None = None,
+        required_worker: str | None = None,
         park_ttl: int | None = None,
     ) -> ExecutionContext:
-        self.save_checked(ctx, uow=uow, preferred_worker=preferred_worker, park_ttl=park_ttl)
+        self.save_checked(
+            ctx,
+            uow=uow,
+            preferred_worker=preferred_worker,
+            required_worker=required_worker,
+            park_ttl=park_ttl,
+        )
         return ctx
 
     def save_checked(
@@ -360,6 +369,7 @@ class DatabaseContextManager(ContextManager):
         *,
         uow: UnitOfWork | None = None,
         preferred_worker: str | None = None,
+        required_worker: str | None = None,
         park_ttl: int | None = None,
     ) -> bool:
         if uow is not None:
@@ -368,6 +378,7 @@ class DatabaseContextManager(ContextManager):
                 uow.session,
                 manage_transaction=False,
                 preferred_worker=preferred_worker,
+                required_worker=required_worker,
                 park_ttl=park_ttl,
             )
         with self.session() as session:
@@ -376,6 +387,7 @@ class DatabaseContextManager(ContextManager):
                 session,
                 manage_transaction=True,
                 preferred_worker=preferred_worker,
+                required_worker=required_worker,
                 park_ttl=park_ttl,
             )
 
@@ -386,6 +398,7 @@ class DatabaseContextManager(ContextManager):
         *,
         manage_transaction: bool,
         preferred_worker: str | None = None,
+        required_worker: str | None = None,
         park_ttl: int | None = None,
     ) -> bool:
         try:
@@ -406,6 +419,8 @@ class DatabaseContextManager(ContextManager):
                     # pick a fresh row up immediately, so a hint written in a
                     # follow-up UPDATE could be missed.
                     new_model.preferred_worker = preferred_worker
+                if required_worker:
+                    new_model.required_worker = required_worker
                 # Park TTL (issue #157): per-run override wins; otherwise the
                 # config default. 0 / unset means park indefinitely (NULL).
                 # int() + fallback: a mocked/partial Configuration (common in
@@ -554,6 +569,10 @@ class DatabaseContextManager(ContextManager):
             )
             for model, workflow in query:
                 constraints: list[str] = []
+                if model.required_worker:
+                    # Named first: it is the likeliest single cause, and the
+                    # caller who set the header cannot see it any other way.
+                    constraints.append(f"bound to worker '{model.required_worker}'")
                 if workflow.affinity:
                     constraints.append(f"affinity={workflow.affinity!r}")
                 if workflow.requests:
@@ -691,6 +710,21 @@ class DatabaseContextManager(ContextManager):
                 )
         return resumed
 
+    @staticmethod
+    def _required_worker_clause(worker: WorkerInfo):
+        """SQL filter honouring a bound execution (X-Flux-Require-Worker).
+
+        Applied in the query rather than the per-row matcher because the
+        unconstrained branch below never runs one: it selects on the workflow
+        having no requests/affinity/metadata and takes the first row, so a
+        bound execution of an unconstrained workflow would otherwise be handed
+        to whichever worker polled first.
+        """
+        return or_(
+            ExecutionContextModel.required_worker.is_(None),
+            ExecutionContextModel.required_worker == worker.name,
+        )
+
     def _next_matching_execution(
         self,
         worker: WorkerInfo,
@@ -702,6 +736,7 @@ class DatabaseContextManager(ContextManager):
             session.query(ExecutionContextModel, WorkflowModel)
             .join(WorkflowModel)
             .filter(ExecutionContextModel.state == state)
+            .filter(self._required_worker_clause(worker))
             .with_for_update(skip_locked=True)
         )
 
@@ -849,6 +884,7 @@ class DatabaseContextManager(ContextManager):
                     .filter(
                         ExecutionContextModel.state == ExecutionState.RESUMING,
                         ExecutionContextModel.worker_name.is_(None),
+                        self._required_worker_clause(worker),
                     )
                     .with_for_update(skip_locked=True)
                 )
@@ -1007,6 +1043,7 @@ class DatabaseContextManager(ContextManager):
                     for w in workers
                     if self._has_free_slot(w, loads)
                     and self._worker_matches_workflow(w, workflow, model.input)
+                    and (not model.required_worker or w.name == model.required_worker)
                 ]
                 if not eligible:
                     continue
@@ -1128,6 +1165,7 @@ class DatabaseContextManager(ContextManager):
                         for w in workers
                         if self._has_free_slot(w, loads)
                         and self._worker_matches_workflow(w, workflow, model.input)
+                        and (not model.required_worker or w.name == model.required_worker)
                     ]
                     if not eligible:
                         continue

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -711,15 +711,21 @@ class DatabaseContextManager(ContextManager):
         return resumed
 
     @staticmethod
-    def _required_worker_clause(worker: WorkerInfo):
-        """SQL filter honouring a bound execution (X-Flux-Require-Worker).
+    def _has_bound_work(session: Session, worker: WorkerInfo) -> bool:
+        return session.query(
+            session.query(ExecutionContextModel)
+            .filter(
+                ExecutionContextModel.state == ExecutionState.CREATED,
+                ExecutionContextModel.required_worker == worker.name,
+            )
+            .exists(),
+        ).scalar()
 
-        Applied in the query rather than the per-row matcher because the
-        unconstrained branch below never runs one: it selects on the workflow
-        having no requests/affinity/metadata and takes the first row, so a
-        bound execution of an unconstrained workflow would otherwise be handed
-        to whichever worker polled first.
-        """
+    @staticmethod
+    def _required_worker_clause(worker: WorkerInfo):
+        """SQL rather than the per-row matcher: the unconstrained branch below
+        never runs one, so a bound execution of an unconstrained workflow would
+        go to whichever worker polled first."""
         return or_(
             ExecutionContextModel.required_worker.is_(None),
             ExecutionContextModel.required_worker == worker.name,
@@ -777,7 +783,13 @@ class DatabaseContextManager(ContextManager):
 
     def next_execution(self, worker: WorkerInfo) -> ExecutionContext | None:
         with self.session() as session:
-            if not self._is_least_loaded_worker(worker, session):
+            # The load gate spreads work; bound work cannot be spread, so
+            # letting it gate a binding parks an execution whose worker is
+            # online and free just because a peer is emptier.
+            if not self._is_least_loaded_worker(worker, session) and not self._has_bound_work(
+                session,
+                worker,
+            ):
                 return None
 
             self._refresh_worker_metadata(session, [worker])
@@ -1042,9 +1054,8 @@ class DatabaseContextManager(ContextManager):
                     w
                     for w in workers
                     if self._has_free_slot(w, loads)
-                    # Name check before the matcher: a bound execution has at
-                    # most one candidate, so evaluating affinity/requests for
-                    # the rest of the fleet is work whose result is discarded.
+                    # Before the matcher: a bound execution has one candidate,
+                    # so matching the rest of the fleet is discarded work.
                     and (not model.required_worker or w.name == model.required_worker)
                     and self._worker_matches_workflow(w, workflow, model.input)
                 ]
@@ -1210,6 +1221,16 @@ class DatabaseContextManager(ContextManager):
                     message=(
                         f"Cannot claim execution {execution_id}: scheduled to "
                         f"'{model.worker_name}', not '{worker.name}'"
+                    ),
+                )
+            # The dispatch queries filter on the binding, but any registered
+            # worker can POST here and the fallback above accepts a CREATED
+            # row — exactly where a bound execution waits.
+            if model.required_worker and model.required_worker != worker.name:
+                raise ExecutionError(
+                    message=(
+                        f"Cannot claim execution {execution_id}: bound to "
+                        f"'{model.required_worker}', not '{worker.name}'"
                     ),
                 )
             ctx = model.to_plain()

--- a/flux/migrations/versions/0022_execution_required_worker.py
+++ b/flux/migrations/versions/0022_execution_required_worker.py
@@ -1,0 +1,44 @@
+"""Add executions.required_worker: bind an execution to one worker.
+
+``preferred_worker`` is a hint the scorer may ignore, which is the wrong
+shape when the execution is a check *on* a worker (verification, an A/B
+against one instance, reproducing a fault). Falling back to another worker
+there is indistinguishable from success at the client, so the binding needs
+its own column rather than a mode on the hint.
+
+Nullable with no backfill: NULL means unbound, which is how every execution
+before this revision behaves.
+
+Revision ID: 0022_execution_required_worker
+Revises: 0021_join_token_subject
+Create Date: 2026-08-11
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0022_execution_required_worker"
+down_revision: str | None = "0021_join_token_subject"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "executions"
+_COLUMN = "required_worker"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    if _COLUMN not in existing:
+        op.add_column(_TABLE, sa.Column(_COLUMN, sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    if _COLUMN in existing:
+        op.drop_column(_TABLE, _COLUMN)

--- a/flux/models.py
+++ b/flux/models.py
@@ -637,11 +637,9 @@ class ExecutionContextModel(Base):
     # connected, healthy, has capacity, and matches — module cache locality
     # for mesh hops. A hint, never a constraint.
     preferred_worker = Column(String, nullable=True)
-    # Binding counterpart (X-Flux-Require-Worker): dispatch may place this
-    # execution on this worker or nowhere. Never falls back — an execution
-    # that checks a worker cannot silently run somewhere else, since the
-    # caller could not tell that from success. Unsatisfiable means it parks
-    # and the park-TTL sweep fails it with a reason.
+    # Binding counterpart (X-Flux-Require-Worker): this worker or nowhere.
+    # Never falls back — from outside, a fallback is indistinguishable from
+    # the binding having been honoured. Unsatisfiable parks.
     required_worker = Column(String, nullable=True)
     scheduling_subject = Column(String, nullable=True)
     scheduling_principal_issuer = Column(String, nullable=True)

--- a/flux/models.py
+++ b/flux/models.py
@@ -637,6 +637,12 @@ class ExecutionContextModel(Base):
     # connected, healthy, has capacity, and matches — module cache locality
     # for mesh hops. A hint, never a constraint.
     preferred_worker = Column(String, nullable=True)
+    # Binding counterpart (X-Flux-Require-Worker): dispatch may place this
+    # execution on this worker or nowhere. Never falls back — an execution
+    # that checks a worker cannot silently run somewhere else, since the
+    # caller could not tell that from success. Unsatisfiable means it parks
+    # and the park-TTL sweep fails it with a reason.
+    required_worker = Column(String, nullable=True)
     scheduling_subject = Column(String, nullable=True)
     scheduling_principal_issuer = Column(String, nullable=True)
     # Set when the execution was dispatched by a schedule; lets schedule

--- a/flux/server.py
+++ b/flux/server.py
@@ -486,6 +486,7 @@ class Server(
         input_data: Any = None,
         version: int | None = None,
         preferred_worker: str | None = None,
+        required_worker: str | None = None,
         park_ttl: int | None = None,
     ) -> ExecutionContext:
         workflow = WorkflowCatalog.create().get(namespace, workflow_name, version)
@@ -503,6 +504,7 @@ class Server(
                 requests=workflow.requests,
             ),
             preferred_worker=preferred_worker or None,
+            required_worker=required_worker or None,
             park_ttl=park_ttl,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.78.1"
+version = "0.79.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_dispatch_batch.py
+++ b/tests/flux/test_dispatch_batch.py
@@ -525,3 +525,99 @@ def test_batch_pairs_require_floor_with_dynamic_prefer(clean_env):
 
     assignments = cm.next_executions_batch([warm, cold, other], limit=10)
     assert [(c.execution_id, w) for c, w in assignments] == [(ctx.execution_id, "warm")]
+
+
+class TestRequiredWorkerBinding:
+    """X-Flux-Require-Worker (issue #187): the execution runs on the named
+    worker or nowhere. Falling back is the failure the binding exists to
+    prevent — from outside it is indistinguishable from having been honoured.
+    """
+
+    def _bind(self, execution_id, worker_name):
+        repo = RepositoryFactory.create_repository()
+        with repo.session() as session:
+            session.get(ExecutionContextModel, execution_id).required_worker = worker_name
+            session.commit()
+
+    def test_batch_dispatches_only_to_the_bound_worker(self, clean_env):
+        cm, registry = clean_env
+        w1 = _register_worker(registry, "w1")
+        w2 = _register_worker(registry, "w2")
+        wf_id = _create_workflow("plain")
+        ctx = _create_execution(cm, wf_id, name="plain")
+        self._bind(ctx.execution_id, "w2")
+
+        assignments = cm.next_executions_batch([w1, w2], limit=10)
+
+        assert [name for _, name in assignments] == ["w2"]
+
+    def test_batch_parks_rather_than_falling_back(self, clean_env):
+        """The bound worker is absent from the fleet: nothing is dispatched
+        and the row stays CREATED for the park-TTL sweep to fail loudly."""
+        cm, registry = clean_env
+        w1 = _register_worker(registry, "w1")
+        wf_id = _create_workflow("plain")
+        ctx = _create_execution(cm, wf_id, name="plain")
+        self._bind(ctx.execution_id, "absent-worker")
+
+        assert cm.next_executions_batch([w1], limit=10) == []
+        assert _states(cm)[ctx.execution_id][0] == ExecutionState.CREATED
+
+    def test_poll_mode_honours_the_binding_on_an_unconstrained_workflow(self, clean_env):
+        """The regression this guards: poll mode's unconstrained branch selects
+        on the *workflow* having no affinity/requests/metadata and takes the
+        first row, so without a row-level filter a bound execution would go to
+        whichever worker polled first."""
+        cm, registry = clean_env
+        w1 = _register_worker(registry, "w1")
+        w2 = _register_worker(registry, "w2")
+        wf_id = _create_workflow("plain")
+        ctx = _create_execution(cm, wf_id, name="plain")
+        self._bind(ctx.execution_id, "w2")
+
+        assert cm.next_execution(w1) is None
+        claimed = cm.next_execution(w2)
+        assert claimed is not None and claimed.execution_id == ctx.execution_id
+
+    def test_unbound_executions_are_unaffected(self, clean_env):
+        cm, registry = clean_env
+        w1 = _register_worker(registry, "w1")
+        wf_id = _create_workflow("plain")
+        ctx = _create_execution(cm, wf_id, name="plain")
+
+        assert [name for _, name in cm.next_executions_batch([w1], limit=10)] == ["w1"]
+        assert _states(cm)[ctx.execution_id][0] == ExecutionState.SCHEDULED
+
+    def test_resume_batch_honours_the_binding(self, clean_env):
+        """A binding honoured only on first dispatch is a hole: a paused
+        execution must not resume somewhere else."""
+        cm, registry = clean_env
+        w1 = _register_worker(registry, "w1")
+        w2 = _register_worker(registry, "w2")
+        wf_id = _create_workflow("plain")
+        ctx = _create_execution(cm, wf_id, name="plain")
+        self._bind(ctx.execution_id, "w2")
+        _force_state(ctx.execution_id, ExecutionState.RESUMING, worker_name=None)
+
+        assignments = cm.next_resumes_batch([w1, w2], limit=10)
+
+        assert [name for _, name in assignments] == ["w2"]
+
+    def test_park_diagnostic_names_the_bound_worker(self, clean_env):
+        from datetime import datetime, timedelta, timezone
+
+        cm, registry = clean_env
+        wf_id = _create_workflow("plain")
+        ctx = _create_execution(cm, wf_id, name="plain")
+        self._bind(ctx.execution_id, "absent-worker")
+        repo = RepositoryFactory.create_repository()
+        with repo.session() as session:
+            model = session.get(ExecutionContextModel, ctx.execution_id)
+            model.park_deadline = datetime.now(timezone.utc) - timedelta(seconds=1)
+            session.commit()
+
+        assert cm.fail_expired_parked() == [ctx.execution_id]
+
+        loaded = cm.get(ctx.execution_id)
+        assert loaded.has_failed
+        assert "absent-worker" in str(loaded.output)

--- a/tests/flux/test_dispatch_batch.py
+++ b/tests/flux/test_dispatch_batch.py
@@ -621,3 +621,56 @@ class TestRequiredWorkerBinding:
         loaded = cm.get(ctx.execution_id)
         assert loaded.has_failed
         assert "absent-worker" in str(loaded.output)
+
+    def test_claim_refuses_a_worker_the_execution_is_not_bound_to(self, clean_env):
+        """The dispatch queries filter on the binding, but /workers/{name}/claim
+        is reachable by any registered worker and its fallback accepts a CREATED
+        row — the state a bound execution waits in. Without this check the
+        binding is advisory: a worker claims what it was not given."""
+        from flux.errors import ExecutionError
+
+        cm, registry = clean_env
+        w1 = _register_worker(registry, "w1")
+        _register_worker(registry, "w2")
+        wf_id = _create_workflow("plain")
+        ctx = _create_execution(cm, wf_id, name="plain")
+        self._bind(ctx.execution_id, "w2")
+
+        with pytest.raises(ExecutionError, match="bound to 'w2'"):
+            cm.claim(ctx.execution_id, w1)
+
+        assert _states(cm)[ctx.execution_id][0] == ExecutionState.CREATED
+
+    def test_claim_allows_the_bound_worker(self, clean_env):
+        cm, registry = clean_env
+        w2 = _register_worker(registry, "w2")
+        wf_id = _create_workflow("plain")
+        ctx = _create_execution(cm, wf_id, name="plain")
+        self._bind(ctx.execution_id, "w2")
+
+        claimed = cm.claim(ctx.execution_id, w2)
+
+        assert claimed.state == ExecutionState.CLAIMED
+
+    def test_load_gate_does_not_block_a_binding(self, clean_env):
+        """Poll mode is the default. The least-loaded gate spreads work, but
+        bound work cannot be spread — without a bypass the execution parks
+        while its worker is online and has capacity, purely because a peer
+        happens to be emptier."""
+        cm, registry = clean_env
+        w1 = _register_worker(registry, "w1")
+        w2 = _register_worker(registry, "w2")
+        wf_id = _create_workflow("plain")
+
+        # Make w2 the busier worker so the load gate would reject it.
+        for _ in range(3):
+            busy = _create_execution(cm, wf_id, name="plain")
+            _force_state(busy.execution_id, ExecutionState.RUNNING, worker_name="w2")
+
+        ctx = _create_execution(cm, wf_id, name="plain")
+        self._bind(ctx.execution_id, "w2")
+
+        claimed = cm.next_execution(w2)
+
+        assert claimed is not None and claimed.execution_id == ctx.execution_id
+        assert cm.next_execution(w1) is None

--- a/tests/flux/test_migrations.py
+++ b/tests/flux/test_migrations.py
@@ -13,7 +13,7 @@ import flux.security.models  # noqa: F401
 from flux.migrations.runner import current_revision, run_migrations
 from flux.models import Base
 
-HEAD = "0021_join_token_subject"
+HEAD = "0022_execution_required_worker"
 BASELINE = "0001_baseline"
 
 # A representative index added after the original create_all schema, used to

--- a/tests/flux/test_migrations_postgresql.py
+++ b/tests/flux/test_migrations_postgresql.py
@@ -30,7 +30,7 @@ pytestmark = [
     ),
 ]
 
-HEAD = "0021_join_token_subject"
+HEAD = "0022_execution_required_worker"
 _BACKFILL_INDEX = "ix_executions_workflow_id"
 
 

--- a/tests/flux/test_sticky_header_routes.py
+++ b/tests/flux/test_sticky_header_routes.py
@@ -93,3 +93,66 @@ def test_boundary_length_hint_is_kept(client):
 def test_absent_header_leaves_no_hint(client):
     execution_id = _run_with_header(client, None)
     assert _preferred_worker(execution_id) is None
+
+
+class TestRequireWorkerHeader:
+    """X-Flux-Require-Worker (issue #187) is the binding counterpart, and
+    takes the opposite validation policy: the hint drops a bad value, the
+    constraint must reject it. Dropping would dispatch the execution anywhere,
+    which the caller cannot distinguish from the binding being honoured.
+    """
+
+    def _run(self, client, value=None, preferred=None):
+        headers = {}
+        if value is not None:
+            headers["X-Flux-Require-Worker"] = value
+        if preferred is not None:
+            headers["X-Flux-Preferred-Worker"] = preferred
+        return client.post(
+            "/workflows/default/sticky_probe/run/async",
+            json=None,
+            headers=headers,
+        )
+
+    def _required_worker(self, execution_id):
+        from flux.models import ExecutionContextModel, RepositoryFactory
+
+        repo = RepositoryFactory.create_repository()
+        with repo.session() as session:
+            return session.get(ExecutionContextModel, execution_id).required_worker
+
+    def test_valid_binding_is_persisted(self, client):
+        resp = self._run(client, "worker-1")
+        assert resp.status_code == 200, resp.text
+        assert self._required_worker(resp.json()["execution_id"]) == "worker-1"
+
+    def test_binding_is_trimmed(self, client):
+        resp = self._run(client, "  worker-1  ")
+        assert self._required_worker(resp.json()["execution_id"]) == "worker-1"
+
+    @pytest.mark.parametrize("bad", ["   ", "w" * 257])
+    def test_invalid_binding_is_rejected_not_dropped(self, client, bad):
+        resp = self._run(client, bad)
+        assert resp.status_code == 400
+        assert "X-Flux-Require-Worker" in resp.text
+
+    def test_boundary_length_is_accepted(self, client):
+        resp = self._run(client, "w" * 256)
+        assert resp.status_code == 200
+        assert self._required_worker(resp.json()["execution_id"]) == "w" * 256
+
+    def test_both_headers_is_rejected(self, client):
+        resp = self._run(client, "worker-1", preferred="worker-2")
+        assert resp.status_code == 400
+        assert "mutually exclusive" in resp.text
+
+    def test_both_headers_rejected_even_when_the_hint_is_invalid(self, client):
+        """Checked on the raw headers: sanitizing the hint to None first would
+        hide that the caller sent two contradictory directives."""
+        resp = self._run(client, "worker-1", preferred="   ")
+        assert resp.status_code == 400
+        assert "mutually exclusive" in resp.text
+
+    def test_absent_header_leaves_no_binding(self, client):
+        resp = self._run(client)
+        assert self._required_worker(resp.json()["execution_id"]) is None

--- a/tests/flux/test_sticky_header_routes.py
+++ b/tests/flux/test_sticky_header_routes.py
@@ -42,6 +42,30 @@ def client(tmp_path):
     DatabaseRepository._engines.clear()
 
 
+def _register_worker(name: str) -> None:
+    """A binding is rejected for a name no worker ever registered."""
+    from flux.worker_registry import (
+        WorkerRegistry,
+        WorkerResourcesInfo,
+        WorkerRuntimeInfo,
+    )
+
+    WorkerRegistry.create().register(
+        name=name,
+        runtime=WorkerRuntimeInfo(os_name="Linux", os_version="6.0", python_version="3.12.0"),
+        packages=[],
+        resources=WorkerResourcesInfo(
+            cpu_total=1,
+            cpu_available=1,
+            memory_total=1_000_000,
+            memory_available=1_000_000,
+            disk_total=1_000_000,
+            disk_free=1_000_000,
+            gpus=[],
+        ),
+    )
+
+
 def _run_with_header(client, header_value: str | None) -> str:
     headers = {}
     if header_value is not None:
@@ -102,9 +126,11 @@ class TestRequireWorkerHeader:
     which the caller cannot distinguish from the binding being honoured.
     """
 
-    def _run(self, client, value=None, preferred=None):
+    def _run(self, client, value=None, preferred=None, register=True):
         headers = {}
         if value is not None:
+            if register and value.strip():
+                _register_worker(value.strip())
             headers["X-Flux-Require-Worker"] = value
         if preferred is not None:
             headers["X-Flux-Preferred-Worker"] = preferred
@@ -141,18 +167,34 @@ class TestRequireWorkerHeader:
         assert resp.status_code == 200
         assert self._required_worker(resp.json()["execution_id"]) == "w" * 256
 
-    def test_both_headers_is_rejected(self, client):
+    def test_binding_supersedes_the_hint(self, client):
+        """Not a 400: FluxClient.for_current_execution() injects the hint as a
+        client-level default, so an in-workflow caller adding a binding would
+        be rejected for a header it never set. The binding leaves one eligible
+        worker anyway, so the hint has nothing left to order."""
         resp = self._run(client, "worker-1", preferred="worker-2")
-        assert resp.status_code == 400
-        assert "mutually exclusive" in resp.text
 
-    def test_both_headers_rejected_even_when_the_hint_is_invalid(self, client):
-        """Checked on the raw headers: sanitizing the hint to None first would
-        hide that the caller sent two contradictory directives."""
-        resp = self._run(client, "worker-1", preferred="   ")
-        assert resp.status_code == 400
-        assert "mutually exclusive" in resp.text
+        assert resp.status_code == 200, resp.text
+        execution_id = resp.json()["execution_id"]
+        assert self._required_worker(execution_id) == "worker-1"
+        assert _preferred_worker(execution_id) is None
 
     def test_absent_header_leaves_no_binding(self, client):
         resp = self._run(client)
         assert self._required_worker(resp.json()["execution_id"]) is None
+
+    def test_unknown_worker_is_rejected(self, client):
+        """A name no worker ever had can only park forever, and park_ttl
+        defaults to no bound — so it fails at submission instead."""
+        resp = self._run(client, "never-registered", register=False)
+
+        assert resp.status_code == 400
+        assert "unknown worker" in resp.text
+
+    def test_registered_but_offline_worker_is_accepted(self, client):
+        """Binding to a worker that is currently down is legitimate: it parks
+        until that worker returns. Only an unknown name is refused."""
+        _register_worker("offline-1")
+        resp = self._run(client, "offline-1", register=False)
+
+        assert resp.status_code == 200, resp.text

--- a/tests/security/test_require_worker_authz.py
+++ b/tests/security/test_require_worker_authz.py
@@ -102,6 +102,29 @@ def _auth_as(identity: FluxIdentity):
         settings.security.auth.api_keys.enabled = original_api_keys
 
 
+def _register_worker(name: str) -> None:
+    from flux.worker_registry import (
+        WorkerRegistry,
+        WorkerResourcesInfo,
+        WorkerRuntimeInfo,
+    )
+
+    WorkerRegistry.create().register(
+        name=name,
+        runtime=WorkerRuntimeInfo(os_name="Linux", os_version="6.0", python_version="3.12.0"),
+        packages=[],
+        resources=WorkerResourcesInfo(
+            cpu_total=1,
+            cpu_available=1,
+            memory_total=1_000_000,
+            memory_available=1_000_000,
+            disk_total=1_000_000,
+            disk_free=1_000_000,
+            gpus=[],
+        ),
+    )
+
+
 def _run(client, headers_extra):
     return client.post(
         "/workflows/default/bind_probe/run/async",
@@ -131,6 +154,7 @@ def test_run_permission_alone_cannot_bind(client):
 
 def test_worker_scoped_grant_allows_binding(client):
     identity = _identity_with([*RUN_PERMS, "worker:w1:target"])
+    _register_worker("w1")
 
     with _auth_as(identity):
         resp = _run(client, {"X-Flux-Require-Worker": "w1"})
@@ -153,6 +177,7 @@ def test_worker_wildcard_satisfies_the_binding(client):
     """The built-in worker role holds worker:*:*, whose terminal wildcard
     covers the narrower target permission."""
     identity = _identity_with([*RUN_PERMS, "worker:*:*"])
+    _register_worker("anything")
 
     with _auth_as(identity):
         resp = _run(client, {"X-Flux-Require-Worker": "anything"})
@@ -169,3 +194,13 @@ def test_advisory_hint_stays_ungated(client):
         resp = _run(client, {"X-Flux-Preferred-Worker": "w1"})
 
     assert resp.status_code == 200, resp.text
+
+
+def test_authorization_precedes_existence(client):
+    """An unauthorized caller must not learn which worker names exist."""
+    identity = _identity_with(RUN_PERMS)
+
+    with _auth_as(identity):
+        resp = _run(client, {"X-Flux-Require-Worker": "never-registered"})
+
+    assert resp.status_code == 403

--- a/tests/security/test_require_worker_authz.py
+++ b/tests/security/test_require_worker_authz.py
@@ -1,0 +1,171 @@
+"""Authorization for X-Flux-Require-Worker (issue #187).
+
+Binding an execution to a named node is not the same capability as running
+the workflow: it concentrates load on one node and compels that node to
+execute the code. So the binding header needs a worker-scoped grant on top of
+the run permission, while the advisory X-Flux-Preferred-Worker stays ungated.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from flux.security.identity import FluxIdentity
+
+SOURCE = b"""
+from flux import workflow
+
+
+@workflow
+async def bind_probe(ctx):
+    return "ok"
+"""
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "require_worker_authz.db"
+    monkeypatch.setenv("FLUX_DATABASE_URL", f"sqlite:///{db_path}")
+    # Auth is enabled below, so a successful run mints an execution token.
+    monkeypatch.setenv("FLUX_EXECUTION_TOKEN_SECRET", "t" * 32)
+
+    from flux.config import Configuration
+    from flux.models import DatabaseRepository
+
+    Configuration._instance = None  # type: ignore[attr-defined]
+    Configuration._config = None  # type: ignore[attr-defined]
+    DatabaseRepository._engines.clear()
+    Configuration.get().override(database_url=f"sqlite:///{db_path}")
+
+    from flux.server import Server
+
+    server = Server("127.0.0.1", 0)
+    test_client = TestClient(server._create_api())
+    files = {"file": ("flow.py", SOURCE, "text/x-python")}
+    assert test_client.post("/workflows", files=files).status_code == 200
+
+    yield test_client
+
+    Configuration._instance = None  # type: ignore[attr-defined]
+    Configuration._config = None  # type: ignore[attr-defined]
+    DatabaseRepository._engines.clear()
+
+
+def _seed_role(name: str, permissions: list[str]) -> None:
+    from flux.models import RepositoryFactory
+    from flux.security.models import RoleModel
+
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        session.add(RoleModel(name=name, permissions=permissions))
+        session.commit()
+
+
+class _AuthProxy:
+    """Real AuthService with only authentication stubbed, so role ->
+    permission resolution is exercised for real."""
+
+    def __init__(self, real, identity: FluxIdentity):
+        self._real = real
+        self._identity = identity
+
+    async def authenticate(self, _token):
+        return self._identity
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+@contextmanager
+def _auth_as(identity: FluxIdentity):
+    from flux.config import Configuration
+    from flux.security import dependencies
+
+    real_service = dependencies._get_auth_service()
+    assert real_service is not None
+    proxy = _AuthProxy(real_service, identity)
+    settings = Configuration.get().settings
+    original_enabled = settings.security.auth.enabled
+    original_api_keys = settings.security.auth.api_keys.enabled
+    settings.security.auth.enabled = True
+    settings.security.auth.api_keys.enabled = True
+    try:
+        with patch("flux.security.dependencies._get_auth_service", return_value=proxy):
+            yield
+    finally:
+        settings.security.auth.enabled = original_enabled
+        settings.security.auth.api_keys.enabled = original_api_keys
+
+
+def _run(client, headers_extra):
+    return client.post(
+        "/workflows/default/bind_probe/run/async",
+        json=None,
+        headers={"Authorization": "Bearer fake-token", **headers_extra},
+    )
+
+
+def _identity_with(permissions: list[str]) -> FluxIdentity:
+    role = f"r_{uuid.uuid4().hex[:8]}"
+    _seed_role(role, permissions)
+    return FluxIdentity(subject="caller", roles=frozenset({role}))
+
+
+RUN_PERMS = ["workflow:*:*:run", "workflow:*:*:read"]
+
+
+def test_run_permission_alone_cannot_bind(client):
+    identity = _identity_with(RUN_PERMS)
+
+    with _auth_as(identity):
+        resp = _run(client, {"X-Flux-Require-Worker": "w1"})
+
+    assert resp.status_code == 403
+    assert "worker:w1:target" in resp.text
+
+
+def test_worker_scoped_grant_allows_binding(client):
+    identity = _identity_with([*RUN_PERMS, "worker:w1:target"])
+
+    with _auth_as(identity):
+        resp = _run(client, {"X-Flux-Require-Worker": "w1"})
+
+    assert resp.status_code == 200, resp.text
+
+
+def test_grant_is_scoped_to_the_named_worker(client):
+    """A grant for one worker must not authorize binding to another."""
+    identity = _identity_with([*RUN_PERMS, "worker:w1:target"])
+
+    with _auth_as(identity):
+        resp = _run(client, {"X-Flux-Require-Worker": "w2"})
+
+    assert resp.status_code == 403
+    assert "worker:w2:target" in resp.text
+
+
+def test_worker_wildcard_satisfies_the_binding(client):
+    """The built-in worker role holds worker:*:*, whose terminal wildcard
+    covers the narrower target permission."""
+    identity = _identity_with([*RUN_PERMS, "worker:*:*"])
+
+    with _auth_as(identity):
+        resp = _run(client, {"X-Flux-Require-Worker": "anything"})
+
+    assert resp.status_code == 200, resp.text
+
+
+def test_advisory_hint_stays_ungated(client):
+    """The pre-existing hint is unaffected: it cannot force placement, so it
+    never needed a worker grant and must not start needing one."""
+    identity = _identity_with(RUN_PERMS)
+
+    with _auth_as(identity):
+        resp = _run(client, {"X-Flux-Preferred-Worker": "w1"})
+
+    assert resp.status_code == 200, resp.text


### PR DESCRIPTION
Closes #187.

## The gap

There was no way to run an execution on one specific worker without telling that worker it was targeted. The only binding mechanism was an affinity term over execution input — and input is forwarded to the worker, so the routing directive and the payload shared a channel. That breaks down exactly when the execution is a check *on* the worker: verification, an A/B against one instance, reproducing a fault on a suspect node. There, the worker learning it is being observed is the thing you were trying to avoid, and it is a one-line check for anyone controlling the process.

`X-Flux-Preferred-Worker` already had the right shape — header, stored on the execution row, absent from the context serialized to the worker (verified: `ExecutionContext.from_json` reconstructs only `workflow_id`/`namespace`/`name`/`input`/`execution_id`/`state`/`current_worker`/`events`, and the column appears nowhere in `encoders.py`, `worker.py`, or `runners/`). It simply was not binding: `sticky()` is score-only, so it biases and silently falls back.

## Header, not a policy term

The issue proposed accepting `sticky()` inside `require()`. Taking the header route instead, for two reasons.

**Layer.** `affinity=` is declared in workflow source and fixed at registration; "run *this* execution on worker-7" is decided per call. The issue's own open question 1 — *"no header supplied, presumably the term is simply not applied"* — is the tell: a `require` term that silently does not apply is not a hard constraint. That is the same silent degradation the feature exists to eliminate, relocated.

**Opposite validation.** The existing code comments its own policy: *"Invalid values are dropped, not rejected — it is only a hint."* Correct for a hint, fatal for a constraint, since a dropped binding value dispatches the execution anywhere — indistinguishable from the binding having been honoured. Two policies, two headers.

| | `X-Flux-Preferred-Worker` | `X-Flux-Require-Worker` |
|---|---|---|
| Unavailable worker | falls back | parks, never falls back |
| Invalid value | dropped | rejected (400) |
| Both headers sent | — | 400, mutually exclusive |
| Permission | none beyond run | `worker:{name}:target` |

## Parks rather than falling back

Unknown, offline, or failing the workflow's own `affinity`/`requests` → the execution stays unclaimed. This is the existing no-match path, so it is bounded by the park TTL (#157) and then failed terminally with a `ParkTimeoutError` that names the worker it was bound to. Visible failure, never silent reassignment.

## Both dispatch modes, and resume

Because the binding is a filter on the execution row rather than a score, it holds in poll mode too — unlike the advisory hint, which is event-mode only.

Poll mode needed care: `_next_matching_execution` splits on the *workflow* having no requests/affinity/metadata and the unconstrained branch takes `limit(1)` with no per-row matcher, so a bound execution of an unconstrained workflow would have gone to whichever worker polled first. The filter is therefore SQL in the query, applied to both branches (`_required_worker_clause`). `test_poll_mode_honours_the_binding_on_an_unconstrained_workflow` guards exactly that.

Re-applied on resume as well — a binding honoured only on first dispatch would be a hole.

## Authorization

Pinning work to a named node concentrates load there and compels that node to execute the code, which running the workflow alone does not authorize. Binding requires `worker:{name}:target` in addition to the run permission, granted per worker. `worker:*:*` (the `worker` role; `admin` via `*`) satisfies it for any worker through the terminal-wildcard rule. The advisory hint stays ungated — it cannot force placement.

## Tests

- `tests/flux/test_dispatch_batch.py::TestRequiredWorkerBinding` — dispatches only to the bound worker, parks rather than falling back, the poll-mode unconstrained-branch regression, resume honours the binding, unbound executions unaffected, park diagnostic names the worker.
- `tests/flux/test_sticky_header_routes.py::TestRequireWorkerHeader` — reject-not-drop for each invalid form, boundary length, mutual exclusion (checked on the raw headers, so an invalid hint cannot hide the conflict).
- `tests/security/test_require_worker_authz.py` — run permission alone is denied, worker-scoped grant allows, the grant does not transfer to another worker, wildcard satisfies, advisory hint stays ungated.

Migration `0022_execution_required_worker` (nullable, no backfill); `HEAD` updated in both migration tests. `0.78.1 → 0.79.0`.