### PR TITLE
fix(security): make claim-generation fencing mandatory, not opt-in per request

### DIFF
--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -139,7 +139,12 @@ the same path. Plain HTTP round-robin works for everything else.
 - **Fencing**: if a partitioned worker is evicted and its executions
   reassigned, its later checkpoints are rejected (stale claim generation)
   and it aborts those local runs — expect `stale-claim` warnings in worker
-  logs after partitions heal; they are the mechanism working.
+  logs after partitions heal; they are the mechanism working. The fence is
+  mandatory once an execution has ever been dispatched: a checkpoint or
+  release without the generation header is rejected the same way, so a
+  writer cannot sidestep the fence by omitting it. The exceptions are the
+  writes that legitimately predate a claim — resolving an unowned
+  cancellation, and declining a dispatch that was never claimed.
 - **Self-health**: each worker probes its own event-loop lag
   (`FLUX_WORKERS__LOOP_LAG_THRESHOLD`, default 1 s; 0 disables). Three
   consecutive breaches — typically in-process workflow code blocking the

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -1030,7 +1030,11 @@ class WorkerRoutesMixin:
             try:
                 self._verify_worker_identity(identity, name)
                 self._worker_last_pong[name] = time.monotonic()
-                self._verify_worker_owns_execution(name, execution_id)
+                await asyncio.to_thread(
+                    self._verify_worker_owns_execution,
+                    name,
+                    execution_id,
+                )
 
                 context_manager = ContextManager.create()
 

--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -1030,9 +1030,14 @@ class WorkerRoutesMixin:
             try:
                 self._verify_worker_identity(identity, name)
                 self._worker_last_pong[name] = time.monotonic()
+                self._verify_worker_owns_execution(name, execution_id)
 
                 context_manager = ContextManager.create()
 
+                current_generation = await asyncio.to_thread(
+                    context_manager.get_claim_generation,
+                    execution_id,
+                )
                 if claim_generation is not None:
                     try:
                         expected_generation = int(claim_generation)
@@ -1041,10 +1046,6 @@ class WorkerRoutesMixin:
                             status_code=400,
                             detail="Invalid X-Flux-Claim-Generation header.",
                         )
-                    current_generation = await asyncio.to_thread(
-                        context_manager.get_claim_generation,
-                        execution_id,
-                    )
                     if expected_generation != current_generation:
                         raise HTTPException(
                             status_code=409,
@@ -1052,6 +1053,31 @@ class WorkerRoutesMixin:
                                 f"stale-claim: release carries generation "
                                 f"{expected_generation} but the row is at "
                                 f"{current_generation}"
+                            ),
+                        )
+                elif current_generation > 0:
+                    # The fence must not be opt-in: without this, omitting
+                    # the header let any worker principal unclaim any
+                    # execution ever dispatched, forcing a re-run. The one
+                    # release that legitimately carries no generation is a
+                    # worker declining a dispatch it never claimed (paused /
+                    # unhealthy) — the claim response is what hands out the
+                    # generation, so pre-claim there is nothing to send.
+                    # That case is exactly a SCHEDULED / RESUME_SCHEDULED row
+                    # assigned to the caller; everything else is fenced.
+                    summary = await asyncio.to_thread(
+                        context_manager.get_summary,
+                        execution_id,
+                    )
+                    if not (
+                        summary["state"] in ("SCHEDULED", "RESUME_SCHEDULED")
+                        and summary["current_worker"] == name
+                    ):
+                        raise HTTPException(
+                            status_code=409,
+                            detail=(
+                                f"stale-claim: release carries no generation "
+                                f"but the row is at {current_generation}"
                             ),
                         )
 

--- a/flux/context_managers.py
+++ b/flux/context_managers.py
@@ -497,6 +497,21 @@ class DatabaseContextManager(ContextManager):
                     expected=expected_claim_generation,
                     actual=model.claim_generation or 0,
                 )
