### PR TITLE
feat(routing): routing-only execution input (#211)

### DIFF
--- a/docs/advanced-features/dynamic-routing.md
+++ b/docs/advanced-features/dynamic-routing.md
@@ -45,6 +45,7 @@ A policy is a weighted combination of terms over **selectors**:
 | `resource("field")` | `cpu_total`, `cpu_available`, `memory_total`, `memory_available`, `disk_total`, `disk_free` | registration-time snapshot (prefer `metric("flux.cpu_percent")` etc. for live values) |
 | `load()` | active executions on the worker | live, computed at dispatch |
 | `utilization()` | active executions ÷ the worker's advertised capacity | live, computed at dispatch |
+| `routing_input("key")` | per-execution values the worker never receives (see [below](#routing-on-values-the-worker-cannot-see)) | set at submission |
 
 And four term types:
 
@@ -177,6 +178,71 @@ Score terms only. Gating a `require(...)` term on load is refused at
 registration: skipping a hard constraint makes a worker match *more*
 easily, so it would drop the requirement on exactly the busy workers it was
 meant to steer away from.
+
+## Routing on values the worker cannot see
+
+Affinity and scoring normally match against execution input — and that input is
+delivered to the worker, because it is how a workflow receives its arguments.
+So a field used *purely* for routing is observable by the worker it routes to.
+
+That matters when the routing decision is **about** the worker: audit sampling,
+A/B assignment, canary probes. There, "does my input contain the cohort field?"
+tells a workflow it is being watched before its body runs — and it is the
+*presence* of the key that gives it away, not the value, so obfuscating the
+value does not help.
+
+`routing_input(...)` reads from a separate channel that is matched at dispatch
+and never delivered:
+
+```python
+@workflow.with_options(
+    affinity=require(optional(label("cohort") == routing_input("cohort"))),
+)
+async def audit_probe(ctx: ExecutionContext[dict]):
+    ...
+```
+
+```bash
+curl -X POST localhost:8000/workflows/default/audit_probe/run/async \
+     -H 'X-Flux-Routing-Input: {"cohort":"canary"}' \
+     -d '{"real":"payload"}'
+
+flux workflow run audit_probe '{"real":"payload"}' -r cohort=canary
+```
+
+It works wherever `input(...)` does — `require`, `prefer`, `when`, and dynamic
+keys such as `label_for("cache.", routing_input("dataset"))` — and is set from
+the run header, a schedule's `routing_input` field, `call(routing_input=...)`,
+or the CLI flag above.
+
+**What is hidden, precisely.** The key name is not secret: it is written in the
+workflow source, and that source travels to the worker. What the worker cannot
+learn is the value **or whether this execution had one at all** — which is the
+classifier that mattered. A worker can read `routing_input("cohort")` in its own
+affinity and still not know whether it was selected by it.
+
+Consequences worth knowing:
+
+- **Values are never delivered or read back.** They are absent from the context
+  the worker receives, from `GET /executions/{id}`, and from both SSE frames.
+  There is no API read path at any privilege level — an admin-scoped read would
+  put them back on the surface this exists to keep them off. Operators get the
+  key *names* in a server log line at ingress, never the values.
+- **Diagnostics say nothing.** A routing constraint that cannot be satisfied
+  fails with `routing constraint unsatisfied` and no key or value, because that
+  message is written to the execution's output, which the worker can read.
+- **Rejected, never dropped.** Malformed JSON, a non-object payload, a value
+  over 4KB, a repeated header, or a key containing `.` at any depth is a 400.
+  A silently discarded routing directive would route the execution somewhere
+  the caller did not intend, and that is invisible from outside.
+- **No extra permission.** Routing values are exactly as powerful as `input` —
+  `require(label("host") == routing_input("host"))` grants the same pinning
+  that `input("host")` does today — so they need no grant beyond running the
+  workflow. Use `X-Flux-Require-Worker` when you want binding placement; that
+  one *does* require `worker:{name}:target`.
+- **CLI values are strings**, as with `--label`, and `key=value` cannot express
+  nesting. Numbers coerce on comparison; booleans do not, so a boolean needs
+  the API.
 
 ## Built-in worker metrics
 

--- a/docs/advanced-features/dynamic-routing.md
+++ b/docs/advanced-features/dynamic-routing.md
@@ -230,7 +230,23 @@ Consequences worth knowing:
   key *names* in a server log line at ingress, never the values.
 - **Diagnostics say nothing.** A routing constraint that cannot be satisfied
   fails with `routing constraint unsatisfied` and no key or value, because that
-  message is written to the execution's output, which the worker can read.
+  message is written to the execution's output and to the server log.
+
+  Worth being precise about who could read it: a *bare worker principal*
+  cannot, since `GET /executions/{id}` also requires
+  `workflow:{ns}:{name}:read`, which the built-in `worker` role does not hold.
+  The reachable vector is the **workflow's own execution token**, which
+  inherits the submitting principal's permissions — and that principal
+  normally does hold workflow read. Deployments that grant workers broader
+  roles widen it further. The blinding is defence in depth against both.
+
+- **A `call()` child can tell it was dispatched.** Passing `routing_input` to
+  `call()` forces the dispatched path, because the in-process fast path never
+  reaches the dispatcher and would discard the values silently. A transient
+  sync child can distinguish the two (dispatched executions have a real
+  `execution_id` and token), so for a canary probe the *fact* of routing is
+  observable even though the values are not. Use a non-transient target, or
+  set `[flux.workers] transient_fast_path = false`, when that matters.
 - **Rejected, never dropped.** Malformed JSON, a non-object payload, a value
   over 4KB, a repeated header, or a key containing `.` at any depth is a 400.
   A silently discarded routing directive would route the execution somewhere

--- a/flux/api/schedule_routes.py
+++ b/flux/api/schedule_routes.py
@@ -19,6 +19,7 @@ from flux.errors import WorkflowNotFoundError
 from flux.schedule_manager import create_schedule_manager
 from flux.security.dependencies import get_identity, require_permission
 from flux.security.identity import FluxIdentity
+from flux.routing_input import RoutingInputError, validate_routing_input
 from flux.utils import get_logger
 from flux.api.schemas import (
     ScheduleRequest,
@@ -196,6 +197,11 @@ class ScheduleRoutesMixin:
                 # Create schedule from configuration
                 schedule = schedule_factory(request.schedule_config)
 
+                try:
+                    checked_routing_input = validate_routing_input(request.routing_input)
+                except RoutingInputError as e:
+                    raise HTTPException(status_code=400, detail=str(e))
+
                 # Create schedule via manager
                 schedule_manager = create_schedule_manager()
                 schedule_model = schedule_manager.create_schedule(
@@ -206,6 +212,7 @@ class ScheduleRoutesMixin:
                     schedule=schedule,
                     description=request.description,
                     input_data=request.input_data,
+                    routing_input=checked_routing_input,
                     run_as_service_account=request.run_as_service_account,
                 )
 
@@ -408,6 +415,11 @@ class ScheduleRoutesMixin:
                             },
                         )
 
+                try:
+                    checked_routing_input = validate_routing_input(request.routing_input)
+                except RoutingInputError as e:
+                    raise HTTPException(status_code=400, detail=str(e))
+
                 # Build update parameters
                 schedule_param = None
                 if request.schedule_config is not None:
@@ -419,6 +431,7 @@ class ScheduleRoutesMixin:
                     schedule=schedule_param,
                     description=request.description,
                     input_data=request.input_data,
+                    routing_input=checked_routing_input,
                     run_as_service_account=request.run_as_service_account,
                 )
 

--- a/flux/api/schedule_routes.py
+++ b/flux/api/schedule_routes.py
@@ -199,6 +199,8 @@ class ScheduleRoutesMixin:
 
                 try:
                     checked_routing_input = validate_routing_input(request.routing_input)
+                    if request.routing_input == {}:
+                        checked_routing_input = {}  # explicit clear
                 except RoutingInputError as e:
                     raise HTTPException(status_code=400, detail=str(e))
 
@@ -417,6 +419,8 @@ class ScheduleRoutesMixin:
 
                 try:
                     checked_routing_input = validate_routing_input(request.routing_input)
+                    if request.routing_input == {}:
+                        checked_routing_input = {}  # explicit clear
                 except RoutingInputError as e:
                     raise HTTPException(status_code=400, detail=str(e))
 

--- a/flux/api/schemas.py
+++ b/flux/api/schemas.py
@@ -90,6 +90,7 @@ class ScheduleRequest(BaseModel):
     schedule_config: dict  # Schedule configuration (cron expression, interval, etc.)
     description: str | None = None
     input_data: Any | None = None
+    routing_input: dict | None = None
     run_as_service_account: str | None = None
 
 
@@ -124,6 +125,7 @@ class ScheduleUpdateRequest(BaseModel):
     schedule_config: dict | None = None
     description: str | None = None
     input_data: Any | None = None
+    routing_input: dict | None = None
     run_as_service_account: str | None = None
 
 

--- a/flux/api/workflow_routes.py
+++ b/flux/api/workflow_routes.py
@@ -203,7 +203,9 @@ class WorkflowRoutesMixin:
             park_ttl: int | None = None,
             preferred_worker: str | None = Header(None, alias="X-Flux-Preferred-Worker"),
             required_worker: str | None = Header(None, alias="X-Flux-Require-Worker"),
-            routing_input: str | None = Header(None, alias="X-Flux-Routing-Input"),
+            # list[str] so FastAPI uses getlist(): as `str` it would silently
+            # keep only the first of repeated headers (#211).
+            routing_input: list[str] | None = Header(None, alias="X-Flux-Routing-Input"),
             identity: FluxIdentity = Depends(get_identity),
         ):
             try:

--- a/flux/api/workflow_routes.py
+++ b/flux/api/workflow_routes.py
@@ -27,6 +27,7 @@ from flux.errors import (
     WorkerNotFoundError,
     WorkflowNotFoundError,
 )
+from flux.routing_input import RoutingInputError, parse_routing_input_header
 from flux.security.dependencies import get_identity
 from flux.security.identity import ANONYMOUS, FluxIdentity
 from flux.servers.models import ExecutionContext as ExecutionContextDTO
@@ -202,6 +203,7 @@ class WorkflowRoutesMixin:
             park_ttl: int | None = None,
             preferred_worker: str | None = Header(None, alias="X-Flux-Preferred-Worker"),
             required_worker: str | None = Header(None, alias="X-Flux-Require-Worker"),
+            routing_input: str | None = Header(None, alias="X-Flux-Routing-Input"),
             identity: FluxIdentity = Depends(get_identity),
         ):
             try:
@@ -299,6 +301,15 @@ class WorkflowRoutesMixin:
                         detail="park_ttl must be >= 0 (0 disables the bound)",
                     )
 
+                # Routing-only values (issue #211): matched at dispatch, never
+                # delivered. Rejected rather than dropped — a discarded routing
+                # directive routes the execution somewhere the caller did not
+                # intend, and that is invisible from outside.
+                try:
+                    parsed_routing_input = parse_routing_input_header(routing_input)
+                except RoutingInputError as e:
+                    raise HTTPException(status_code=400, detail=str(e))
+
                 ctx = self._create_execution(
                     namespace,
                     workflow_name,
@@ -306,6 +317,7 @@ class WorkflowRoutesMixin:
                     version,
                     preferred_worker=preferred_worker,
                     required_worker=required_worker,
+                    routing_input=parsed_routing_input,
                     park_ttl=park_ttl,
                 )
                 manager = ContextManager.create()

--- a/flux/api/workflow_routes.py
+++ b/flux/api/workflow_routes.py
@@ -322,6 +322,17 @@ class WorkflowRoutesMixin:
                     routing_input=parsed_routing_input,
                     park_ttl=park_ttl,
                 )
+
+                if parsed_routing_input:
+                    # Key names only. They are already public (they appear in
+                    # the workflow source); the values and their presence are
+                    # not, and this log is not reachable through the execution
+                    # API a worker can call. It is the only operator-visible
+                    # trace of a routing directive, by design.
+                    logger.info(
+                        f"Execution {ctx.execution_id} carries routing input "
+                        f"keys: {sorted(parsed_routing_input)}",
+                    )
                 manager = ContextManager.create()
 
                 # Record agent-session linkage for "agents" namespace runs so

--- a/flux/catalogs.py
+++ b/flux/catalogs.py
@@ -165,6 +165,12 @@ def _enrich_workflow_metadata(source: bytes, workflow_infos: list) -> None:
 
 logger = get_logger(__name__)
 
