### PR TITLE
ci(perf): keep and upload server/worker logs when the perf suite fails

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -267,13 +267,17 @@ jobs:
     # (T0-T7) run in the short 'ci' profile: correctness gates hard-fail,
     # performance gates are soft (recorded in the artifact, never red on a
     # shared runner). Full-length runs: the on-demand 'perf' workflow.
+    # KEEP_LOGS + a fixed basetemp so the server/worker logs survive teardown
+    # at a path the upload step can name. Every failure here has been CI-only
+    # (issue #189), so a run that leaves nothing behind cannot be diagnosed.
     - name: Run perf suite (PostgreSQL, ci profile)
       env:
         FLUX_PERF: "1"
         FLUX_PERF_PROFILE: ci
         FLUX_PERF_DATABASE_URL: postgresql://flux_perf_user:flux_perf_password@localhost:5432/flux_perf
+        FLUX_PERF_KEEP_LOGS: "1"
       run: |
-        poetry run pytest tests/perf -m perf -v
+        poetry run pytest tests/perf -m perf -v --basetemp=perf-tmp
 
     - name: Archive perf results
       if: always()
@@ -284,6 +288,16 @@ jobs:
           tests/perf/results/
           tests/perf/RESULTS.md
         retention-days: 14
+
+    # Only on failure: a green run's logs are noise, and they are large.
+    - name: Archive perf logs
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: perf-logs
+        path: perf-tmp/**/logs/
+        retention-days: 14
+        if-no-files-found: warn
 
   e2e:
     needs: [version-check]

--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,6 @@ Pipfile
 
 # Worktrees
 .worktrees/
+
+# pytest basetemp for the perf suite (CI archives its logs on failure)
+perf-tmp/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.79.0"
+version = "0.79.1"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"


### PR DESCRIPTION
Groundwork for #189, which has now recurred four times and is still unexplained.

## Why there is nothing to debug with

Every occurrence has been CI-only, and the `perf-results` artifact contains only `tests/perf/results/*.json` plus `RESULTS.md`. A test that times out dies *before* writing its result file — in the most recent occurrence, `T6a` was the only scenario with no result for that run. So the artifact from a failing run is exactly the artifact from a passing run, minus one file.

## What was actually missing

Less than I claimed on the issue. The harness already writes `server.log` and `worker.log` per run (`tests/perf/fixtures/harness/env.py`), and `tests/perf/conftest.py` already honours `FLUX_PERF_KEEP_LOGS` to skip the teardown `rmtree`. Two gaps, both in CI:

1. `FLUX_PERF_KEEP_LOGS` was never set, so the logs were deleted at teardown.
2. The logs live under `tmp_path_factory.mktemp("perf")`, whose path is generated per run — nothing an `upload-artifact` step can name.

`--basetemp=perf-tmp` fixes the second: the layout becomes `perf-tmp/perf0/logs/server.log`, so `perf-tmp/**/logs/` matches. Verified the layout directly rather than assuming it.

## Failure-only upload

A separate step with `if: failure()`, so green runs do not carry tens of MB of logs for nothing. `if-no-files-found: warn` keeps a failure that never reached the harness (dependency install, service startup) from turning into a second, misleading error.

`perf-tmp/` is gitignored.

Nothing about the suite's behaviour changes — same tests, same profile, same gates.