### PR TITLE
ci(e2e): keep and upload server/worker logs when the e2e suite fails

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -340,6 +340,21 @@ jobs:
       if: steps.cached-e2e-deps.outputs.cache-hit == 'true'
       run: poetry install --no-interaction
 
+    # KEEP_LOGS + a fixed basetemp so the server/worker logs survive teardown
+    # at a path the upload step can name. The cancellation flake (#189) has
+    # only ever reproduced in CI, so a failing run must leave evidence.
     - name: Run E2E tests
+      env:
+        FLUX_E2E_KEEP_LOGS: "1"
       run: |
-        poetry run pytest tests/e2e/ -m "not ollama and not network" -v
+        poetry run pytest tests/e2e/ -m "not ollama and not network" -v --basetemp=e2e-tmp
+
+    # Only on failure: a green run's logs are large and say nothing.
+    - name: Archive e2e logs
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: e2e-logs
+        path: e2e-tmp/**/logs/
+        retention-days: 14
+        if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -189,5 +189,6 @@ Pipfile
 # Worktrees
 .worktrees/
 
-# pytest basetemp for the perf suite (CI archives its logs on failure)
+# pytest basetemp for the perf and e2e suites (CI archives their logs on failure)
 perf-tmp/
+e2e-tmp/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.79.2"
+version = "0.79.3"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"


### PR DESCRIPTION
The missing half of #214, which did this for the perf suite.

## Why

Of the five recorded occurrences of #189, **three are e2e** (`test_transient_cancellation`) and two are perf. #214 made the perf job leave evidence behind; the e2e job still leaves none, so the more frequent side of the flake stays undiagnosable.

The gaps are identical to the ones #214 closed, and neither is in the harness:

- `tests/e2e/conftest.py` already writes `server.log`/`worker.log` and already honours `FLUX_E2E_KEEP_LOGS` to skip the teardown `rmtree` — CI just never set it.
- The logs live under `tmp_path_factory.mktemp("e2e")`, a per-run generated path no `upload-artifact` step can name. `--basetemp=e2e-tmp` makes it `e2e-tmp/e2e0/logs/`.

## Scope

Failure-only upload with `if-no-files-found: warn`, mirroring the perf job exactly — a green run's logs are large and say nothing, and a failure before the harness ever starts shouldn't produce a second, misleading error.

`e2e-tmp/` gitignored alongside `perf-tmp/`.

No change to which tests run, the markers, or the gates.

## Why this matters now

#189 has grown past its original description. The latest occurrence ended in `COMPLETED` rather than stranding in `CANCELLING`, so the real statement is "a cancel issued against a running transient execution is not reliably honoured", with two observed endings. Distinguishing those needs the worker log — specifically whether the cancellation frame arrived at all.

`0.79.1 → 0.79.3`, leaving `0.79.2` for #215, which is green and waiting.