### PR TITLE
fix(cancellation): persist CANCELLED against a second cancel, resolve unowned rows

### DIFF
--- a/docs/advanced-features/cancellation.md
+++ b/docs/advanced-features/cancellation.md
@@ -83,3 +83,20 @@ The cancellation feature works as follows:
 5. The worker sends a checkpoint back to the server with the final state
 
 This approach ensures that the workflow is cancelled cleanly and all resources are properly released.
+
+The server re-sends the cancellation on every dispatch cycle for as long as the
+execution remains `CANCELLING`, so delivery edge cases resolve rather than park:
+
+- **The terminal write survives a second cancellation.** The checkpoint that
+  persists `CANCELLED` runs shielded with a bounded wait; a further
+  cancellation arriving mid-write cannot discard it. If the wait ends before
+  the write lands, the write continues detached and its outcome is logged.
+- **A worker that is not running the execution resolves it.** If the notified
+  worker has no matching running task — for example, it restarted after the
+  claim — it checkpoints the execution as `CANCELLED` itself. Executions
+  already in a terminal state are never rewritten; the server rejects state
+  writes to finished executions.
+- **A claim in flight defers.** Between claiming an execution and starting it,
+  the worker declines to resolve a cancellation and waits for the next
+  delivery, which either cancels the now-running task or resolves the row if
+  the claim failed.

--- a/flux/_concurrency.py
+++ b/flux/_concurrency.py
@@ -58,6 +58,16 @@ DEFAULT_DRAIN_TIMEOUT = 2.0
 # the original body.
 CANCELLED_ROLLBACK_TIMEOUT = 10.0
 
+# Bound on persisting a cancelled workflow's terminal state
+# (flux/workflow.py). That checkpoint runs in the `finally` of a coroutine
+# already unwinding from a delivered CancelledError, so a *second* cancel — and
+# the dispatcher re-sends a cancellation every cycle while the row is still
+# CANCELLING — interrupts the await and the CANCELLED state is never written.
+# The row then stays CANCELLING, which is re-dispatched, which cancels again
+# (issue #189). Shielded for the same reason as the rollback above, and bounded
+# for the same reason: a wedged checkpoint must not strand a worker drain.
+CANCELLED_CHECKPOINT_TIMEOUT = 10.0
+
 
 async def gather_batch(
     awaitables: Iterable[Awaitable[Any]],

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -125,6 +125,9 @@ class Worker:
         self.base_url = f"{server_url or config.server_url}/workers"
         self.client = httpx.AsyncClient(timeout=config.http_timeout or None)
         self._running_workflows: dict[str, asyncio.Task] = {}
+        # Claims in flight: claimed server-side but not yet in
+        # _running_workflows. The cancellation handler must not resolve these.
+        self._claiming: set[str] = set()
         self._checkpoint_outboxes: dict[str, _CheckpointOutbox] = {}
         self._claim_generations: dict[str, str] = {}
         # Transient executions whose RUNNING transition has been persisted.
@@ -790,6 +793,18 @@ class Worker:
                         )
                 finally:
                     self._running_workflows.pop(context.execution_id, None)
+            elif context.execution_id in self._claiming:
+                # Claimed here but not yet registered in _running_workflows —
+                # the claim POST and task registration are separated by awaits.
+                # Resolving now would write CANCELLED, stop re-delivery, and
+                # let the body then run to completion with every checkpoint
+                # rejected. Defer: the dispatcher re-sends next cycle, by which
+                # point the task is registered (or the claim failed and the
+                # branch below resolves it).
+                logger.info(
+                    f"Execution {context.execution_id} claim is in flight; "
+                    "deferring cancellation to the next delivery",
+                )
             else:
                 # Not running here. Before this branch existed the handler
                 # simply returned: nothing was written, the row stayed
@@ -980,6 +995,7 @@ class Worker:
             return
 
         is_transient = bool(event_data.get("transient"))