+            if expected_claim_generation is None and (model.claim_generation or 0) > 0:
+                # The fence was opt-in per request: omitting the generation
+                # skipped it entirely, so a write fenced at claim time could
+                # land by simply not carrying the header — worst case a late
+                # RUNNING write onto an evicted-and-unclaimed row, leaving it
+                # RUNNING with no owner, invisible to dispatch, the reaper,
+                # and the cancellation sweep. Ever-claimed rows now require
+                # the fence. The one writer with no claim by design stays
+                # legal: a worker resolving an unowned CANCELLING row to a
+                # terminal state (issue #189).
+                if not (model.state == ExecutionState.CANCELLING and ctx.state in _TERMINAL_STATES):
+                    raise StaleClaimError(
+                        ctx.execution_id,
+                        actual=model.claim_generation or 0,
+                    )
             if _accept_state_write(ctx.state, model.state):
                 model.state = ctx.state
                 model.output = ctx.output

--- a/flux/errors.py
+++ b/flux/errors.py
@@ -207,9 +207,10 @@ class StaleClaimError(Exception):
         # Defaults cover the worker side, which learns only *that* it was
         # fenced (409 from the server), not the row's current generation.
         self.execution_id = execution_id
+        carried = "no generation" if expected < 0 else f"generation {expected}"
         super().__init__(
             f"Stale claim for execution {execution_id}: checkpoint carries "
-            f"generation {expected} but the row is at {actual}; the execution "
+            f"{carried} but the row is at {actual}; the execution "
             f"was reassigned",
         )
 

--- a/flux/errors.py
+++ b/flux/errors.py
@@ -205,14 +205,18 @@ class StaleClaimError(Exception):
 
     def __init__(self, execution_id: str, expected: int = -1, actual: int = -1):
         # Defaults cover the worker side, which learns only *that* it was
-        # fenced (409 from the server), not the row's current generation.
+        # fenced (409 from the server), not the row's current generation —
+        # there the message must not claim to know what was carried.
         self.execution_id = execution_id
-        carried = "no generation" if expected < 0 else f"generation {expected}"
-        super().__init__(
-            f"Stale claim for execution {execution_id}: checkpoint carries "
-            f"{carried} but the row is at {actual}; the execution "
-            f"was reassigned",
-        )
+        if actual < 0:
+            detail = "the server fenced this write; the claim was superseded"
+        else:
+            carried = "no generation" if expected < 0 else f"generation {expected}"
+            detail = (
+                f"checkpoint carries {carried} but the row is at {actual}; "
+                f"the execution was reassigned"
+            )
+        super().__init__(f"Stale claim for execution {execution_id}: {detail}")
 
 
 class WorkerProcessCrashed(Exception):

--- a/flux/worker.py
+++ b/flux/worker.py
@@ -116,6 +116,12 @@ class _CheckpointOutbox:
         self.sender: asyncio.Task | None = None
         self.delivered = asyncio.Event()  # set once a terminal snapshot is acked
         self.closed = False  # handler ended; sender exits after catching up
+        # The claim generation this lifecycle checkpoints under, pinned at
+        # creation. Read from the box, never the worker's shared dict: after
+        # a fenced abort and same-worker re-dispatch, a stale lifecycle's
+        # sender must not pick up (or its cleanup delete) the fresh claim's
+        # fence.
+        self.claim_generation: str | None = None
         # Event ids already acknowledged by the server. Snapshots are
         # cumulative, so each send carries only events NOT in this set —
         # O(delta) payloads instead of O(history) per checkpoint.
@@ -966,8 +972,7 @@ class Worker:
 
                 claim_data = response.json()
                 generation = response.headers.get("X-Flux-Claim-Generation")
-                if generation is not None:
-                    self._claim_generations[request.context.execution_id] = generation
+                self._begin_claim_lifecycle(request.context.execution_id, generation)
                 request.context = ExecutionContext.from_json(claim_data, self._checkpoint)
                 if request.exec_token:
                     request.context.set_exec_token(request.exec_token)
@@ -1076,8 +1081,7 @@ class Worker:
                 response.raise_for_status()
                 claim_data = response.json()
                 generation = response.headers.get("X-Flux-Claim-Generation")
-                if generation is not None:
-                    self._claim_generations[request.context.execution_id] = generation
+                self._begin_claim_lifecycle(request.context.execution_id, generation)
                 request.context = ExecutionContext.from_json(claim_data, self._checkpoint)
                 if is_transient:
                     request.context.mark_transient()
