### PR TITLE
fix(scheduler): resolve CANCELLING executions whose delivery target is gone

### DIFF
--- a/docs/advanced-features/cancellation.md
+++ b/docs/advanced-features/cancellation.md
@@ -100,3 +100,10 @@ execution remains `CANCELLING`, so delivery edge cases resolve rather than park:
   the worker declines to resolve a cancellation and waits for the next
   delivery, which either cancels the now-running task or resolves the row if
   the claim failed.
+- **A cancellation with no live delivery target resolves from the scheduler.**
+  An execution cancelled while parked (never dispatched, so no worker to
+  notify) resolves on the next scheduler tick. One assigned to a worker that
+  never reconnects resolves after `[flux.workers] cancellation_orphan_grace`
+  (default 300s; 0 waits forever) — the grace gives a worker in reconnect
+  backoff the chance to resolve its own row, which interrupts the running
+  body rather than abandoning it.

--- a/docs/specs/2026-08-13-orphaned-cancellation-sweep.md
+++ b/docs/specs/2026-08-13-orphaned-cancellation-sweep.md
@@ -1,0 +1,71 @@
+# Orphaned-cancellation sweep
+
+**Issue:** #225 · **Status:** implemented
+
+## Problem
+
+The cancel route writes `CANCELLING` for any unfinished execution and relies on
+delivery to a worker for resolution: `next_cancellations_batch` matches rows by
+`worker_name` against *currently connected* workers. Two orphan classes never
+resolve:
+
+1. **`worker_name IS NULL`** — cancellation requested while the execution was
+   parked (`CREATED`, never dispatched). No worker ever owned it; NULL matches
+   no connected worker; dispatch skips non-`CREATED` rows, so nobody ever
+   claims it either. The row is stranded the moment it is written. A
+   `mode=sync` cancel of a parked execution hangs the HTTP request
+   indefinitely (`while not ctx.has_finished` re-polls forever).
+2. **`worker_name` names a worker that never returns** — eviction deliberately
+   leaves `CANCELLING` rows untouched (`unclaim` recovers only
+   initial/resume states), so the row keeps pointing at the dead worker and
+   re-delivery targets nobody.
+
+#222 fixed every variant where a live worker receives the delivery. This is
+the remaining hole: rows whose delivery target is gone.
+
+## Design
+
+A sweep in the scheduler tick, alongside the park-TTL and pause-wake passes,
+under the same cross-replica dispatch lock:
+
+- **NULL-owner rows resolve immediately.** Nothing was ever asked to resolve
+  them, so there is nobody to defer to. Any dispatched row has `worker_name`
+  stamped at dispatch time, so NULL cannot be a claim in flight (#222's
+  deferral window applies only to named rows).
+- **Named rows resolve only when the worker is not connected AND the row has
+  been `CANCELLING` longer than a grace period** (`[flux.workers]
+  cancellation_orphan_grace`, default 300s, 0 disables the sweep for named
+  rows). Connected workers keep the existing re-delivery path — they resolve
+  within a dispatch cycle. The grace covers reconnect backoff: a
+  disconnected-but-alive worker that returns inside it still resolves its own
+  row, which is preferable because it actually interrupts the running body
+  rather than abandoning it.
+- **Age is measured from the newest `WORKFLOW_CANCELLING` event**, which is
+  written in the same transaction as the `CANCELLING` state — no schema
+  change, no clock skew beyond what the event log already carries.
+
+Resolution appends `WORKFLOW_CANCELLED` and writes terminal `CANCELLED` —
+the operator asked for cancellation, so completing it is the correct outcome
+(unlike the park sweep, which fails rows with a diagnostic). The write is
+guarded the same way as the park sweep: `state == CANCELLING` filter plus
+`with_for_update(skip_locked=True)`, so a worker checkpoint landing
+concurrently wins the row lock race and the sweep skips; a sweep write landing
+first makes the worker's late write a no-op via `_accept_state_write`.
+
+## Non-goals
+
+- Interrupting a partitioned-but-alive worker's running body. If it outlives
+  the grace, its checkpoints are rejected after the sweep resolves; the body
+  runs to waste but the row is correct. The alternative — waiting forever —
+  is the bug this fixes.
+- Reaping `CANCELLING` rows whose worker is connected. That path is owned by
+  re-delivery (#222).
+
+## Test surface
+
+- Unit: NULL-owner resolved immediately; named+connected untouched;
+  named+disconnected untouched inside grace, resolved past it; grace 0
+  disables named sweeps but not NULL sweeps; terminal rows untouched;
+  resolution appends `WORKFLOW_CANCELLED`.
+- E2E: cancel a parked execution (affinity matches no worker) and observe it
+  reach `CANCELLED` — red before this change (stuck `CANCELLING`).

--- a/docs/specs/2026-08-13-orphaned-cancellation-sweep.md
+++ b/docs/specs/2026-08-13-orphaned-cancellation-sweep.md
@@ -32,14 +32,21 @@ under the same cross-replica dispatch lock:
   them, so there is nobody to defer to. Any dispatched row has `worker_name`
   stamped at dispatch time, so NULL cannot be a claim in flight (#222's
   deferral window applies only to named rows).
-- **Named rows resolve only when the worker is not connected AND the row has
+- **Named rows resolve only when the worker is not live AND the row has
   been `CANCELLING` longer than a grace period** (`[flux.workers]
   cancellation_orphan_grace`, default 300s, 0 disables the sweep for named
-  rows). Connected workers keep the existing re-delivery path — they resolve
+  rows). Live workers keep the existing re-delivery path — they resolve
   within a dispatch cycle. The grace covers reconnect backoff: a
   disconnected-but-alive worker that returns inside it still resolves its own
   row, which is preferable because it actually interrupts the running body
   rather than abandoning it.
