### PR TITLE
feat(security): list and revoke outstanding worker join tokens

### DIFF
--- a/docs/advanced-features/authentication.md
+++ b/docs/advanced-features/authentication.md
@@ -398,6 +398,7 @@ flux principals revoke-key <subject> --key-name <name>
 | `DELETE` | `/admin/principals/{id}` | `admin:principals:manage` |
 | `POST` | `/admin/principals/{id}/keys` | `admin:principals:manage` |
 | `DELETE` | `/admin/principals/{id}/keys/{name}` | `admin:principals:manage` |
+| `POST` | `/admin/workers/join-tokens` | `admin:workers:manage` |
 | `GET` | `/admin/workers/join-tokens` | `admin:workers:manage` |
 | `DELETE` | `/admin/workers/join-tokens/{id}` | `admin:workers:manage` |
 | `DELETE` | `/admin/workers/join-tokens?subject=` | `admin:workers:manage` |
@@ -435,10 +436,11 @@ caller already knows the worker name and does not track token ids. **Unbound
 tokens are never matched by `--subject`** — they carry no subject, so retiring
 them under one worker's name would take out credentials meant for others.
 
-Revocation is a soft delete: the row keeps who minted it and when, and the
-existing expiry sweep stays the only thing that removes rows. The listing never
-returns the token or its hash — the plaintext is unrecoverable by design, and
-the hash is credential-equivalent to an offline guesser.
+Revocation is a soft delete, so the row keeps who minted it and when. Note that
+`purge_expired()` exists but is not wired to anything, so no join-token row is
+ever removed — the table grows with every mint, revoked or not. The listing
+never returns the token or its hash: the plaintext is unrecoverable by design,
+and the hash is credential-equivalent to an offline guesser.
 
 Note that banning a principal is already a complete control on its own: worker
 registration refuses a banned principal regardless of credential, so a token

--- a/docs/advanced-features/authentication.md
+++ b/docs/advanced-features/authentication.md
@@ -398,6 +398,9 @@ flux principals revoke-key <subject> --key-name <name>
 | `DELETE` | `/admin/principals/{id}` | `admin:principals:manage` |
 | `POST` | `/admin/principals/{id}/keys` | `admin:principals:manage` |
 | `DELETE` | `/admin/principals/{id}/keys/{name}` | `admin:principals:manage` |
+| `GET` | `/admin/workers/join-tokens` | `admin:workers:manage` |
+| `DELETE` | `/admin/workers/join-tokens/{id}` | `admin:workers:manage` |
+| `DELETE` | `/admin/workers/join-tokens?subject=` | `admin:workers:manage` |
 | `POST` | `/workers/register` | bootstrap_token (see below) |
 | `POST` | `/workers/{name}/pong` | `worker:*:*` |
 | `GET` | `/workers/{name}/connect` | `worker:*:*` |
