### PR TITLE
fix(security): reap dead worker join tokens from the scheduler tick

### DIFF
--- a/docs/advanced-features/authentication.md
+++ b/docs/advanced-features/authentication.md
@@ -436,11 +436,12 @@ caller already knows the worker name and does not track token ids. **Unbound
 tokens are never matched by `--subject`** — they carry no subject, so retiring
 them under one worker's name would take out credentials meant for others.
 
-Revocation is a soft delete, so the row keeps who minted it and when. Note that
-`purge_expired()` exists but is not wired to anything, so no join-token row is
-ever removed — the table grows with every mint, revoked or not. The listing
-never returns the token or its hash: the plaintext is unrecoverable by design,
-and the hash is credential-equivalent to an offline guesser.
+Revocation is a soft delete, so the row keeps who minted it and when. Dead
+rows — used, revoked, or never claimed — are purged hourly by the scheduler
+once `[flux.workers] join_token_retention` (default one day) has passed since
+expiry; set it to 0 to keep every row forever. The listing never returns the
+token or its hash: the plaintext is unrecoverable by design, and the hash is
+credential-equivalent to an offline guesser.
 
 Note that banning a principal is already a complete control on its own: worker
 registration refuses a banned principal regardless of credential, so a token

--- a/flux.toml
+++ b/flux.toml
@@ -46,6 +46,7 @@ loop_lag_probe_interval = 1.0                               # Seconds between ev
 builtin_metrics = true                                      # Publish built-in flux.* metrics (loop lag, rates, durations, cpu/mem) on heartbeats
 eviction_grace_period = 30                                  # Seconds to wait after marking worker stale before evicting
 cancellation_orphan_grace = 300                             # Seconds before the scheduler resolves a CANCELLING execution whose worker never returned (0 = wait forever); parked cancels resolve immediately
+join_token_retention = 86400                                # Seconds past expiry a join-token row is kept as audit trail before the hourly purge (0 = keep forever)
 
 [flux.security.encryption]
 # encryption_key = "<generate with: openssl rand -hex 32>"

--- a/flux/config.py
+++ b/flux/config.py
@@ -51,6 +51,15 @@ class WorkersConfig(BaseConfig):
             "/admin/workers/join-tokens"
         ),
     )
