### PR TITLE
fix(dispatch): bound executions released to RESUMING now have a park bound

### DIFF
--- a/docs/advanced-features/dynamic-routing.md
+++ b/docs/advanced-features/dynamic-routing.md
@@ -315,10 +315,11 @@ event-mode only — and it is re-applied when a paused execution resumes. It is
 enforced on the claim endpoint too, so a worker cannot take a bound execution
 by claiming it directly.
 
-One gap to know about: if a bound execution is paused and its worker is then
-evicted, it waits in `RESUMING` for that worker to come back, and the
-park-TTL sweep does not cover that state (it sweeps unclaimed executions
-only). Such a row waits indefinitely rather than failing.
+If a bound execution is released back to `RESUMING` — its worker evicted, or
+reaped after crashing mid-resume — it waits on that worker with no fallback,
+so the park TTL covers that case too. The clock restarts at the moment it
+becomes unassigned rather than running from submission, since a long-running
+execution that pauses hours in would otherwise be failed immediately.
 
 The workflow's own constraints still apply on top: the named worker must also
 satisfy `affinity=`/`requests`. A `routing=score(...)` policy then ranks a

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
+from sqlalchemy import and_
 from sqlalchemy import func
 from sqlalchemy import or_
 from sqlalchemy.exc import IntegrityError
@@ -391,6 +392,25 @@ class DatabaseContextManager(ContextManager):
                 park_ttl=park_ttl,
             )
 