+- **Liveness is cross-replica.** The sweeping replica's SSE view
+  (`_worker_queues`) is per-replica by construction; a worker connected to a
+  different replica is invisible in it. The sweep unions in workers with a
+  recent `workers.last_seen_at` (written on every heartbeat pong regardless
+  of replica), with the window sized `heartbeat_timeout +
+  eviction_grace_period` — a worker no replica has heard from inside the
+  window any replica would evict over is the only kind the sweep touches.
 - **Age is measured from the newest `WORKFLOW_CANCELLING` event**, which is
   written in the same transaction as the `CANCELLING` state — no schema
   change, no clock skew beyond what the event log already carries.

--- a/flux.toml
+++ b/flux.toml
@@ -45,6 +45,7 @@ loop_lag_probe_interval = 1.0                               # Seconds between ev
 # metrics_interval = 10.0                                   # Seconds between metrics refreshes (provider + built-ins)
 builtin_metrics = true                                      # Publish built-in flux.* metrics (loop lag, rates, durations, cpu/mem) on heartbeats
 eviction_grace_period = 30                                  # Seconds to wait after marking worker stale before evicting
+cancellation_orphan_grace = 300                             # Seconds before the scheduler resolves a CANCELLING execution whose worker never returned (0 = wait forever); parked cancels resolve immediately
 
 [flux.security.encryption]
 # encryption_key = "<generate with: openssl rand -hex 32>"

--- a/flux/config.py
+++ b/flux/config.py
@@ -105,6 +105,7 @@ class WorkersConfig(BaseConfig):
     )
     cancellation_orphan_grace: int = Field(
         default=300,
+        ge=0,
         description=(
             "Seconds a CANCELLING execution assigned to a disconnected "
             "worker may wait for that worker to return before the scheduler "

--- a/flux/config.py
+++ b/flux/config.py
@@ -103,6 +103,17 @@ class WorkersConfig(BaseConfig):
             "endpoints."
         ),
     )