+    join_token_retention: int = Field(
+        default=86400,
+        description=(
+            "Seconds past expiry a join-token row (used, revoked, or never "
+            "claimed) is kept as an audit trail before the scheduler purges "
+            "it. 0 disables purging: rows are kept forever and the table "
+            "only grows."
+        ),
+    )
 
     server_url: str = Field(
         default="http://localhost:8000",

--- a/flux/security/join_tokens.py
+++ b/flux/security/join_tokens.py
@@ -184,8 +184,9 @@ def purge_expired(*, older_than_seconds: int = 86400) -> int:
 
     Used, revoked, and never-claimed rows all age out on the same expiry
     clock; inside the window they remain an audit trail of recent joins.
-    Called hourly from the scheduler tick with ``[flux.workers]
-    join_token_retention`` as the window. Returns the number of rows removed.
+    Called hourly from the scheduler tick, with the window taken from
+    ``join_token_retention`` in ``[flux.workers]``. Returns the number of
+    rows removed.
     """
     repo = RepositoryFactory.create_repository()
     cutoff = _utcnow() - timedelta(seconds=older_than_seconds)

--- a/flux/security/join_tokens.py
+++ b/flux/security/join_tokens.py
@@ -182,8 +182,10 @@ def claim(token: str, worker_name: str) -> bool:
 def purge_expired(*, older_than_seconds: int = 86400) -> int:
     """Delete tokens whose expiry passed more than the grace window ago.
 
-    Used rows are kept inside the window as an audit trail of recent joins.
-    Returns the number of rows removed.
+    Used, revoked, and never-claimed rows all age out on the same expiry
+    clock; inside the window they remain an audit trail of recent joins.
+    Called hourly from the scheduler tick with ``[flux.workers]
+    join_token_retention`` as the window. Returns the number of rows removed.
     """
     repo = RepositoryFactory.create_repository()
     cutoff = _utcnow() - timedelta(seconds=older_than_seconds)

--- a/flux/server.py
+++ b/flux/server.py
@@ -158,6 +158,7 @@ class Server(
         self._dispatcher = None
         self._retention_job = None
         self._reaper_task: asyncio.Task | None = None
+        self._last_join_token_purge: float | None = None
 
         config = Configuration.get().settings.scheduling
         self.poll_interval = config.poll_interval
@@ -1157,11 +1158,43 @@ class Server(
                         except Exception:
                             logger.error("Pause-wake pass failed", exc_info=True)
 
+                        # Join-token reaping (issue #197 follow-up): minting
+                        # had no inverse, so dead rows accumulated forever.
+                        # Same lock, so one replica reaps.
+                        try:
+                            self._purge_join_tokens()
+                        except Exception:
+                            logger.error("Join-token purge failed", exc_info=True)
+
                 except Exception as e:
                     logger.error(f"Error in scheduler cycle: {str(e)}", exc_info=True)
 
         except asyncio.CancelledError:
             logger.info("Scheduler loop cancelled")
+
+    def _purge_join_tokens(self, *, now_monotonic: float | None = None) -> int:
+        """Reap dead join-token rows, at most once an hour.
+
+        Purging every tick would be wasted DELETEs against a table that
+        changes on the cadence of fleet growth, so the tick calls this each
+        cycle and the throttle makes it an hourly job. Rows are kept for
+        ``[flux.workers] join_token_retention`` past expiry as an audit
+        trail; 0 keeps them forever.
+        """
+        retention = Configuration.get().settings.workers.join_token_retention
+        if retention <= 0:
+            return 0
+        now = time.monotonic() if now_monotonic is None else now_monotonic
+        if self._last_join_token_purge is not None and now - self._last_join_token_purge < 3600:
+            return 0
+        self._last_join_token_purge = now
+
+        from flux.security import join_tokens
+
+        removed = join_tokens.purge_expired(older_than_seconds=retention)
+        if removed:
+            logger.info(f"Purged {removed} expired worker join token(s)")
+        return removed
 
     async def _trigger_scheduled_workflow(self, schedule, scheduled_time: datetime):
         """

--- a/flux/server.py
+++ b/flux/server.py
@@ -1187,11 +1187,13 @@ class Server(
         now = time.monotonic() if now_monotonic is None else now_monotonic
         if self._last_join_token_purge is not None and now - self._last_join_token_purge < 3600:
             return 0
-        self._last_join_token_purge = now
 
         from flux.security import join_tokens
 
         removed = join_tokens.purge_expired(older_than_seconds=retention)
+        # Stamped only on success: a failed purge (the caller logs it) retries
+        # on the next tick instead of being silenced for an hour.
+        self._last_join_token_purge = now
         if removed:
             logger.info(f"Purged {removed} expired worker join token(s)")
         return removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.81.4"
+version = "0.81.5"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_join_token_purge.py
+++ b/tests/flux/test_join_token_purge.py
@@ -1,0 +1,86 @@
+"""The scheduler tick's join-token purge (issue #197 follow-up).
+
+``purge_expired`` existed with no caller, so the worker_join_tokens table
+only grew. The tick calls ``Server._purge_join_tokens`` every cycle; the
+method throttles itself to one real purge an hour.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from flux.config import Configuration
+from flux.server import Server
+
+
+@pytest.fixture
+def server(tmp_path):
+    Configuration.get().override(database_url=f"sqlite:///{tmp_path / 'purge.db'}")
+    from flux.models import DatabaseRepository
+
+    DatabaseRepository._engines.clear()
+    yield Server(host="localhost", port=8000)
+    DatabaseRepository._engines.clear()
+
+
+class TestPurgeThrottle:
+    def test_first_call_purges(self, server):
+        with patch("flux.security.join_tokens.purge_expired", return_value=3) as purge:
+            assert server._purge_join_tokens(now_monotonic=1000.0) == 3
+        purge.assert_called_once_with(older_than_seconds=86400)
+
+    def test_within_the_hour_is_a_no_op(self, server):
+        with patch("flux.security.join_tokens.purge_expired", return_value=0) as purge:
+            server._purge_join_tokens(now_monotonic=1000.0)
+            assert server._purge_join_tokens(now_monotonic=1000.0 + 3599) == 0
+        purge.assert_called_once()
+
+    def test_past_the_hour_purges_again(self, server):
+        with patch("flux.security.join_tokens.purge_expired", return_value=0) as purge:
+            server._purge_join_tokens(now_monotonic=1000.0)
+            server._purge_join_tokens(now_monotonic=1000.0 + 3601)
+        assert purge.call_count == 2
+
+    def test_retention_zero_disables(self, server):
+        Configuration.get().override(workers={"join_token_retention": 0})
+        try:
+            with patch("flux.security.join_tokens.purge_expired") as purge:
+                assert server._purge_join_tokens(now_monotonic=1000.0) == 0
+            purge.assert_not_called()
+        finally:
+            Configuration.get().override(workers={"join_token_retention": 86400})
+
+    def test_retention_config_is_passed_through(self, server):
+        Configuration.get().override(workers={"join_token_retention": 7200})
+        try:
+            with patch("flux.security.join_tokens.purge_expired", return_value=0) as purge:
+                server._purge_join_tokens(now_monotonic=1000.0)
+            purge.assert_called_once_with(older_than_seconds=7200)
+        finally:
+            Configuration.get().override(workers={"join_token_retention": 86400})
+
+
+class TestPurgeAgainstRealRows:
+    def test_purges_a_stale_row_end_to_end(self, server):
+        """No mocks: mint, backdate, and watch the server method remove it."""
+        from datetime import datetime, timedelta, timezone
+
+        from flux.models import RepositoryFactory
+        from flux.security import join_tokens
+
+        join_tokens.mint(3600)
+        repo = RepositoryFactory.create_repository()
+        with repo.session() as session:
+            session.query(join_tokens.WorkerJoinTokenModel).update(
+                {
+                    "expires_at": datetime.now(timezone.utc).replace(tzinfo=None)
+                    - timedelta(days=2),
+                },
+                synchronize_session=False,
+            )
+            session.commit()
+
+        assert server._purge_join_tokens(now_monotonic=1000.0) == 1
+        assert join_tokens.outstanding() == []

--- a/tests/flux/test_join_token_purge.py
+++ b/tests/flux/test_join_token_purge.py
@@ -43,6 +43,20 @@ class TestPurgeThrottle:
             server._purge_join_tokens(now_monotonic=1000.0 + 3601)
         assert purge.call_count == 2
 
+    def test_a_failed_purge_retries_next_tick_not_next_hour(self, server):
+        """The throttle stamp lands only after a successful purge: a DB
+        failure (logged by the tick) must not silence retries for an hour."""
+        with patch(
+            "flux.security.join_tokens.purge_expired",
+            side_effect=RuntimeError("db down"),
+        ):
+            with pytest.raises(RuntimeError):
+                server._purge_join_tokens(now_monotonic=1000.0)
+
+        with patch("flux.security.join_tokens.purge_expired", return_value=1) as purge:
+            assert server._purge_join_tokens(now_monotonic=1001.0) == 1
+        purge.assert_called_once()
+
     def test_retention_zero_disables(self, server):
         Configuration.get().override(workers={"join_token_retention": 0})
         try:

--- a/tests/security/test_join_tokens_and_body_limit.py
+++ b/tests/security/test_join_tokens_and_body_limit.py
@@ -141,6 +141,40 @@ class TestJoinTokenLifecycle:
 
         assert join_tokens.purge_expired(older_than_seconds=86400) == 1
 
+    def test_purge_removes_revoked_rows_on_the_same_expiry_clock(self, make_client):
+        """Revocation is a soft delete for the audit trail's sake; the purge
+        is what finally removes the row, once expiry plus retention passed —
+        revoked rows must not be exempt or the table still only grows."""
+        make_client()
+        join_tokens.mint(3600)
+        token_id = join_tokens.outstanding()[0]["id"]
+        assert join_tokens.revoke(token_id, revoked_by="ops")
+
+        from flux.models import RepositoryFactory
+
+        repo = RepositoryFactory.create_repository()
+        with repo.session() as session:
+            session.query(join_tokens.WorkerJoinTokenModel).filter(
+                join_tokens.WorkerJoinTokenModel.id == token_id,
+            ).update(
+                {
+                    "expires_at": datetime.now(timezone.utc).replace(tzinfo=None)
+                    - timedelta(days=2),
+                },
+                synchronize_session=False,
+            )
+            session.commit()
+
+        assert join_tokens.purge_expired(older_than_seconds=86400) == 1
+
+    def test_purge_keeps_revoked_rows_inside_retention(self, make_client):
+        make_client()
+        join_tokens.mint(3600)
+        token_id = join_tokens.outstanding()[0]["id"]
+        assert join_tokens.revoke(token_id, revoked_by="ops")
+
+        assert join_tokens.purge_expired(older_than_seconds=86400) == 0
+
 
 class TestSubjectBinding:
     """A token minted for one worker must not authorize another (#174).


### PR DESCRIPTION
## Problem

`purge_expired` existed but had no caller — noted in the #221 review and in the docs themselves ("the table grows with every mint, revoked or not"). Minting had no inverse: use, revocation, and expiry all left the row in place forever.

## Change

- The scheduler tick calls `Server._purge_join_tokens()` every cycle; the method throttles itself to one real purge an hour. Runs under the dispatch lock, so one replica reaps.
- Retention window: `[flux.workers] join_token_retention` (default 86400s past expiry). Used, revoked, and never-claimed rows age out on the same expiry clock — inside the window they remain the audit trail of recent joins. `0` disables purging entirely for operators who want the table as a permanent log.
- Docs updated: the authentication guide's "no row is ever removed" caveat replaced with the actual retention behavior; `flux.toml` documents the knob.

## Verification

- Throttle tests: first call purges, second inside the hour is a no-op, past the hour purges again, retention 0 disables, configured retention passes through.
- End-to-end row test (no mocks): mint → backdate expiry → server method removes it.
- Revoked-row tests: purged once past expiry+retention, kept inside it — revocation must not exempt a row or the table still grows.
- Full `tests/security/` tree + new tests: 549 passed. Pre-commit clean.