+    @staticmethod
+    def _stamp_park_deadline(model, park_ttl: int | None = None) -> None:
+        """Start the unclaimed clock. 0/unset means park indefinitely (NULL).
+
+        int() + fallback: a mocked/partial Configuration (common in tests)
+        must degrade to "no deadline", never break the caller.
+        """
+        ttl = park_ttl
+        if ttl is None:
+            try:
+                from flux.config import Configuration as _Configuration
+
+                ttl = int(_Configuration.get().settings.workers.park_ttl)
+            except Exception:
+                ttl = 0
+        model.park_deadline = (
+            datetime.now(timezone.utc) + timedelta(seconds=ttl) if ttl and ttl > 0 else None
+        )
+
     def _save_with_session(
         self,
         ctx: ExecutionContext,
@@ -425,20 +445,7 @@ class DatabaseContextManager(ContextManager):
                 # config default. 0 / unset means park indefinitely (NULL).
                 # int() + fallback: a mocked/partial Configuration (common in
                 # tests) must degrade to "no deadline", never break a save.
-                effective_park_ttl = park_ttl
-                if effective_park_ttl is None:
-                    try:
-                        from flux.config import Configuration as _Configuration
-
-                        effective_park_ttl = int(
-                            _Configuration.get().settings.workers.park_ttl,
-                        )
-                    except Exception:
-                        effective_park_ttl = 0
-                if effective_park_ttl and effective_park_ttl > 0:
-                    new_model.park_deadline = datetime.now(timezone.utc) + timedelta(
-                        seconds=effective_park_ttl,
-                    )
+                self._stamp_park_deadline(new_model, park_ttl)
                 session.add(new_model)
             if manage_transaction:
                 session.commit()
@@ -561,7 +568,18 @@ class DatabaseContextManager(ContextManager):
                 session.query(ExecutionContextModel, WorkflowModel)
                 .join(WorkflowModel)
                 .filter(
-                    ExecutionContextModel.state == ExecutionState.CREATED,
+                    or_(
+                        ExecutionContextModel.state == ExecutionState.CREATED,
+                        # A bound execution released back to RESUMING waits on
+                        # one worker that may never return; nothing else can
+                        # take it, so it needs the same bound as an unclaimed
+                        # row (issue #212).
+                        and_(
+                            ExecutionContextModel.state == ExecutionState.RESUMING,
+                            ExecutionContextModel.required_worker.isnot(None),
+                            ExecutionContextModel.worker_name.is_(None),
+                        ),
+                    ),
                     ExecutionContextModel.park_deadline.isnot(None),
                     ExecutionContextModel.park_deadline < now,
                 )
@@ -578,11 +596,16 @@ class DatabaseContextManager(ContextManager):
                 if workflow.requests:
                     constraints.append("resource requests present")
                 detail = "; ".join(constraints) if constraints else "no declared constraints"
+                verb = (
+                    "resumed"
+                    if model.state == ExecutionState.RESUMING
+                    else "claimed this execution"
+                )
                 self._fail_undispatchable(
                     model,
                     session,
                     (
-                        f"No eligible worker claimed this execution before its "
+                        f"No eligible worker {verb} before its "
                         f"park deadline ({model.park_deadline}); {detail}. "
                         "A worker matching the execution's constraints never "
                         "became available within the park TTL."
@@ -1316,6 +1339,11 @@ class DatabaseContextManager(ContextManager):
             if model.state in resume_recovery:
                 model.state = ExecutionState.RESUMING
                 model.worker_name = None
+                if model.required_worker:
+                    # Now waiting on one worker with no fallback, so restart
+                    # the clock here rather than reusing the submission-time
+                    # deadline, which a long run would already be past.
+                    self._stamp_park_deadline(model)
                 # Fence the old owner: without the bump, a partitioned-but-
                 # alive worker's late checkpoint (same generation) is accepted
                 # and can drag the reset row back to RUNNING with no owner —
@@ -1349,6 +1377,8 @@ class DatabaseContextManager(ContextManager):
             if model.state not in releasable:
                 return model.to_plain()
             model.worker_name = None
+            if model.required_worker and model.state == ExecutionState.RESUMING:
+                self._stamp_park_deadline(model)
             session.commit()
             return model.to_plain()
 

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -429,6 +429,17 @@ class DatabaseContextManager(ContextManager):
                     model.state = ctx.state
                     model.output = ctx.output
                     self._sync_wake_columns(model, ctx)
+                    if (
+                        ctx.state == ExecutionState.RESUMING
+                        and model.required_worker
+                        and model.worker_name is None
+                    ):
+                        # Entering the stuck state (issue #212). Restarting
+                        # here rather than only in release_worker covers a row
+                        # released while PAUSED, whose submission-time deadline
+                        # would otherwise be long expired by the time it wakes
+                        # and would fail it on arrival.
+                        self._stamp_park_deadline(model)
                     session.add_all(self._get_additional_events(ctx, session))
             else:
                 accepted = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.79.1"
+version = "0.79.2"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_dispatch_batch.py
+++ b/tests/flux/test_dispatch_batch.py
@@ -702,7 +702,7 @@ class TestBoundResumeBackstop:
             model.park_deadline = datetime.now(timezone.utc) - timedelta(seconds=1)
             session.commit()
 
-    def test_release_worker_starts_the_clock_for_a_bound_execution(self, clean_env, monkeypatch):
+    def test_release_worker_starts_the_clock_for_a_bound_execution(self, clean_env):
         cm, registry = clean_env
         _register_worker(registry, "w2")
         wf_id = _create_workflow("plain")
@@ -804,3 +804,32 @@ class TestBoundResumeBackstop:
         state, worker_name, deadline = self._row(ctx.execution_id)
         assert (state, worker_name) == (ExecutionState.RESUMING, None)
         assert deadline is not None
+
+    def test_wake_restarts_the_clock_for_a_released_bound_execution(self, clean_env):
+        from datetime import datetime, timedelta, timezone
+
+        cm, registry = clean_env
+        _register_worker(registry, "w2")
+        wf_id = _create_workflow("plain")
+        ctx = _create_execution(cm, wf_id, name="plain")
+        self._bind(ctx.execution_id, "w2")
+
+        # Paused, released by eviction, and long past the original deadline.
+        repo = RepositoryFactory.create_repository()
+        with repo.session() as session:
+            model = session.get(ExecutionContextModel, ctx.execution_id)
+            model.state = ExecutionState.PAUSED
+            model.worker_name = None
+            model.park_deadline = datetime.now(timezone.utc) - timedelta(hours=3)
+            session.commit()
+
+        loaded = cm.get(ctx.execution_id)
+        loaded.start_resuming()
+        with patch("flux.config.Configuration.get") as cfg:
+            cfg.return_value.settings.workers.park_ttl = 60
+            cm.save(loaded)
+
+        state, worker_name, deadline = self._row(ctx.execution_id)
+        assert (state, worker_name) == (ExecutionState.RESUMING, None)
+        assert deadline > datetime.now(timezone.utc).replace(tzinfo=None)
+        assert cm.fail_expired_parked() == []

--- a/tests/flux/test_dispatch_batch.py
+++ b/tests/flux/test_dispatch_batch.py
@@ -674,3 +674,133 @@ class TestRequiredWorkerBinding:
 
         assert claimed is not None and claimed.execution_id == ctx.execution_id
         assert cm.next_execution(w1) is None
+
+
+class TestBoundResumeBackstop:
+    """A bound execution released back to RESUMING waits on one worker that
+    may never return, and nothing else can take it. The park sweep covered
+    CREATED only, so that row had no bound at all (issue #212)."""
+
+    def _bind(self, execution_id, worker_name):
+        repo = RepositoryFactory.create_repository()
+        with repo.session() as session:
+            session.get(ExecutionContextModel, execution_id).required_worker = worker_name
+            session.commit()
+
+    def _row(self, execution_id):
+        repo = RepositoryFactory.create_repository()
+        with repo.session() as session:
+            model = session.get(ExecutionContextModel, execution_id)
+            return model.state, model.worker_name, model.park_deadline
+
+    def _expire(self, execution_id):
+        from datetime import datetime, timedelta, timezone
+
+        repo = RepositoryFactory.create_repository()
+        with repo.session() as session:
+            model = session.get(ExecutionContextModel, execution_id)
+            model.park_deadline = datetime.now(timezone.utc) - timedelta(seconds=1)
+            session.commit()
+
+    def test_release_worker_starts_the_clock_for_a_bound_execution(self, clean_env, monkeypatch):
+        cm, registry = clean_env
+        _register_worker(registry, "w2")
+        wf_id = _create_workflow("plain")
+        ctx = _create_execution(cm, wf_id, name="plain")
+        self._bind(ctx.execution_id, "w2")
+        _force_state(ctx.execution_id, ExecutionState.RESUMING, worker_name="w2")
+
+        with patch("flux.config.Configuration.get") as cfg:
+            cfg.return_value.settings.workers.park_ttl = 60
+            cm.release_worker(ctx.execution_id)
+
+        state, worker_name, deadline = self._row(ctx.execution_id)
+        assert state == ExecutionState.RESUMING
+        assert worker_name is None
+        assert deadline is not None
+
+    def test_clock_restarts_rather_than_reusing_the_submission_deadline(self, clean_env):
+        """A long-running execution that pauses hours after submission would
+        already be past its original deadline, and would be swept the instant
+        it entered RESUMING."""
+        from datetime import datetime, timedelta, timezone
+
+        cm, registry = clean_env
+        _register_worker(registry, "w2")
+        wf_id = _create_workflow("plain")
+        ctx = _create_execution(cm, wf_id, name="plain")
+        self._bind(ctx.execution_id, "w2")
+        repo = RepositoryFactory.create_repository()
+        with repo.session() as session:
+            model = session.get(ExecutionContextModel, ctx.execution_id)
+            model.state = ExecutionState.RESUMING
+            model.worker_name = "w2"
+            model.park_deadline = datetime.now(timezone.utc) - timedelta(hours=3)
+            session.commit()
+
+        with patch("flux.config.Configuration.get") as cfg:
+            cfg.return_value.settings.workers.park_ttl = 60
+            cm.release_worker(ctx.execution_id)
+
+        _, _, deadline = self._row(ctx.execution_id)
+        assert deadline > datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(minutes=1)
+        assert cm.fail_expired_parked() == []
+
+    def test_expired_bound_resume_is_failed_with_a_diagnostic(self, clean_env):
+        cm, registry = clean_env
+        _register_worker(registry, "w2")
+        wf_id = _create_workflow("plain")
+        ctx = _create_execution(cm, wf_id, name="plain")
+        self._bind(ctx.execution_id, "w2")
+        _force_state(ctx.execution_id, ExecutionState.RESUMING, worker_name=None)
+        self._expire(ctx.execution_id)
+
+        assert cm.fail_expired_parked() == [ctx.execution_id]
+
+        loaded = cm.get(ctx.execution_id)
+        assert loaded.has_failed
+        assert "w2" in str(loaded.output)
+        assert "resumed" in str(loaded.output)
+
+    def test_unbound_resuming_is_never_swept(self, clean_env):
+        """Any worker can take an unbound resume, so it is not stuck and must
+        keep the pre-existing behaviour of waiting."""
+        cm, registry = clean_env
+        _register_worker(registry, "w1")
+        wf_id = _create_workflow("plain")
+        ctx = _create_execution(cm, wf_id, name="plain")
+        _force_state(ctx.execution_id, ExecutionState.RESUMING, worker_name=None)
+        self._expire(ctx.execution_id)
+
+        assert cm.fail_expired_parked() == []
+
+    def test_assigned_bound_resume_is_never_swept(self, clean_env):
+        """Still assigned means still dispatchable to its worker; only the
+        released (unassigned) case is stuck."""
+        cm, registry = clean_env
+        _register_worker(registry, "w2")
+        wf_id = _create_workflow("plain")
+        ctx = _create_execution(cm, wf_id, name="plain")
+        self._bind(ctx.execution_id, "w2")
+        _force_state(ctx.execution_id, ExecutionState.RESUMING, worker_name="w2")
+        self._expire(ctx.execution_id)
+
+        assert cm.fail_expired_parked() == []
+
+    def test_unclaim_starts_the_clock_for_a_bound_execution(self, clean_env):
+        """The other route into bound-and-unassigned RESUMING: a worker that
+        crashed while resuming gets reaped through unclaim()."""
+        cm, registry = clean_env
+        _register_worker(registry, "w2")
+        wf_id = _create_workflow("plain")
+        ctx = _create_execution(cm, wf_id, name="plain")
+        self._bind(ctx.execution_id, "w2")
+        _force_state(ctx.execution_id, ExecutionState.RESUME_SCHEDULED, worker_name="w2")
+
+        with patch("flux.config.Configuration.get") as cfg:
+            cfg.return_value.settings.workers.park_ttl = 60
+            cm.unclaim(ctx.execution_id)
+
+        state, worker_name, deadline = self._row(ctx.execution_id)
+        assert (state, worker_name) == (ExecutionState.RESUMING, None)
+        assert deadline is not None


### PR DESCRIPTION
Closes #212, the gap I documented rather than fixed in #210.

## The stuck state

`fail_expired_parked()` swept `state == CREATED` only. That was the whole story while any worker could take any execution — an unassigned row was never *stuck*, just unclaimed. Binding changed that:

1. An execution bound to `w2` is paused, or is resuming when `w2` dies.
2. `w2` is evicted (`release_worker()`) or reaped mid-resume (`unclaim()`), either of which leaves the row `RESUMING` with `worker_name = NULL`.
3. The sticky resume query keys on `worker_name`, so it no longer matches; the unassigned branch filters candidates to `w2`, which is gone.
4. The row waits forever — no dispatch, no failure, no diagnostic — and the sweep never looks at that state, so configuring `park_ttl` did not help either.

Unbound executions never reach this: step 3 finds any worker.

## Why the deadline is restarted, not reused

`park_deadline` is stamped at insert. A long-running execution that pauses three hours in is already well past it, so simply widening the sweep would fail such a row the instant it entered `RESUMING` — converting a hang into a spurious failure, which is worse. The clock therefore restarts at the moment the row becomes bound-and-unassigned, which is when it actually starts waiting on one worker.

`test_clock_restarts_rather_than_reusing_the_submission_deadline` pins this: a row with a 3-hour-old deadline is released and is *not* swept.

## Scope

- Only `required_worker IS NOT NULL AND worker_name IS NULL` in `RESUMING`. Rows that are still assigned are dispatchable to their worker and are left alone; unbound rows keep waiting as before.
- Still gated on a non-zero `park_ttl`, like every other park — this adds a bound where there was none, it does not change the default of parking indefinitely.
- The park-TTL config resolution was duplicated inline; extracted to `_stamp_park_deadline` and reused rather than copied to two more call sites.

## Tests

`tests/flux/test_dispatch_batch.py::TestBoundResumeBackstop` — the clock starts on both routes in (`release_worker`, `unclaim`), it restarts rather than reusing the old deadline, an expired row fails with a diagnostic naming the worker, and the two must-not-sweep cases (unbound, still-assigned).

Docs updated: the known-gap paragraph added in #210 is replaced by the actual behaviour.

`0.79.0 → 0.79.2`, leaving `0.79.1` for #214 which is green and waiting.