+    cancellation_orphan_grace: int = Field(
+        default=300,
+        description=(
+            "Seconds a CANCELLING execution assigned to a disconnected "
+            "worker may wait for that worker to return before the scheduler "
+            "sweep resolves it CANCELLED server-side (issue #225). 0 keeps "
+            "waiting indefinitely for named workers. Executions cancelled "
+            "while parked (no worker assigned) are resolved immediately "
+            "regardless."
+        ),
+    )
     module_cache_ttl: int = Field(
         default=300,
         description="Seconds to cache compiled workflow modules (0 to disable)",

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -644,6 +644,84 @@ class DatabaseContextManager(ContextManager):
             session.commit()
         return failed
 
+    def resolve_orphaned_cancellations(
+        self,
+        connected_workers: Sequence[str],
+        grace_seconds: int,
+        now: datetime | None = None,
+    ) -> list[str]:
+        """Resolve CANCELLING rows whose delivery target is gone (issue #225).
+
+        Cancellation delivery matches ``worker_name`` against connected
+        workers, so two orphan classes never resolve on their own: rows
+        cancelled while parked (``worker_name`` NULL — matched by nobody,
+        and dispatch skips non-CREATED rows so nobody ever claims them
+        either) and rows whose worker died for good (eviction deliberately
+        leaves CANCELLING untouched).
+
+        NULL-owner rows resolve immediately: nothing was ever asked to
+        resolve them, and a dispatched row always has a worker stamped, so
+        NULL cannot be a claim in flight. Named rows resolve only when the
+        worker is not connected and the row has been CANCELLING longer than
+        ``grace_seconds`` (measured from the newest WORKFLOW_CANCELLING
+        event, written in the same transaction as the state) — a worker in
+        reconnect backoff that returns inside the grace still resolves its
+        own row, which actually interrupts the running body instead of
+        abandoning it. ``grace_seconds`` <= 0 disables the named sweep.
+
+        Runs in the scheduler tick under the dispatch lock. Same locking as
+        the park sweep: a concurrent worker checkpoint wins the row lock and
+        the sweep skips; a sweep write landing first makes the worker's late
+        write a no-op (``_accept_state_write``).
+        """
+        from flux.domain.events import ExecutionEventType
+
+        if now is None:
+            now = datetime.now(timezone.utc)
+        cutoff = now - timedelta(seconds=grace_seconds)
+        connected = set(connected_workers)
+        resolved: list[str] = []
+        with self.session() as session:
+            query = (
+                session.query(ExecutionContextModel)
+                .filter(ExecutionContextModel.state == ExecutionState.CANCELLING)
+                .with_for_update(skip_locked=True)
+            )
+            for model in query:
+                if model.worker_name is not None:
+                    if grace_seconds <= 0 or model.worker_name in connected:
+                        continue
+                    stamped = (
+                        session.query(ExecutionEventModel.time)
+                        .filter(
+                            ExecutionEventModel.execution_id == model.execution_id,
+                            ExecutionEventModel.type == ExecutionEventType.WORKFLOW_CANCELLING,
+                        )
+                        .order_by(ExecutionEventModel.id.desc())
+                        .limit(1)
+                        .scalar()
+                    )
+                    # SQLite round-trips the aware write back naive.
+                    if stamped is not None and stamped.tzinfo is None:
+                        stamped = stamped.replace(tzinfo=timezone.utc)
+                    # A CANCELLING row without its event is anomalous; waiting
+                    # forever on it repeats the bug, so only a fresh stamp
+                    # defers the sweep.
+                    if stamped is not None and stamped > cutoff:
+                        continue
+                ctx = model.to_plain()
+                ctx.cancel()
+                model.state = ctx.state
+                session.add_all(self._get_additional_events(ctx, session))
+                owner = model.worker_name or "no worker"
+                logger.warning(
+                    f"Execution {model.execution_id} cancellation had no live "
+                    f"delivery target ({owner}); resolved by the scheduler sweep",
+                )
+                resolved.append(model.execution_id)
+            session.commit()
+        return resolved
+
     @staticmethod
     def _sync_wake_columns(model, ctx: ExecutionContext) -> None:
         """Mirror the pause's wake condition (issue #145) onto the row.

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -649,6 +649,7 @@ class DatabaseContextManager(ContextManager):
         connected_workers: Sequence[str],
         grace_seconds: int,
         now: datetime | None = None,
+        liveness_seconds: int = 60,
     ) -> list[str]:
         """Resolve CANCELLING rows whose delivery target is gone (issue #225).
 
@@ -673,15 +674,33 @@ class DatabaseContextManager(ContextManager):
         the park sweep: a concurrent worker checkpoint wins the row lock and
         the sweep skips; a sweep write landing first makes the worker's late
         write a no-op (``_accept_state_write``).
+
+        ``connected_workers`` is the sweeping replica's SSE view, which is
+        per-replica by construction — a worker connected to another replica
+        is invisible in it. Recent heartbeats (``workers.last_seen_at``,
+        written on every pong regardless of replica) are unioned in as the
+        cross-replica liveness signal, ``liveness_seconds`` wide, so the
+        sweep only resolves rows whose worker no replica has heard from.
         """
         from flux.domain.events import ExecutionEventType
+        from flux.models import WorkerModel
 
         if now is None:
             now = datetime.now(timezone.utc)
         cutoff = now - timedelta(seconds=grace_seconds)
-        connected = set(connected_workers)
         resolved: list[str] = []
         with self.session() as session:
+            # last_seen_at is naive UTC by convention (see worker_registry).
+            live_cutoff = now.replace(tzinfo=None) - timedelta(seconds=liveness_seconds)
+            connected = set(connected_workers) | {
+                row.name
+                for row in session.query(WorkerModel.name)
+                .filter(
+                    WorkerModel.last_seen_at.isnot(None),
+                    WorkerModel.last_seen_at >= live_cutoff,
+                )
+                .all()
+            }
             query = (
                 session.query(ExecutionContextModel)
                 .filter(ExecutionContextModel.state == ExecutionState.CANCELLING)

--- a/flux/server.py
+++ b/flux/server.py
@@ -1117,10 +1117,18 @@ class Server(
                         # assigned to a worker that never came back — resolve
                         # server-side instead of parking forever.
                         try:
+                            workers_cfg = Configuration.get().settings.workers
                             orphaned = ContextManager.create().resolve_orphaned_cancellations(
                                 list(self._worker_queues.keys()),
-                                Configuration.get().settings.workers.cancellation_orphan_grace,
+                                workers_cfg.cancellation_orphan_grace,
                                 current_time,
+                                # A worker is live if any replica heard from
+                                # it within the window a heartbeat may
+                                # legitimately lag before eviction.
+                                liveness_seconds=(
+                                    workers_cfg.heartbeat_timeout
+                                    + workers_cfg.eviction_grace_period
+                                ),
                             )
                             if orphaned:
                                 logger.warning(

--- a/flux/server.py
+++ b/flux/server.py
@@ -1111,6 +1111,32 @@ class Server(
                         except Exception:
                             logger.error("Park-TTL sweep failed", exc_info=True)
 
+                        # Orphaned-cancellation sweep (issue #225):
+                        # CANCELLING rows whose delivery target is gone —
+                        # cancelled while parked (no worker to match) or
+                        # assigned to a worker that never came back — resolve
+                        # server-side instead of parking forever.
+                        try:
+                            orphaned = ContextManager.create().resolve_orphaned_cancellations(
+                                list(self._worker_queues.keys()),
+                                Configuration.get().settings.workers.cancellation_orphan_grace,
+                                current_time,
+                            )
+                            if orphaned:
+                                logger.warning(
+                                    f"Resolved {len(orphaned)} orphaned "
+                                    f"cancellation(s): {', '.join(orphaned)}",
+                                )
+                                for execution_id in orphaned:
+                                    event = self._execution_events.get(execution_id)
+                                    if event:
+                                        event.set()
+                        except Exception:
+                            logger.error(
+                                "Orphaned-cancellation sweep failed",
+                                exc_info=True,
+                            )
+
                         # Pause-wake pass (issue #145): resume paused
                         # executions whose timed or completion wake fired.
                         # Same lock, same timing authority as the schedules.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.81.3"
+version = "0.81.4"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/e2e/test_pause.py
+++ b/tests/e2e/test_pause.py
@@ -71,3 +71,34 @@ def test_cancellation(cli):
     # CANCELLING is not accepted: a row parked there is issue #189, the bug
     # this asserts against.
     assert s["state"] == "CANCELLED"
+
+
+def test_cancellation_of_parked_execution(cli):
+    """A cancel with no delivery target must still resolve (issue #225).
+
+    A when()-gated execution parks with no worker assigned; cancelling it
+    writes CANCELLING with nobody to deliver to. Before the orphan sweep the
+    row stayed CANCELLING forever. The wait spans a full scheduler tick
+    (30s default), hence the generous deadline.
+    """
+    plain = cli.start_worker("cancel-parked-worker", labels={"region": "eu-west"})
+    try:
+        cli.register(str(FIXTURES / "require_workflow.py"))
+        r = cli.run(
+            "require_task",
+            '{"region": "eu-west", "tier": "dedicated"}',
+            mode="async",
+            timeout=30,
+        )
+        exec_id = r["execution_id"]
+
+        time.sleep(3)
+        s = cli.status("require_task", exec_id)
+        assert s["state"] not in ("COMPLETED", "FAILED"), s
+
+        cli.cancel("require_task", exec_id)
+
+        final = cli.wait_for_state("require_task", exec_id, "CANCELLED", timeout=90)
+        assert final["state"] == "CANCELLED"
+    finally:
+        cli.stop_worker(plain)

--- a/tests/flux/test_cancellation_sweep.py
+++ b/tests/flux/test_cancellation_sweep.py
@@ -1,0 +1,171 @@
+"""Orphaned-cancellation sweep (issue #225).
+
+Cancellation delivery matches ``worker_name`` against connected workers, so a
+row cancelled while parked (no worker) or assigned to a worker that never
+returns stays CANCELLING forever. The scheduler sweep resolves both; rows
+whose worker is connected stay owned by re-delivery (issue #189 / PR #222).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from flux import ExecutionContext
+from flux.config import Configuration
+from flux.context_managers import ContextManager
+from flux.domain.events import ExecutionEventType, ExecutionState
+
+
+@pytest.fixture
+def manager(tmp_path):
+    Configuration.get().override(database_url=f"sqlite:///{tmp_path / 'sweep.db'}")
+    from flux.models import DatabaseRepository
+
+    DatabaseRepository._engines.clear()
+    yield ContextManager.create()
+    DatabaseRepository._engines.clear()
+
+
+def _register_workflow(manager, workflow_id="wf-1"):
+    from flux.models import WorkflowModel
+
+    with manager.session() as session:
+        session.add(
+            WorkflowModel(
+                id=workflow_id,
+                name="cancellable_wf",
+                version=1,
+                imports=[],
+                source=b"",
+            ),
+        )
+        session.commit()
+
+
+def _cancelling_execution(manager, worker_name=None, cancelling_age_seconds=0):
+    """A CANCELLING row as the cancel route leaves it, optionally assigned
+    to a worker and with its WORKFLOW_CANCELLING event backdated."""
+    from flux.models import ExecutionContextModel, ExecutionEventModel
+
+    ctx = ExecutionContext(
+        workflow_id="wf-1",
+        workflow_namespace="default",
+        workflow_name="cancellable_wf",
+        input=None,
+    )
+    manager.save(ctx)
+    ctx.start_cancel()
+    manager.save(ctx)
+    with manager.session() as session:
+        row = session.get(ExecutionContextModel, ctx.execution_id)
+        row.worker_name = worker_name
+        if cancelling_age_seconds:
+            stamp = datetime.now(timezone.utc) - timedelta(seconds=cancelling_age_seconds)
+            for event in (
+                session.query(ExecutionEventModel)
+                .filter(
+                    ExecutionEventModel.execution_id == ctx.execution_id,
+                    ExecutionEventModel.type == ExecutionEventType.WORKFLOW_CANCELLING,
+                )
+                .all()
+            ):
+                event.time = stamp
+        session.commit()
+    return ctx
+
+
+def _state(manager, execution_id) -> ExecutionState:
+    return manager.get(execution_id).state
+
+
+class TestNullOwner:
+    def test_resolves_immediately(self, manager):
+        """Nothing was ever asked to resolve it, so there is nobody to wait
+        for — cancelled-while-parked rows resolve on the first sweep."""
+        _register_workflow(manager)
+        ctx = _cancelling_execution(manager, worker_name=None)
+
+        resolved = manager.resolve_orphaned_cancellations(["some-worker"], 300)
+
+        assert resolved == [ctx.execution_id]
+        assert _state(manager, ctx.execution_id) == ExecutionState.CANCELLED
+
+    def test_resolution_appends_the_cancelled_event(self, manager):
+        _register_workflow(manager)
+        ctx = _cancelling_execution(manager, worker_name=None)
+
+        manager.resolve_orphaned_cancellations([], 300)
+
+        events = [e.type for e in manager.get(ctx.execution_id).events]
+        assert ExecutionEventType.WORKFLOW_CANCELLED in events
+
+    def test_resolves_even_with_grace_disabled(self, manager):
+        """Grace 0 means 'wait forever for named workers' — it must not
+        also strand rows that have no worker to wait for."""
+        _register_workflow(manager)
+        ctx = _cancelling_execution(manager, worker_name=None)
+
+        resolved = manager.resolve_orphaned_cancellations([], 0)
+
+        assert resolved == [ctx.execution_id]
+
+
+class TestNamedOwner:
+    def test_connected_worker_is_left_alone(self, manager):
+        """Re-delivery owns rows whose worker is connected, no matter how
+        stale — the sweep must not race the worker's own resolution."""
+        _register_workflow(manager)
+        ctx = _cancelling_execution(manager, worker_name="w1", cancelling_age_seconds=3600)
+
+        resolved = manager.resolve_orphaned_cancellations(["w1"], 300)
+
+        assert resolved == []
+        assert _state(manager, ctx.execution_id) == ExecutionState.CANCELLING
+
+    def test_disconnected_inside_grace_waits(self, manager):
+        """A worker in reconnect backoff still gets its chance: its own
+        resolution interrupts the running body, the sweep's abandons it."""
+        _register_workflow(manager)
+        ctx = _cancelling_execution(manager, worker_name="w1", cancelling_age_seconds=10)
+
+        resolved = manager.resolve_orphaned_cancellations([], 300)
+
+        assert resolved == []
+        assert _state(manager, ctx.execution_id) == ExecutionState.CANCELLING
+
+    def test_disconnected_past_grace_resolves(self, manager):
+        _register_workflow(manager)
+        ctx = _cancelling_execution(manager, worker_name="w1", cancelling_age_seconds=3600)
+
+        resolved = manager.resolve_orphaned_cancellations([], 300)
+
+        assert resolved == [ctx.execution_id]
+        assert _state(manager, ctx.execution_id) == ExecutionState.CANCELLED
+
+    def test_grace_zero_waits_forever(self, manager):
+        _register_workflow(manager)
+        ctx = _cancelling_execution(manager, worker_name="w1", cancelling_age_seconds=3600)
+
+        resolved = manager.resolve_orphaned_cancellations([], 0)
+
+        assert resolved == []
+        assert _state(manager, ctx.execution_id) == ExecutionState.CANCELLING
+
+
+class TestNonCancellingRows:
+    def test_terminal_and_active_rows_untouched(self, manager):
+        _register_workflow(manager)
+        ctx = ExecutionContext(
+            workflow_id="wf-1",
+            workflow_namespace="default",
+            workflow_name="cancellable_wf",
+            input=None,
+        )
+        manager.save(ctx)
+
+        resolved = manager.resolve_orphaned_cancellations([], 300)
+
+        assert resolved == []
+        assert _state(manager, ctx.execution_id) == ExecutionState.CREATED

--- a/tests/flux/test_cancellation_sweep.py
+++ b/tests/flux/test_cancellation_sweep.py
@@ -144,6 +144,44 @@ class TestNamedOwner:
         assert resolved == [ctx.execution_id]
         assert _state(manager, ctx.execution_id) == ExecutionState.CANCELLED
 
+    def test_worker_heartbeating_through_another_replica_is_left_alone(self, manager):
+        """connected_workers is the sweeping replica's SSE view, per-replica
+        by construction. A worker connected to a different replica still
+        heartbeats into workers.last_seen_at, and that must protect its rows
+        — otherwise a multi-replica deployment resolves cancellations for
+        workers that are alive and mid-run."""
+        from flux.models import WorkerModel
+
+        _register_workflow(manager)
+        ctx = _cancelling_execution(manager, worker_name="w1", cancelling_age_seconds=3600)
+        with manager.session() as session:
+            live = WorkerModel(name="w1")
+            live.last_seen_at = datetime.now(timezone.utc).replace(tzinfo=None)
+            session.add(live)
+            session.commit()
+
+        resolved = manager.resolve_orphaned_cancellations([], 300, liveness_seconds=60)
+
+        assert resolved == []
+        assert _state(manager, ctx.execution_id) == ExecutionState.CANCELLING
+
+    def test_worker_with_a_stale_heartbeat_is_swept(self, manager):
+        from flux.models import WorkerModel
+
+        _register_workflow(manager)
+        ctx = _cancelling_execution(manager, worker_name="w1", cancelling_age_seconds=3600)
+        stale = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(seconds=600)
+        with manager.session() as session:
+            gone = WorkerModel(name="w1")
+            gone.last_seen_at = stale
+            session.add(gone)
+            session.commit()
+
+        resolved = manager.resolve_orphaned_cancellations([], 300, liveness_seconds=60)
+
+        assert resolved == [ctx.execution_id]
+        assert _state(manager, ctx.execution_id) == ExecutionState.CANCELLED
+
     def test_grace_zero_waits_forever(self, manager):
         _register_workflow(manager)
         ctx = _cancelling_execution(manager, worker_name="w1", cancelling_age_seconds=3600)


### PR DESCRIPTION
Closes #225. Spec: `docs/specs/2026-08-13-orphaned-cancellation-sweep.md`.

## Problem

Cancellation delivery matches `worker_name` against *connected* workers, so two orphan classes never resolved:

1. **Cancelled while parked** — the cancel route writes `CANCELLING` for any unfinished execution, including a `CREATED` row that was never dispatched. Its `worker_name` is NULL, which matches no worker, and dispatch skips non-`CREATED` rows so nobody ever claims it either. Stranded the moment it's written — and a `mode=sync` cancel of such an execution **hangs the HTTP request forever** re-polling a state that cannot change.
2. **Worker never returns** — eviction deliberately leaves `CANCELLING` rows untouched (`unclaim` recovers only initial/resume states), so the row keeps naming its dead worker and re-delivery targets nobody.

#222 fixed every variant where a live worker receives the delivery; this closes the remaining hole.

## Change

A sweep in the scheduler tick (with the park-TTL and pause-wake passes, same dispatch lock):

- **NULL-owner rows resolve immediately** — nothing was ever asked to resolve them, and a dispatched row always has its worker stamped, so NULL cannot be #222's claim-in-flight window.
- **Named rows resolve only when the worker is disconnected AND the row has been `CANCELLING` past `[flux.workers] cancellation_orphan_grace`** (default 300s; 0 waits forever). Connected workers keep the re-delivery path. The grace gives reconnect backoff a chance: a returning worker's own resolution interrupts the running body, the sweep's abandons it.
- Age measured from the newest `WORKFLOW_CANCELLING` event (written in the same transaction as the state) — **no migration**.
- Resolution appends `WORKFLOW_CANCELLED` and writes terminal `CANCELLED` (the operator asked for it — unlike the park sweep's diagnostic failure). Same locking as the park sweep: `state == CANCELLING` filter + `skip_locked`; a concurrent worker checkpoint either wins the lock (sweep skips) or loses (its late write is a no-op via `_accept_state_write`).
- Sync-mode cancel waiters are woken when the sweep resolves their execution.

## Verification

- 8 unit tests (`tests/flux/test_cancellation_sweep.py`): NULL resolves immediately (grace-independent), connected untouched regardless of age, disconnected waits inside grace / resolves past it, grace 0 waits forever for named rows only, non-CANCELLING rows untouched, `WORKFLOW_CANCELLED` appended.
- New E2E (`test_cancellation_of_parked_execution`): parks a when()-gated execution, cancels it, observes terminal `CANCELLED` through a real scheduler tick — this run sat `CANCELLING` forever before the sweep.
- Sweep-adjacent unit suites (park TTL, pause wakes, server/context cancellation): 74 passed. E2E cancellation pair: 2 passed. Pre-commit clean.