+# Both spellings of a per-execution value reference. routing_input() resolves
+# from the routing-only column instead of `input`, and both AST parsers below
+# (affinity and routing) must accept either — a spelling one parser rejects
+# fails registration in only one of the two decorator arguments (#211).
+_VALUE_REF_CALLS = ("input", "routing_input")
+
 
 def resolve_workflow_ref(ref: str | None) -> tuple[str, str]:
     """Parse a user-provided workflow reference into ``(namespace, name)``.
@@ -615,12 +621,14 @@ class WorkflowCatalog(ABC):
 
         def extract_input_ref(ref_node: ast.AST) -> Any:
             assert isinstance(ref_node, ast.Call)
+            name = call_name(ref_node) or "input"
+            factory = routing_dsl.routing_input if name == "routing_input" else routing_dsl.input
             if len(ref_node.args) == 1 and isinstance(ref_node.args[0], ast.Constant):
                 try:
-                    return routing_dsl.input(ref_node.args[0].value)
+                    return factory(ref_node.args[0].value)
                 except (TypeError, ValueError) as e:
-                    raise SyntaxError(f"Invalid input() reference: {e}") from e
-            fail("input() takes a single literal path")
+                    raise SyntaxError(f"Invalid {name}() reference: {e}") from e
+            fail(f"{name}() takes a single literal path")
 
         def extract_selector(sel_node: ast.AST) -> Any:
             name = call_name(sel_node)
@@ -638,7 +646,7 @@ class WorkflowCatalog(ABC):
                 if (
                     len(sel_node.args) == 2
                     and isinstance(sel_node.args[0], ast.Constant)
-                    and call_name(sel_node.args[1]) == "input"
+                    and call_name(sel_node.args[1]) in _VALUE_REF_CALLS
                 ):
                     try:
                         return dyn(
@@ -653,7 +661,7 @@ class WorkflowCatalog(ABC):
         def extract_value(value_node: ast.AST) -> Any:
             if isinstance(value_node, ast.Constant):
                 return value_node.value
-            if call_name(value_node) == "input":
+            if call_name(value_node) in _VALUE_REF_CALLS:
                 return extract_input_ref(value_node)
             fail(f"unsupported value expression at line {getattr(value_node, 'lineno', '?')}")
 
@@ -730,10 +738,10 @@ class WorkflowCatalog(ABC):
             if op is None:
                 fail(f"unsupported when() operator at line {cond_node.lineno}")
             left, right = cond_node.left, cond_node.comparators[0]
-            if call_name(left) == "input" or call_name(right) == "input":
+            if call_name(left) in _VALUE_REF_CALLS or call_name(right) in _VALUE_REF_CALLS:
                 if op not in ("==", "!="):
                     fail("when() input conditions support only == and !=")
-                if call_name(left) == "input":
+                if call_name(left) in _VALUE_REF_CALLS:
                     ref, const = extract_input_ref(left), right
                 else:
                     ref, const = extract_input_ref(right), left
@@ -763,7 +771,7 @@ class WorkflowCatalog(ABC):
             arg = svc_node.args[0]
             if isinstance(arg, ast.Constant):
                 value: Any = arg.value
-            elif call_name(arg) == "input":
+            elif call_name(arg) in _VALUE_REF_CALLS:
                 value = extract_input_ref(arg)
             else:
                 fail("service() takes a literal name or input(...)")
@@ -861,12 +869,14 @@ class WorkflowCatalog(ABC):
 
         def extract_input_ref(ref_node: ast.AST) -> Any:
             assert isinstance(ref_node, ast.Call)
+            name = call_name(ref_node) or "input"
+            factory = routing_dsl.routing_input if name == "routing_input" else routing_dsl.input
             if len(ref_node.args) == 1 and isinstance(ref_node.args[0], ast.Constant):
                 try:
-                    return routing_dsl.input(ref_node.args[0].value)
+                    return factory(ref_node.args[0].value)
                 except (TypeError, ValueError) as e:
-                    raise SyntaxError(f"Invalid input() reference: {e}") from e
-            fail("input() takes a single literal path")
+                    raise SyntaxError(f"Invalid {name}() reference: {e}") from e
+            fail(f"{name}() takes a single literal path")
 
         def extract_selector(sel_node: ast.AST) -> Any:
             name = call_name(sel_node)
@@ -881,7 +891,7 @@ class WorkflowCatalog(ABC):
                 if (
                     len(sel_node.args) == 2
                     and isinstance(sel_node.args[0], ast.Constant)
-                    and call_name(sel_node.args[1]) == "input"
+                    and call_name(sel_node.args[1]) in _VALUE_REF_CALLS
                 ):
                     try:
                         return dyn(
@@ -910,7 +920,7 @@ class WorkflowCatalog(ABC):
         def extract_value(value_node: ast.AST) -> Any:
             if isinstance(value_node, ast.Constant):
                 return value_node.value
-            if call_name(value_node) == "input":
+            if call_name(value_node) in _VALUE_REF_CALLS:
                 return extract_input_ref(value_node)
             fail(f"unsupported value expression at line {getattr(value_node, 'lineno', '?')}")
 
@@ -975,10 +985,10 @@ class WorkflowCatalog(ABC):
             if op is None:
                 fail(f"unsupported when() operator at line {cond_node.lineno}")
             left, right = cond_node.left, cond_node.comparators[0]
-            if call_name(left) == "input" or call_name(right) == "input":
+            if call_name(left) in _VALUE_REF_CALLS or call_name(right) in _VALUE_REF_CALLS:
                 if op not in ("==", "!="):
                     fail("when() input conditions support only == and !=")
-                if call_name(left) == "input":
+                if call_name(left) in _VALUE_REF_CALLS:
                     ref, const = extract_input_ref(left), right
                 else:
                     ref, const = extract_input_ref(right), left
@@ -1008,7 +1018,7 @@ class WorkflowCatalog(ABC):
             arg = svc_node.args[0]
             if isinstance(arg, ast.Constant):
                 value: Any = arg.value
-            elif call_name(arg) == "input":
+            elif call_name(arg) in _VALUE_REF_CALLS:
                 value = extract_input_ref(arg)
             else:
                 fail("service() takes a literal name or input(...)")

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -394,6 +394,13 @@ def list_workflow_versions(
     help="Show detailed execution information",
 )
 @click.option(
+    "--routing-input",
+    "-r",
+    multiple=True,
+    help="Routing-only value in key=value format (repeatable). Matched by "
+    "dispatch, never delivered to the worker.",
+)
+@click.option(
     "--server-url",
     "-cp-url",
     default=None,
@@ -405,6 +412,7 @@ def run_workflow(
     mode: str,
     version: int | None,
     detailed: bool,
+    routing_input: tuple[str, ...],
     server_url: str | None,
 ):
     """Run the specified workflow."""
@@ -420,11 +428,20 @@ def run_workflow(
         if version is not None:
             params["version"] = version
 
+        from flux.routing_input import RoutingInputError, parse_cli_pairs
+
+        try:
+            routing_values = parse_cli_pairs(routing_input)
+        except RoutingInputError as e:
+            raise click.ClickException(str(e))
+        headers = {"X-Flux-Routing-Input": json.dumps(routing_values)} if routing_values else None
+
         with get_http_client(timeout=60.0) as client:
             response = client.post(
                 f"{base_url}/workflows/{namespace}/{name}/run/{mode}",
                 json=parsed_input,
                 params=params,
+                headers=headers,
             )
             response.raise_for_status()
 
@@ -1745,6 +1762,13 @@ def schedule():
     help="Input data for scheduled workflow executions (JSON format)",
 )
 @click.option(
+    "--routing-input",
+    "-r",
+    multiple=True,
+    help="Routing-only value in key=value format (repeatable). Matched by "
+    "dispatch, never delivered to the worker.",
+)
+@click.option(
     "--run-as",
     default=None,
     help="Service account to run the schedule as (required when auth is enabled)",
@@ -1780,6 +1804,7 @@ def create_schedule(
     timezone: str,
     description: str | None,
     input: str | None,
+    routing_input: tuple[str, ...],
     run_as: str | None,
     overlap: str,
     format: str,
@@ -1791,6 +1816,13 @@ def create_schedule(
         from flux.utils import parse_value
 
         namespace, wf_name = resolve_workflow_ref(workflow_name)
+
+        from flux.routing_input import RoutingInputError, parse_cli_pairs
+
+        try:
+            routing_values = parse_cli_pairs(routing_input)
+        except RoutingInputError as e:
+            raise click.ClickException(str(e))
 
         # Validate schedule parameters
         if not cron and not interval_hours and not interval_minutes:
@@ -1830,6 +1862,7 @@ def create_schedule(
             "schedule_config": schedule_config,
             "description": description,
             "input_data": input_data,
+            "routing_input": routing_values,
             "run_as_service_account": run_as,
         }
 

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -461,6 +461,11 @@ def run_workflow(
                 result = response.json()
                 click.echo(to_json(result))
 
+    except click.ClickException:
+        # Click exceptions carry their own non-zero exit code. Flattening them
+        # into a printed message below would report success for a rejected
+        # routing directive — the silent-drop this feature refuses.
+        raise
     except httpx.HTTPStatusError as ex:
         if ex.response.status_code == 404:
             click.echo(f"Workflow '{workflow_name}' not found.", err=True)
@@ -1882,6 +1887,8 @@ def create_schedule(
             click.echo(f"Schedule ID: {result['id']}")
             click.echo(f"Next run: {result.get('next_run_at', 'Not scheduled')}")
 
+    except click.ClickException:
+        raise
     except Exception as ex:
         click.echo(f"Error creating schedule: {str(ex)}", err=True)
 

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -1892,7 +1892,7 @@ def create_schedule(
     except click.ClickException:
         raise
     except Exception as ex:
-        click.echo(f"Error creating schedule: {str(ex)}", err=True)
+        raise click.ClickException(f"Error creating schedule: {str(ex)}")
 
 
 @schedule.command("list")

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -467,12 +467,14 @@ def run_workflow(
         # routing directive — the silent-drop this feature refuses.
         raise
     except httpx.HTTPStatusError as ex:
+        # Server-side rejection is the same hazard as client-side: a scripted
+        # `flux workflow run ... && next-step` must not proceed because the
+        # error was merely printed.
         if ex.response.status_code == 404:
-            click.echo(f"Workflow '{workflow_name}' not found.", err=True)
-        else:
-            click.echo(f"Error running workflow: {str(ex)}", err=True)
+            raise click.ClickException(f"Workflow '{workflow_name}' not found.")
+        raise click.ClickException(f"Error running workflow: {str(ex)}")
     except Exception as ex:
-        click.echo(f"Error running workflow: {str(ex)}", err=True)
+        raise click.ClickException(f"Error running workflow: {str(ex)}")
 
 
 @workflow.command("resume")

--- a/flux/client.py
+++ b/flux/client.py
@@ -12,6 +12,20 @@ logger = get_logger(__name__)
 DEFAULT_TIMEOUT: float = 10.0
 
 
+def _routing_input_headers(routing_input: dict | None) -> dict[str, str] | None:
+    """Per-request routing values.
+
+    ``for_current_execution`` sets ``X-Flux-Preferred-Worker`` as a
+    client-level default, so routing values — which are per call, not per
+    client — need their own channel rather than reusing it.
+    """
+    if not routing_input:
+        return None
+    import json as _json
+
+    return {"X-Flux-Routing-Input": _json.dumps(routing_input)}
+
+
 class FluxClient:
     """Async HTTP client for the Flux REST API."""
 
@@ -112,11 +126,17 @@ class FluxClient:
         response.raise_for_status()
         return response.json()
 
-    async def run_workflow(self, workflow_ref: str, input_data: Any = None) -> dict[str, Any]:
+    async def run_workflow(
+        self,
+        workflow_ref: str,
+        input_data: Any = None,
+        routing_input: dict | None = None,
+    ) -> dict[str, Any]:
         namespace, name = resolve_workflow_ref(workflow_ref)
         response = await self._http_client.post(
             f"/workflows/{namespace}/{name}/run/async",
             json=input_data,
+            headers=_routing_input_headers(routing_input),
         )
         response.raise_for_status()
         return response.json()
@@ -126,6 +146,7 @@ class FluxClient:
         workflow_ref: str,
         input_data: Any = None,
         detailed: bool = False,
+        routing_input: dict | None = None,
     ) -> dict[str, Any]:
         namespace, name = resolve_workflow_ref(workflow_ref)
         # Only add params when asked: existing callers (and their tests) pin
@@ -133,6 +154,9 @@ class FluxClient:
         kwargs: dict[str, Any] = {"json": input_data}
         if detailed:
             kwargs["params"] = {"detailed": "true"}
+        headers = _routing_input_headers(routing_input)
+        if headers:
+            kwargs["headers"] = headers
         response = await self._http_client.post(
             f"/workflows/{namespace}/{name}/run/sync",
             **kwargs,

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -72,6 +72,7 @@ class ContextManager(ABC):
         uow: UnitOfWork | None = None,
         preferred_worker: str | None = None,
         required_worker: str | None = None,
+        routing_input: dict | None = None,
         park_ttl: int | None = None,
     ) -> ExecutionContext:  # pragma: no cover
         raise NotImplementedError()
@@ -84,6 +85,7 @@ class ContextManager(ABC):
         uow: UnitOfWork | None = None,
         preferred_worker: str | None = None,
         required_worker: str | None = None,
+        routing_input: dict | None = None,
         park_ttl: int | None = None,
     ) -> bool:  # pragma: no cover
         """Like ``save`` but report whether the state write was applied.
@@ -356,6 +358,7 @@ class DatabaseContextManager(ContextManager):
         uow: UnitOfWork | None = None,
         preferred_worker: str | None = None,
         required_worker: str | None = None,
+        routing_input: dict | None = None,
         park_ttl: int | None = None,
     ) -> ExecutionContext:
         self.save_checked(
@@ -363,6 +366,7 @@ class DatabaseContextManager(ContextManager):
             uow=uow,
             preferred_worker=preferred_worker,
             required_worker=required_worker,
+            routing_input=routing_input,
             park_ttl=park_ttl,
         )
         return ctx
@@ -374,6 +378,7 @@ class DatabaseContextManager(ContextManager):
         uow: UnitOfWork | None = None,
         preferred_worker: str | None = None,
         required_worker: str | None = None,
+        routing_input: dict | None = None,
         park_ttl: int | None = None,
     ) -> bool:
         if uow is not None:
@@ -383,6 +388,7 @@ class DatabaseContextManager(ContextManager):
                 manage_transaction=False,
                 preferred_worker=preferred_worker,
                 required_worker=required_worker,
+                routing_input=routing_input,
                 park_ttl=park_ttl,
             )
         with self.session() as session:
@@ -392,6 +398,7 @@ class DatabaseContextManager(ContextManager):
                 manage_transaction=True,
                 preferred_worker=preferred_worker,
                 required_worker=required_worker,
+                routing_input=routing_input,
                 park_ttl=park_ttl,
             )
 
@@ -422,6 +429,7 @@ class DatabaseContextManager(ContextManager):
         manage_transaction: bool,
         preferred_worker: str | None = None,
         required_worker: str | None = None,