+        self._claiming.add(request.context.execution_id)
         try:
             with span_cm as span:
                 logger.info(
@@ -1040,6 +1056,7 @@ class Worker:
             logger.error(f"Error handling execution_scheduled event: {str(ex)}")
             logger.debug(f"Exception details: {type(ex).__name__}: {str(ex)}", exc_info=True)
         finally:
+            self._claiming.discard(request.context.execution_id)
             self._close_checkpoint_outbox(request.context.execution_id)
 
     async def _execute_workflow(self, request: WorkflowExecutionRequest) -> ExecutionContext:
@@ -1116,6 +1133,10 @@ class Worker:
         logger.debug(f"Executing workflow {request.workflow.name} via runner '{runner_name}'")
         task = asyncio.create_task(runner.execute(request, hooks))
         self._running_workflows[ctx.execution_id] = task
+        # Same synchronous block as the registration above: no await between
+        # them, so the cancellation handler always finds the execution in one
+        # of the two structures.
+        self._claiming.discard(ctx.execution_id)
         start_time = asyncio.get_event_loop().time()
         if self._metrics_collector and not ctx.is_transient:
             # Resolved by the first checkpoint -> flux.startup_overhead_seconds.

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -790,6 +790,22 @@ class Worker:
                         )
                 finally:
                     self._running_workflows.pop(context.execution_id, None)
+            else:
+                # Not running here. Before this branch existed the handler
+                # simply returned: nothing was written, the row stayed
+                # CANCELLING, and the dispatcher re-sent the cancellation every
+                # cycle — 57,905 times in the run that finally produced logs
+                # (issue #189). Resolve it instead. A row that already reached a
+                # terminal state rejects this write server-side
+                # (_accept_state_write), so a completed execution is not
+                # rewritten as cancelled; only a genuinely stuck CANCELLING row
+                # advances.
+                logger.info(
+                    f"Execution {context.execution_id} is not running here; "
+                    "resolving its cancellation",
+                )
+                context.cancel()
+                await context.checkpoint()
         except Exception as ex:
             logger.error(f"Error handling execution_cancelled event: {str(ex)}")
             logger.debug(f"Exception details: {type(ex).__name__}: {str(ex)}", exc_info=True)

--- a/flux/workflow.py
+++ b/flux/workflow.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from flux._namespace import validate_namespace
 from flux.context_managers import ContextManager
 from flux.domain.events import ExecutionState
+from flux._concurrency import CANCELLED_CHECKPOINT_TIMEOUT
 from flux.domain.execution_context import ExecutionContext
 from flux.domain.resource_request import ResourceRequest
 from flux.domain.schedule import Schedule
@@ -15,6 +16,11 @@ from flux.errors import PauseRequested
 from flux.output_storage import OutputStorage
 from flux.utils import maybe_awaitable
 from flux.worker_registry import WorkerInfo
+
+from flux.utils import get_logger
+
+logger = get_logger(__name__)
+
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -209,6 +215,7 @@ class workflow:
             ctx.start(self.id)
 
         token = ExecutionContext.set(ctx)
+        cancelled = False
         try:
             output = await maybe_awaitable(self._func(ctx))
             output_value = (
@@ -225,13 +232,48 @@ class workflow:
             )
         except asyncio.CancelledError:
             ctx.cancel()
+            cancelled = True
             raise
         except Exception as ex:
             ctx.fail(self.id, ex)
         finally:
-            await ctx.checkpoint()
+            if cancelled:
+                await self._checkpoint_cancelled(ctx)
+            else:
+                await ctx.checkpoint()
             ExecutionContext.reset(token)
         return ctx
+
+    @staticmethod
+    async def _checkpoint_cancelled(ctx: ExecutionContext) -> None:
+        """Persist CANCELLED against a second cancellation.
+
+        This runs while already unwinding from a delivered CancelledError, so a
+        plain ``await`` here is interrupted by the next cancel — and the
+        dispatcher re-sends a cancellation every cycle for as long as the row
+        is CANCELLING, so the next cancel is imminent by construction. Losing
+        this write leaves the row CANCELLING forever and turns one missed
+        checkpoint into an endless re-dispatch loop (issue #189).
+
+        Its own task, so the awaits inside start uncancelled, awaited through a
+        shield with a deadline: a wedged checkpoint must not strand a drain.
+        """
+        checkpoint = asyncio.ensure_future(ctx.checkpoint())
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(checkpoint),
+                timeout=CANCELLED_CHECKPOINT_TIMEOUT,
+            )
+        except (TimeoutError, asyncio.CancelledError):
+            # The shield means the write is still in flight; the caller is
+            # unwinding regardless. Losing the race is what the park sweep and
+            # the worker-side resolution below it are for.
+            logger.warning(
+                f"Execution {ctx.execution_id}: terminal CANCELLED checkpoint did not "
+                f"complete within {CANCELLED_CHECKPOINT_TIMEOUT}s",
+            )
+        except Exception as ex:  # pragma: no cover - defensive
+            logger.error(f"Execution {ctx.execution_id}: cancelled checkpoint failed: {ex}")
 
     def run(self, *args, **kwargs) -> ExecutionContext:
         if "execution_id" in kwargs:

--- a/flux/workflow.py
+++ b/flux/workflow.py
@@ -5,10 +5,10 @@ from functools import wraps
 from typing import Any, TypeVar
 from collections.abc import Callable
 
+from flux._concurrency import CANCELLED_CHECKPOINT_TIMEOUT
 from flux._namespace import validate_namespace
 from flux.context_managers import ContextManager
 from flux.domain.events import ExecutionState
-from flux._concurrency import CANCELLED_CHECKPOINT_TIMEOUT
 from flux.domain.execution_context import ExecutionContext
 from flux.domain.resource_request import ResourceRequest
 from flux.domain.schedule import Schedule
@@ -276,9 +276,9 @@ class workflow:
             )
         except (TimeoutError, asyncio.CancelledError):
             # The shield means the write is still in flight; the caller is
-            # unwinding regardless. Losing the race is what the park sweep and
-            # the worker-side resolution below it are for. Nobody awaits the
-            # task now, so attach a callback: an exception it raises later
+            # unwinding regardless. Losing the race is what the worker-side
+            # resolution of an unowned CANCELLING row is for. Nobody awaits
+            # the task now, so attach a callback: an exception it raises later
             # would otherwise surface only as asyncio's "Task exception was
             # never retrieved" at garbage-collection time, detached from the
             # execution it belongs to.
@@ -286,10 +286,15 @@ class workflow:
                 lambda t: _report_detached_checkpoint(t, ctx.execution_id),
             )
             logger.warning(
-                f"Execution {ctx.execution_id}: terminal CANCELLED checkpoint did not "
-                f"complete within {CANCELLED_CHECKPOINT_TIMEOUT}s",
+                f"Execution {ctx.execution_id}: wait for the terminal CANCELLED "
+                f"checkpoint ended early (interrupted or past the "
+                f"{CANCELLED_CHECKPOINT_TIMEOUT}s bound); its outcome is logged "
+                "when it lands",
             )
-        except Exception as ex:  # pragma: no cover - defensive
+        except Exception as ex:
+            # Reachable inline, where checkpoint() saves straight to the
+            # database: a save failure lands here. Swallowed deliberately —
+            # the original CancelledError must keep unwinding.
             logger.error(f"Execution {ctx.execution_id}: cancelled checkpoint failed: {ex}")
 
     def run(self, *args, **kwargs) -> ExecutionContext:

--- a/flux/workflow.py
+++ b/flux/workflow.py
@@ -14,12 +14,22 @@ from flux.domain.resource_request import ResourceRequest
 from flux.domain.schedule import Schedule
 from flux.errors import PauseRequested
 from flux.output_storage import OutputStorage
-from flux.utils import maybe_awaitable
+from flux.utils import get_logger, maybe_awaitable
 from flux.worker_registry import WorkerInfo
 
-from flux.utils import get_logger
-
 logger = get_logger(__name__)
+
+
+def _report_detached_checkpoint(task: asyncio.Future, execution_id: str) -> None:
+    """Log the outcome of a checkpoint nobody is awaiting any more."""
+    if task.cancelled():
+        logger.warning(f"Execution {execution_id}: detached CANCELLED checkpoint was cancelled")
+        return
+    error = task.exception()
+    if error is not None:
+        logger.error(f"Execution {execution_id}: detached CANCELLED checkpoint failed: {error}")
+    else:
+        logger.info(f"Execution {execution_id}: detached CANCELLED checkpoint landed late")
 
 
 F = TypeVar("F", bound=Callable[..., Any])
@@ -267,7 +277,14 @@ class workflow:
         except (TimeoutError, asyncio.CancelledError):
             # The shield means the write is still in flight; the caller is
             # unwinding regardless. Losing the race is what the park sweep and