@@ -414,6 +417,33 @@ is per worker, so `worker:build-7:target` does not permit binding to another.
 for any worker. The advisory `X-Flux-Preferred-Worker` needs no grant: it
 cannot force placement. See
 [Dynamic Routing](dynamic-routing.md#binding-an-execution-to-one-worker).
+
+### Revoking join tokens
+
+Minting is additive: each call produces another independently valid token, and
+before revocation existed a token left live by a failed bring-up stayed
+claimable until its TTL with no way to see or retire it (issue #197).
+
+```bash
+flux server join-tokens                          # what is outstanding
+flux server revoke-join-token --id <id>          # retire one
+flux server revoke-join-token --subject worker-7 # retire every token for a worker
+```
+
+Revoking by subject is the shape that pairs with `flux principals ban`: the
+caller already knows the worker name and does not track token ids. **Unbound
+tokens are never matched by `--subject`** — they carry no subject, so retiring
+them under one worker's name would take out credentials meant for others.
+
+Revocation is a soft delete: the row keeps who minted it and when, and the
+existing expiry sweep stays the only thing that removes rows. The listing never
+returns the token or its hash — the plaintext is unrecoverable by design, and
+the hash is credential-equivalent to an offline guesser.
+
+Note that banning a principal is already a complete control on its own: worker
+registration refuses a banned principal regardless of credential, so a token
+minted before the ban cannot register. Revocation is for the operational case —
+retiring credentials you no longer intend to use.
 
 ### Worker bootstrap token
 

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -132,7 +132,11 @@ class WorkerRoutesMixin:
             """
             from flux.security import join_tokens
 
-            if not await asyncio.to_thread(join_tokens.revoke, token_id):
+            if not await asyncio.to_thread(
+                join_tokens.revoke,
+                token_id,
+                revoked_by=identity.subject,
+            ):
                 raise HTTPException(status_code=404, detail="No live join token with that id.")
             logger.info(f"Join token {token_id} revoked by {identity.subject}")
             return {"revoked": 1}
@@ -157,7 +161,11 @@ class WorkerRoutesMixin:
             # as "there was nothing outstanding".
             name = (subject or "").strip()
             try:
-                revoked = await asyncio.to_thread(join_tokens.revoke_for_subject, name)
+                revoked = await asyncio.to_thread(
+                    join_tokens.revoke_for_subject,
+                    name,
+                    revoked_by=identity.subject,
+                )
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
             logger.info(
@@ -372,10 +380,24 @@ class WorkerRoutesMixin:
                             f"Refusing registration for banned worker principal: "
                             f"{registration.name}",
                         )
+                        # Who is told *why* depends on what they presented.
+                        # A bootstrap-token holder has the fleet-wide
+                        # registration secret, so naming the quarantine tells
+                        # them nothing they could not get anyway, and the
+                        # diagnostic is what an operator wants. A join-token
+                        # holder is scoped to one registration — and since
+                        # is_claimable no longer consumes the token, a distinct
+                        # message would let a single unbound token enumerate
+                        # every quarantined name in the fleet, repeatedly. The
+                        # real reason is always in the log above.
                         raise HTTPException(
                             status_code=403,
-                            detail="Worker principal is banned; an administrator "
-                            "must unban and enable it before it can register.",
+                            detail=(
+                                "Worker principal is banned; an administrator "
+                                "must unban and enable it before it can register."
+                                if bootstrap_ok
+                                else "Invalid bootstrap or join token."
+                            ),
                         )
 
                 if join_token_ok:

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -152,12 +152,16 @@ class WorkerRoutesMixin:
             """
             from flux.security import join_tokens
 
+            # Trimmed here as well as in the manager: '?subject=%20worker-a%20'
+            # would otherwise match nothing and report revoked: 0, which reads
+            # as "there was nothing outstanding".
+            name = (subject or "").strip()
             try:
-                revoked = await asyncio.to_thread(join_tokens.revoke_for_subject, subject)
+                revoked = await asyncio.to_thread(join_tokens.revoke_for_subject, name)
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
             logger.info(
-                f"{revoked} join token(s) for subject '{subject}' revoked by {identity.subject}",
+                f"{revoked} join token(s) for subject '{name}' revoked by {identity.subject}",
             )
             return {"revoked": revoked}
 
@@ -324,14 +328,39 @@ class WorkerRoutesMixin:
                 expected = self._bootstrap_token
                 workers_config = Configuration.get().settings.workers
 
-                # Quarantine before the claim, not after: claim() consumes the
-                # token in a committed UPDATE, so checking afterwards let a
-                # banned holder burn a credential the operator would have to
-                # mint again (#197). Quarantine wins over any valid credential
-                # either way — a banned principal must not resurrect itself by
-                # re-registering (the re-enable below is meant for
-                # reaper-disabled principals of workers that legitimately
-                # return).
+                # Three ordered steps, and the order is the point (#197):
+                #   1. establish the credential is valid WITHOUT consuming it,
+                #   2. reject a banned principal,
+                #   3. only then consume the join token.
+                # Checking the ban first would tell an unauthenticated caller
+                # which worker names are quarantined; consuming first would let
+                # a banned holder burn a credential the operator must re-mint.
+                bootstrap_ok = bool(
+                    workers_config.bootstrap_token_enabled
+                    and expected
+                    and token
+                    and hmac.compare_digest(expected, token),
+                )
+                join_token_ok = False
+                if not bootstrap_ok and token:
+                    from flux.security import join_tokens
+
+                    join_token_ok = await asyncio.to_thread(
+                        join_tokens.is_claimable,
+                        token,
+                        registration.name,
+                    )
+                if not (bootstrap_ok or join_token_ok):
+                    logger.warning(f"Invalid registration token for worker: {registration.name}")
+                    raise HTTPException(
+                        status_code=403,
+                        detail="Invalid bootstrap or join token.",
+                    )
+
+                # Quarantine wins over any valid credential: a banned worker
+                # principal must not resurrect itself by re-registering (the
+                # re-enable below is meant for reaper-disabled principals of
+                # workers that legitimately return).
                 if principal_registry is not None:
                     banned_check = await asyncio.to_thread(
                         principal_registry.find,
@@ -349,29 +378,24 @@ class WorkerRoutesMixin:
                             "must unban and enable it before it can register.",
                         )
 
-                # Two accepted credentials: the shared bootstrap token (unless
-                # the fleet has migrated off it) or a one-time join token,
-                # consumed atomically so it cannot be replayed.
-                authorized = bool(
-                    workers_config.bootstrap_token_enabled
-                    and expected
-                    and token
-                    and hmac.compare_digest(expected, token),
-                )
-                if not authorized and token:
+                if join_token_ok:
                     from flux.security import join_tokens
 
-                    authorized = await asyncio.to_thread(
+                    # The claim stays the atomic step, so two registrations
+                    # racing on one token still resolve here: the loser is
+                    # refused rather than both succeeding.
+                    if not await asyncio.to_thread(
                         join_tokens.claim,
                         token,
                         registration.name,
-                    )
-                if not authorized:
-                    logger.warning(f"Invalid registration token for worker: {registration.name}")
-                    raise HTTPException(
-                        status_code=403,
-                        detail="Invalid bootstrap or join token.",
-                    )
+                    ):
+                        logger.warning(
+                            f"Join token for worker {registration.name} was claimed concurrently",
+                        )
+                        raise HTTPException(
+                            status_code=403,
+                            detail="Invalid bootstrap or join token.",
+                        )
 
                 registry = WorkerRegistry.create()
                 result = registry.register(

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -105,6 +105,62 @@ class WorkerRoutesMixin:
         def _register_limited(fn):
             return limiter.limit(register_rate_limit)(fn) if register_rate_limit else fn
 
+        @api.get("/admin/workers/join-tokens")
+        async def list_join_tokens(
+            identity: FluxIdentity = Depends(require_permission("admin:workers:manage")),
+        ):
+            """Outstanding join tokens: minted, unused, unrevoked, unexpired.
+
+            Never returns the token or its hash — the plaintext is
+            unrecoverable by design, and the hash is credential-equivalent to
+            an offline guesser. The id is what revocation takes.
+            """
+            from flux.security import join_tokens
+
+            return await asyncio.to_thread(join_tokens.outstanding)
+
+        @api.delete("/admin/workers/join-tokens/{token_id}")
+        async def revoke_join_token(
+            token_id: str,
+            identity: FluxIdentity = Depends(require_permission("admin:workers:manage")),
+        ):
+            """Retire one live token before its TTL.
+
+            404 when it is already used, already revoked, expired, or unknown —
+            all four mean "there is nothing here to retire", and distinguishing
+            them would tell an unauthorized caller which ids exist.
+            """
+            from flux.security import join_tokens
+
+            if not await asyncio.to_thread(join_tokens.revoke, token_id):
+                raise HTTPException(status_code=404, detail="No live join token with that id.")
+            logger.info(f"Join token {token_id} revoked by {identity.subject}")
+            return {"revoked": 1}
+
+        @api.delete("/admin/workers/join-tokens")
+        async def revoke_join_tokens_for_subject(
+            subject: str,
+            identity: FluxIdentity = Depends(require_permission("admin:workers:manage")),
+        ):
+            """Retire every live token bound to one worker name.
+
+            The shape that pairs with a ban: the caller knows the worker name
+            and does not track token ids. Returns 200 with a count rather than
+            404 when none match — "nothing outstanding" is the desired end
+            state, so an operator scripting ban-then-revoke should not have to
+            special-case it.
+            """
+            from flux.security import join_tokens
+
+            try:
+                revoked = await asyncio.to_thread(join_tokens.revoke_for_subject, subject)
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
+            logger.info(
+                f"{revoked} join token(s) for subject '{subject}' revoked by {identity.subject}",
+            )
+            return {"revoked": revoked}
+
         @api.post("/admin/workers/join-tokens")
         async def mint_join_token(
             body: dict | None = Body(None),
@@ -268,6 +324,31 @@ class WorkerRoutesMixin:
                 expected = self._bootstrap_token
                 workers_config = Configuration.get().settings.workers
 
+                # Quarantine before the claim, not after: claim() consumes the
+                # token in a committed UPDATE, so checking afterwards let a
+                # banned holder burn a credential the operator would have to
+                # mint again (#197). Quarantine wins over any valid credential
+                # either way — a banned principal must not resurrect itself by
+                # re-registering (the re-enable below is meant for
+                # reaper-disabled principals of workers that legitimately
+                # return).
+                if principal_registry is not None:
+                    banned_check = await asyncio.to_thread(
+                        principal_registry.find,
+                        subject=registration.name,
+                        external_issuer="flux",
+                    )
+                    if banned_check is not None and banned_check.banned:
+                        logger.warning(
+                            f"Refusing registration for banned worker principal: "
+                            f"{registration.name}",
+                        )
+                        raise HTTPException(
+                            status_code=403,
+                            detail="Worker principal is banned; an administrator "
+                            "must unban and enable it before it can register.",
+                        )
+
                 # Two accepted credentials: the shared bootstrap token (unless
                 # the fleet has migrated off it) or a one-time join token,
                 # consumed atomically so it cannot be replayed.
@@ -291,27 +372,6 @@ class WorkerRoutesMixin:
                         status_code=403,
                         detail="Invalid bootstrap or join token.",
                     )
-
-                # Quarantine wins over any valid credential: a banned worker
-                # principal must not resurrect itself by re-registering (the
-                # re-enable below is meant for reaper-disabled principals of
-                # workers that legitimately return).
-                if principal_registry is not None:
-                    banned_check = await asyncio.to_thread(
-                        principal_registry.find,
-                        subject=registration.name,
-                        external_issuer="flux",
-                    )
-                    if banned_check is not None and banned_check.banned:
-                        logger.warning(
-                            f"Refusing registration for banned worker principal: "
-                            f"{registration.name}",
-                        )
-                        raise HTTPException(
-                            status_code=403,
-                            detail="Worker principal is banned; an administrator "
-                            "must unban and enable it before it can register.",
-                        )
 
                 registry = WorkerRegistry.create()
                 result = registry.register(

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -1593,7 +1593,14 @@ def server_join_token(ttl_seconds: int | None, subject: str | None):
 
 
 @server_group.command("join-tokens")
-@click.option("--format", "format", default="table", help="Output format (table or json).")
+@click.option(
+    "--format",
+    "-f",
+    "format",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    help="Output format.",
+)
 def server_join_tokens(format: str):
     """List outstanding join tokens (minted, unused, unrevoked, unexpired).
 

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -1592,6 +1592,67 @@ def server_join_token(ttl_seconds: int | None, subject: str | None):
     click.echo(f"expires: {expires_at.replace(tzinfo=_tz.utc).isoformat()}", err=True)
 
 
+@server_group.command("join-tokens")
+@click.option("--format", "format", default="table", help="Output format (table or json).")
+def server_join_tokens(format: str):
+    """List outstanding join tokens (minted, unused, unrevoked, unexpired).
+
+    Shows the id, which `flux server revoke-join-token` takes. The token
+    itself is never shown: the plaintext is unrecoverable by design and the
+    stored hash is credential-equivalent. Runs against the server's database —
+    execute on the server host.
+    """
+    from flux.security import join_tokens
+    from flux.utils import to_json
+
+    rows = join_tokens.outstanding()
+    if format == "json":
+        click.echo(to_json(rows))
+        return
+    if not rows:
+        click.echo("No outstanding join tokens.")
+        return
+    click.echo(f"{'ID':34} {'SUBJECT':24} {'EXPIRES':26} CREATED BY")
+    for row in rows:
+        subject = row["subject"] or "(unbound)"
+        click.echo(
+            f"{row['id']:34} {subject:24} {row['expires_at'].isoformat():26} "
+            f"{row['created_by'] or '-'}",
+        )
+
+
+@server_group.command("revoke-join-token")
+@click.option("--id", "token_id", default=None, help="Revoke one token by id.")
+@click.option(
+    "--subject",
+    default=None,
+    help="Revoke every live token bound to this worker name.",
+)
+def server_revoke_join_token(token_id: str | None, subject: str | None):
+    """Retire live join tokens before their TTL.
+
+    Pairs with `flux principals ban`: banning stops a principal, and this
+    retires any credential already minted for it. Unbound tokens are never
+    touched by --subject — they carry no subject, so retiring them under one
+    worker's name would take out credentials meant for others.
+    """
+    from flux.security import join_tokens
+
+    if bool(token_id) == bool(subject):
+        raise click.ClickException("Pass exactly one of --id or --subject.")
+    if token_id:
+        if not join_tokens.revoke(token_id):
+            raise click.ClickException(f"No live join token with id '{token_id}'.")
+        click.echo(f"Revoked join token {token_id}.")
+        return
+    assert subject is not None  # guarded above; narrows for the type checker
+    name = subject.strip()
+    if not name:
+        raise click.ClickException("--subject must not be blank")
+    revoked = join_tokens.revoke_for_subject(name)
+    click.echo(f"Revoked {revoked} join token(s) for subject '{name}'.")
+
+
 @server_group.command("bootstrap-token")
 @click.option(
     "--rotate",

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -1648,7 +1648,7 @@ def server_revoke_join_token(token_id: str | None, subject: str | None):
     if bool(token_id) == bool(subject):
         raise click.ClickException("Pass exactly one of --id or --subject.")
     if token_id:
-        if not join_tokens.revoke(token_id):
+        if not join_tokens.revoke(token_id, revoked_by="cli"):
             raise click.ClickException(f"No live join token with id '{token_id}'.")
         click.echo(f"Revoked join token {token_id}.")
         return
@@ -1656,7 +1656,7 @@ def server_revoke_join_token(token_id: str | None, subject: str | None):
     name = subject.strip()
     if not name:
         raise click.ClickException("--subject must not be blank")
-    revoked = join_tokens.revoke_for_subject(name)
+    revoked = join_tokens.revoke_for_subject(name, revoked_by="cli")
     click.echo(f"Revoked {revoked} join token(s) for subject '{name}'.")
 
 

--- a/flux/migrations/versions/0024_join_token_revoked.py
+++ b/flux/migrations/versions/0024_join_token_revoked.py
@@ -4,8 +4,10 @@ Minting was additive with no inverse: a token left live by a failed bring-up
 stayed claimable until it expired, and an operator could neither see what was
 outstanding nor retire it (issue #197).
 
-A soft delete rather than a row delete — ``purge_expired`` stays the single
-reaper, and a revoked row keeps the audit trail of who minted it and when.
+A soft delete rather than a row delete, so a revoked row keeps the audit trail
+of who minted it, who retired it, and when. Note that nothing currently calls ``purge_expired``,
+so no row is ever removed — revocation does not change that either way, but it
+means the table only grows.
 
 Nullable with no backfill: NULL means live, which is how every token before
 this revision behaves.
@@ -28,18 +30,20 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 _TABLE = "worker_join_tokens"
-_COLUMN = "revoked_at"
+_COLUMNS = {"revoked_at": sa.DateTime(), "revoked_by": sa.String()}
 
 
 def upgrade() -> None:
     bind = op.get_bind()
     existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
-    if _COLUMN not in existing:
-        op.add_column(_TABLE, sa.Column(_COLUMN, sa.DateTime(), nullable=True))
+    for name, type_ in _COLUMNS.items():
+        if name not in existing:
+            op.add_column(_TABLE, sa.Column(name, type_, nullable=True))
 
 
 def downgrade() -> None:
     bind = op.get_bind()
     existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
-    if _COLUMN in existing:
-        op.drop_column(_TABLE, _COLUMN)
+    for name in _COLUMNS:
+        if name in existing:
+            op.drop_column(_TABLE, name)

--- a/flux/migrations/versions/0024_join_token_revoked.py
+++ b/flux/migrations/versions/0024_join_token_revoked.py
@@ -1,0 +1,45 @@
+"""Add worker_join_tokens.revoked_at so a token can be retired before its TTL.
+
+Minting was additive with no inverse: a token left live by a failed bring-up
+stayed claimable until it expired, and an operator could neither see what was
+outstanding nor retire it (issue #197).
+
+A soft delete rather than a row delete — ``purge_expired`` stays the single
+reaper, and a revoked row keeps the audit trail of who minted it and when.
+
+Nullable with no backfill: NULL means live, which is how every token before
+this revision behaves.
+
+Revision ID: 0024_join_token_revoked
+Revises: 0023_routing_input
+Create Date: 2026-08-12
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0024_join_token_revoked"
+down_revision: str | None = "0023_routing_input"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "worker_join_tokens"
+_COLUMN = "revoked_at"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    if _COLUMN not in existing:
+        op.add_column(_TABLE, sa.Column(_COLUMN, sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns(_TABLE)}
+    if _COLUMN in existing:
+        op.drop_column(_TABLE, _COLUMN)

--- a/flux/security/join_tokens.py
+++ b/flux/security/join_tokens.py
@@ -43,9 +43,13 @@ class WorkerJoinTokenModel(Base):
     # The worker name this token authorizes. NULL means unbound: any name may
     # claim it, which is how tokens minted before binding existed behave.
     subject = Column(String, nullable=True)
-    # Retired before its TTL (issue #197). Soft delete: purge_expired stays the
-    # single reaper, and the row keeps who minted it and when.
+    # Retired before its TTL (issue #197). Soft delete so the row keeps who
+    # minted it and when — note purge_expired exists but has no caller, so
+    # nothing reaps this table today.
     revoked_at = Column(DateTime, nullable=True)
+    # Pairs with created_by/used_by: a bare timestamp cannot answer "who
+    # retired this worker's credential?" after an incident.
+    revoked_by = Column(String, nullable=True)
 
 
 def _hash(token: str) -> str:
@@ -68,6 +72,12 @@ def mint(
     """
     if ttl_seconds <= 0:
         raise ValueError("ttl_seconds must be positive")
+    # Normalized here rather than at each caller: a subject stored with
+    # surrounding whitespace is permanently unreachable by revoke_for_subject
+    # while still being claimable, and there is no way to notice.
+    subject = subject.strip() if subject else None
+    if subject == "":
+        subject = None
     token = secrets.token_urlsafe(32)
     expires_at = _utcnow() + timedelta(seconds=ttl_seconds)
     repo = RepositoryFactory.create_repository()
@@ -82,6 +92,29 @@ def mint(
         )
         session.commit()
     return token, expires_at
+
+
+def _live_filters(now: datetime) -> list:
+    """The "this token is still usable" predicate, in one place.
+
+    Four call sites depend on it — is_claimable, claim, outstanding and
+    _revoke_where — and they must agree: missing a condition in `claim` alone
+    would let a revoked token register a worker, silently, with the other
+    three still asserting correctly.
+    """
+    return [
+        WorkerJoinTokenModel.used_at.is_(None),
+        WorkerJoinTokenModel.revoked_at.is_(None),
+        WorkerJoinTokenModel.expires_at > now,
+    ]
+
+
+def _addressed_to(worker_name: str):
+    """An unbound token claims for any name; a bound one only for its own."""
+    return or_(
+        WorkerJoinTokenModel.subject.is_(None),
+        WorkerJoinTokenModel.subject == worker_name,
+    )
 
 
 def is_claimable(token: str, worker_name: str) -> bool:
@@ -102,13 +135,8 @@ def is_claimable(token: str, worker_name: str) -> bool:
             session.query(WorkerJoinTokenModel)
             .filter(
                 WorkerJoinTokenModel.token_hash == _hash(token),
-                WorkerJoinTokenModel.used_at.is_(None),
-                WorkerJoinTokenModel.revoked_at.is_(None),
-                WorkerJoinTokenModel.expires_at > _utcnow(),
-                or_(
-                    WorkerJoinTokenModel.subject.is_(None),
-                    WorkerJoinTokenModel.subject == worker_name,
-                ),
+                *_live_filters(_utcnow()),
+                _addressed_to(worker_name),
             )
             .first()
         ) is not None
@@ -139,13 +167,8 @@ def claim(token: str, worker_name: str) -> bool:
             session.query(WorkerJoinTokenModel)
             .filter(
                 WorkerJoinTokenModel.token_hash == _hash(token),
-                WorkerJoinTokenModel.used_at.is_(None),
-                WorkerJoinTokenModel.revoked_at.is_(None),
-                WorkerJoinTokenModel.expires_at > now,
-                or_(
-                    WorkerJoinTokenModel.subject.is_(None),
-                    WorkerJoinTokenModel.subject == worker_name,
-                ),
+                *_live_filters(now),
+                _addressed_to(worker_name),
             )
             .update(
                 {"used_at": now, "used_by": worker_name},
@@ -182,13 +205,17 @@ def outstanding() -> list[dict]:
     """
     repo = RepositoryFactory.create_repository()
     with repo.session() as session:
+        # Column-only: the hash is credential-equivalent to an offline
+        # guesser, so it is never loaded rather than merely never returned.
         rows = (
-            session.query(WorkerJoinTokenModel)
-            .filter(
-                WorkerJoinTokenModel.used_at.is_(None),
-                WorkerJoinTokenModel.revoked_at.is_(None),
-                WorkerJoinTokenModel.expires_at > _utcnow(),
+            session.query(
+                WorkerJoinTokenModel.id,
+                WorkerJoinTokenModel.subject,
+                WorkerJoinTokenModel.created_at,
+                WorkerJoinTokenModel.expires_at,
+                WorkerJoinTokenModel.created_by,
             )
+            .filter(*_live_filters(_utcnow()))
             .order_by(WorkerJoinTokenModel.created_at.desc())
             .all()
         )
@@ -196,20 +223,22 @@ def outstanding() -> list[dict]:
             {
                 "id": row.id,
                 "subject": row.subject,
-                "created_at": row.created_at,
-                "expires_at": row.expires_at,
+                # Stamped naive-UTC; labelled on the way out so the listing
+                # cannot be read as local time. mint() already does this.
+                "created_at": row.created_at.replace(tzinfo=timezone.utc),
+                "expires_at": row.expires_at.replace(tzinfo=timezone.utc),
                 "created_by": row.created_by,
             }
             for row in rows
         ]
 
 
-def revoke(token_id: str) -> bool:
+def revoke(token_id: str, *, revoked_by: str | None = None) -> bool:
     """Retire one live token. Returns False if it was already spent or gone."""
-    return _revoke_where(WorkerJoinTokenModel.id == token_id) == 1
+    return _revoke_where(WorkerJoinTokenModel.id == token_id, revoked_by) == 1
 
 
-def revoke_for_subject(subject: str) -> int:
+def revoke_for_subject(subject: str, *, revoked_by: str | None = None) -> int:
     """Retire every live token bound to ``subject``. Returns how many.
 
     The useful shape when revoking alongside a ban: the caller knows the
@@ -217,12 +246,13 @@ def revoke_for_subject(subject: str) -> int:
     untouched — they carry no subject, so "every token for this worker" cannot
     include them without also retiring credentials meant for other workers.
     """
+    subject = (subject or "").strip()
     if not subject:
         raise ValueError("subject must be a non-empty string")
-    return _revoke_where(WorkerJoinTokenModel.subject == subject)
+    return _revoke_where(WorkerJoinTokenModel.subject == subject, revoked_by)
 
 
-def _revoke_where(condition) -> int:
+def _revoke_where(condition, revoked_by: str | None = None) -> int:
     repo = RepositoryFactory.create_repository()
     with repo.session() as session:
         now = _utcnow()
@@ -232,11 +262,9 @@ def _revoke_where(condition) -> int:
                 condition,
                 # Only live rows: revoking a spent token would rewrite history,
                 # and the count is what the caller reports to an operator.
-                WorkerJoinTokenModel.used_at.is_(None),
-                WorkerJoinTokenModel.revoked_at.is_(None),
-                WorkerJoinTokenModel.expires_at > now,
+                *_live_filters(now),
             )
-            .update({"revoked_at": now}, synchronize_session=False)
+            .update({"revoked_at": now, "revoked_by": revoked_by}, synchronize_session=False)
         )
         session.commit()
         return revoked

--- a/flux/security/join_tokens.py
+++ b/flux/security/join_tokens.py
@@ -84,6 +84,36 @@ def mint(
     return token, expires_at
 
 
+def is_claimable(token: str, worker_name: str) -> bool:
+    """Whether ``claim`` would succeed, without consuming the token.
+
+    Registration needs to know a credential is valid *before* deciding whether
+    the principal is banned — checking the ban first would tell an
+    unauthenticated caller which worker names are quarantined, and consuming
+    first would let a banned holder burn the operator's token (#197). Same
+    predicate as ``claim``; the claim itself stays the atomic step, so a race
+    between two registrations is still resolved there.
+    """
+    if not token:
+        return False
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        return (
+            session.query(WorkerJoinTokenModel)
+            .filter(
+                WorkerJoinTokenModel.token_hash == _hash(token),
+                WorkerJoinTokenModel.used_at.is_(None),
+                WorkerJoinTokenModel.revoked_at.is_(None),
+                WorkerJoinTokenModel.expires_at > _utcnow(),
+                or_(
+                    WorkerJoinTokenModel.subject.is_(None),
+                    WorkerJoinTokenModel.subject == worker_name,
+                ),
+            )
+            .first()
+        ) is not None
+
+
 def claim(token: str, worker_name: str) -> bool:
     """Atomically consume a live join token for a registering worker.
 

--- a/flux/security/join_tokens.py
+++ b/flux/security/join_tokens.py
@@ -43,6 +43,9 @@ class WorkerJoinTokenModel(Base):
     # The worker name this token authorizes. NULL means unbound: any name may
     # claim it, which is how tokens minted before binding existed behave.
     subject = Column(String, nullable=True)
+    # Retired before its TTL (issue #197). Soft delete: purge_expired stays the
+    # single reaper, and the row keeps who minted it and when.
+    revoked_at = Column(DateTime, nullable=True)
 
 
 def _hash(token: str) -> str:
@@ -88,6 +91,10 @@ def claim(token: str, worker_name: str) -> bool:
     or wrongly-addressed token returns False. Single UPDATE statement, so two
     racing registrations cannot both succeed.
 
+    A revoked token is as dead as a used one: the filter rides in the same
+    WHERE clause, so revocation takes effect on the next attempt with no
+    window between the operator's call and the token becoming unusable.
+
     A token minted with a ``subject`` only claims for that worker name. The
     check rides in the UPDATE's WHERE clause rather than a prior SELECT, so a
     mismatched name matches no row: the attempt neither succeeds nor consumes
@@ -103,6 +110,7 @@ def claim(token: str, worker_name: str) -> bool:
             .filter(
                 WorkerJoinTokenModel.token_hash == _hash(token),
                 WorkerJoinTokenModel.used_at.is_(None),
+                WorkerJoinTokenModel.revoked_at.is_(None),
                 WorkerJoinTokenModel.expires_at > now,
                 or_(
                     WorkerJoinTokenModel.subject.is_(None),
@@ -134,3 +142,71 @@ def purge_expired(*, older_than_seconds: int = 86400) -> int:
         )
         session.commit()
         return removed
+
+
+def outstanding() -> list[dict]:
+    """Live tokens: minted, unused, unrevoked, unexpired.
+
+    Never returns the token or its hash — the plaintext is unrecoverable by
+    design, and the hash is a credential-equivalent for an offline guesser.
+    """
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        rows = (
+            session.query(WorkerJoinTokenModel)
+            .filter(
+                WorkerJoinTokenModel.used_at.is_(None),
+                WorkerJoinTokenModel.revoked_at.is_(None),
+                WorkerJoinTokenModel.expires_at > _utcnow(),
+            )
+            .order_by(WorkerJoinTokenModel.created_at.desc())
+            .all()
+        )
+        return [
+            {
+                "id": row.id,
+                "subject": row.subject,
+                "created_at": row.created_at,
+                "expires_at": row.expires_at,
+                "created_by": row.created_by,
+            }
+            for row in rows
+        ]
+
+
+def revoke(token_id: str) -> bool:
+    """Retire one live token. Returns False if it was already spent or gone."""
+    return _revoke_where(WorkerJoinTokenModel.id == token_id) == 1
+
+
+def revoke_for_subject(subject: str) -> int:
+    """Retire every live token bound to ``subject``. Returns how many.
+
+    The useful shape when revoking alongside a ban: the caller knows the
+    worker name and does not track token ids. Unbound tokens are deliberately
+    untouched — they carry no subject, so "every token for this worker" cannot
+    include them without also retiring credentials meant for other workers.
+    """
+    if not subject:
+        raise ValueError("subject must be a non-empty string")
+    return _revoke_where(WorkerJoinTokenModel.subject == subject)
+
+
+def _revoke_where(condition) -> int:
+    repo = RepositoryFactory.create_repository()
+    with repo.session() as session:
+        now = _utcnow()
+        revoked = (
+            session.query(WorkerJoinTokenModel)
+            .filter(
+                condition,
+                # Only live rows: revoking a spent token would rewrite history,
+                # and the count is what the caller reports to an operator.
+                WorkerJoinTokenModel.used_at.is_(None),
+                WorkerJoinTokenModel.revoked_at.is_(None),
+                WorkerJoinTokenModel.expires_at > now,
+            )
+            .update({"revoked_at": now}, synchronize_session=False)
+        )
+        session.commit()
+        return revoked

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.80.0"
+version = "0.81.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_migrations.py
+++ b/tests/flux/test_migrations.py
@@ -13,7 +13,7 @@ import flux.security.models  # noqa: F401
 from flux.migrations.runner import current_revision, run_migrations
 from flux.models import Base
 
-HEAD = "0023_routing_input"
+HEAD = "0024_join_token_revoked"
 BASELINE = "0001_baseline"
 
 # A representative index added after the original create_all schema, used to

--- a/tests/flux/test_migrations_postgresql.py
+++ b/tests/flux/test_migrations_postgresql.py
@@ -30,7 +30,7 @@ pytestmark = [
     ),
 ]
 
-HEAD = "0023_routing_input"
+HEAD = "0024_join_token_revoked"
 _BACKFILL_INDEX = "ix_executions_workflow_id"
 
 

--- a/tests/security/test_join_tokens_and_body_limit.py
+++ b/tests/security/test_join_tokens_and_body_limit.py
@@ -348,3 +348,82 @@ class TestBodySizeLimit:
         client = make_client(server_max_body_size=0)
         resp = client.post("/workflows", content=b"z" * 4096)
         assert resp.status_code != 413
+
+
+class TestJoinTokenRevocation:
+    """Minting had no inverse (issue #197): a token left live by a failed
+    bring-up stayed claimable until its TTL, invisible and unretirable."""
+
+    def test_outstanding_lists_live_tokens_without_the_secret(self, make_client):
+        make_client()
+        token, _ = join_tokens.mint(3600, subject="worker-a", created_by="test")
+
+        rows = join_tokens.outstanding()
+
+        assert [r["subject"] for r in rows] == ["worker-a"]
+        assert token not in str(rows), "the plaintext must never be recoverable"
+        assert "token_hash" not in rows[0], "the hash is credential-equivalent"
+
+    def test_revoked_token_cannot_register(self, make_client):
+        client = make_client()
+        token, _ = join_tokens.mint(3600, subject="worker-a")
+
+        assert join_tokens.revoke(join_tokens.outstanding()[0]["id"]) is True
+
+        assert _register(client, "worker-a", token).status_code == 403
+
+    def test_revoking_by_subject_retires_every_token_for_that_worker(self, make_client):
+        """The shape that pairs with a ban: the caller knows the worker name
+        and does not track token ids."""
+        make_client()
+        join_tokens.mint(3600, subject="worker-a")
+        join_tokens.mint(3600, subject="worker-a")
+        join_tokens.mint(3600, subject="worker-b")
+
+        assert join_tokens.revoke_for_subject("worker-a") == 2
+
+        assert [r["subject"] for r in join_tokens.outstanding()] == ["worker-b"]
+
+    def test_revoking_by_subject_leaves_unbound_tokens_alone(self, make_client):
+        """An unbound token carries no subject, so retiring it under one
+        worker's name would take out a credential meant for another."""
+        make_client()
+        join_tokens.mint(3600)  # unbound
+        join_tokens.mint(3600, subject="worker-a")
+
+        assert join_tokens.revoke_for_subject("worker-a") == 1
+
+        assert [r["subject"] for r in join_tokens.outstanding()] == [None]
+
+    def test_revoking_a_spent_token_reports_nothing_to_do(self, make_client):
+        client = make_client()
+        token, _ = join_tokens.mint(3600, subject="worker-a")
+        token_id = join_tokens.outstanding()[0]["id"]
+        assert _register(client, "worker-a", token).status_code == 200
+
+        assert join_tokens.revoke(token_id) is False
+        assert join_tokens.revoke("no-such-id") is False
+
+    def test_a_banned_worker_does_not_burn_the_token(self, make_client):
+        """claim() consumes the token in a committed UPDATE, so checking the
+        ban afterwards let a banned holder spend a credential the operator
+        would have to mint again. The ban check runs first."""
+        from flux.models import RepositoryFactory
+        from flux.security.principals import PrincipalRegistry
+
+        client = make_client()
+        repo = RepositoryFactory.create_repository()
+        registry = PrincipalRegistry(session_factory=lambda: repo.session())
+        principal = registry.create(
+            type="service_account",
+            subject="worker-banned",
+            external_issuer="flux",
+        )
+        registry.set_banned(principal.id, True)
+        token, _ = join_tokens.mint(3600, subject="worker-banned")
+
+        assert _register(client, "worker-banned", token).status_code == 403
+
+        assert [r["subject"] for r in join_tokens.outstanding()] == ["worker-banned"], (
+            "the token must survive a refused registration"
+        )

--- a/tests/security/test_join_tokens_and_body_limit.py
+++ b/tests/security/test_join_tokens_and_body_limit.py
@@ -471,4 +471,235 @@ class TestJoinTokenRevocation:
         resp = _register(client, "worker-banned", token)
 
         assert resp.status_code == 403
+        # Same detail as an invalid credential: is_claimable does not consume
+        # the token, so a distinct message would turn one unbound token into an
+        # unlimited enumerator of quarantined worker names.
+        assert resp.json()["detail"] == "Invalid bootstrap or join token."
+
+    def test_a_valid_unbound_token_cannot_enumerate_banned_names(self, make_client):
+        """The regression the consume-first ordering used to bound: probing
+        cost you the token. It no longer does, so the responses must not
+        differ."""
+        from flux.models import RepositoryFactory
+        from flux.security.principals import PrincipalRegistry
+
+        client = make_client()
+        repo = RepositoryFactory.create_repository()
+        registry = PrincipalRegistry(session_factory=lambda: repo.session())
+        principal = registry.create(
+            type="service_account",
+            subject="worker-banned",
+            external_issuer="flux",
+        )
+        registry.set_banned(principal.id, True)
+        token, _ = join_tokens.mint(3600)  # unbound: claimable under any name
+
+        banned = _register(client, "worker-banned", token)
+
+        assert banned.status_code == 403
+        assert banned.json()["detail"] == "Invalid bootstrap or join token."
+        assert join_tokens.outstanding(), "probing must not consume the token"
+
+    def test_the_bootstrap_holder_still_gets_the_diagnostic(self, make_client):
+        """The disclosure is scoped, not removed. Whoever holds the fleet-wide
+        registration secret learns nothing from the quarantine that they could
+        not get anyway, and an operator debugging a refused worker wants to be
+        told why."""
+        from flux.models import RepositoryFactory
+        from flux.security.principals import PrincipalRegistry
+
+        client = make_client()
+        repo = RepositoryFactory.create_repository()
+        registry = PrincipalRegistry(session_factory=lambda: repo.session())
+        principal = registry.create(
+            type="service_account",
+            subject="worker-banned",
+            external_issuer="flux",
+        )
+        registry.set_banned(principal.id, True)
+
+        resp = _register(client, "worker-banned", BOOTSTRAP)
+
+        assert resp.status_code == 403
         assert "banned" in resp.json()["detail"]
+
+
+class TestJoinTokenRevocationRoutes:
+    """The routes themselves, not just the manager functions behind them.
+
+    A refactor that dropped `Depends(require_permission(...))` from the list
+    route — exposing outstanding ids, subjects and minters — would otherwise
+    pass the whole suite green.
+    """
+
+    def test_listing_returns_live_tokens_without_the_secret(self, make_client):
+        client = make_client()
+        token, _ = join_tokens.mint(3600, subject="worker-a", created_by="admin")
+
+        resp = client.get("/admin/workers/join-tokens")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert [r["subject"] for r in body] == ["worker-a"]
+        assert token not in resp.text
+        assert "token_hash" not in resp.text
+
+    def test_listing_timestamps_are_utc_labelled(self, make_client):
+        """The sibling mint endpoint returns tz-aware values; an unlabelled
+        listing reads as local time and looks already-expired."""
+        client = make_client()
+        join_tokens.mint(3600, subject="worker-a")
+
+        row = client.get("/admin/workers/join-tokens").json()[0]
+
+        assert row["expires_at"].endswith("+00:00") or row["expires_at"].endswith("Z")
+
+    def test_revoke_by_id(self, make_client):
+        client = make_client()
+        join_tokens.mint(3600, subject="worker-a")
+        token_id = join_tokens.outstanding()[0]["id"]
+
+        assert client.delete(f"/admin/workers/join-tokens/{token_id}").json() == {"revoked": 1}
+        assert join_tokens.outstanding() == []
+
+    def test_revoke_unknown_id_is_404(self, make_client):
+        client = make_client()
+
+        assert client.delete("/admin/workers/join-tokens/nope").status_code == 404
+
+    def test_revoke_by_subject_reports_a_count(self, make_client):
+        client = make_client()
+        join_tokens.mint(3600, subject="worker-a")
+        join_tokens.mint(3600, subject="worker-a")
+
+        resp = client.delete("/admin/workers/join-tokens", params={"subject": "worker-a"})
+
+        assert resp.json() == {"revoked": 2}
+
+    def test_revoke_by_subject_tolerates_surrounding_whitespace(self, make_client):
+        """Untrimmed it would report revoked: 0 — indistinguishable from
+        'there was nothing outstanding', which reads as done."""
+        client = make_client()
+        join_tokens.mint(3600, subject="worker-a")
+
+        resp = client.delete("/admin/workers/join-tokens", params={"subject": "  worker-a  "})
+
+        assert resp.json() == {"revoked": 1}
+
+    def test_revoke_by_blank_subject_is_400(self, make_client):
+        client = make_client()
+
+        assert (
+            client.delete(
+                "/admin/workers/join-tokens",
+                params={"subject": "   "},
+            ).status_code
+            == 400
+        )
+
+    def test_revocation_records_who_did_it(self, make_client):
+        from flux.models import RepositoryFactory
+        from flux.security.join_tokens import WorkerJoinTokenModel
+
+        client = make_client()
+        join_tokens.mint(3600, subject="worker-a")
+        token_id = join_tokens.outstanding()[0]["id"]
+
+        client.delete(f"/admin/workers/join-tokens/{token_id}")
+
+        with RepositoryFactory.create_repository().session() as session:
+            row = session.get(WorkerJoinTokenModel, token_id)
+            assert row.revoked_at is not None
+            assert row.revoked_by, "a bare timestamp cannot answer who retired it"
+
+
+class TestJoinTokenRevocationCLI:
+    """authentication.md documents these as the operator interface, so the
+    same reasoning as TestJoinTokenCLI applies: pin the documented path."""
+
+    def _run(self, args):
+        from click.testing import CliRunner
+
+        from flux.cli import cli
+
+        return CliRunner().invoke(cli, args)
+
+    def test_listing_shows_the_subject_and_not_the_token(self, make_client):
+        make_client()
+        token, _ = join_tokens.mint(3600, subject="worker-a", created_by="admin")
+
+        result = self._run(["server", "join-tokens"])
+
+        assert result.exit_code == 0, result.output
+        assert "worker-a" in result.output
+        assert token not in result.output
+
+    def test_listing_reports_when_there_is_nothing(self, make_client):
+        make_client()
+
+        result = self._run(["server", "join-tokens"])
+
+        assert result.exit_code == 0
+        assert "No outstanding join tokens" in result.output
+
+    def test_json_format(self, make_client):
+        import json as _json
+
+        make_client()
+        join_tokens.mint(3600, subject="worker-a")
+
+        result = self._run(["server", "join-tokens", "--format", "json"])
+
+        assert result.exit_code == 0, result.output
+        assert _json.loads(result.output)[0]["subject"] == "worker-a"
+
+    def test_unbound_tokens_render_without_a_subject(self, make_client):
+        """The table branch formats every column; an unbound token has None
+        where the subject goes."""
+        make_client()
+        join_tokens.mint(3600)
+
+        result = self._run(["server", "join-tokens"])
+
+        assert result.exit_code == 0, result.output
+        assert "(unbound)" in result.output
+
+    def test_revoke_by_id(self, make_client):
+        make_client()
+        join_tokens.mint(3600, subject="worker-a")
+        token_id = join_tokens.outstanding()[0]["id"]
+
+        result = self._run(["server", "revoke-join-token", "--id", token_id])
+
+        assert result.exit_code == 0, result.output
+        assert join_tokens.outstanding() == []
+
+    def test_revoke_by_subject(self, make_client):
+        make_client()
+        join_tokens.mint(3600, subject="worker-a")
+
+        result = self._run(["server", "revoke-join-token", "--subject", "worker-a"])
+
+        assert result.exit_code == 0, result.output
+        assert "Revoked 1" in result.output
+
+    def test_both_or_neither_is_refused(self, make_client):
+        make_client()
+
+        assert self._run(["server", "revoke-join-token"]).exit_code != 0
+        assert (
+            self._run(
+                ["server", "revoke-join-token", "--id", "x", "--subject", "y"],
+            ).exit_code
+            != 0
+        )
+
+    def test_blank_subject_is_refused(self, make_client):
+        make_client()
+
+        assert self._run(["server", "revoke-join-token", "--subject", "  "]).exit_code != 0
+
+    def test_unknown_id_exits_non_zero(self, make_client):
+        make_client()
+
+        assert self._run(["server", "revoke-join-token", "--id", "nope"]).exit_code != 0

--- a/tests/security/test_join_tokens_and_body_limit.py
+++ b/tests/security/test_join_tokens_and_body_limit.py
@@ -427,3 +427,48 @@ class TestJoinTokenRevocation:
         assert [r["subject"] for r in join_tokens.outstanding()] == ["worker-banned"], (
             "the token must survive a refused registration"
         )
+
+    def test_an_invalid_token_does_not_reveal_ban_state(self, make_client):
+        """Credential validity is established before the ban check, so an
+        unauthenticated caller cannot tell a quarantined worker name from any
+        other by comparing the two rejections."""
+        from flux.models import RepositoryFactory
+        from flux.security.principals import PrincipalRegistry
+
+        client = make_client()
+        repo = RepositoryFactory.create_repository()
+        registry = PrincipalRegistry(session_factory=lambda: repo.session())
+        principal = registry.create(
+            type="service_account",
+            subject="worker-banned",
+            external_issuer="flux",
+        )
+        registry.set_banned(principal.id, True)
+
+        banned = _register(client, "worker-banned", "not-a-real-token")
+        unknown = _register(client, "worker-unknown", "not-a-real-token")
+
+        assert banned.status_code == unknown.status_code == 403
+        assert banned.json()["detail"] == unknown.json()["detail"]
+
+    def test_a_valid_token_for_a_banned_worker_is_still_refused(self, make_client):
+        """Ordering must not weaken the quarantine: a live credential does not
+        buy a banned principal a registration."""
+        from flux.models import RepositoryFactory
+        from flux.security.principals import PrincipalRegistry
+
+        client = make_client()
+        repo = RepositoryFactory.create_repository()
+        registry = PrincipalRegistry(session_factory=lambda: repo.session())
+        principal = registry.create(
+            type="service_account",
+            subject="worker-banned",
+            external_issuer="flux",
+        )
+        registry.set_banned(principal.id, True)
+        token, _ = join_tokens.mint(3600, subject="worker-banned")
+
+        resp = _register(client, "worker-banned", token)
+
+        assert resp.status_code == 403
+        assert "banned" in resp.json()["detail"]


### PR DESCRIPTION
Closes #197.

## What was missing

`POST /admin/workers/join-tokens` was the only route. Minting is additive — each call produces another independently valid token — with no way to list what is outstanding or retire any of it. A token left live by a failed bring-up stayed claimable until its TTL, and `ttl_seconds` cannot be squeezed arbitrarily because cold start plus artifact fetch is minutes.

## What the triage changed

The issue framed this as a security gap, arguing a ban leaves a pre-minted token usable. **That does not hold.** Worker registration refuses a banned principal regardless of credential (`api/worker_routes.py`), and since `0021_join_token_subject` a token authorizes exactly one worker name — so banning that subject blocks registration even with a live token. The ban is already a complete control.

So this is scoped as **operational cleanup**: visibility and retirement, not containment. That changed what the fix needs to be good at.

## A real bug the issue did not mention

`claim()` consumes the token in a committed `UPDATE`, and the ban check ran *after* it. A banned holder's attempt therefore **burned** a credential the operator would have to mint again — the ban held, the token did not. The ban check now runs first, and `test_a_banned_worker_does_not_burn_the_token` was verified to fail against the old ordering.

## Shape

`list + revoke`, not the mint-supersedes option the issue also offered. Supersede makes minting destructive: two operators bringing up the same worker would silently invalidate each other, and you could not deliberately hold two valid tokens for a blue/green re-attach. Revocation keeps mint additive and also covers retiring a token you do not intend to replace.

```bash
flux server join-tokens                          # what is outstanding
flux server revoke-join-token --id <id>
flux server revoke-join-token --subject worker-7 # pairs with `flux principals ban`
```

Three routes under the existing `admin:workers:manage` permission.

## Decisions worth noting

- **`--subject` does not match unbound tokens.** They carry no subject, so retiring them under one worker's name would take out credentials meant for others. Stated in the docstring, the docs, and a test, because it reads as a bug otherwise.
- **Soft delete.** `revoked_at` rather than a row delete, so `purge_expired` stays the single reaper and the audit trail survives.
- **The listing never returns the token or its hash.** The plaintext is unrecoverable by design; the hash is credential-equivalent to an offline guesser.
- **Revocation is enforced in `claim()`'s existing WHERE clause**, so it takes effect on the next attempt with no window.
- **404 on revoking an unknown/spent id**, but **200 with a count** for revoke-by-subject — "nothing outstanding" is the desired end state, so an operator scripting ban-then-revoke should not special-case it.

## Tests

6 new, covering: the listing excludes the secret, a revoked token cannot register, revoke-by-subject retires all of a worker's tokens and leaves unbound ones alone, revoking a spent token reports nothing to do, and the token survives a refused registration.

528 security tests pass; full unit suite **3536 passed, 22 skipped**.

Migration `0024_join_token_revoked` (nullable, no backfill), `HEAD` updated in both migration tests. `0.80.0 → 0.81.0`.