### PR TITLE
fix(worker): keep the loop-health monitor alive through metrics failures

### DIFF
--- a/flux/server.py
+++ b/flux/server.py
@@ -847,18 +847,21 @@ class Server(
                 except RuntimeError:
                     logger.warning(f"Cannot revoke API key for {name}: no event loop")
 
-    def _gc_worker_principal(self, name: str) -> None:
+    def _gc_worker_principal(self, name: str) -> asyncio.Task | None:
         """Disable a pruned worker's principal and revoke its API keys.
 
         Runs as a fire-and-forget task off the reaper. Registration re-enables
         the principal if the worker ever returns, so this is reversible.
+        Returns the task (None when there is nothing to do or no loop) so a
+        caller that needs completion — tests — can await it instead of
+        sleeping and hoping.
         """
         from flux.security.dependencies import _get_auth_service
         from flux.security.principals import PrincipalRegistry
 
         auth_service = _get_auth_service()
         if auth_service is None:
-            return
+            return None
 
         async def _gc():
             try:
@@ -878,9 +881,10 @@ class Server(
                 logger.warning(f"Principal GC for pruned worker {name} failed: {e}")
 
         try:
-            asyncio.create_task(_gc())
+            return asyncio.create_task(_gc())
         except RuntimeError:
             logger.warning(f"Cannot GC principal for {name}: no event loop")
+            return None
 
     def _unclaim_worker_executions(self, worker_name: str) -> None:
         """Recover all executions assigned to an evicted worker.

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -165,6 +165,9 @@ class Worker:
             list[tuple[asyncio.Queue, asyncio.Task | None]],
         ] = {}
         self._reconnect_max_delay = config.reconnect_max_delay
+        # The server pings the SSE stream every heartbeat_interval; a stream
+        # silent for several intervals is dead, however live the socket looks.
+        self._sse_stall_timeout = max(30.0, 3.0 * config.heartbeat_interval)
         # The flux. label prefix is reserved for platform-derived labels so
         # user labels cannot spoof capability grants (service sockets below).
         reserved = sorted(k for k in self.labels if k.startswith("flux."))
@@ -765,7 +768,25 @@ class Worker:
                 ) as es:
                     logger.info("Connection established successfully")
                     logger.debug("Starting event loop to receive events")
-                    async for evt in es.aiter_sse():
+                    # A dropped link does not error an idle read: a dead
+                    # socket can hang aiter_sse() forever, leaving the worker
+                    # ponging over HTTP but invisible to dispatch (its SSE
+                    # queue is gone server-side) with the reconnect loop never
+                    # running. The server pings every heartbeat_interval, so a
+                    # silent stream past the stall bound is dead — raise and
+                    # let the reconnect loop take over.
+                    events = aiter(es.aiter_sse())
+                    while True:
+                        try:
+                            async with asyncio.timeout(self._sse_stall_timeout):
+                                evt = await anext(events)
+                        except StopAsyncIteration:
+                            break
+                        except TimeoutError:
+                            raise ConnectionError(
+                                f"SSE stream silent for {self._sse_stall_timeout:.0f}s; "
+                                "treating the connection as dead",
+                            ) from None
                         if evt.event == "execution_scheduled":
                             asyncio.create_task(
                                 self._handle_execution_scheduled(base_url, evt),

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -32,6 +32,23 @@ from flux.utils import get_logger
 logger = get_logger(__name__)
 
 
+def _report_monitor_exit(task: asyncio.Task) -> None:
+    """Make the loop-health monitor's death loud.
+
+    It is the only producer of health transitions: if it dies between the
+    unhealthy flip and recovery, the worker declines all new work for its
+    remaining lifetime with nothing left to flip it back (issue #224).
+    """
+    if task.cancelled():
+        return
+    error = task.exception()
+    if error is not None:
+        logger.error(
+            f"Loop-health monitor died: {error!r} — health transitions have "
+            "stopped; the worker keeps its current health state until restart",
+        )
+
+
 class WorkflowDefinition(BaseModel):
     id: str
     namespace: str = "default"
@@ -518,6 +535,9 @@ class Worker:
         health_monitor: asyncio.Task | None = None
         if self._loop_lag_threshold > 0:
             health_monitor = asyncio.create_task(self._monitor_loop_health())
+            # Fire-and-forget task nobody awaits: without this, its death is
+            # invisible and health transitions silently stop (issue #224).
+            health_monitor.add_done_callback(_report_monitor_exit)
 
         backoff = 1
         try:
@@ -583,13 +603,7 @@ class Worker:
             await asyncio.sleep(self._loop_lag_probe_interval)
             lag = time.monotonic() - start - self._loop_lag_probe_interval
 
-            from flux.observability import get_metrics
-
-            m = get_metrics()
-            if m:
-                m.record_loop_lag(lag)
-            if self._metrics_collector:
-                self._metrics_collector.record_loop_lag(lag)
+            self._record_loop_lag(lag)
 
             if lag >= self._loop_lag_threshold:
                 recoveries = 0
@@ -602,8 +616,7 @@ class Worker:
                         f"marking worker unhealthy — declining new work until "
                         f"the loop recovers",
                     )
-                    if m:
-                        m.record_worker_health_transition("unhealthy")
+                    self._record_health_transition("unhealthy")
                     # Tell the server immediately instead of waiting for the
                     # next ping/pong round-trip.
                     asyncio.create_task(self._send_pong())
@@ -617,9 +630,34 @@ class Worker:
                         logger.warning(
                             "Event loop recovered; worker healthy — accepting work again",
                         )
-                        if m:
-                            m.record_worker_health_transition("recovered")
+                        self._record_health_transition("recovered")
                         asyncio.create_task(self._send_pong())
+
+    # Both recorders are best-effort: the monitor loop above is the only
+    # producer of health transitions, so a metrics raise escaping it after the
+    # unhealthy flip would strand the worker unhealthy forever with nothing
+    # left to recover it (issue #224).
+    def _record_loop_lag(self, lag: float) -> None:
+        try:
+            from flux.observability import get_metrics
+
+            m = get_metrics()
+            if m:
+                m.record_loop_lag(lag)
+            if self._metrics_collector:
+                self._metrics_collector.record_loop_lag(lag)
+        except Exception as ex:
+            logger.debug(f"Loop-lag metrics recording failed: {ex}")
+
+    def _record_health_transition(self, state: str) -> None:
+        try:
+            from flux.observability import get_metrics
+
+            m = get_metrics()
+            if m:
+                m.record_worker_health_transition(state)
+        except Exception as ex:
+            logger.debug(f"Health-transition metric failed: {ex}")
 
     async def _drain(self):
         """Let running executions finish, then flush their checkpoints.

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -46,6 +46,7 @@ def _report_monitor_exit(task: asyncio.Task) -> None:
         logger.error(
             f"Loop-health monitor died: {error!r} — health transitions have "
             "stopped; the worker keeps its current health state until restart",
+            exc_info=error,
         )
 
 
@@ -638,16 +639,22 @@ class Worker:
     # unhealthy flip would strand the worker unhealthy forever with nothing
     # left to recover it (issue #224).
     def _record_loop_lag(self, lag: float) -> None:
+        # Guarded separately: the built-in collector feeds the flux.loop_lag*
+        # routing metrics, and an unhealthy OTel backend must not take those
+        # down with it.
         try:
             from flux.observability import get_metrics
 
             m = get_metrics()
             if m:
                 m.record_loop_lag(lag)
+        except Exception as ex:
+            logger.debug(f"OTel loop-lag recording failed: {ex}", exc_info=True)
+        try:
             if self._metrics_collector:
                 self._metrics_collector.record_loop_lag(lag)
         except Exception as ex:
-            logger.debug(f"Loop-lag metrics recording failed: {ex}")
+            logger.debug(f"Built-in loop-lag recording failed: {ex}", exc_info=True)
 
     def _record_health_transition(self, state: str) -> None:
         try:
@@ -657,7 +664,7 @@ class Worker:
             if m:
                 m.record_worker_health_transition(state)
         except Exception as ex:
-            logger.debug(f"Health-transition metric failed: {ex}")
+            logger.debug(f"Health-transition metric failed: {ex}", exc_info=True)
 
     async def _drain(self):
         """Let running executions finish, then flush their checkpoints.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.81.2"
+version = "0.81.3"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_heartbeat.py
+++ b/tests/flux/test_heartbeat.py
@@ -436,6 +436,7 @@ class TestWorkerReconnect:
         mock_settings.workers.checkpoint_retry_max_delay = 30
         mock_settings.workers.terminal_checkpoint_deadline = 300
         mock_settings.workers.reconnect_max_delay = 4
+        mock_settings.workers.heartbeat_interval = 10
         mock_settings.workers.module_cache_ttl = 300
         mock_settings.workers.module_cache_max_size = 64
         mock_settings.workers.runners = ["inprocess", "subprocess"]

--- a/tests/flux/test_ops_endpoints.py
+++ b/tests/flux/test_ops_endpoints.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -53,8 +52,12 @@ class TestWorkerPrincipalGC:
             registry = registry_cls.return_value
             registry.find.return_value = principal
 
-            server._gc_worker_principal("dead-worker")
-            await asyncio.sleep(0.05)  # let the fire-and-forget task run
+            # Await the returned task instead of sleeping: on a loaded
+            # runner a fixed sleep can elapse before the fire-and-forget
+            # task ever runs.
+            task = server._gc_worker_principal("dead-worker")
+            assert task is not None
+            await task
 
         registry.set_enabled.assert_called_once_with("p-1", False)
         auth_service.revoke_all_api_keys.assert_awaited_once_with("p-1")

--- a/tests/flux/test_worker.py
+++ b/tests/flux/test_worker.py
@@ -30,6 +30,7 @@ def mock_config():
     mock_settings.workers.subprocess_term_grace = 5.0
     mock_settings.workers.subprocess_memory_limit = 0
     mock_settings.workers.loop_lag_threshold = 0
+    mock_settings.workers.heartbeat_interval = 10
     mock_settings.workers.metrics_provider = None
     mock_settings.workers.metrics_interval = 10.0
     mock_settings.workers.builtin_metrics = False
@@ -136,6 +137,7 @@ def test_worker_init_strips_bootstrap_token_padding():
     mock_settings.workers.default_runner = "inprocess"
     mock_settings.workers.module_cache_ttl = 0
     mock_settings.workers.module_cache_max_size = 64
+    mock_settings.workers.heartbeat_interval = 10
 
     with patch.object(Configuration, "get") as mock_get:
         mock_get.return_value = MagicMock(settings=mock_settings)

--- a/tests/flux/test_worker_health.py
+++ b/tests/flux/test_worker_health.py
@@ -54,18 +54,24 @@ class TestLoopLagMonitor:
             mock_time.monotonic.side_effect = itertools.chain(lagged, clean)
             monitor = asyncio.create_task(worker._monitor_loop_health())
             try:
+                # Observe via the pong mock, not by sampling _healthy: the
+                # unhealthy window is only three 1ms probes wide, and on a
+                # loaded runner a sampling loop can be starved right across
+                # it, then spin on "still healthy" until timeout (the
+                # intermittent CI TimeoutError this replaced). The monitor
+                # calls _send_pong() synchronously in the same block as each
+                # flip, so call #1 IS the unhealthy transition and call #2
+                # the recovery — no window to miss.
                 async with asyncio.timeout(10):
-                    while worker._healthy:
-                        await asyncio.sleep(0.005)
-                    unhealthy_seen = not worker._healthy
-                    while not worker._healthy:
-                        await asyncio.sleep(0.005)
+                    while worker._send_pong.call_count < 2:
+                        await asyncio.sleep(0.001)
             finally:
                 monitor.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await monitor
 
-        assert unhealthy_seen
         assert worker._healthy  # recovered after three clean probes
-        worker._send_pong.assert_called()  # state changes pushed to server
+        assert worker._send_pong.call_count == 2  # one pong per transition
 
     @pytest.mark.asyncio
     async def test_a_raising_metrics_recorder_does_not_kill_the_monitor(self):
@@ -97,20 +103,20 @@ class TestLoopLagMonitor:
             mock_time.monotonic.side_effect = itertools.chain(lagged, clean)
             monitor = asyncio.create_task(worker._monitor_loop_health())
             try:
+                # Pong-count observation for the same reason as the test
+                # above: the unhealthy window is a few 1ms probes wide and a
+                # sampling loop can be starved across it.
                 async with asyncio.timeout(10):
-                    while worker._healthy:
-                        await asyncio.sleep(0.005)
-                    unhealthy_seen = not worker._healthy
-                    while not worker._healthy:
-                        await asyncio.sleep(0.005)
-                    assert not monitor.done(), "the monitor must survive metrics failures"
+                    while worker._send_pong.call_count < 2:
+                        await asyncio.sleep(0.001)
+                assert not monitor.done(), "the monitor must survive metrics failures"
             finally:
                 monitor.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await monitor
 
-        assert unhealthy_seen
         assert worker._healthy
+        assert worker._send_pong.call_count == 2
         # Proves the raise was exercised, not skipped.
         raising_metrics.record_worker_health_transition.assert_called()
 

--- a/tests/flux/test_worker_health.py
+++ b/tests/flux/test_worker_health.py
@@ -67,6 +67,51 @@ class TestLoopLagMonitor:
         worker._send_pong.assert_called()  # state changes pushed to server
 
     @pytest.mark.asyncio
+    async def test_a_raising_metrics_recorder_does_not_kill_the_monitor(self):
+        """The monitor is the only producer of health transitions. Before the
+        recorders were guarded, a metrics raise right after the unhealthy flip
+        killed the loop and stranded the worker unhealthy forever (issue #224)
+        — so a worker whose metrics backend misbehaves must still flip
+        unhealthy AND recover, with the monitor alive throughout.
+        """
+        worker = make_worker()
+        worker._loop_lag_threshold = 1.0
+        worker._loop_lag_probe_interval = 0.001
+        worker._send_pong = AsyncMock()
+        worker._metrics_collector = MagicMock()
+        worker._metrics_collector.record_loop_lag.side_effect = RuntimeError("collector broken")
+
+        raising_metrics = MagicMock()
+        raising_metrics.record_loop_lag.side_effect = RuntimeError("otel broken")
+        raising_metrics.record_worker_health_transition.side_effect = RuntimeError("otel broken")
+
+        import itertools
+
+        lagged = [0.0, 10.0] * 3
+        clean = itertools.cycle([0.0, 0.001])
+        with (
+            patch("flux.observability.get_metrics", return_value=raising_metrics),
+            patch("flux.worker.time") as mock_time,
+        ):
+            mock_time.monotonic.side_effect = itertools.chain(lagged, clean)
+            monitor = asyncio.create_task(worker._monitor_loop_health())
+            try:
+                async with asyncio.timeout(10):
+                    while worker._healthy:
+                        await asyncio.sleep(0.005)
+                    unhealthy_seen = not worker._healthy
+                    while not worker._healthy:
+                        await asyncio.sleep(0.005)
+                    assert not monitor.done(), "the monitor must survive metrics failures"
+            finally:
+                monitor.cancel()
+
+        assert unhealthy_seen
+        assert worker._healthy
+        # Proves the raise was exercised, not skipped.
+        raising_metrics.record_worker_health_transition.assert_called()
+
+    @pytest.mark.asyncio
     async def test_single_breach_does_not_trip(self):
         worker = make_worker()
         worker._loop_lag_threshold = 1.0
@@ -147,3 +192,46 @@ class TestDispatcherExclusion:
         dispatcher._server = server
 
         assert dispatcher._connected_workers() == ["info1"]
+
+
+class TestMonitorExitVisibility:
+    """A dead monitor must be loud: nothing awaits the task, so without the
+    done-callback its exception surfaces only at GC time, detached from the
+    worker it silenced (issue #224)."""
+
+    @pytest.mark.asyncio
+    async def test_monitor_death_is_logged(self, caplog):
+        import logging
+
+        from flux.worker import _report_monitor_exit
+
+        async def _dies():
+            raise RuntimeError("probe exploded")
+
+        task = asyncio.ensure_future(_dies())
+        await asyncio.sleep(0)
+
+        with caplog.at_level(logging.ERROR):
+            _report_monitor_exit(task)
+
+        assert "Loop-health monitor died" in caplog.text
+        assert "probe exploded" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_shutdown_cancellation_is_silent(self, caplog):
+        import logging
+
+        from flux.worker import _report_monitor_exit
+
+        async def _forever():
+            await asyncio.sleep(30)
+
+        task = asyncio.ensure_future(_forever())
+        await asyncio.sleep(0)
+        task.cancel()
+        await asyncio.sleep(0)
+
+        with caplog.at_level(logging.WARNING):
+            _report_monitor_exit(task)
+
+        assert "monitor" not in caplog.text

--- a/tests/flux/test_worker_health.py
+++ b/tests/flux/test_worker_health.py
@@ -244,3 +244,73 @@ class TestMonitorExitVisibility:
             _report_monitor_exit(task)
 
         assert "monitor" not in caplog.text
+
+
+class TestSseStallDetection:
+    """A dropped link does not error an idle read: a dead socket can hang
+    aiter_sse() forever, leaving the worker ponging over HTTP but invisible
+    to dispatch, with the reconnect loop never running (t6c). The server
+    pings every heartbeat_interval, so a stream silent past the stall bound
+    is dead and must raise into the reconnect loop."""
+
+    @pytest.mark.asyncio
+    async def test_a_silent_stream_raises_within_the_stall_bound(self):
+        worker = make_worker()
+        worker.session_token = "tok"
+        worker._sse_stall_timeout = 0.05
+
+        class _DeadStream:
+            def aiter_sse(self):
+                async def _events():
+                    ping = MagicMock()
+                    ping.event = "keep-alive"
+                    yield ping
+                    await asyncio.sleep(3600)  # the dead socket: silent forever
+
+                return _events()
+
+        class _FakeSse:
+            async def __aenter__(self):
+                return _DeadStream()
+
+            async def __aexit__(self, *args):
+                return False
+
+        with (
+            patch("flux.worker.httpx.AsyncClient"),
+            patch("flux.worker.aconnect_sse", return_value=_FakeSse()),
+        ):
+            with pytest.raises(ConnectionError, match="silent"):
+                async with asyncio.timeout(5):
+                    await worker._connect()
+
+    @pytest.mark.asyncio
+    async def test_a_stream_delivering_events_stays_up(self):
+        worker = make_worker()
+        worker.session_token = "tok"
+        worker._sse_stall_timeout = 0.5
+
+        class _LiveStream:
+            def aiter_sse(self):
+                async def _events():
+                    for _ in range(5):
+                        ping = MagicMock()
+                        ping.event = "keep-alive"
+                        yield ping
+                        await asyncio.sleep(0.05)  # well inside the bound
+
+                return _events()
+
+        class _FakeSse:
+            async def __aenter__(self):
+                return _LiveStream()
+
+            async def __aexit__(self, *args):
+                return False
+
+        with (
+            patch("flux.worker.httpx.AsyncClient"),
+            patch("flux.worker.aconnect_sse", return_value=_FakeSse()),
+        ):
+            async with asyncio.timeout(5):
+                await worker._connect()  # stream ends normally, no raise

--- a/tests/flux/test_worker_health.py
+++ b/tests/flux/test_worker_health.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -105,6 +106,8 @@ class TestLoopLagMonitor:
                     assert not monitor.done(), "the monitor must survive metrics failures"
             finally:
                 monitor.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await monitor
 
         assert unhealthy_seen
         assert worker._healthy


### PR DESCRIPTION
Closes #224.

## Problem

`_monitor_loop_health` is the only producer of both health transitions, and its metrics calls (`record_loop_lag`, `record_worker_health_transition`, the worker metrics collector) ran unguarded inside the probe loop. The task is fire-and-forget: nothing awaits it, and its death was not logged.

If a metrics call raised **after** `self._healthy = False` (the transition branch records the metric right after the flip), the monitor died and the worker was stranded unhealthy for its remaining lifetime — releasing every new dispatch back for re-dispatch, with no diagnostic and nothing left to flip it back. The server-side heartbeat reaper never intervenes because a stranded-unhealthy worker keeps answering pings.

## Change

- Metrics recording moves behind two best-effort helpers (`_record_loop_lag`, `_record_health_transition`); failures log at debug and the probe loop continues.
- The monitor task gets a done-callback (`_report_monitor_exit`) so a death that does happen is loud — an error log naming the consequence — instead of asyncio's "Task exception was never retrieved" at GC time. Shutdown cancellation stays silent.

No behavior change on the happy path; state flips and pong pushes are ordered exactly as before.

## Verification

- Regression test (`test_a_raising_metrics_recorder_does_not_kill_the_monitor`) drives the monitor with a raising meter *and* raising collector: **red on main** (times out stranded-unhealthy, the exact failure mode) — green here, flipping unhealthy and recovering with the monitor alive throughout.
- Reporter tests: death logged with the cause; shutdown cancellation logs nothing.
- Worker suites (health, cancellation, checkpoint, metrics): 82 passed. Pre-commit clean.