+        routing_input: dict | None = None,
         park_ttl: int | None = None,
     ) -> bool:
         try:
@@ -455,6 +463,8 @@ class DatabaseContextManager(ContextManager):
                     new_model.preferred_worker = preferred_worker
                 if required_worker:
                     new_model.required_worker = required_worker
+                if routing_input:
+                    new_model.routing_input = routing_input
                 # Park TTL (issue #157): per-run override wins; otherwise the
                 # config default. 0 / unset means park indefinitely (NULL).
                 # int() + fallback: a mocked/partial Configuration (common in

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -4,7 +4,7 @@ from abc import ABC
 from abc import abstractmethod
 from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from sqlalchemy import and_
 from sqlalchemy import func
@@ -513,8 +513,11 @@ class DatabaseContextManager(ContextManager):
         self,
         worker: WorkerInfo,
         workflow: WorkflowModel,
-        input_value: Any = None,
+        model,
     ) -> bool:
+        """Takes the row rather than its input so a caller cannot pass one
+        value source and forget the other — a missed routing value resolves
+        against ``input`` and silently matches on the wrong thing (#211)."""
         from flux.domain.resource_request import worker_matches
 
         return worker_matches(
@@ -522,7 +525,8 @@ class DatabaseContextManager(ContextManager):
             workflow.requests,
             workflow.affinity,
             runner=(workflow.wf_metadata or {}).get("runner"),
-            input_value=input_value,
+            input_value=model.input,
+            routing_value=model.routing_input,
         )
 
     def _affinity_diagnostic(self, workflow: WorkflowModel, model) -> str | None:
@@ -538,7 +542,7 @@ class DatabaseContextManager(ContextManager):
             return None
         from flux.routing import require_diagnostic
 
-        return require_diagnostic(workflow.affinity, model.input)
+        return require_diagnostic(workflow.affinity, model.input, model.routing_input)
 
     def _fail_undispatchable(
         self,
@@ -813,7 +817,7 @@ class DatabaseContextManager(ContextManager):
                 # nothing ends up claimed on this poll tick.
                 session.info["affinity_failed"] = True
                 continue
-            if not self._worker_matches_workflow(worker, workflow, model.input):
+            if not self._worker_matches_workflow(worker, workflow, model):
                 continue
             return model, workflow
         return None, None
@@ -938,7 +942,7 @@ class DatabaseContextManager(ContextManager):
                     .with_for_update(skip_locked=True)
                 )
                 for model, workflow in fallback_query:
-                    if self._worker_matches_workflow(worker, workflow, model.input):
+                    if self._worker_matches_workflow(worker, workflow, model):
                         result = (model, workflow)
                         break
 
@@ -1112,7 +1116,7 @@ class DatabaseContextManager(ContextManager):
                     # Binding before the matcher: a bound execution has one
                     # candidate, so matching the fleet is discarded work.
                     if (not model.required_worker or w.name == model.required_worker)
-                    and self._worker_matches_workflow(w, workflow, model.input)
+                    and self._worker_matches_workflow(w, workflow, model)
                 ]
                 if not eligible:
                     if unmatched is not None:
@@ -1135,6 +1139,7 @@ class DatabaseContextManager(ContextManager):
                         policy,
                         loads=loads,
                         input_value=model.input,
+                        routing_value=model.routing_input,
                         preferred=preferred,
                     )
                 elif preferred:
@@ -1236,7 +1241,7 @@ class DatabaseContextManager(ContextManager):
                         for w in workers
                         if self._has_free_slot(w, loads)
                         and (not model.required_worker or w.name == model.required_worker)
-                        and self._worker_matches_workflow(w, workflow, model.input)
+                        and self._worker_matches_workflow(w, workflow, model)
                     ]
                     if not eligible:
                         continue