@@ -1406,6 +1410,7 @@ class Worker:
         box = self._checkpoint_outboxes.get(ctx.execution_id)
         if box is None:
             box = self._checkpoint_outboxes[ctx.execution_id] = _CheckpointOutbox()
+            box.claim_generation = self._claim_generations.get(ctx.execution_id)
 
         box.latest = ctx
         box.generation += 1
@@ -1454,6 +1459,7 @@ class Worker:
                     sent_ids = await self._send_checkpoint(
                         ctx,
                         exclude_event_ids=box.acked_ids,
+                        claim_generation=box.claim_generation,
                     )
                     box.acked_ids.update(sent_ids)
                     box.acked = generation
@@ -1475,15 +1481,45 @@ class Worker:
             latest = box.latest
             if latest is not None and latest.has_finished:
                 box.delivered.set()
-                self._checkpoint_outboxes.pop(execution_id, None)
-                self._claim_generations.pop(execution_id, None)
-                self._transient_started.discard(execution_id)
+                self._discard_outbox_state(execution_id, box)
                 return
             if box.closed:
-                self._checkpoint_outboxes.pop(execution_id, None)
-                self._claim_generations.pop(execution_id, None)
-                self._transient_started.discard(execution_id)
+                self._discard_outbox_state(execution_id, box)
                 return
+
+    def _begin_claim_lifecycle(self, execution_id: str, generation: str | None) -> None:
+        """A fresh claim supersedes anything a previous lifecycle left behind.
+
+        A same-worker re-dispatch (fenced abort raced re-assignment) can find
+        the old lifecycle's outbox still draining under the same execution id.
+        Its events predate the unclaim, so every send would be fenced anyway —
+        detach it so the new run starts with a clean fence and outbox, and so
+        the stale sender exits without flushing into the new claim.
+        """
+        stale = self._checkpoint_outboxes.pop(execution_id, None)
+        if stale is not None:
+            stale.closed = True
+            stale.wakeup.set()
+            stale.delivered.set()
+        if generation is not None:
+            self._claim_generations[execution_id] = generation
+        else:
+            # A claim without the header (pre-fencing server) must not leave
+            # an older claim's generation behind as this run's fence.
+            self._claim_generations.pop(execution_id, None)
+
+    def _discard_outbox_state(self, execution_id: str, box: _CheckpointOutbox) -> None:
+        """Drop an ended lifecycle's shared state — only if it still owns it.
+
+        The dicts are keyed by execution id, and a same-worker re-dispatch
+        starts a new lifecycle under the same id: an owner check keeps a
+        stale sender's exit from deleting the fresh claim's outbox and fence.
+        """
+        if self._checkpoint_outboxes.get(execution_id) is not box:
+            return
+        self._checkpoint_outboxes.pop(execution_id, None)
+        self._claim_generations.pop(execution_id, None)
+        self._transient_started.discard(execution_id)
 
     def _abort_fenced_execution(self, execution_id: str, box: _CheckpointOutbox):
         """The server rejected our claim generation: another worker owns the
@@ -1492,12 +1528,18 @@ class Worker:
         logger.warning(
             f"Execution {execution_id} was reassigned (stale claim); aborting the local copy",
         )
-        task = self._running_workflows.get(execution_id)
-        if task and not task.done():
-            task.cancel()
         # Unblock any terminal-checkpoint waiter; the result is discarded
         # server-side anyway.
         box.delivered.set()
+        # Only clear shared state this lifecycle still owns: the "new owner"
+        # can be this same worker under a fresh claim (fenced-abort raced a
+        # re-dispatch), and destroying the fresh lifecycle's task, outbox, or
+        # fence would kill the run the server just handed us.
+        if self._checkpoint_outboxes.get(execution_id) is not box:
+            return
+        task = self._running_workflows.get(execution_id)
+        if task and not task.done():
+            task.cancel()
         self._checkpoint_outboxes.pop(execution_id, None)
         self._claim_generations.pop(execution_id, None)
         self._transient_started.discard(execution_id)
@@ -1571,6 +1613,7 @@ class Worker:
         self,
         ctx: ExecutionContext,
         exclude_event_ids: set[str] | None = None,
+        claim_generation: str | None = None,
     ) -> list[str]:
         """POST one checkpoint; returns the ids of the events it carried.
 