-            # the worker-side resolution below it are for.
+            # the worker-side resolution below it are for. Nobody awaits the
+            # task now, so attach a callback: an exception it raises later
+            # would otherwise surface only as asyncio's "Task exception was
+            # never retrieved" at garbage-collection time, detached from the
+            # execution it belongs to.
+            checkpoint.add_done_callback(
+                lambda t: _report_detached_checkpoint(t, ctx.execution_id),
+            )
             logger.warning(
                 f"Execution {ctx.execution_id}: terminal CANCELLED checkpoint did not "
                 f"complete within {CANCELLED_CHECKPOINT_TIMEOUT}s",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.81.0"
+version = "0.81.1"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/e2e/test_pause.py
+++ b/tests/e2e/test_pause.py
@@ -65,7 +65,9 @@ def test_cancellation(cli):
     deadline = time.monotonic() + 60
     while time.monotonic() < deadline:
         s = cli.status("cancellable_e2e", exec_id)
-        if s["state"] in ("CANCELLED", "CANCELLING"):
+        if s["state"] == "CANCELLED":
             break
         time.sleep(2)
-    assert s["state"] in ("CANCELLED", "CANCELLING")
+    # CANCELLING is not accepted: a row parked there is issue #189, the bug
+    # this asserts against.
+    assert s["state"] == "CANCELLED"

--- a/tests/flux/test_worker_cancellation.py
+++ b/tests/flux/test_worker_cancellation.py
@@ -103,6 +103,31 @@ class TestWorkerCancellation:
         assert checkpointed.state == ExecutionState.CANCELLED
 
     @pytest.mark.asyncio
+    async def test_handle_execution_cancelled_defers_while_claim_in_flight(
+        self,
+        worker,
+        execution_context,
+    ):
+        """Between the claim POST and task registration the execution is owned
+        here but absent from _running_workflows. Resolving it in that window
+        would write CANCELLED, stop re-delivery, and let the body then run to
+        completion with every checkpoint rejected — so the handler must defer
+        to the next delivery instead.
+        """
+        worker._running_workflows = {}
+        worker._claiming = {"test-execution-id"}
+        execution_context.start_cancel()
+
+        mock_event = MagicMock()
+        mock_event.json.return_value = {"context": execution_context.to_dict()}
+
+        await worker._handle_execution_cancelled(mock_event)
+
+        assert worker._checkpoint.await_count == 0, (
+            "an in-flight claim must not be resolved as CANCELLED"
+        )
+
+    @pytest.mark.asyncio
     async def test_handle_execution_cancelled_task_already_done(self, worker, execution_context):
         """Test handling execution cancelled when task is already done."""
         # Create a mock task that raises CancelledError when awaited
@@ -210,3 +235,67 @@ class TestCancelledCheckpointSurvivesASecondCancel:
 
         assert "checkpoint exploded" in caplog.text
         assert "exec-1" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_timeout_detaches_the_write_and_reports_its_landing(
+        self,
+        caplog,
+        monkeypatch,
+    ):
+        """Drives _checkpoint_cancelled itself into its timeout, covering the
+        callback-attach wiring the test above only exercises directly."""
+        import logging
+        import sys
+
+        from flux.workflow import workflow
+
+        # flux.workflow the *attribute* resolves to the class; the module
+        # global being patched lives on the module object in sys.modules.
+        monkeypatch.setattr(sys.modules["flux.workflow"], "CANCELLED_CHECKPOINT_TIMEOUT", 0.01)
+        landed = asyncio.Event()
+
+        async def _slow_checkpoint(ctx):
+            await asyncio.sleep(0.1)
+            landed.set()
+
+        ctx = ExecutionContext(
+            workflow_id="default/_slow",
+            workflow_namespace="default",
+            workflow_name="_slow",
+            checkpoint=_slow_checkpoint,
+        )
+
+        with caplog.at_level(logging.INFO):
+            await workflow._checkpoint_cancelled(ctx)
+            assert "ended early" in caplog.text, "the bounded wait must give up at the timeout"
+            assert not landed.is_set()
+
+            await asyncio.wait_for(landed.wait(), timeout=5)
+            await asyncio.sleep(0)  # let the done-callback run
+
+        assert "landed late" in caplog.text, "the detached write's outcome must be reported"
+
+    @pytest.mark.asyncio
+    async def test_a_failing_checkpoint_does_not_mask_the_cancellation(self, caplog):
+        """Inline mode saves straight to the database, so a save failure lands
+        in _checkpoint_cancelled directly. It must be logged and swallowed —
+        the original CancelledError keeps unwinding."""
+        import logging
+
+        from flux.workflow import workflow
+
+        async def _failing_checkpoint(ctx):
+            raise RuntimeError("db unavailable")
+
+        ctx = ExecutionContext(
+            workflow_id="default/_slow",
+            workflow_namespace="default",
+            workflow_name="_slow",
+            checkpoint=_failing_checkpoint,
+        )
+
+        with caplog.at_level(logging.ERROR):
+            await workflow._checkpoint_cancelled(ctx)
+
+        assert "cancelled checkpoint failed" in caplog.text
+        assert "db unavailable" in caplog.text

--- a/tests/flux/test_worker_cancellation.py
+++ b/tests/flux/test_worker_cancellation.py
@@ -188,3 +188,25 @@ class TestCancelledCheckpointSurvivesASecondCancel:
         assert "CANCELLED" in checkpoints, (
             "the terminal state was lost to the second cancel, leaving the row CANCELLING forever"
         )
+
+    @pytest.mark.asyncio
+    async def test_a_checkpoint_that_outlives_the_wait_is_still_observed(self, caplog):
+        """On timeout the shielded write keeps running with nobody awaiting it.
+        An exception it raises then would otherwise surface only as asyncio's
+        "Task exception was never retrieved" at GC time, detached from the
+        execution it belongs to."""
+        import logging
+
+        from flux.workflow import _report_detached_checkpoint
+
+        async def _boom():
+            raise RuntimeError("checkpoint exploded")
+
+        task = asyncio.ensure_future(_boom())
+        await asyncio.sleep(0)
+
+        with caplog.at_level(logging.ERROR):
+            _report_detached_checkpoint(task, "exec-1")
+
+        assert "checkpoint exploded" in caplog.text
+        assert "exec-1" in caplog.text

--- a/tests/flux/test_worker_cancellation.py
+++ b/tests/flux/test_worker_cancellation.py
@@ -7,6 +7,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from flux import ExecutionContext
+from flux.domain import ExecutionState
 from flux.worker import Worker
 
 
@@ -78,21 +79,28 @@ class TestWorkerCancellation:
 
     @pytest.mark.asyncio
     async def test_handle_execution_cancelled_no_running_task(self, worker, execution_context):
-        """Test handling execution cancelled when no task is running."""
-        # Set up an empty running workflows dictionary
-        worker._running_workflows = {}
+        """A cancellation for an execution this worker is not running must
+        still resolve the row.
 
-        # Set up the execution context to be cancelled
+        This asserted only "does not raise" before, which is precisely the
+        behaviour that made issue #189 survive: the handler returned without
+        writing anything, the row stayed CANCELLING, and the dispatcher re-sent
+        the cancellation every cycle — 57,905 times in the run that finally
+        captured logs.
+        """
+        worker._running_workflows = {}
         execution_context.start_cancel()
 
-        # Create a mock event
         mock_event = MagicMock()
         mock_event.json.return_value = {"context": execution_context.to_dict()}
 
-        # Call the handler - should not raise an exception
         await worker._handle_execution_cancelled(mock_event)
 
-        # No assertions needed since we're just ensuring it doesn't throw an exception
+        assert worker._checkpoint.await_count == 1, (
+            "the row must be resolved, not silently left CANCELLING"
+        )
+        checkpointed = worker._checkpoint.await_args.args[0]
+        assert checkpointed.state == ExecutionState.CANCELLED
 
     @pytest.mark.asyncio
     async def test_handle_execution_cancelled_task_already_done(self, worker, execution_context):
@@ -124,3 +132,59 @@ class TestWorkerCancellation:
 
         # Verify the task was removed from running workflows
         assert "test-execution-id" not in worker._running_workflows
+
+
+class TestCancelledCheckpointSurvivesASecondCancel:
+    """The other half of issue #189, and the deeper one.
+
+    `workflow.run` writes CANCELLED in a `finally` that awaits — while already
+    unwinding from a delivered CancelledError. A second cancel interrupts that
+    await and the terminal state is never written, so the row stays CANCELLING
+    and gets re-dispatched, which cancels again. The dispatcher re-sends a
+    cancellation every cycle for as long as the row is CANCELLING, so the
+    second cancel is imminent by construction rather than a rare race.
+    """
+
+    @pytest.mark.asyncio
+    async def test_terminal_state_persists_under_repeated_cancellation(self):
+        from flux import task, workflow
+
+        checkpoints: list[str] = []
+
+        async def _checkpoint(ctx):
+            # Yield, so a cancellation delivered now lands mid-write — which is
+            # exactly what happened in CI.
+            await asyncio.sleep(0)
+            checkpoints.append(ctx.state.value)
+
+        @task
+        async def _forever():
+            await asyncio.sleep(30)
+
+        @workflow
+        async def _slow(ctx: ExecutionContext):
+            await _forever()
+            return "done"
+
+        ctx = ExecutionContext(
+            workflow_id="default/_slow",
+            workflow_namespace="default",
+            workflow_name="_slow",
+            checkpoint=_checkpoint,
+        )
+
+        running = asyncio.ensure_future(_slow(ctx))
+        await asyncio.sleep(0.05)
+
+        running.cancel()
+        await asyncio.sleep(0)
+        running.cancel()  # the second delivery, mid-checkpoint
+        with pytest.raises(asyncio.CancelledError):
+            await running
+
+        # Give the shielded write its moment to land.
+        await asyncio.sleep(0.05)
+
+        assert "CANCELLED" in checkpoints, (
+            "the terminal state was lost to the second cancel, leaving the row CANCELLING forever"
+        )

--- a/tests/flux/test_worker_checkpoint.py
+++ b/tests/flux/test_worker_checkpoint.py
@@ -17,6 +17,7 @@ def make_worker() -> Worker:
     worker.session_token = "tok"
     worker.client = AsyncMock()
     worker._running_workflows = {}
+    worker._claiming = set()
     worker._checkpoint_outboxes = {}
     worker._claim_generations = {}
     worker._transient_started = set()


### PR DESCRIPTION
Closes #189 — six occurrences, diagnosed from the logs #216 finally captured.

## The loop

From `e2e-logs` on the run that failed #221:

```
22:25:16  Cancelling Execution - transient_slow - 03fe01…    <- 1st
22:25:16  Cancelling Execution - transient_slow - 03fe01…    <- 2nd
22:25:16  Execution 03fe01… cancelled successfully  (×2)
22:25:16  Cancelling Execution - transient_slow - 03fe01…    <- and 57,903 more
```

Two causes, and the second is the one that starts it.

### 1. The terminal write is lost to the second cancel

`workflow.run` persists `CANCELLED` in a `finally` that **awaits**, while already unwinding from a delivered `CancelledError`:

```python
except asyncio.CancelledError:
    ctx.cancel()
    raise
finally:
    await ctx.checkpoint()      # a second cancel interrupts this
```

That is not a rare race. The dispatcher re-sends a cancellation **every cycle** for as long as the row is `CANCELLING` — so losing the write guarantees another cancel arrives, which loses it again. One missed checkpoint is self-sustaining.

Now shielded with a bounded deadline, the same shape as the cancelled-task rollback in `task.py`, and for the same reason: compensation must survive a second cancel, but must not strand a drain.

### 2. The worker dropped cancellations for executions it wasn't running

`_handle_execution_cancelled` was `if task := self._running_workflows.get(...)` with **no `else`** — it logged the line and returned, writing nothing. Once the task was cancelled and popped, every later delivery fell through.

It now resolves the row. A terminal row rejects that write server-side (`_accept_state_write`), so a completed execution is never rewritten as cancelled; only a genuinely stuck row advances.

## This also explains the other variant

The [#215 run](https://github.com/edurdias/flux/actions/runs/31548905391) failed the same test with `COMPLETED`, not `CANCELLING`. Same handler: the workflow finished before the cancel arrived, the `if` was False on the very first delivery, and the already-recorded terminal state stood. So the issue title understates it — it is not "strands in CANCELLING", it is **a cancellation delivered for a non-running execution is dropped**, which strands or is ignored depending on timing.

## Why the tests are the argument, not the green run

#189 is intermittent; the suite passed on plenty of runs while the bug was live, so a green e2e proves little on its own. Both regression tests were verified to **fail without their fix**:

- `test_terminal_state_persists_under_repeated_cancellation` reproduces the CI sequence deterministically — cancel, yield, cancel again mid-checkpoint — rather than hoping to catch the race.
- `test_handle_execution_cancelled_no_running_task` already existed and asserted **nothing**: *"No assertions needed since we're just ensuring it doesn't throw an exception."* That is why this survived six occurrences — the test pinned "doesn't crash" as the contract. It now asserts the row is resolved.

## Not included

The re-delivery storm itself. One missing write became 57,905 deliveries because cancellations are dispatched with no in-flight marker; with the write fixed the loop terminates, but a row that cannot be resolved for any other reason would still be re-sent at full tick rate. That is a dispatcher concern and deserves its own change.

3558 unit tests pass; 20 e2e including `test_transient_cancellation`. `0.81.0 → 0.81.1`.