--- a/flux/domain/resource_request.py
+++ b/flux/domain/resource_request.py
@@ -312,14 +312,15 @@ def worker_matches(
     affinity: dict | list | None,
     runner: str | None = None,
     input_value: Any = None,
+    routing_value: Any = None,
 ) -> bool:
     """Whether a worker satisfies a workflow's affinity labels, resource
-    requests, and required runner. Shared by the SQL dispatch paths and the
-    transient (no-row) dispatch, which has no session to hang the check on.
+    requests, and required runner. Reached from the SQL dispatch paths.
 
     ``affinity`` is either the static label dict or a ``require(...)``
     expression (a list of term specs) whose terms resolve against the
-    execution input (``input_value``) — see :mod:`flux.routing`."""
+    execution input (``input_value``) or its routing-only input
+    (``routing_value``) — see :mod:`flux.routing`."""
     if runner is not None:
         # A worker that never advertised runners (None) is a legacy
         # in-process-only worker: it can honor runner="inprocess" and nothing
@@ -337,6 +338,7 @@ def worker_matches(
                 affinity,
                 worker.labels,
                 input_value,
+                routing_value=routing_value,
                 worker_metadata=getattr(worker, "metadata", None),
                 worker_metrics=getattr(worker, "metrics", None),
             ):

--- a/flux/migrations/versions/0023_routing_input.py
+++ b/flux/migrations/versions/0023_routing_input.py
@@ -1,0 +1,51 @@
+"""Add routing_input to executions and schedules.
+
+Values the scheduler matches on that the target worker never receives (issue
+#211). Kept off ``input`` rather than stripped out of it on the way to the
+worker: the input is readable back through the execution API by anything
+holding ``execution:*:read``, which the ``worker`` built-in role does, so
+removing it at delivery would not hide it.
+
+Signed like ``executions.input`` and ``schedules.input_data`` — caller-supplied
+data deserialized in the dispatch loop, and dill executes on load.
+
+Nullable with no backfill: NULL means no routing values, which is how every
+execution before this revision behaves.
+
+Revision ID: 0023_routing_input
+Revises: 0022_execution_required_worker
+Create Date: 2026-08-12
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0023_routing_input"
+down_revision: str | None = "0022_execution_required_worker"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_COLUMN = "routing_input"
+_TABLES = ("executions", "schedules")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    for table in _TABLES:
+        existing = {c["name"] for c in inspector.get_columns(table)}
+        if _COLUMN not in existing:
+            op.add_column(table, sa.Column(_COLUMN, sa.LargeBinary(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    for table in _TABLES:
+        existing = {c["name"] for c in inspector.get_columns(table)}
+        if _COLUMN in existing:
+            op.drop_column(table, _COLUMN)

--- a/flux/models.py
+++ b/flux/models.py
@@ -641,6 +641,10 @@ class ExecutionContextModel(Base):
     # Never falls back — from outside, a fallback is indistinguishable from
     # the binding having been honoured. Unsatisfiable parks.
     required_worker = Column(String, nullable=True)
+    # Values dispatch matches on that the worker never receives (issue #211).
+    # Signed like `input`: caller-supplied and deserialized in the dispatch
+    # loop, where dill would execute on load.
+    routing_input = Column(SignedPickleType(), nullable=True)
     scheduling_subject = Column(String, nullable=True)
     scheduling_principal_issuer = Column(String, nullable=True)
     # Set when the execution was dispatched by a schedule; lets schedule
@@ -924,6 +928,9 @@ class ScheduleModel(Base):
 
     # Optional input for scheduled executions
     input_data = Column(SignedPickleType(), nullable=True)
+
+    # Routing-only values stamped onto every execution this schedule fires.
+    routing_input = Column(SignedPickleType(), nullable=True)
 
     # Service account to run scheduled executions as (required when auth is enabled)
     run_as_service_account = Column(String, nullable=True)

--- a/flux/models.py
+++ b/flux/models.py
@@ -968,6 +968,7 @@ class ScheduleModel(Base):
         schedule: Schedule,
         description: str | None = None,
         input_data: Any = None,
+        routing_input: dict | None = None,
         status: ScheduleStatus = ScheduleStatus.ACTIVE,
         run_as_service_account: str | None = None,
         workflow_namespace: str = "default",
@@ -981,6 +982,7 @@ class ScheduleModel(Base):
         self.schedule_type = schedule.type
         self.status = status
         self.input_data = input_data
+        self.routing_input = routing_input
         self.run_as_service_account = run_as_service_account
         # getattr: Schedule objects unpickled from pre-#142 rows have no
         # overlap attribute.

--- a/flux/routing.py
+++ b/flux/routing.py
@@ -653,8 +653,12 @@ def when(condition: Any, term: Condition | dict) -> dict:
                 f"{spec}() gates score terms only — prefer()/least()/most()/sticky(); "
                 "it cannot gate a require() term",
             )
-        if isinstance(condition.value, dict) and "$input" in condition.value:
-            raise ValueError("when() conditions compare against a constant, not input(...)")
+        if isinstance(condition.value, dict) and any(
+            k in condition.value for k in _WRAPPED_REF_KEYS
+        ):
+            raise ValueError(
+                "when() conditions compare against a constant, not input(...)/routing_input(...)",
+            )
         cond_spec = {"selector": spec, "op": condition.op, "value": condition.value}
     else:
         raise ValueError(
@@ -890,7 +894,7 @@ def pick_worker(
             if not isinstance(then, dict):
                 logger.warning(f"Malformed routing term ignored: {term!r}")
                 return None
-            if isinstance(cond, dict) and "input" in cond:
+            if isinstance(cond, dict) and any(k in cond for k in _BARE_REF_KEYS):
                 # Input-gated score term: inactive conditions skip it; a
                 # malformed condition degrades the whole policy like any
                 # other malformed term.
@@ -1127,7 +1131,8 @@ def _resolve_selector_key(
             return (
                 kind,
                 "",
-                _Problem(
+                _routing_blind(
+                    from_routing,
                     "invalid",
                     f"input '{path}' resolves to an invalid {kind} key: '{key}'",
                 ),

--- a/flux/routing.py
+++ b/flux/routing.py
@@ -947,7 +947,7 @@ def pick_worker(
             # against the execution input. Unresolved input or an invalid
             # resolved key means the term cannot discriminate — everyone
             # scores 0 for it — while a malformed spec degrades the policy.
-            selector_kind, key, problem = _resolve_selector_key(
+            selector_kind, key, problem, _key_from_routing = _resolve_selector_key(
                 selector,
                 input_value,
                 routing_value,
@@ -1067,24 +1067,33 @@ def _resolve_selector_key(
     selector: Any,
     input_value: Any,
     routing_value: Any = None,
-) -> tuple[str, str, _Problem | None]:
+) -> tuple[str, str, _Problem | None, bool]:
     """Resolve a label/meta selector (static ``"label:key"`` or dynamic
     ``{"kind": "label"|"meta", "prefix", "input"}``) to its kind and key.
 
-    Returns ``(kind, key, None)`` or ``(kind, "", problem)``."""
+    Returns ``(kind, key, problem_or_None, key_came_from_routing)``. The last
+    element matters because a key resolved from routing input carries the
+    routing *value* inside it, so any message naming that key must be blinded
+    even when the term's comparison value is a plain ``input(...)``.
+    """
     if isinstance(selector, str) and selector.startswith("label:"):
-        return "label", selector[len("label:") :], None
+        return "label", selector[len("label:") :], None, False
     if isinstance(selector, str) and selector.startswith("meta:"):
         # Callers usually branch on static meta selectors before reaching
         # here; handled anyway so the resolver's contract holds for every
         # selector shape it documents.
-        return "meta", selector[len("meta:") :], None
+        return "meta", selector[len("meta:") :], None, False
     if isinstance(selector, dict) and selector.get("kind") in ("label", "meta"):
         kind = selector["kind"]
         prefix = selector.get("prefix")
         path, from_routing = _ref_path(selector, _BARE_REF_KEYS)
         if not isinstance(prefix, str) or not prefix or not path:
-            return kind, "", _Problem("malformed", f"malformed {kind} selector: {selector!r}")
+            return (
+                kind,
+                "",
+                _Problem("malformed", f"malformed {kind} selector: {selector!r}"),
+                False,
+            )
         resolved = _resolve_require_input(
             _ref_source(from_routing, input_value, routing_value),
             path,
@@ -1098,6 +1107,7 @@ def _resolve_selector_key(
                     "unresolved",
                     f"{kind} key requires input '{path}', which is not present",
                 ),
+                from_routing,
             )
         if resolved is None or isinstance(resolved, (dict, list)):
             return (
@@ -1108,6 +1118,7 @@ def _resolve_selector_key(
                     "invalid",
                     f"{kind} key input '{path}' must be a scalar",
                 ),
+                from_routing,
             )
         fragment = _label_value_str(resolved)
         if kind == "label" and prefix == SERVICE_LABEL_PREFIX:
@@ -1122,6 +1133,7 @@ def _resolve_selector_key(
                         "invalid",
                         f"input '{path}' resolves to an invalid service name: '{fragment}'",
                     ),
+                    from_routing,
                 )
         key = prefix + fragment
         # Metadata keys are held to the admin-API bound (validate_worker_metadata)
@@ -1136,9 +1148,10 @@ def _resolve_selector_key(
                     "invalid",
                     f"input '{path}' resolves to an invalid {kind} key: '{key}'",
                 ),
+                from_routing,
             )
-        return kind, key, None
-    return "label", "", _Problem("malformed", f"malformed label selector: {selector!r}")
+        return kind, key, None, from_routing
+    return "label", "", _Problem("malformed", f"malformed label selector: {selector!r}"), False
 
 
 def _resolve_require_term(
@@ -1154,7 +1167,11 @@ def _resolve_require_term(
     if isinstance(selector, str) and selector.startswith("meta:"):
         kind, key = "meta", selector[len("meta:") :]
     else:
-        kind, key, problem = _resolve_selector_key(selector, input_value, routing_value)
+        kind, key, problem, key_from_routing = _resolve_selector_key(
+            selector,
+            input_value,
+            routing_value,
+        )
         if problem is not None:
             if problem.category == "malformed":
                 return problem
@@ -1174,8 +1191,11 @@ def _resolve_require_term(
             path,
         )
         if value is _UNRESOLVED:
+            # key_from_routing too: a key resolved from routing input contains
+            # the routing value, so naming it leaks even when the comparison
+            # value is a plain input(...).
             return _routing_blind(
-                from_routing,
+                from_routing or key_from_routing,
                 "unresolved",
                 f"affinity term on {kind} '{key}' requires input '{path}', which is not present",
             )

--- a/flux/routing.py
+++ b/flux/routing.py
@@ -1047,6 +1047,18 @@ class _Problem(NamedTuple):
     message: str
 
 
+def _routing_blind(from_routing: bool, category: str, message: str) -> _Problem:
+    """Problems from a routing reference say nothing about it.
+
+    ``_fail_undispatchable`` writes these into ``executions.output``, which the
+    execution read API returns to anything holding ``execution:*:read`` — the
+    ``worker`` built-in role included. Naming the value would hand the worker
+    the thing routing input exists to keep from it, and naming the key alone
+    still distinguishes "absent" from "present but unmatched" (#211).
+    """
+    return _Problem(category, "routing constraint unsatisfied" if from_routing else message)
+
+
 def _resolve_selector_key(
     selector: Any,
     input_value: Any,
@@ -1077,13 +1089,22 @@ def _resolve_selector_key(
             return (
                 kind,
                 "",
-                _Problem(
+                _routing_blind(
+                    from_routing,
                     "unresolved",
                     f"{kind} key requires input '{path}', which is not present",
                 ),
             )
         if resolved is None or isinstance(resolved, (dict, list)):
-            return kind, "", _Problem("invalid", f"{kind} key input '{path}' must be a scalar")
+            return (
+                kind,
+                "",
+                _routing_blind(
+                    from_routing,
+                    "invalid",
+                    f"{kind} key input '{path}' must be a scalar",
+                ),
+            )
         fragment = _label_value_str(resolved)
         if kind == "label" and prefix == SERVICE_LABEL_PREFIX:
             if not is_valid_service_name(fragment):
@@ -1092,7 +1113,8 @@ def _resolve_selector_key(
                 return (
                     kind,
                     "",
-                    _Problem(
+                    _routing_blind(
+                        from_routing,
                         "invalid",
                         f"input '{path}' resolves to an invalid service name: '{fragment}'",
                     ),
@@ -1147,7 +1169,8 @@ def _resolve_require_term(
             path,
         )
         if value is _UNRESOLVED:
-            return _Problem(
+            return _routing_blind(
+                from_routing,
                 "unresolved",
                 f"affinity term on {kind} '{key}' requires input '{path}', which is not present",
             )

--- a/flux/routing.py
+++ b/flux/routing.py
@@ -92,13 +92,22 @@ class InputRef:
     ``when(input("tier") == "dedicated", ...)``.
     """
 
+    # The compiled spec has three encodings for a value reference, and each
+    # reads one of these keys. Subclassing for routing_input() rather than
+    # branching keeps every isinstance(..., InputRef) check working and makes
+    # a missed encoding a KeyError at authoring rather than a silent read of
+    # the wrong source (#211).
+    spec_key = "input"
+    wrapper_key = "$input"
+    factory_name = "input"
+
     def __init__(self, path: str):
         if not path or not isinstance(path, str):
-            raise ValueError("input() requires a non-empty string path")
+            raise ValueError(f"{self.factory_name}() requires a non-empty string path")
         self.path = path
 
     def to_spec(self) -> dict[str, str]:
-        return {"$input": self.path}
+        return {self.wrapper_key: self.path}
 
     def __eq__(self, other: Any) -> InputCondition:  # type: ignore[override]
         return InputCondition(self, "==", other)
@@ -134,6 +143,30 @@ class InputCondition:
 
 def input(path: str) -> InputRef:  # noqa: A001 - deliberate DSL name
     return InputRef(path)
+
+
+class RoutingInputRef(InputRef):
+    """A value resolved from the execution's routing input at dispatch time.
+
+    Identical to :class:`InputRef` in every way except where the value comes
+    from: routing input is stored on its own column and never delivered to the
+    worker, so an expression can discriminate on a value the target cannot
+    observe (issue #211).
+    """
+
+    spec_key = "routing_input"
+    wrapper_key = "$routing_input"
+    factory_name = "routing_input"
+
+
+def routing_input(path: str) -> RoutingInputRef:
+    """Reference a routing-only value: matched by dispatch, never delivered.
+
+    Named for the column, header, schedule field, ``call()`` kwarg and CLI flag
+    that set it — ``routing(...)`` would collide with the scoring policy that
+    ``@workflow.with_options(routing=...)`` takes.
+    """
+    return RoutingInputRef(path)
 
 
 class Condition:
@@ -301,7 +334,7 @@ class DynamicLabel(Selector):
         # produce a valid key from an invalid namespace.
         if not _LABEL_KEY_RE.match(prefix.rstrip("._-") or ""):
             raise ValueError(f"label_for() prefix is not a valid label key prefix: '{prefix}'")
-        self.spec = {"kind": "label", "prefix": prefix, "input": ref.path}
+        self.spec = {"kind": "label", "prefix": prefix, ref.spec_key: ref.path}
 
 
 class DynamicMeta(Selector):
@@ -336,7 +369,7 @@ class DynamicMeta(Selector):
                 f"meta_for() prefix exceeds the metadata key bound "
                 f"({MAX_METADATA_KEY_LENGTH} chars): '{prefix}'",
             )
-        self.spec = {"kind": "meta", "prefix": prefix, "input": ref.path}
+        self.spec = {"kind": "meta", "prefix": prefix, ref.spec_key: ref.path}
 
 
 def _validate_weight(weight: Any) -> float:
@@ -596,7 +629,11 @@ def when(condition: Any, term: Condition | dict) -> dict:
     """
     is_score_term = isinstance(term, dict) and term.get("kind") in _SCORE_TERM_KINDS
     if isinstance(condition, InputCondition):
-        cond_spec = {"input": condition.ref.path, "op": condition.op, "value": condition.value}
+        cond_spec = {
+            condition.ref.spec_key: condition.ref.path,
+            "op": condition.op,
+            "value": condition.value,
+        }
     elif isinstance(condition, Condition):
         spec = condition.selector.spec
         server_computed = spec in _SERVER_EVALUATED_SELECTORS
@@ -723,6 +760,28 @@ def validate_worker_metrics(payload: Any, max_keys: int = MAX_METRICS) -> dict[s
 # ---------------------------------------------------------------------------
 
 
+_WRAPPED_REF_KEYS = ("$input", "$routing_input")
+_BARE_REF_KEYS = ("input", "routing_input")
+
+
+def _ref_path(spec: dict, keys: tuple[str, ...]) -> tuple[str | None, bool]:
+    """``(path, from_routing_input)`` for a value reference in ``spec``.
+
+    Every reader goes through here so adding an encoding cannot leave one
+    resolving against ``input`` — which would silently read the wrong source
+    for a value that exists to be unreadable (#211).
+    """
+    for key in keys:
+        if key in spec:
+            path = spec[key]
+            return (path if isinstance(path, str) and path else None), key.endswith("routing_input")
+    return None, False
+
+
+def _ref_source(from_routing: bool, input_value: Any, routing_value: Any) -> Any:
+    return routing_value if from_routing else input_value
+
+
 def _resolve_input_path(input_value: Any, path: str) -> Any:
     current = input_value
     for part in path.split("."):
@@ -802,6 +861,7 @@ def pick_worker(
     *,
     loads: dict[str, int],
     input_value: Any = None,
+    routing_value: Any = None,
     preferred: str | None = None,
 ) -> WorkerInfo | None:
     """Rank eligible workers by the policy and return the winner.
@@ -834,7 +894,7 @@ def pick_worker(
                 # Input-gated score term: inactive conditions skip it; a
                 # malformed condition degrades the whole policy like any
                 # other malformed term.
-                active = _when_condition_active(term, input_value)
+                active = _when_condition_active(term, input_value, routing_value)
                 if isinstance(active, str):
                     logger.warning(f"Malformed routing term ignored: {term!r}")
                     return None
@@ -848,6 +908,7 @@ def pick_worker(
                     a = _when_condition_active(
                         term,
                         input_value,
+                        routing_value,
                         worker_labels=w.labels or {},
                         worker_metadata=getattr(w, "metadata", None) or {},
                         worker_metrics=getattr(w, "metrics", None) or {},
@@ -882,7 +943,11 @@ def pick_worker(
             # against the execution input. Unresolved input or an invalid
             # resolved key means the term cannot discriminate — everyone
             # scores 0 for it — while a malformed spec degrades the policy.
-            selector_kind, key, problem = _resolve_selector_key(selector, input_value)
+            selector_kind, key, problem = _resolve_selector_key(
+                selector,
+                input_value,
+                routing_value,
+            )
             if problem is not None:
                 if problem.category == "malformed":
                     logger.warning(f"Malformed routing term ignored: {term!r}")
@@ -899,8 +964,13 @@ def pick_worker(
                 logger.warning(f"Malformed routing term ignored: {term!r}")
                 return None
             right = term.get("value")
-            if isinstance(right, dict) and "$input" in right:
-                right = _resolve_input_path(input_value, right["$input"])
+            if isinstance(right, dict):
+                ref_path, from_routing = _ref_path(right, _WRAPPED_REF_KEYS)
+                if ref_path:
+                    right = _resolve_input_path(
+                        _ref_source(from_routing, input_value, routing_value),
+                        ref_path,
+                    )
             for w in applies_to:
                 if _compare(_selector_value(w, selector, loads), op, right):
                     totals[w.name] += weight
@@ -977,7 +1047,11 @@ class _Problem(NamedTuple):
     message: str
 
 
-def _resolve_selector_key(selector: Any, input_value: Any) -> tuple[str, str, _Problem | None]:
+def _resolve_selector_key(
+    selector: Any,
+    input_value: Any,
+    routing_value: Any = None,
+) -> tuple[str, str, _Problem | None]:
     """Resolve a label/meta selector (static ``"label:key"`` or dynamic
     ``{"kind": "label"|"meta", "prefix", "input"}``) to its kind and key.
 
@@ -991,10 +1065,14 @@ def _resolve_selector_key(selector: Any, input_value: Any) -> tuple[str, str, _P
         return "meta", selector[len("meta:") :], None
     if isinstance(selector, dict) and selector.get("kind") in ("label", "meta"):
         kind = selector["kind"]
-        prefix, path = selector.get("prefix"), selector.get("input")
-        if not isinstance(prefix, str) or not prefix or not isinstance(path, str) or not path:
+        prefix = selector.get("prefix")
+        path, from_routing = _ref_path(selector, _BARE_REF_KEYS)
+        if not isinstance(prefix, str) or not prefix or not path:
             return kind, "", _Problem("malformed", f"malformed {kind} selector: {selector!r}")
-        resolved = _resolve_require_input(input_value, path)
+        resolved = _resolve_require_input(
+            _ref_source(from_routing, input_value, routing_value),
+            path,
+        )
         if resolved is _UNRESOLVED:
             return (
                 kind,
@@ -1036,7 +1114,11 @@ def _resolve_selector_key(selector: Any, input_value: Any) -> tuple[str, str, _P
     return "label", "", _Problem("malformed", f"malformed label selector: {selector!r}")
 
 
-def _resolve_require_term(term: dict, input_value: Any) -> tuple[str, str, Any] | _Problem:
+def _resolve_require_term(
+    term: dict,
+    input_value: Any,
+    routing_value: Any = None,
+) -> tuple[str, str, Any] | _Problem:
     """Resolve a match term's selector kind, key, and comparison value against
     the execution input. Returns ``(kind, key, value)`` — kind is ``"label"``
     or ``"meta"`` — or a :class:`_Problem`. Meta values stay raw (numeric
@@ -1045,7 +1127,7 @@ def _resolve_require_term(term: dict, input_value: Any) -> tuple[str, str, Any] 
     if isinstance(selector, str) and selector.startswith("meta:"):
         kind, key = "meta", selector[len("meta:") :]
     else:
-        kind, key, problem = _resolve_selector_key(selector, input_value)
+        kind, key, problem = _resolve_selector_key(selector, input_value, routing_value)
         if problem is not None:
             if problem.category == "malformed":
                 return problem
@@ -1057,10 +1139,13 @@ def _resolve_require_term(term: dict, input_value: Any) -> tuple[str, str, Any] 
 
     value = term.get("value")
     if isinstance(value, dict):
-        path = value.get("$input")
-        if not isinstance(path, str) or not path:
+        path, from_routing = _ref_path(value, _WRAPPED_REF_KEYS)
+        if not path:
             return _Problem("malformed", f"malformed affinity value: {value!r}")
-        value = _resolve_require_input(input_value, path)
+        value = _resolve_require_input(
+            _ref_source(from_routing, input_value, routing_value),
+            path,
+        )
         if value is _UNRESOLVED:
             return _Problem(
                 "unresolved",
@@ -1076,6 +1161,7 @@ def _resolve_require_term(term: dict, input_value: Any) -> tuple[str, str, Any] 
 def _when_condition_active(
     term: dict,
     input_value: Any,
+    routing_value: Any = None,
     *,
     worker_labels: dict[str, Any] | None = None,
     worker_metadata: dict[str, Any] | None = None,
@@ -1095,11 +1181,15 @@ def _when_condition_active(
     cond = term.get("if")
     if not isinstance(cond, dict):
         return f"malformed affinity when-condition: {cond!r}"
-    if "input" in cond:
-        path, op = cond.get("input"), cond.get("op")
-        if not isinstance(path, str) or not path or op not in _REQUIRE_OPS:
+    if any(k in cond for k in _BARE_REF_KEYS):
+        path, from_routing = _ref_path(cond, _BARE_REF_KEYS)
+        op = cond.get("op")
+        if not path or op not in _REQUIRE_OPS:
             return f"malformed affinity when-condition: {cond!r}"
-        resolved = _resolve_require_input(input_value, path)
+        resolved = _resolve_require_input(
+            _ref_source(from_routing, input_value, routing_value),
+            path,
+        )
         if resolved is _UNRESOLVED:
             return False
         expected = cond.get("value")
@@ -1134,7 +1224,7 @@ def _when_condition_active(
     return f"malformed affinity when-condition: {cond!r}"
 
 
-def require_diagnostic(terms: Any, input_value: Any) -> str | None:
+def require_diagnostic(terms: Any, input_value: Any, routing_value: Any = None) -> str | None:
     """Execution-level reason this affinity expression can never match, or None.
 
     Unresolved input on a non-optional term, an invalid resolved label key,
@@ -1151,7 +1241,7 @@ def require_diagnostic(terms: Any, input_value: Any) -> str | None:
         if not isinstance(term, dict):
             return f"malformed affinity term: {term!r}"
         if term.get("kind") == "when":
-            active = _when_condition_active(term, input_value)
+            active = _when_condition_active(term, input_value, routing_value)
             if isinstance(active, str):
                 return active
             if active is None or not active:
@@ -1161,7 +1251,7 @@ def require_diagnostic(terms: Any, input_value: Any) -> str | None:
                 return f"malformed affinity when-term body: {term!r}"
         elif term.get("kind") != "match":
             return f"malformed affinity term: {term!r}"
-        resolved = _resolve_require_term(term, input_value)
+        resolved = _resolve_require_term(term, input_value, routing_value)
         if isinstance(resolved, _Problem):
             # optional(...) forgives absent input — nothing else: an invalid
             # resolved key or a malformed spec diagnoses regardless.
@@ -1177,6 +1267,7 @@ def require_matches(
     input_value: Any,
     worker_metadata: dict[str, Any] | None = None,
     *,
+    routing_value: Any = None,
     worker_metrics: dict[str, Any] | None = None,
     loads: dict[str, int] | None = None,
 ) -> bool:
@@ -1200,6 +1291,7 @@ def require_matches(
             active = _when_condition_active(
                 term,
                 input_value,
+                routing_value,
                 worker_labels=labels,
                 worker_metadata=metadata,
                 worker_metrics=worker_metrics or {},
@@ -1215,7 +1307,7 @@ def require_matches(
                 return False
         elif term.get("kind") != "match":
             return False
-        resolved = _resolve_require_term(term, input_value)
+        resolved = _resolve_require_term(term, input_value, routing_value)
         if isinstance(resolved, _Problem):
             if resolved.category == "unresolved" and term.get("optional"):
                 continue

--- a/flux/routing_input.py
+++ b/flux/routing_input.py
@@ -1,0 +1,113 @@
+"""Validation for routing-only execution input (issue #211).
+
+Every ingress path — the run header, the schedule field, ``call()``, the CLI —
+goes through :func:`validate_routing_input`, so the rules cannot drift between
+them.
+
+Rejected, never dropped. A silently discarded routing directive does not fail:
+it routes the execution somewhere the caller did not intend, and from outside
+that is indistinguishable from having been honoured.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+# A header is not a payload channel, and servers cap header bytes anyway. An
+# explicit limit makes the rejection ours and legible rather than a proxy's
+# opaque 431.
+MAX_ROUTING_INPUT_BYTES = 4096
+MAX_ROUTING_INPUT_KEYS = 64
+MAX_ROUTING_INPUT_DEPTH = 8
+
+_SCALARS = (str, int, float, bool)
+
+
+class RoutingInputError(ValueError):
+    """Raised for any routing input a caller cannot have meant."""
+
+
+def parse_routing_input_header(raw: str | list[str] | None) -> dict[str, Any] | None:
+    """Parse and validate the ``X-Flux-Routing-Input`` header value."""
+    if raw is None:
+        return None
+    if isinstance(raw, list):
+        # Starlette joins duplicates with ", ", which happens to produce
+        # invalid JSON. Rejecting by rule rather than by that coincidence.
+        raise RoutingInputError(
+            "X-Flux-Routing-Input must be sent once; received it more than once",
+        )
+    if len(raw.encode("utf-8")) > MAX_ROUTING_INPUT_BYTES:
+        raise RoutingInputError(
+            f"X-Flux-Routing-Input exceeds {MAX_ROUTING_INPUT_BYTES} bytes",
+        )
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise RoutingInputError(f"X-Flux-Routing-Input is not valid JSON: {e}") from e
+    return validate_routing_input(parsed)
+
+
+def validate_routing_input(value: Any) -> dict[str, Any] | None:
+    """Validate an already-parsed routing input mapping."""
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise RoutingInputError(
+            f"routing input must be a JSON object, got {type(value).__name__}",
+        )
+    if not value:
+        return None
+    encoded = json.dumps(value, default=str)
+    if len(encoded.encode("utf-8")) > MAX_ROUTING_INPUT_BYTES:
+        raise RoutingInputError(f"routing input exceeds {MAX_ROUTING_INPUT_BYTES} bytes")
+    _check_mapping(value, depth=1, seen_keys=[0])
+    return dict(value)
+
+
+def _check_mapping(mapping: dict, depth: int, seen_keys: list[int]) -> None:
+    if depth > MAX_ROUTING_INPUT_DEPTH:
+        raise RoutingInputError(
+            f"routing input nests deeper than {MAX_ROUTING_INPUT_DEPTH} levels",
+        )
+    for key, item in mapping.items():
+        if not isinstance(key, str) or not key:
+            raise RoutingInputError(f"routing input keys must be non-empty strings, got {key!r}")
+        if "." in key:
+            # Path resolution splits the whole path on dots and descends one
+            # level per part, so a dotted key is unreachable at ANY depth --
+            # {"a": {"b.c": 1}} is as unreachable as {"a.b": 1}.
+            raise RoutingInputError(
+                f"routing input key '{key}' contains '.', which path resolution "
+                "reserves for descending nested objects",
+            )
+        seen_keys[0] += 1
+        if seen_keys[0] > MAX_ROUTING_INPUT_KEYS:
+            raise RoutingInputError(f"routing input has more than {MAX_ROUTING_INPUT_KEYS} keys")
+        if isinstance(item, dict):
+            _check_mapping(item, depth + 1, seen_keys)
+        elif item is not None and not isinstance(item, _SCALARS):
+            raise RoutingInputError(
+                f"routing input value for '{key}' must be a scalar or object, "
+                f"got {type(item).__name__}",
+            )
+
+
+def parse_cli_pairs(pairs: tuple[str, ...] | list[str] | None) -> dict[str, str] | None:
+    """Build routing input from repeatable ``key=value`` CLI arguments.
+
+    Flat by construction: `key=value` cannot express nesting, and dots are
+    refused in keys, so nested structures are an API/SDK affair.
+    """
+    if not pairs:
+        return None
+    out: dict[str, str] = {}
+    for pair in pairs:
+        key, sep, value = pair.partition("=")
+        if not sep or not key:
+            raise RoutingInputError(f"routing input must be key=value, got '{pair}'")
+        if key in out:
+            raise RoutingInputError(f"routing input key '{key}' given more than once")
+        out[key] = value
+    return validate_routing_input(out)

--- a/flux/routing_input.py
+++ b/flux/routing_input.py
@@ -29,15 +29,23 @@ class RoutingInputError(ValueError):
 
 
 def parse_routing_input_header(raw: str | list[str] | None) -> dict[str, Any] | None:
-    """Parse and validate the ``X-Flux-Routing-Input`` header value."""
+    """Parse and validate the ``X-Flux-Routing-Input`` header value.
+
+    The route declares this header as ``list[str]`` so FastAPI reads it with
+    ``getlist()``. Declared as ``str`` it would use ``get()``, which returns
+    only the first of repeated headers — silently discarding the rest, which
+    is the failure this module exists to refuse.
+    """
     if raw is None:
         return None
     if isinstance(raw, list):
-        # Starlette joins duplicates with ", ", which happens to produce
-        # invalid JSON. Rejecting by rule rather than by that coincidence.
-        raise RoutingInputError(
-            "X-Flux-Routing-Input must be sent once; received it more than once",
-        )
+        if not raw:
+            return None
+        if len(raw) > 1:
+            raise RoutingInputError(
+                f"X-Flux-Routing-Input must be sent once; received it {len(raw)} times",
+            )
+        raw = raw[0]
     if len(raw.encode("utf-8")) > MAX_ROUTING_INPUT_BYTES:
         raise RoutingInputError(
             f"X-Flux-Routing-Input exceeds {MAX_ROUTING_INPUT_BYTES} bytes",

--- a/flux/routing_input.py
+++ b/flux/routing_input.py
@@ -54,6 +54,12 @@ def parse_routing_input_header(raw: str | list[str] | None) -> dict[str, Any] | 
         parsed = json.loads(raw)
     except json.JSONDecodeError as e:
         raise RoutingInputError(f"X-Flux-Routing-Input is not valid JSON: {e}") from e
+    if parsed is None:
+        # Sending the header at all is a directive. `null` reaching
+        # validate_routing_input would return None, which is also "absent" —
+        # so the caller would get a 200 for a routing directive that was
+        # dropped, the failure this module exists to refuse.
+        raise RoutingInputError("X-Flux-Routing-Input must be a JSON object, got null")
     return validate_routing_input(parsed)
 
 
@@ -70,11 +76,12 @@ def validate_routing_input(value: Any) -> dict[str, Any] | None:
     encoded = json.dumps(value, default=str)
     if len(encoded.encode("utf-8")) > MAX_ROUTING_INPUT_BYTES:
         raise RoutingInputError(f"routing input exceeds {MAX_ROUTING_INPUT_BYTES} bytes")
-    _check_mapping(value, depth=1, seen_keys=[0])
+    _check_mapping(value, depth=1)
     return dict(value)
 
 
-def _check_mapping(mapping: dict, depth: int, seen_keys: list[int]) -> None:
+def _check_mapping(mapping: dict, depth: int, counted: int = 0) -> int:
+    """Returns the running key count so the bound spans the whole structure."""
     if depth > MAX_ROUTING_INPUT_DEPTH:
         raise RoutingInputError(
             f"routing input nests deeper than {MAX_ROUTING_INPUT_DEPTH} levels",
@@ -90,16 +97,17 @@ def _check_mapping(mapping: dict, depth: int, seen_keys: list[int]) -> None:
                 f"routing input key '{key}' contains '.', which path resolution "
                 "reserves for descending nested objects",
             )
-        seen_keys[0] += 1
-        if seen_keys[0] > MAX_ROUTING_INPUT_KEYS:
+        counted += 1
+        if counted > MAX_ROUTING_INPUT_KEYS:
             raise RoutingInputError(f"routing input has more than {MAX_ROUTING_INPUT_KEYS} keys")
         if isinstance(item, dict):
-            _check_mapping(item, depth + 1, seen_keys)
+            counted = _check_mapping(item, depth + 1, counted)
         elif item is not None and not isinstance(item, _SCALARS):
             raise RoutingInputError(
                 f"routing input value for '{key}' must be a scalar or object, "
                 f"got {type(item).__name__}",
             )
+    return counted
 
 
 def parse_cli_pairs(pairs: tuple[str, ...] | list[str] | None) -> dict[str, str] | None:

--- a/flux/schedule_manager.py
+++ b/flux/schedule_manager.py
@@ -46,6 +46,7 @@ class ScheduleManager(ABC):
         schedule: Schedule,
         description: str | None = None,
         input_data: Any = None,
+        routing_input: dict | None = None,
         run_as_service_account: str | None = None,
         workflow_namespace: str = "default",
     ) -> ScheduleModel:
@@ -80,6 +81,7 @@ class ScheduleManager(ABC):
         schedule: Schedule | None = None,
         description: str | None = None,
         input_data: Any = None,
+        routing_input: dict | None = None,
         run_as_service_account: str | None = None,
     ) -> ScheduleModel:
         """Update an existing schedule"""
@@ -163,6 +165,7 @@ class DatabaseScheduleManager(ScheduleManager):
         schedule: Schedule,
         description: str | None = None,
         input_data: Any = None,
+        routing_input: dict | None = None,
         run_as_service_account: str | None = None,
         workflow_namespace: str = "default",
     ) -> ScheduleModel:
@@ -192,6 +195,7 @@ class DatabaseScheduleManager(ScheduleManager):
                     schedule=schedule,
                     description=description,
                     input_data=input_data,
+                    routing_input=routing_input,
                     run_as_service_account=run_as_service_account,
                 )
 
@@ -266,6 +270,7 @@ class DatabaseScheduleManager(ScheduleManager):
         schedule: Schedule | None = None,
         description: str | None = None,
         input_data: Any = None,
+        routing_input: dict | None = None,
         run_as_service_account: str | None = None,
     ) -> ScheduleModel:
         """Update an existing schedule"""
@@ -287,6 +292,9 @@ class DatabaseScheduleManager(ScheduleManager):
 
                 if input_data is not None:
                     schedule_model.input_data = input_data
+
+                if routing_input is not None:
+                    schedule_model.routing_input = routing_input
 
                 if run_as_service_account is not None:
                     schedule_model.run_as_service_account = run_as_service_account

--- a/flux/schedule_manager.py
+++ b/flux/schedule_manager.py
@@ -294,7 +294,10 @@ class DatabaseScheduleManager(ScheduleManager):
                     schedule_model.input_data = input_data
 
                 if routing_input is not None:
-                    schedule_model.routing_input = routing_input
+                    # {} clears: validate_routing_input normalises an empty
+                    # object to None, so without this an operator could set
+                    # routing values on a schedule and never remove them.
+                    schedule_model.routing_input = routing_input or None
 
                 if run_as_service_account is not None:
                     schedule_model.run_as_service_account = run_as_service_account

--- a/flux/server.py
+++ b/flux/server.py
@@ -487,6 +487,7 @@ class Server(
         version: int | None = None,
         preferred_worker: str | None = None,
         required_worker: str | None = None,
+        routing_input: dict | None = None,
         park_ttl: int | None = None,
     ) -> ExecutionContext:
         workflow = WorkflowCatalog.create().get(namespace, workflow_name, version)
@@ -505,6 +506,7 @@ class Server(
             ),
             preferred_worker=preferred_worker or None,
             required_worker=required_worker or None,
+            routing_input=routing_input or None,
             park_ttl=park_ttl,
         )
 

--- a/flux/server.py
+++ b/flux/server.py
@@ -1212,6 +1212,7 @@ class Server(
                 _sched_ns,
                 schedule.workflow_name,
                 schedule.input_data,
+                routing_input=schedule.routing_input,
             )
 
             # Link the execution to its schedule (so history can be scoped to

--- a/flux/server.py
+++ b/flux/server.py
@@ -1215,6 +1215,15 @@ class Server(
                 routing_input=schedule.routing_input,
             )
 
+            if schedule.routing_input:
+                # Key names only, as at the run endpoint. Schedules are where
+                # routing values are set once and applied to every later fire,
+                # so this is the trace that matters most.
+                logger.info(
+                    f"Execution {ctx.execution_id} carries routing input keys "
+                    f"from schedule '{schedule.name}': {sorted(schedule.routing_input)}",
+                )
+
             # Link the execution to its schedule (so history can be scoped to
             # this schedule) and, when auth is on, attach its execution token.
             # Both writes share one session/commit so the row is updated in a

--- a/flux/task.py
+++ b/flux/task.py
@@ -93,6 +93,7 @@ class _WithOptions:
         cache: bool = False,
         metadata: bool = False,
         auth_exempt: bool = False,
+        digest_exclude: tuple[str, ...] = (),
         requires_approval: bool | Callable[..., bool | Awaitable[bool]] = False,
         approval_target: str | None = None,
         risk: str | None = None,
@@ -114,6 +115,7 @@ class _WithOptions:
                 cache=cache,
                 metadata=metadata,
                 auth_exempt=auth_exempt,
+                digest_exclude=digest_exclude,
                 requires_approval=requires_approval,
                 approval_target=approval_target,
                 risk=risk,
@@ -142,6 +144,7 @@ class task:
         cache: bool = False,
         metadata: bool = False,
         auth_exempt: bool = False,
+        digest_exclude: tuple[str, ...] = (),
         requires_approval: bool | Callable[..., bool | Awaitable[bool]] = False,
         approval_target: str | None = None,
         risk: str | None = None,
@@ -170,6 +173,11 @@ class task:
         self.cache = cache
         self.metadata = metadata
         self.auth_exempt = auth_exempt
+        # kwargs kept out of the identity digest. The digest is the task_id,
+        # which is also the cache key and the approval call_id, so excluding a
+        # kwarg here makes calls differing only in it identical — declared per
+        # task rather than by name in the shared machinery.
+        self.digest_exclude = digest_exclude
         self.requires_approval = requires_approval
         # Name of the argument whose value a target-scoped standing grant
         # binds to (issue #143). A task that declares nothing cannot mint
@@ -238,6 +246,18 @@ class task:
             detail = f"{type_name}: {detail}"
         return ExecutionError(message=detail)
 
+    def _digest_kwargs(self, kwargs: dict) -> dict:
+        """kwargs contributing to the task id, minus any the task excludes.
+
+        The id is also the cache key and the approval call_id, so an excluded
+        kwarg makes calls differing only in it identical — right for
+        call(routing_input=...), wrong for a task that merely happens to take
+        a kwarg of that name.
+        """
+        if not self.digest_exclude:
+            return kwargs
+        return {k: v for k, v in kwargs.items() if k not in self.digest_exclude}
+
     @staticmethod
     def _compute_task_id(full_name: str, task_args: dict, args: tuple, kwargs: dict) -> str:
         """Deterministic, cross-process-stable id for a task call.
@@ -259,14 +279,12 @@ class task:
         task_args = get_func_args(self._func, args)
         full_name = self.name.format(**task_args)
 
-        # routing_input is excluded from the digest: the id becomes the
-        # source_id of a recorded event, and anything holding execution:*:read
-        # — which the `worker` built-in role does — could read the parent
-        # execution and brute-force a small cohort space offline, recovering
-        # values the routing channel exists to hide (#211). The occurrence
-        # counter below already disambiguates repeated calls.
-        digest_kwargs = {k: v for k, v in kwargs.items() if k != "routing_input"}
-        task_id = self._compute_task_id(full_name, task_args, args, digest_kwargs)
+        task_id = self._compute_task_id(
+            full_name,
+            task_args,
+            args,
+            self._digest_kwargs(kwargs),
+        )
 
         ctx = await ExecutionContext.get()
 
@@ -609,6 +627,7 @@ class task:
         cache: bool | None = None,
         metadata: bool | None = None,
         auth_exempt: bool | None = None,
+        digest_exclude: tuple[str, ...] | None = None,
         requires_approval: bool | Callable[..., bool | Awaitable[bool]] | None = None,
         approval_target: str | None = None,
         risk: str | None = None,
@@ -636,6 +655,7 @@ class task:
             cache=cache if cache is not None else self.cache,
             metadata=metadata if metadata is not None else self.metadata,
             auth_exempt=auth_exempt if auth_exempt is not None else self.auth_exempt,
+            digest_exclude=(digest_exclude if digest_exclude is not None else self.digest_exclude),
             requires_approval=(
                 requires_approval if requires_approval is not None else self.requires_approval
             ),

--- a/flux/task.py
+++ b/flux/task.py
@@ -259,7 +259,14 @@ class task:
         task_args = get_func_args(self._func, args)
         full_name = self.name.format(**task_args)
 
-        task_id = self._compute_task_id(full_name, task_args, args, kwargs)
+        # routing_input is excluded from the digest: the id becomes the
+        # source_id of a recorded event, and anything holding execution:*:read
+        # — which the `worker` built-in role does — could read the parent
+        # execution and brute-force a small cohort space offline, recovering
+        # values the routing channel exists to hide (#211). The occurrence
+        # counter below already disambiguates repeated calls.
+        digest_kwargs = {k: v for k, v in kwargs.items() if k != "routing_input"}
+        task_id = self._compute_task_id(full_name, task_args, args, digest_kwargs)
 
         ctx = await ExecutionContext.get()
 

--- a/flux/tasks/call.py
+++ b/flux/tasks/call.py
@@ -61,7 +61,12 @@ async def _call_in_process(workflow: workflow_cls, args: tuple):
 
 
 @task.with_options(name="call_workflow_{workflow}")
-async def call(workflow: workflow_cls | str, *args, mode: Literal["sync", "async"] = "sync"):
+async def call(
+    workflow: workflow_cls | str,
+    *args,
+    mode: Literal["sync", "async"] = "sync",
+    routing_input: dict | None = None,
+):
     """Call a workflow — in-process when possible, otherwise via the HTTP API.
 
     Args:
@@ -86,7 +91,10 @@ async def call(workflow: workflow_cls | str, *args, mode: Literal["sync", "async
     from flux.catalogs import resolve_workflow_ref
     from flux.config import Configuration
 
+    from flux.routing_input import validate_routing_input
+
     settings = Configuration.get().settings
+    checked_routing_input = validate_routing_input(routing_input)
 
     if isinstance(workflow, workflow_cls):
         namespace = workflow.namespace
@@ -99,6 +107,10 @@ async def call(workflow: workflow_cls | str, *args, mode: Literal["sync", "async
             # may run inside the caller's process.
             and workflow.runner in (None, "inprocess")
             and settings.workers.transient_fast_path
+            # Routing values are matched by the dispatcher, which the fast
+            # path skips entirely. Taking it would discard them silently —
+            # the failure this feature refuses everywhere else (#211).
+            and not routing_input
         ):
             return await _call_in_process(workflow, args)
     else:
@@ -123,10 +135,19 @@ async def call(workflow: workflow_cls | str, *args, mode: Literal["sync", "async
         # eligible. A hint only — the server's matching still decides.
         async with await FluxClient.for_current_execution() as client:
             if mode == "async":
-                data = await client.run_workflow(workflow_ref, payload)
+                data = await client.run_workflow(
+                    workflow_ref,
+                    payload,
+                    routing_input=checked_routing_input,
+                )
                 return data["execution_id"]
 
-            data = await client.run_workflow_sync(workflow_ref, payload, detailed=True)
+            data = await client.run_workflow_sync(
+                workflow_ref,
+                payload,
+                detailed=True,
+                routing_input=checked_routing_input,
+            )
 
             ctx: ExecutionContext = ExecutionContext(
                 workflow_id=data["workflow_id"],

--- a/flux/tasks/call.py
+++ b/flux/tasks/call.py
@@ -115,6 +115,10 @@ async def call(
             # Routing values are matched by the dispatcher, which the fast
             # path skips entirely. Taking it would discard them silently —
             # the failure this feature refuses everywhere else (#211).
+            # Consequence worth knowing: a transient sync child can tell the
+            # two paths apart (a dispatched one has a real execution_id and
+            # token), so routing a probe this way hides the values but not the
+            # fact of routing. Documented in dynamic-routing.md.
             and not routing_input
         ):
             return await _call_in_process(workflow, args)

--- a/flux/tasks/call.py
+++ b/flux/tasks/call.py
@@ -60,7 +60,12 @@ async def _call_in_process(workflow: workflow_cls, args: tuple):
     )
 
 
-@task.with_options(name="call_workflow_{workflow}")
+# routing_input never enters the task id: that id is the source_id of a
+# recorded event, and anything holding execution:*:read — the `worker` role
+# included — could read the parent execution and brute-force a small cohort
+# space offline, recovering values this channel exists to hide (#211). The
+# occurrence counter already disambiguates repeated calls.
+@task.with_options(name="call_workflow_{workflow}", digest_exclude=("routing_input",))
 async def call(
     workflow: workflow_cls | str,
     *args,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.79.6"
+version = "0.80.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -140,11 +140,12 @@ class FluxCLI:
         input: str = "null",
         mode: str = "sync",
         timeout: int = 60,
+        routing_input: dict[str, str] | None = None,
     ) -> dict:
-        return self._server_json(
-            ["workflow", "run", ref, input, "--mode", mode],
-            timeout=timeout,
-        )
+        args = ["workflow", "run", ref, input, "--mode", mode]
+        for key, value in (routing_input or {}).items():
+            args.extend(["--routing-input", f"{key}={value}"])
+        return self._server_json(args, timeout=timeout)
 
     def show(self, ref: str) -> dict:
         return self._server_json(["workflow", "show", ref, "--format", "json"])

--- a/tests/e2e/fixtures/routing_input_workflow.py
+++ b/tests/e2e/fixtures/routing_input_workflow.py
@@ -1,0 +1,19 @@
+from flux import ExecutionContext, workflow
+from flux.routing import label, optional, require, routing_input
+
+
+@workflow
+async def routing_echo(ctx: ExecutionContext):
+    """Returns exactly what the worker received.
+
+    The point of the assertion downstream: routing values must be absent from
+    this, even though dispatch matched on them.
+    """
+    return {"seen_input": ctx.input}
+
+
+@workflow.with_options(
+    affinity=require(optional(label("cohort") == routing_input("cohort"))),
+)
+async def routing_pinned(ctx: ExecutionContext):
+    return {"worker": ctx.current_worker, "seen_input": ctx.input}

--- a/tests/e2e/test_routing_input.py
+++ b/tests/e2e/test_routing_input.py
@@ -1,0 +1,93 @@
+"""Routing-only execution input against a real server and worker (issue #211).
+
+The unit tests prove the pieces; this proves the path. A defect in this feature
+found during review was invisible to unit tests precisely because it lived in
+the ingress rather than the validator, so the assertions here run through the
+CLI and a live worker.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from .conftest import FluxCLIError
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def registered(cli):
+    cli.register(str(FIXTURES / "routing_input_workflow.py"))
+
+
+def test_routing_values_never_reach_the_worker(cli):
+    """The guarantee, end to end: the workflow returns what it received, and
+    the routing values are not in it."""
+    result = cli.run(
+        "routing_echo",
+        '{"real": "payload"}',
+        routing_input={"cohort": "canary"},
+    )
+
+    assert result["state"] == "COMPLETED"
+    seen = result["output"]["seen_input"]
+    assert seen == {"real": "payload"}
+    assert "cohort" not in str(seen)
+
+
+def test_routing_values_are_absent_from_the_execution_read(cli):
+    """`workflow status` is the API a worker can call for itself — the worker
+    built-in role holds execution:*:read."""
+    result = cli.run(
+        "routing_echo",
+        '{"real": "payload"}',
+        routing_input={"cohort": "canary"},
+    )
+
+    status = cli.status("routing_echo", result["execution_id"])
+
+    assert "canary" not in str(status)
+    assert "routing_input" not in str(status)
+
+
+def test_an_execution_with_and_without_routing_values_look_alike(cli):
+    """Indistinguishability is the actual claim, so compare the two directly
+    rather than asserting on one of them."""
+    with_values = cli.run("routing_echo", '{"real": "payload"}', routing_input={"cohort": "canary"})
+    without = cli.run("routing_echo", '{"real": "payload"}')
+
+    assert with_values["output"]["seen_input"] == without["output"]["seen_input"]
+
+    keys_with = set(cli.status("routing_echo", with_values["execution_id"]))
+    keys_without = set(cli.status("routing_echo", without["execution_id"]))
+    assert keys_with == keys_without
+
+
+def test_routing_values_steer_dispatch(cli):
+    """They are invisible *and* effective — a value the worker cannot see still
+    decides where the execution runs."""
+    worker = cli.start_worker("cohort-canary", labels={"cohort": "canary"})
+    try:
+        result = cli.run(
+            "routing_pinned",
+            "null",
+            routing_input={"cohort": "canary"},
+            timeout=120,
+        )
+
+        assert result["state"] == "COMPLETED"
+        assert result["output"]["worker"] == "cohort-canary"
+        assert result["output"]["seen_input"] is None, "routing values must not become input"
+    finally:
+        cli.stop_worker(worker)
+
+
+def test_invalid_routing_input_is_rejected_by_the_cli(cli):
+    """Rejected, never dropped — a dropped directive routes somewhere the
+    caller did not intend and reports success."""
+    with pytest.raises(FluxCLIError) as excinfo:
+        cli.run("routing_echo", "null", routing_input={"a.b": "1"})
+
+    assert excinfo.value.returncode != 0

--- a/tests/flux/test_migrations.py
+++ b/tests/flux/test_migrations.py
@@ -13,7 +13,7 @@ import flux.security.models  # noqa: F401
 from flux.migrations.runner import current_revision, run_migrations
 from flux.models import Base
 
-HEAD = "0022_execution_required_worker"
+HEAD = "0023_routing_input"
 BASELINE = "0001_baseline"
 
 # A representative index added after the original create_all schema, used to

--- a/tests/flux/test_migrations_postgresql.py
+++ b/tests/flux/test_migrations_postgresql.py
@@ -30,7 +30,7 @@ pytestmark = [
     ),
 ]
 
-HEAD = "0022_execution_required_worker"
+HEAD = "0023_routing_input"
 _BACKFILL_INDEX = "ix_executions_workflow_id"
 
 

--- a/tests/flux/test_require.py
+++ b/tests/flux/test_require.py
@@ -591,13 +591,26 @@ class TestMetaFor:
     def test_selector_key_resolver_handles_every_documented_shape(self):
         from flux.routing import _resolve_selector_key
 
-        assert _resolve_selector_key("label:gpu", None) == ("label", "gpu", None)
-        assert _resolve_selector_key("meta:zone", None) == ("meta", "zone", None)
-        kind, key, problem = _resolve_selector_key(
+        # The fourth element reports whether the resolved key came from routing
+        # input, so a diagnostic naming that key can be blinded (#211).
+        assert _resolve_selector_key("label:gpu", None) == ("label", "gpu", None, False)
+        assert _resolve_selector_key("meta:zone", None) == ("meta", "zone", None, False)
+        kind, key, problem, from_routing = _resolve_selector_key(
             {"kind": "meta", "prefix": "approved.", "input": "artefact"},
             {"artefact": "model-a"},
         )
-        assert (kind, key, problem) == ("meta", "approved.model-a", None)
+        assert (kind, key, problem, from_routing) == ("meta", "approved.model-a", None, False)
+
+    def test_selector_key_reports_a_routing_derived_key(self):
+        from flux.routing import _resolve_selector_key
+
+        _, key, problem, from_routing = _resolve_selector_key(
+            {"kind": "label", "prefix": "cohort.", "routing_input": "c"},
+            None,
+            {"c": "canary"},
+        )
+
+        assert (key, problem, from_routing) == ("cohort.canary", None, True)
 
 
 class TestRequireWhenWorkerState:

--- a/tests/flux/test_routing_input.py
+++ b/tests/flux/test_routing_input.py
@@ -326,3 +326,48 @@ class TestAuthoringGuards:
 
         with pytest.raises(ValueError, match="constant"):
             when(meta("region") == input_ref("r"), prefer(label("x") == "1"))
+
+
+class TestDigestExclusion:
+    """The task id is also the cache key and the approval call_id, so excluding
+    a kwarg from it collapses calls that differ only in that kwarg. That is
+    wanted for call(routing_input=...) and wrong for anything else — hence a
+    declared option rather than a name matched in the shared machinery."""
+
+    def test_call_excludes_routing_input(self):
+        from flux.tasks.call import call
+
+        assert call.digest_exclude == ("routing_input",)
+
+        kwargs = {"workflow": "w", "routing_input": {"cohort": "canary"}}
+        assert call._digest_kwargs(kwargs) == {"workflow": "w"}
+
+        # and therefore the same id as a call carrying no routing values
+        assert call._compute_task_id(
+            "c",
+            {},
+            (),
+            call._digest_kwargs(kwargs),
+        ) == call._compute_task_id("c", {}, (), {"workflow": "w"})
+
+    def test_an_unrelated_task_keeps_the_kwarg_in_its_identity(self):
+        """Otherwise a cached task taking a kwarg of that name would return the
+        first call's output for every later value."""
+        from flux.task import task
+
+        @task
+        async def scorer(model, routing_input=None):
+            return model
+
+        assert scorer.digest_exclude == ()
+        kwargs = {"model": "m", "routing_input": "a"}
+        assert scorer._digest_kwargs(kwargs) == kwargs, "nothing is stripped"
+
+        a = scorer._compute_task_id("s", {}, (), scorer._digest_kwargs(kwargs))
+        b = scorer._compute_task_id(
+            "s",
+            {},
+            (),
+            scorer._digest_kwargs({"model": "m", "routing_input": "b"}),
+        )
+        assert a != b, "cache keys must stay distinct for an unrelated task"

--- a/tests/flux/test_routing_input.py
+++ b/tests/flux/test_routing_input.py
@@ -115,6 +115,26 @@ class TestDiagnosticsAreBlind:
         assert "my/bad key" not in message
         assert "dataset" not in message
 
+    def test_routing_key_is_blinded_even_when_the_value_ref_is_plain_input(self):
+        """The blind flag tracked the *value* reference, but the message names
+        the resolved *key* — which for a routing-derived dynamic selector is
+        the routing value itself. A plain input() on the right-hand side
+        therefore routed around the blinding."""
+        terms = [
+            {
+                "kind": "match",
+                "selector": {"kind": "label", "prefix": "cohort.", "routing_input": "c"},
+                "op": "==",
+                "value": {"$input": "missing"},
+            },
+        ]
+
+        message = str(require_diagnostic(terms, {}, {"c": "canary-secret"}))
+
+        assert "canary-secret" not in message
+        assert "cohort." not in message
+        assert "routing constraint unsatisfied" in message
+
     def test_input_diagnostics_keep_their_detail(self):
         terms = require(label("cohort") == input_ref("normal_field"))
 
@@ -371,3 +391,112 @@ class TestDigestExclusion:
             scorer._digest_kwargs({"model": "m", "routing_input": "b"}),
         )
         assert a != b, "cache keys must stay distinct for an unrelated task"
+
+
+class TestScheduleIngress:
+    """The clear semantics are the most intricate logic in the feature and had
+    no coverage: validate_routing_input normalises {} to None, which the update
+    path would otherwise read as "not supplied"."""
+
+    @pytest.fixture
+    def client(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("FLUX_SECURITY__AUTH__ALLOW_ANONYMOUS", "true")
+        from flux.config import Configuration
+        from flux.models import DatabaseRepository
+
+        Configuration.get().override(database_url=f"sqlite:///{tmp_path / 'sched.db'}")
+        DatabaseRepository._engines.clear()
+        from fastapi.testclient import TestClient
+
+        from flux.server import Server
+
+        client = TestClient(Server("127.0.0.1", 0)._create_api())
+        source = b"""
+from flux import workflow, ExecutionContext
+
+
+@workflow
+async def probe(ctx: ExecutionContext):
+    return "ok"
+"""
+        assert (
+            client.post(
+                "/workflows",
+                files={"file": ("f.py", source, "text/x-python")},
+            ).status_code
+            == 200
+        )
+        yield client
+        DatabaseRepository._engines.clear()
+
+    def _create(self, client, name, routing_input=None):
+        body = {
+            "workflow_name": "probe",
+            "workflow_namespace": "default",
+            "name": name,
+            "schedule_config": {"type": "interval", "interval_seconds": 3600},
+        }
+        if routing_input is not None:
+            body["routing_input"] = routing_input
+        return client.post("/schedules", json=body)
+
+    def _stored(self, name):
+        from flux.models import RepositoryFactory, ScheduleModel
+
+        with RepositoryFactory.create_repository().session() as session:
+            return session.query(ScheduleModel).filter(ScheduleModel.name == name).first()
+
+    def test_created_with_routing_values(self, client):
+        assert self._create(client, "canary", {"cohort": "canary"}).status_code == 200
+
+        assert self._stored("canary").routing_input == {"cohort": "canary"}
+
+    def test_response_omits_them(self, client):
+        """Consistent with input_data, which ScheduleResponse also omits."""
+        resp = self._create(client, "quiet", {"cohort": "canary"})
+
+        assert "routing_input" not in resp.json()
+
+    def test_invalid_values_are_rejected(self, client):
+        assert self._create(client, "bad", {"a.b": 1}).status_code == 400
+
+    def test_empty_object_clears_them(self, client):
+        """Without this an operator could set routing values on a schedule and
+        never remove them — every future fire keeps routing to the cohort."""
+        self._create(client, "clearme", {"cohort": "canary"})
+        schedule_id = self._stored("clearme").id
+
+        resp = client.put(f"/schedules/{schedule_id}", json={"routing_input": {}})
+
+        assert resp.status_code == 200
+        assert not self._stored("clearme").routing_input
+
+    def test_omitting_the_field_leaves_them_untouched(self, client):
+        """Absent must mean "unchanged", or every unrelated edit would wipe
+        the routing values."""
+        self._create(client, "keepme", {"cohort": "canary"})
+        schedule_id = self._stored("keepme").id
+
+        resp = client.put(f"/schedules/{schedule_id}", json={"description": "edited"})
+
+        assert resp.status_code == 200
+        assert self._stored("keepme").routing_input == {"cohort": "canary"}
+
+
+class TestCallIngress:
+    """call() validates eagerly and refuses the fast path, which is the
+    security-relevant branch: that path never reaches dispatch, so a routing
+    value there would be silently discarded."""
+
+    def test_invalid_values_raise_before_any_dispatch(self):
+        import asyncio
+
+        from flux.tasks.call import call
+
+        with pytest.raises(RoutingInputError):
+            asyncio.run(call._func("some_workflow", routing_input={"a.b": 1}))
+
+    def test_call_declares_the_digest_exclusion(self):
+        from flux.tasks.call import call
+
+        assert "routing_input" in call.digest_exclude

--- a/tests/flux/test_routing_input.py
+++ b/tests/flux/test_routing_input.py
@@ -102,6 +102,19 @@ class TestDiagnosticsAreBlind:
         assert message == "routing constraint unsatisfied"
         assert "secret_cohort" not in message
 
+    def test_dynamic_key_diagnostic_leaks_neither(self):
+        """The dynamic-key path had an unblinded diagnostic that named the
+        routing key *and* its resolved value. It reaches executions.output,
+        which the worker role can read."""
+        from flux.routing import label_for
+
+        terms = require(label_for("cache.", routing_input("dataset")) == "true")
+
+        message = str(require_diagnostic(terms, None, {"dataset": "my/bad key"}))
+
+        assert "my/bad key" not in message
+        assert "dataset" not in message
+
     def test_input_diagnostics_keep_their_detail(self):
         terms = require(label("cohort") == input_ref("normal_field"))
 
@@ -144,6 +157,12 @@ class TestValidation:
     def test_single_element_list_is_the_normal_case(self):
         """getlist() always yields a list, so one header arrives as one item."""
         assert parse_routing_input_header(['{"cohort":"canary"}']) == CANARY
+
+    def test_null_body_is_rejected_not_treated_as_absent(self):
+        """Sending the header at all is a directive. `null` collapsing to the
+        same None as an absent header would return 200 for a dropped one."""
+        with pytest.raises(RoutingInputError, match="null"):
+            parse_routing_input_header("null")
 
     def test_oversized_is_rejected(self):
         with pytest.raises(RoutingInputError, match="exceeds"):
@@ -290,3 +309,20 @@ async def probe(ctx: ExecutionContext):
         assert resp.status_code == 200
         routing, _ = self._stored(resp.json()["execution_id"])
         assert routing is None
+
+
+class TestAuthoringGuards:
+    """Rejections that must fire for routing_input() exactly as they do for
+    input(), or an expression compiles into a term that can never match."""
+
+    def test_worker_condition_against_a_routing_ref_is_rejected(self):
+        from flux.routing import meta
+
+        with pytest.raises(ValueError, match="constant"):
+            when(meta("region") == routing_input("r"), prefer(label("x") == "1"))
+
+    def test_same_rejection_as_the_input_spelling(self):
+        from flux.routing import meta
+
+        with pytest.raises(ValueError, match="constant"):
+            when(meta("region") == input_ref("r"), prefer(label("x") == "1"))

--- a/tests/flux/test_routing_input.py
+++ b/tests/flux/test_routing_input.py
@@ -135,11 +135,15 @@ class TestValidation:
             validate_routing_input({"a": {"b.c": 1}})
 
     def test_repeated_header_is_rejected_by_rule(self):
-        """Starlette joins duplicates into invalid JSON, which would reject it
-        by accident. Resting the rule on that coincidence is the silent-drop
-        risk this validation exists to remove."""
-        with pytest.raises(RoutingInputError, match="more than once"):
+        """By rule, not by the coincidence that joined duplicates happen to be
+        invalid JSON. The route reads the header with getlist() so the repeat
+        is visible here rather than collapsed before it arrives."""
+        with pytest.raises(RoutingInputError, match="sent once"):
             parse_routing_input_header(["{}", "{}"])
+
+    def test_single_element_list_is_the_normal_case(self):
+        """getlist() always yields a list, so one header arrives as one item."""
+        assert parse_routing_input_header(['{"cohort":"canary"}']) == CANARY
 
     def test_oversized_is_rejected(self):
         with pytest.raises(RoutingInputError, match="exceeds"):
@@ -193,3 +197,96 @@ class TestNotVisibleToTheWorker:
 
         assert restored.input == {"real": "payload"}
         assert not hasattr(restored, "routing_input")
+
+
+class TestRunEndpointIngress:
+    """Exercised through the real route, not the validator.
+
+    The unit tests above passed while the ingress was broken: the header was
+    typed `str`, so FastAPI read it with `get()` and silently kept only the
+    first of repeated headers. Validating the parser proves nothing about the
+    path that feeds it.
+    """
+
+    SOURCE = b"""
+from flux import workflow, ExecutionContext
+
+
+@workflow
+async def probe(ctx: ExecutionContext):
+    return "ok"
+"""
+
+    @pytest.fixture
+    def client(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("FLUX_SECURITY__AUTH__ALLOW_ANONYMOUS", "true")
+        from flux.config import Configuration
+        from flux.models import DatabaseRepository
+
+        Configuration.get().override(database_url=f"sqlite:///{tmp_path / 'ri.db'}")
+        DatabaseRepository._engines.clear()
+        from fastapi.testclient import TestClient
+
+        from flux.server import Server
+
+        client = TestClient(Server("127.0.0.1", 0)._create_api())
+        assert (
+            client.post(
+                "/workflows",
+                files={"file": ("f.py", self.SOURCE, "text/x-python")},
+            ).status_code
+            == 200
+        )
+        yield client
+        DatabaseRepository._engines.clear()
+
+    def _run(self, client, headers=None):
+        return client.post(
+            "/workflows/default/probe/run/async",
+            json={"real": "payload"},
+            headers=headers,
+        )
+
+    def _stored(self, execution_id):
+        from flux.models import ExecutionContextModel, RepositoryFactory
+
+        with RepositoryFactory.create_repository().session() as session:
+            row = session.get(ExecutionContextModel, execution_id)
+            return row.routing_input, row.input
+
+    def test_values_are_stored_off_the_payload(self, client):
+        resp = self._run(client, {"X-Flux-Routing-Input": '{"cohort":"canary"}'})
+
+        assert resp.status_code == 200
+        routing, payload = self._stored(resp.json()["execution_id"])
+        assert routing == {"cohort": "canary"}
+        assert payload == {"real": "payload"}, "input must be untouched"
+
+    def test_repeated_header_is_rejected(self, client):
+        """Two contradictory directives used to return 200 with one silently
+        applied — the exact silent-drop this feature refuses."""
+        resp = client.post(
+            "/workflows/default/probe/run/async",
+            json={"real": "payload"},
+            headers=[
+                ("X-Flux-Routing-Input", '{"cohort":"canary"}'),
+                ("X-Flux-Routing-Input", '{"cohort":"control"}'),
+            ],
+        )
+
+        assert resp.status_code == 400
+        assert "sent once" in str(resp.json()["detail"])
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["{oops", '"scalar"', '{"a.b":1}', '{"a":{"b.c":1}}'],
+    )
+    def test_invalid_values_are_rejected_not_dropped(self, client, raw):
+        assert self._run(client, {"X-Flux-Routing-Input": raw}).status_code == 400
+
+    def test_absent_header_leaves_no_routing_values(self, client):
+        resp = self._run(client)
+
+        assert resp.status_code == 200
+        routing, _ = self._stored(resp.json()["execution_id"])
+        assert routing is None

--- a/tests/flux/test_routing_input.py
+++ b/tests/flux/test_routing_input.py
@@ -1,0 +1,195 @@
+"""Routing-only execution input (issue #211).
+
+The claim is indistinguishability: an execution carrying routing values must
+look identical, to the worker, to one that carries none. Nothing else in the
+suite fails when that breaks — the values simply start being visible — so the
+surface assertions below mirror the design's table one-to-one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from flux.domain.execution_context import ExecutionContext
+from flux.routing import (
+    input as input_ref,
+    label,
+    prefer,
+    require,
+    require_diagnostic,
+    require_matches,
+    routing_input,
+    score,
+    when,
+)
+from flux.routing_input import (
+    RoutingInputError,
+    parse_cli_pairs,
+    parse_routing_input_header,
+    validate_routing_input,
+)
+
+LABELS = {"cohort": "canary"}
+CANARY = {"cohort": "canary"}
+
+
+class TestSourcesNeverCross:
+    """The whole design rests on routing_input() and input() reading different
+    stores. If they ever cross, the value being hidden is read from the payload
+    that is delivered."""
+
+    def test_routing_term_reads_routing_values(self):
+        terms = require(label("cohort") == routing_input("cohort"))
+
+        assert require_matches(terms, LABELS, None, routing_value=CANARY) is True
+        assert require_matches(terms, LABELS, None, routing_value={"cohort": "control"}) is False
+
+    def test_routing_term_does_not_fall_back_to_input(self):
+        terms = require(label("cohort") == routing_input("cohort"))
+
+        assert require_matches(terms, LABELS, CANARY, routing_value=None) is False
+
+    def test_input_term_does_not_read_routing_values(self):
+        terms = require(label("cohort") == input_ref("cohort"))
+
+        assert require_matches(terms, LABELS, None, routing_value=CANARY) is False
+        assert require_matches(terms, LABELS, CANARY) is True
+
+
+class TestEveryEncoding:
+    """input() compiles three different ways and each needed a routing twin. A
+    missed one does not raise — it resolves against `input`, silently reading
+    the wrong source."""
+
+    def test_comparison_value(self):
+        spec = require(label("cohort") == routing_input("cohort"))
+
+        assert spec[0]["value"] == {"$routing_input": "cohort"}
+
+    def test_when_condition(self):
+        spec = score(when(routing_input("tier") == "gold", prefer(label("x") == "1")))
+
+        assert spec["terms"][0]["if"]["routing_input"] == "tier"
+
+    def test_dynamic_key(self):
+        from flux.routing import label_for
+
+        spec = require(label_for("cache.", routing_input("dataset")) == "true")
+
+        assert spec[0]["selector"]["routing_input"] == "dataset"
+
+    def test_dynamic_key_resolves_from_routing_values(self):
+        from flux.routing import label_for
+
+        terms = require(label_for("cache.", routing_input("dataset")) == "true")
+        labels = {"cache.orders": "true"}
+
+        assert require_matches(terms, labels, None, routing_value={"dataset": "orders"}) is True
+        assert require_matches(terms, labels, {"dataset": "orders"}) is False
+
+
+class TestDiagnosticsAreBlind:
+    """`_fail_undispatchable` writes diagnostics into `output`, which the
+    execution read API returns — and the `worker` built-in role holds
+    execution:*:read. A message naming the key still separates "absent" from
+    "present but unmatched"."""
+
+    def test_routing_diagnostic_names_neither_key_nor_value(self):
+        terms = require(label("cohort") == routing_input("secret_cohort"))
+
+        message = require_diagnostic(terms, None, None)
+
+        assert message == "routing constraint unsatisfied"
+        assert "secret_cohort" not in message
+
+    def test_input_diagnostics_keep_their_detail(self):
+        terms = require(label("cohort") == input_ref("normal_field"))
+
+        message = require_diagnostic(terms, None, None)
+
+        assert "normal_field" in message
+
+
+class TestValidation:
+    """Rejected, never dropped: a discarded routing directive routes the
+    execution somewhere the caller did not intend, invisibly."""
+
+    def test_valid_shapes(self):
+        assert parse_routing_input_header('{"cohort":"canary"}') == CANARY
+        assert parse_routing_input_header('{"a":{"b":1}}') == {"a": {"b": 1}}
+        assert parse_routing_input_header(None) is None
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["{oops", '"scalar"', "[1,2]", '{"a.b":1}'],
+    )
+    def test_rejected_shapes(self, raw):
+        with pytest.raises(RoutingInputError):
+            parse_routing_input_header(raw)
+
+    def test_nested_dotted_key_is_rejected_too(self):
+        """Path resolution splits the whole path on dots, so {"a": {"b.c": 1}}
+        is exactly as unreachable as {"a.b": 1}. A rule written only for the
+        top level re-admits the silent unreachability it exists to prevent."""
+        with pytest.raises(RoutingInputError, match=r"contains '\.'"):
+            validate_routing_input({"a": {"b.c": 1}})
+
+    def test_repeated_header_is_rejected_by_rule(self):
+        """Starlette joins duplicates into invalid JSON, which would reject it
+        by accident. Resting the rule on that coincidence is the silent-drop
+        risk this validation exists to remove."""
+        with pytest.raises(RoutingInputError, match="more than once"):
+            parse_routing_input_header(["{}", "{}"])
+
+    def test_oversized_is_rejected(self):
+        with pytest.raises(RoutingInputError, match="exceeds"):
+            parse_routing_input_header('{"k":"' + "x" * 5000 + '"}')
+
+    @pytest.mark.parametrize("pairs", [("nokey",), ("=v",), ("a=1", "a=2")])
+    def test_cli_pairs_rejected(self, pairs):
+        with pytest.raises(RoutingInputError):
+            parse_cli_pairs(pairs)
+
+    def test_cli_pairs_accepted(self):
+        assert parse_cli_pairs(("cohort=canary", "region=eu")) == {
+            "cohort": "canary",
+            "region": "eu",
+        }
+
+
+class TestNotVisibleToTheWorker:
+    """One assertion per surface in the design's table. Each fails if the
+    field is ever added to that surface — verified by adding it temporarily,
+    not assumed."""
+
+    def _ctx(self):
+        return ExecutionContext(
+            workflow_id="default/probe",
+            workflow_namespace="default",
+            workflow_name="probe",
+            input={"real": "payload"},
+        )
+
+    def test_execution_context_has_no_routing_input(self):
+        ctx = self._ctx()
+
+        assert not hasattr(ctx, "routing_input")
+        assert "routing_input" not in ctx.to_dict()
+
+    def test_serialized_context_has_no_routing_input(self):
+        assert "routing_input" not in self._ctx().to_json()
+
+    def test_summary_has_no_routing_input(self):
+        from flux.servers.models import ExecutionContext as ExecutionContextDTO
+
+        dto = ExecutionContextDTO.from_domain(self._ctx())
+
+        assert "routing_input" not in dto.summary()
+
+    def test_round_trip_through_the_wire_drops_nothing_and_adds_nothing(self):
+        ctx = self._ctx()
+
+        restored = ExecutionContext.from_json(ctx.to_dict())
+
+        assert restored.input == {"real": "payload"}
+        assert not hasattr(restored, "routing_input")


### PR DESCRIPTION
Closes #211. Implements the design in `docs/specs/2026-08-12-routing-only-input-spec.md`.

## What it does

Values the scheduler matches on that the target worker never receives:

```python
@workflow.with_options(
    affinity=require(optional(label("cohort") == routing_input("cohort"))),
)
async def audit_probe(ctx: ExecutionContext[dict]): ...
```

```bash
flux workflow run audit_probe '{"real":"payload"}' -r cohort=canary
```

Affinity normally matches against `input`, and `input` is delivered to the worker — so a field used purely for routing tells the worker it is being watched. It is the field's *presence* that classifies, not its value, so obfuscation does not help.

## Why storage rather than stripping

The rejected alternative — a reserved key removed on the way to the worker — leaves the values in the persisted `input`, and a running workflow reads them straight back: `scope_to_execution` keeps `execution:*`, `GET /executions/{id}` needs `execution:*:read`, and `summary()` returns `input`. The **`worker` built-in role holds `execution:*:read`**, so the reading party is directly entitled.

Storing off the payload is additive: no path has to remember to strip what was never there.

## The parts that were easy to get wrong

Reviews of the design caught four things that would have shipped broken. Each is now implemented and tested:

- **`require_diagnostic` bypasses `worker_matches`.** It decides whether an affinity can *never* match, and feeds `_fail_undispatchable`. Un-plumbed, a non-optional routing term would diagnose as unsatisfiable and **fail every routing-matched execution at dispatch**. `pick_worker` is a third entry, for the score stage.
- **`input()` has three compiled encodings**, not one — wrapper key, `when()`, dynamic keys. A missed one does not raise; it silently resolves against `input`, reading the wrong source for the value being hidden. One `_ref_path` helper knows all three.
- **The task-id digest was an oracle.** `_compute_task_id` hashes kwargs into the id, which becomes an event's `source_id`. A worker could read the parent execution and brute-force a small cohort space offline. Excluded from the digest.
- **`Base64Type` is unsigned dill.** Caller-supplied execution data uses `SignedPickleType` precisely because dill executes on load, and this is deserialized in the dispatch loop.

## Two structural choices

`_worker_matches_workflow` takes the execution **row**, not `model.input` — a caller can no longer pass one value source and forget the other, which is exactly the bug above.

Routing-derived diagnostics collapse to `"routing constraint unsatisfied"` by construction. These messages land in `executions.output`, which the worker can read; naming the key alone would still separate "absent" from "present but unmatched". Wording discipline decays, a function does not.

## Coverage

25 new tests: sources never cross, all three encodings resolve correctly, diagnostics stay blind, every rejection rule, and one assertion per surface in the spec's table. The surface assertions were checked to **fail** when the field is present rather than assumed meaningful.

Full unit suite: **3482 passed, 22 skipped**.

Migration `0023_routing_input` (nullable, no backfill), `HEAD` updated in both migration tests. `0.79.6 → 0.80.0`.

## Not included, deliberately

Service invocation (`service_routes.py`) is the fourth `_create_execution` caller and is excluded — a workflow service is a public endpoint whose callers are consumers, not operators. There is no API read path at any privilege level; operators get key *names* in an ingress log line, never values.