@@ -1579,6 +1622,10 @@ class Worker:
         can be omitted — the server reconciles by event id either way. Raises
         ``StaleClaimError`` if the server fences the claim (409): the
         execution was reassigned and this worker's copy must abort.
+
+        ``claim_generation`` is the sender's pinned fence — passed in rather
+        than read from the shared dict so a stale lifecycle cannot checkpoint
+        under a newer claim's generation.
         """
         base_url = f"{self.base_url}/{self.name}"
         try:
@@ -1603,9 +1650,8 @@ class Worker:
             )
 
             headers = {}
-            generation = self._claim_generations.get(ctx.execution_id)
-            if generation is not None:
-                headers["X-Flux-Claim-Generation"] = generation
+            if claim_generation is not None:
+                headers["X-Flux-Claim-Generation"] = claim_generation
 
             checkpoint_start = time.monotonic()
             response = await self._authorized_post(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.81.5"
+version = "0.81.6"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_checkpoint_fencing.py
+++ b/tests/flux/test_checkpoint_fencing.py
@@ -163,15 +163,68 @@ def test_update_rejects_stale_generation(env):
     cm.update(ctx, expected_claim_generation=1)
 
 
-def test_update_without_generation_is_unfenced(env):
-    """Legacy workers send no generation header and keep working."""
+def test_update_without_generation_is_fenced_once_claimed(env):
+    """The fence must not be opt-in per request: omitting the generation
+    used to skip it entirely, so a write fenced at claim time could land by
+    simply not carrying the header — worst case a late RUNNING write onto
+    an evicted-and-unclaimed row, leaving it RUNNING with no owner,
+    invisible to dispatch, the reaper, and the cancellation sweep."""
     cm, registry = env
     w1 = _register(registry, "w1")
     wf_id = _create_workflow(cm)
     cm.save(ExecutionContext(workflow_id=wf_id, workflow_namespace="default", workflow_name="wf"))
     ctx = _dispatch(cm, w1)
 
-    cm.update(ctx)  # no expected generation: accepted
+    with pytest.raises(StaleClaimError):
+        cm.update(ctx)
+
+
+def test_update_without_generation_on_a_never_dispatched_row_is_accepted(env):
+    """Inline saves and pre-dispatch writes carry no generation because the
+    row has none; only ever-claimed rows require the fence."""
+    cm, registry = env
+    wf_id = _create_workflow(cm)
+    ctx = ExecutionContext(workflow_id=wf_id, workflow_namespace="default", workflow_name="wf")
+    cm.save(ctx)
+
+    cm.update(ctx)  # generation 0: accepted
+
+
+def test_unowned_cancellation_resolution_stays_legal(env):
+    """The one writer with no claim by design (issue #189): a worker
+    resolving an unowned CANCELLING row to CANCELLED never claimed the
+    execution, so its checkpoint carries no generation and must land."""
+    cm, registry = env
+    w1 = _register(registry, "w1")
+    wf_id = _create_workflow(cm)
+    cm.save(ExecutionContext(workflow_id=wf_id, workflow_namespace="default", workflow_name="wf"))
+    ctx = _dispatch(cm, w1)
+    ctx.start_cancel()
+    cm.update(ctx, expected_claim_generation=1)
+
+    resolution = cm.get(ctx.execution_id)
+    resolution.cancel()
+    cm.update(resolution)  # no generation: CANCELLING -> terminal is allowed
+
+    assert cm.get(ctx.execution_id).state.value == "CANCELLED"
+
+
+def test_unfenced_noncancelling_write_cannot_resurrect_an_unclaimed_row(env):
+    """The concrete wedge the fence closes: evict-and-unclaim resets the row
+    to CREATED with no owner; a late claimless RUNNING write must not drag
+    it back to RUNNING-with-no-owner."""
+    cm, registry = env
+    w1 = _register(registry, "w1")
+    wf_id = _create_workflow(cm)
+    cm.save(ExecutionContext(workflow_id=wf_id, workflow_namespace="default", workflow_name="wf"))
+    ctx = _dispatch(cm, w1)
+    cm.unclaim(ctx.execution_id)  # eviction: CREATED, no owner, generation bumped
+
+    ctx.start(ctx.execution_id)  # the partitioned worker's stale RUNNING state
+    with pytest.raises(StaleClaimError):
+        cm.update(ctx)
+
+    assert cm.get(ctx.execution_id).state.value == "CREATED"
 
 
 def test_batch_dispatch_bumps_generation(env):

--- a/tests/flux/test_worker_checkpoint.py
+++ b/tests/flux/test_worker_checkpoint.py
@@ -416,3 +416,94 @@ async def test_release_claim_is_fenced_even_after_sender_drained():
     assert len(release_calls) == 1
     assert release_calls[0][1].get("X-Flux-Claim-Generation") == "3"
     assert "exec-1" not in worker._claim_generations
+
+
+class TestLifecycleOwnership:
+    """A same-worker re-dispatch reuses the execution id, so the outbox and
+    claim-generation dicts hold state for whichever lifecycle wrote last.
+    Cleanup from the stale lifecycle (a fenced abort, a sender's exit) must
+    not destroy the fresh claim's state — before the fence became mandatory
+    that destruction was masked (header-less checkpoints were accepted
+    unfenced); after it, the fresh run's checkpoints were 409-fenced by its
+    own worker's cleanup (t6c connection-drop wedge)."""
+
+    def test_begin_claim_lifecycle_detaches_the_stale_outbox(self):
+        worker = make_worker()
+        from flux.worker import _CheckpointOutbox
+
+        stale = _CheckpointOutbox()
+        worker._checkpoint_outboxes["exec-1"] = stale
+        worker._claim_generations["exec-1"] = "1"
+
+        worker._begin_claim_lifecycle("exec-1", "3")
+
+        assert "exec-1" not in worker._checkpoint_outboxes
+        assert stale.closed and stale.delivered.is_set()
+        assert worker._claim_generations["exec-1"] == "3"
+
+    def test_begin_claim_lifecycle_without_header_clears_the_old_fence(self):
+        worker = make_worker()
+        worker._claim_generations["exec-1"] = "1"
+
+        worker._begin_claim_lifecycle("exec-1", None)
+
+        assert "exec-1" not in worker._claim_generations
+
+    def test_stale_abort_leaves_the_fresh_lifecycle_alone(self):
+        worker = make_worker()
+        from flux.worker import _CheckpointOutbox
+
+        stale = _CheckpointOutbox()
+        fresh = _CheckpointOutbox()
+        fresh.claim_generation = "3"
+        worker._checkpoint_outboxes["exec-1"] = fresh
+        worker._claim_generations["exec-1"] = "3"
+        fresh_task = MagicMock()
+        fresh_task.done.return_value = False
+        worker._running_workflows["exec-1"] = fresh_task
+
+        worker._abort_fenced_execution("exec-1", stale)
+
+        assert worker._checkpoint_outboxes["exec-1"] is fresh
+        assert worker._claim_generations["exec-1"] == "3"
+        fresh_task.cancel.assert_not_called()
+        assert stale.delivered.is_set()  # its own waiter is still unblocked
+
+    def test_stale_sender_exit_leaves_the_fresh_lifecycle_alone(self):
+        worker = make_worker()
+        from flux.worker import _CheckpointOutbox
+
+        stale = _CheckpointOutbox()
+        fresh = _CheckpointOutbox()
+        worker._checkpoint_outboxes["exec-1"] = fresh
+        worker._claim_generations["exec-1"] = "3"
+
+        worker._discard_outbox_state("exec-1", stale)
+
+        assert worker._checkpoint_outboxes["exec-1"] is fresh
+        assert worker._claim_generations["exec-1"] == "3"
+
+    @pytest.mark.asyncio
+    async def test_sender_uses_its_pinned_generation_not_the_shared_dict(self):
+        """After a re-claim stores a newer generation, a still-draining stale
+        sender must keep checkpointing under its own fence (and get fenced),
+        never under the fresh claim's."""
+        worker = make_worker()
+        worker._claim_generations["exec-1"] = "1"
+        seen_headers = []
+
+        async def capture_post(url, **kwargs):
+            seen_headers.append(kwargs.get("headers") or {})
+            return ok_response()
+
+        worker._authorized_post = capture_post
+
+        ctx = make_ctx(finished=True)
+        checkpoint = asyncio.ensure_future(worker._checkpoint(ctx))
+        await asyncio.sleep(0)
+        # Re-claim lands while the sender is in flight.
+        worker._claim_generations["exec-1"] = "9"
+        await asyncio.wait_for(checkpoint, timeout=5)
+
+        assert seen_headers, "no checkpoint was sent"
+        assert seen_headers[0].get("X-Flux-Claim-Generation") == "1"

--- a/tests/flux/test_worker_release_route.py
+++ b/tests/flux/test_worker_release_route.py
@@ -1,0 +1,152 @@
+"""Route-level tests for the release fence.
+
+The release endpoint hands a claimed execution back for re-dispatch. Its
+claim-generation fence was opt-in per request — omit the header and any
+worker principal could unclaim any dispatched execution — and it never
+verified the caller owned the execution at all. The one legitimate
+claimless release is a worker declining a dispatch it never claimed
+(paused / unhealthy): the claim response is what hands out the generation,
+so pre-claim there is nothing to send.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from flux import ExecutionContext
+from flux.config import Configuration
+from flux.context_managers import ContextManager
+from flux.domain.events import ExecutionState
+from flux.server import Server
+
+
+@pytest.fixture
+def manager(tmp_path):
+    Configuration.get().override(database_url=f"sqlite:///{tmp_path / 'release.db'}")
+    from flux.models import DatabaseRepository
+
+    DatabaseRepository._engines.clear()
+    yield ContextManager.create()
+    DatabaseRepository._engines.clear()
+
+
+@pytest.fixture
+def server_instance(manager):
+    return Server(host="localhost", port=8000)
+
+
+@pytest.fixture
+def test_client(server_instance):
+    from flux.security.identity import FluxIdentity
+
+    worker_identity = FluxIdentity(subject="w1", roles=frozenset({"worker"}))
+    mock_auth = MagicMock()
+
+    async def mock_authenticate(token):
+        return worker_identity
+
+    async def mock_is_authorized(identity, permission):
+        return True
+
+    mock_auth.authenticate = mock_authenticate
+    mock_auth.is_authorized = mock_is_authorized
+
+    with (
+        patch.object(server_instance, "_verify_worker_identity"),
+        patch.object(server_instance, "_record_heartbeat", new=AsyncMock()),
+        patch("flux.security.dependencies._get_auth_service", return_value=mock_auth),
+    ):
+        yield TestClient(server_instance._create_api())
+
+
+def _execution(manager, state, worker_name, generation=1):
+    from flux.models import ExecutionContextModel, WorkflowModel
+
+    with manager.session() as session:
+        if session.get(WorkflowModel, "wf-1") is None:
+            session.add(
+                WorkflowModel(id="wf-1", name="wf", version=1, imports=[], source=b""),
+            )
+            session.commit()
+
+    ctx = ExecutionContext(
+        workflow_id="wf-1",
+        workflow_namespace="default",
+        workflow_name="wf",
+        input=None,
+    )
+    manager.save(ctx)
+    with manager.session() as session:
+        row = session.get(ExecutionContextModel, ctx.execution_id)
+        row.state = state
+        row.worker_name = worker_name
+        row.claim_generation = generation
+        session.commit()
+    return ctx.execution_id
+
+
+class TestClaimlessRelease:
+    def test_declining_an_unclaimed_dispatch_is_allowed(self, test_client, manager):
+        """The paused/unhealthy path: SCHEDULED, assigned here, never
+        claimed — no generation exists to send."""
+        execution_id = _execution(manager, ExecutionState.SCHEDULED, "w1")
+
+        resp = test_client.post(f"/workers/w1/release/{execution_id}")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "released"
+
+    def test_declining_an_unclaimed_resume_dispatch_is_allowed(self, test_client, manager):
+        execution_id = _execution(manager, ExecutionState.RESUME_SCHEDULED, "w1")
+
+        resp = test_client.post(f"/workers/w1/release/{execution_id}")
+
+        assert resp.status_code == 200
+
+    def test_claimless_release_of_a_running_execution_is_fenced(self, test_client, manager):
+        """Post-claim the worker holds a generation; a release without it is
+        either a stale duplicate or a caller sidestepping the fence."""
+        execution_id = _execution(manager, ExecutionState.RUNNING, "w1")
+
+        resp = test_client.post(f"/workers/w1/release/{execution_id}")
+
+        assert resp.status_code == 409
+        assert "stale-claim" in resp.text
+        assert manager.get(execution_id).state == ExecutionState.RUNNING
+
+    def test_release_of_another_workers_execution_is_forbidden(self, test_client, manager):
+        """The route verified only that the caller is a worker, not that it
+        owns the execution it is releasing."""
+        execution_id = _execution(manager, ExecutionState.RUNNING, "w2")
+
+        resp = test_client.post(f"/workers/w1/release/{execution_id}")
+
+        assert resp.status_code == 403
+        assert manager.get(execution_id).state == ExecutionState.RUNNING
+
+
+class TestFencedRelease:
+    def test_current_generation_releases(self, test_client, manager):
+        execution_id = _execution(manager, ExecutionState.RUNNING, "w1", generation=3)
+
+        resp = test_client.post(
+            f"/workers/w1/release/{execution_id}",
+            headers={"X-Flux-Claim-Generation": "3"},
+        )
+
+        assert resp.status_code == 200
+        assert manager.get(execution_id).state == ExecutionState.CREATED
+
+    def test_stale_generation_is_fenced(self, test_client, manager):
+        execution_id = _execution(manager, ExecutionState.RUNNING, "w1", generation=3)
+
+        resp = test_client.post(
+            f"/workers/w1/release/{execution_id}",
+            headers={"X-Flux-Claim-Generation": "2"},
+        )
+
+        assert resp.status_code == 409
+        assert manager.get(execution_id).state == ExecutionState.RUNNING


### PR DESCRIPTION
## Problem

Claim-generation fencing (v0.53) only ran when the request carried `X-Flux-Claim-Generation`:

- **Checkpoints** — header absent → `update()` skipped the generation check entirely. The residual ownership check passes whenever the row is unclaimed (the documented recovery window after eviction) or owned by the caller (same-worker re-dispatch). Worst case: a late claimless `RUNNING` write onto an evicted-and-unclaimed row leaves it **RUNNING with no owner** — `update()` writes state/output/events but never `worker_name`, so the row is invisible to dispatch (`CREATED`-only), the heartbeat reaper (no worker), and the cancellation sweep (`CANCELLING`-only). Permanently wedged.
- **Releases** — the route verified only that the caller *is a worker*, never that it owns the execution, and the fence was equally opt-in. Any `worker:*:*` principal could unclaim any dispatched execution (→ `CREATED`, generation bumped), forcing a re-run.

Since the fence exists precisely to stop writers whose claim was superseded, an opt-in fence protects only against well-behaved stale writers.

## Change

- **`update()`**: a claimless write to a row that has ever been dispatched (`claim_generation > 0`) raises `StaleClaimError` (409 stale-claim, which workers already handle by abandoning cleanly). Carve-out: `CANCELLING → terminal`, the #189/#222 path — a worker resolving an unowned cancellation never claimed it, so it has no generation by design.
- **Release route**: gains `_verify_worker_owns_execution` and the same mandatory fence. Carve-out: a `SCHEDULED`/`RESUME_SCHEDULED` row assigned to the caller — the paused/unhealthy decline happens *before* the claim, and the claim response is what hands out the generation.
- `StaleClaimError` message distinguishes "carries no generation" from a stale one.

**Compatibility:** workers ≥ v0.53 always send the header when they hold one; the cost lands only on pre-v0.53 workers, whose newly-rejected writes are exactly the unsafe ones.

## Verification

- `test_checkpoint_fencing.py` (10 tests): the old `test_update_without_generation_is_unfenced` ("legacy workers keep working") is deliberately flipped to assert fail-closed; new tests cover the never-dispatched row (generation 0 still accepted — inline path), the #222 carve-out landing, and the concrete wedge (claimless RUNNING onto an unclaimed row stays CREATED).
- `test_worker_release_route.py` (6 route-level tests, real DB): pre-claim declines allowed (SCHEDULED and RESUME_SCHEDULED), claimless release of a RUNNING row fenced 409, cross-worker release 403, correct generation releases, stale generation 409.
- Full unit tree: **2901 passed**. Full E2E as CI runs it: **145 passed** — crash-release, pause/resume, both cancellation paths, all through the now-mandatory fence. Pre-commit clean.