### PR TITLE
fix(dispatch): stop unmatchable executions from stalling the whole queue

### DIFF
--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -1071,6 +1071,12 @@ class DatabaseContextManager(ContextManager):
         to the least-loaded eligible worker. The load aggregate runs once per
         batch — not once per worker per poll tick as in ``next_execution``.
         Unmatched rows keep state CREATED and their locks release at commit.
+
+        ``exclude_ids`` skips rows the caller already knows no worker can take;
+        ``unmatched`` collects the ids of rows found unplaceable here. Together
+        they let the caller advance past a head of unmatchable work instead of
+        re-selecting it every call (#213). Saturation is deliberately not
+        reported as unmatchable — those rows are placeable once a slot frees.
         """
         if not workers or limit <= 0:
             return []
@@ -1094,13 +1100,18 @@ class DatabaseContextManager(ContextManager):
                 if diagnostic:
                     self._fail_undispatchable(model, session, diagnostic)
                     continue
+                with_capacity = [w for w in workers if self._has_free_slot(w, loads)]
+                if not with_capacity:
+                    # Saturated, not unmatchable: these rows become placeable
+                    # as soon as a slot frees, so they must not be excluded
+                    # from the next pass, and scanning on would place nothing.
+                    break
                 eligible = [
                     w
-                    for w in workers
-                    if self._has_free_slot(w, loads)
-                    # Before the matcher: a bound execution has one candidate,
-                    # so matching the rest of the fleet is discarded work.
-                    and (not model.required_worker or w.name == model.required_worker)
+                    for w in with_capacity
+                    # Binding before the matcher: a bound execution has one
+                    # candidate, so matching the fleet is discarded work.
+                    if (not model.required_worker or w.name == model.required_worker)
                     and self._worker_matches_workflow(w, workflow, model.input)
                 ]
                 if not eligible:

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -156,6 +156,9 @@ class ContextManager(ABC):
         self,
         workers: list[WorkerInfo],
         limit: int,
+        *,
+        exclude_ids: Sequence[str] | None = None,
+        unmatched: set[str] | None = None,
     ) -> list[tuple[ExecutionContext, str]]:  # pragma: no cover
         """Claim up to ``limit`` pending executions and assign them across workers.
 
@@ -1056,6 +1059,9 @@ class DatabaseContextManager(ContextManager):
         self,
         workers: list[WorkerInfo],
         limit: int,
+        *,
+        exclude_ids: Sequence[str] | None = None,
+        unmatched: set[str] | None = None,
     ) -> list[tuple[ExecutionContext, str]]:
         """Claim up to ``limit`` pending executions and assign them across workers.
 
@@ -1076,9 +1082,13 @@ class DatabaseContextManager(ContextManager):
                 session.query(ExecutionContextModel, WorkflowModel)
                 .join(WorkflowModel)
                 .filter(ExecutionContextModel.state == ExecutionState.CREATED)
-                .with_for_update(skip_locked=True, of=ExecutionContextModel)
-                .limit(limit)
             )
+            if exclude_ids:
+                # Rows the caller already found unplaceable. Without this the
+                # LIMIT re-selects the same head every call, so matchable work
+                # queued behind an unmatchable row is never reached (#213).
+                query = query.filter(ExecutionContextModel.execution_id.notin_(exclude_ids))
+            query = query.with_for_update(skip_locked=True, of=ExecutionContextModel).limit(limit)
             for model, workflow in query:
                 diagnostic = self._affinity_diagnostic(workflow, model)
                 if diagnostic:
@@ -1094,6 +1104,8 @@ class DatabaseContextManager(ContextManager):
                     and self._worker_matches_workflow(w, workflow, model.input)
                 ]
                 if not eligible:
+                    if unmatched is not None:
+                        unmatched.add(model.execution_id)
                     continue
                 preferred = getattr(model, "preferred_worker", None)
                 worker = None

--- a/flux/dispatcher.py
+++ b/flux/dispatcher.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from functools import partial
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
@@ -54,6 +55,10 @@ class Dispatcher:
         self._server = server
         settings = Configuration.get().settings
         self._batch_size = settings.dispatch.batch_size
+        # Bounds one cycle's scan when the queue holds many unmatchable
+        # rows: they are re-examined next cycle anyway, since a worker
+        # that joins meanwhile may match them.
+        self._max_scan_per_cycle = self._batch_size * 20
         self._fallback_interval = settings.dispatch.fallback_interval
         self._is_postgresql = settings.database_type == "postgresql"
         self._database_url = settings.database_url
@@ -214,16 +219,31 @@ class Dispatcher:
             return
         manager = ContextManager.create()
 
-        # New executions: keep claiming while full batches come back.
+        # New executions: keep claiming while full batches come back. The loop
+        # ends on a short *selection*, not on a short assignment: a full batch
+        # that placed nothing means unmatchable rows at the head of the queue,
+        # and treating that as "drained" stalls every execution behind them
+        # (#213). Those rows are excluded from the next pass so the scan
+        # advances instead of re-reading the same head.
+        unplaceable: set[str] = set()
+        scanned = 0
         while True:
+            unmatched: set[str] = set()
             assignments = await asyncio.to_thread(
-                manager.next_executions_batch,
-                workers,
-                self._batch_size,
+                partial(
+                    manager.next_executions_batch,
+                    workers,
+                    self._batch_size,
+                    exclude_ids=tuple(unplaceable),
+                    unmatched=unmatched,
+                ),
             )
             for ctx, worker_name in assignments:
                 await self._deliver(manager, ctx, worker_name, "execution_scheduled")
-            if len(assignments) < self._batch_size:
+            unplaceable |= unmatched
+            selected = len(assignments) + len(unmatched)
+            scanned += selected
+            if selected < self._batch_size or scanned >= self._max_scan_per_cycle:
                 break
             workers = self._connected_workers()
             if not workers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.79.3"
+version = "0.79.4"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_dispatch_batch.py
+++ b/tests/flux/test_dispatch_batch.py
@@ -833,3 +833,136 @@ class TestBoundResumeBackstop:
         assert (state, worker_name) == (ExecutionState.RESUMING, None)
         assert deadline > datetime.now(timezone.utc).replace(tzinfo=None)
         assert cm.fail_expired_parked() == []
+
+
+class TestHeadOfLineBlocking:
+    """Unmatchable rows at the head of the queue must not starve the work
+    behind them (issue #213). The LIMIT is applied before eligibility and
+    there is no ORDER BY, so without exclusion each call re-selects the same
+    unplaceable head forever."""
+
+    def test_unmatched_rows_are_reported(self, clean_env):
+        cm, registry = clean_env
+        w1 = _register_worker(registry, "w1", labels={"gpu": "false"})
+        gpu_wf = _create_workflow("gpu_only", affinity={"gpu": "true"})
+        blocked = _create_execution(cm, gpu_wf, name="gpu_only")
+
+        unmatched: set[str] = set()
+        assignments = cm.next_executions_batch([w1], limit=10, unmatched=unmatched)
+
+        assert assignments == []
+        assert unmatched == {blocked.execution_id}
+
+    def test_excluding_them_reaches_the_work_behind(self, clean_env):
+        cm, registry = clean_env
+        w1 = _register_worker(registry, "w1", labels={"gpu": "false"})
+        gpu_wf = _create_workflow("gpu_only", affinity={"gpu": "true"})
+        plain_wf = _create_workflow("plain")
+
+        # Two unmatchable rows queued ahead of a matchable one, with a limit
+        # that the blockers alone fill.
+        blockers = [_create_execution(cm, gpu_wf, name="gpu_only") for _ in range(2)]
+        runnable = _create_execution(cm, plain_wf, name="plain")
+
+        first = cm.next_executions_batch([w1], limit=2)
+        assert first == [], "the blockers fill the batch and place nothing"
+
+        unmatched: set[str] = set()
+        second = cm.next_executions_batch(
+            [w1],
+            limit=2,
+            exclude_ids=tuple(b.execution_id for b in blockers),
+            unmatched=unmatched,
+        )
+
+        assert [ctx.execution_id for ctx, _ in second] == [runnable.execution_id]
+
+    def test_exclusion_does_not_affect_an_unblocked_queue(self, clean_env):
+        cm, registry = clean_env
+        w1 = _register_worker(registry, "w1")
+        wf_id = _create_workflow("plain")
+        ctx = _create_execution(cm, wf_id, name="plain")
+
+        unmatched: set[str] = set()
+        assignments = cm.next_executions_batch([w1], limit=10, unmatched=unmatched)
+
+        assert [c.execution_id for c, _ in assignments] == [ctx.execution_id]
+        assert unmatched == set()
+
+
+class TestDispatchCycleDoesNotStall:
+    """The dispatcher ended its claim loop on a short *assignment*, so a full
+    batch that placed nothing read as "queue drained" and every execution
+    behind the blockers waited for the next cycle — indefinitely, if the
+    blockers stayed unmatchable (issue #213)."""
+
+    def _dispatcher(self, batch_size=2, max_scan=100):
+        from unittest.mock import MagicMock
+
+        from flux.dispatcher import Dispatcher
+
+        d = Dispatcher.__new__(Dispatcher)
+        d._batch_size = batch_size
+        d._max_scan_per_cycle = max_scan
+        worker = MagicMock()
+        worker.name = "w1"  # set after construction: name is a MagicMock kwarg
+        server = MagicMock()
+        server._worker_info = {"w1": worker}
+        server._worker_queues = {"w1": MagicMock()}
+        server._worker_unhealthy = set()
+        server._worker_paused = set()
+        d._server = server
+        return d
+
+    async def test_full_batch_that_places_nothing_keeps_scanning(self):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        d = self._dispatcher(batch_size=2)
+        delivered = []
+        d._deliver = AsyncMock(side_effect=lambda m, ctx, w, kind: delivered.append(ctx))
+
+        manager = MagicMock()
+        manager.next_resumes_batch.return_value = []
+        manager.next_cancellations_batch.return_value = []
+        calls = []
+
+        def _batch(workers, limit, *, exclude_ids=(), unmatched=None):
+            calls.append(set(exclude_ids))
+            if not exclude_ids:
+                # A full batch of unmatchable rows: selected 2, placed 0.
+                unmatched.update({"blocked-a", "blocked-b"})
+                return []
+            return [("ctx-behind", "w1")]
+
+        manager.next_executions_batch.side_effect = _batch
+
+        with patch("flux.dispatcher.ContextManager.create", return_value=manager):
+            await d._dispatch_cycle()
+
+        assert len(calls) >= 2, "loop stopped after the blocked batch"
+        assert calls[1] == {"blocked-a", "blocked-b"}
+        assert delivered == ["ctx-behind"], "work behind the blockers never dispatched"
+
+    async def test_scan_is_bounded(self):
+        """An endless supply of unmatchable rows must not spin the cycle: they
+        are re-examined next cycle anyway, when a matching worker may exist."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        d = self._dispatcher(batch_size=2, max_scan=6)
+        d._deliver = AsyncMock()
+        manager = MagicMock()
+        manager.next_resumes_batch.return_value = []
+        manager.next_cancellations_batch.return_value = []
+        n = {"calls": 0}
+
+        def _batch(workers, limit, *, exclude_ids=(), unmatched=None):
+            n["calls"] += 1
+            unmatched.update({f"blocked-{n['calls']}-a", f"blocked-{n['calls']}-b"})
+            return []
+
+        manager.next_executions_batch.side_effect = _batch
+
+        with patch("flux.dispatcher.ContextManager.create", return_value=manager):
+            await d._dispatch_cycle()
+
+        assert n["calls"] == 3, f"expected max_scan/batch_size passes, got {n['calls']}"

--- a/tests/flux/test_dispatch_batch.py
+++ b/tests/flux/test_dispatch_batch.py
@@ -966,3 +966,27 @@ class TestDispatchCycleDoesNotStall:
             await d._dispatch_cycle()
 
         assert n["calls"] == 3, f"expected max_scan/batch_size passes, got {n['calls']}"
+
+    def test_saturation_is_not_reported_as_unmatchable(self, clean_env):
+        """A full fleet leaves rows placeable as soon as a slot frees, so they
+        must not be excluded from the next pass — otherwise a busy cluster
+        scans and excludes its whole queue every cycle for nothing."""
+        cm, registry = clean_env
+        registry.register(
+            name="full",
+            runtime=_make_runtime(),
+            packages=[],
+            resources=_make_resources(),
+            max_concurrent_executions=1,
+        )
+        w = registry.get("full")
+        wf_id = _create_workflow("plain")
+        busy = _create_execution(cm, wf_id, name="plain")
+        _force_state(busy.execution_id, ExecutionState.RUNNING, worker_name="full")
+        _create_execution(cm, wf_id, name="plain")
+
+        unmatched: set[str] = set()
+        assignments = cm.next_executions_batch([w], limit=10, unmatched=unmatched)
+
+        assert assignments == []
+        assert unmatched == set(), "saturated rows were treated as unplaceable"


### PR DESCRIPTION
Closes #213.

## The stall

Two things combined into an availability bug:

- `next_executions_batch` applies `.limit()` **before** per-row eligibility and has no `ORDER BY`, so it selects the same head of the queue every call.
- `_dispatch_cycle` ended its claim loop on a short **assignment** (`len(assignments) < batch_size`), treating "placed nothing" as "queue drained".

So `batch_size` rows that no connected worker can match stop dispatch **entirely** — not just for themselves, but for every runnable execution queued behind them. With `park_ttl` at its default of 0 those rows are never reaped, so it does not clear on its own.

"Unmatchable" is anything no connected worker satisfies: an affinity label nobody advertises, resource requests nobody meets, a runner nobody enables, or (since #210) a binding to a decommissioned worker.

## The fix

Both halves, because either alone is wrong:

- **Termination** now keys on a short *selection*, not a short assignment. A full batch that placed nothing means blockers, not an empty queue.
- **Selection** excludes rows already found unplaceable this cycle, so the scan advances instead of re-reading the same head.

Terminating on selection *without* the exclusion would spin forever on the same rows; excluding *without* the termination change would still stop after one batch. Together, each pass either places work or grows the exclusion set, so the loop advances through the queue and ends.

## Two deliberate choices

**The exclusion set is per cycle, not persisted.** A row unmatchable now may match a worker that joins a second later, so the next cycle must see it again. The cost is re-scanning blockers once per cycle, which is bounded; the alternative needs invalidation on every worker-set change and risks stranding work that became matchable.

**A per-cycle scan bound** (`batch_size * 20`) caps the work when the queue holds many unmatchable rows, since they are re-examined next cycle anyway.

## Tests

- `TestHeadOfLineBlocking` — unmatched rows are reported; excluding them reaches the work behind (a limit the blockers alone fill); an unblocked queue is unaffected.
- `TestDispatchCycleDoesNotStall` — a full batch that places nothing keeps scanning and delivers the execution behind it, with the second call receiving the first batch's ids; and the scan is bounded rather than spinning.

Verified the loop test fails against the old termination condition and passes with the fix.

`0.79.2 → 0.79.4`, leaving `0.79.3` for #216.