### PR TITLE
docs: close the review leftovers from the routing-input and sweep work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,10 @@ Implementation hot-spots:
 
 - `flux/task.py` — `task` is a class with `__call__`; `task.with_options(...)` returns a decorator.
   Options: `name`, `fallback`, `rollback`, `retry_max_attempts/_delay/_backoff`, `timeout`,
-  `secret_requests`, `config_requests`, `output_storage`, `cache`, `metadata`, `auth_exempt`, plus:
+  `secret_requests`, `config_requests`, `output_storage`, `cache`, `metadata`, `auth_exempt`,
+  `digest_exclude` (kwargs kept out of the identity digest — the task_id doubles as cache key and
+  approval call_id, so excluded kwargs make calls differing only in them identical; how
+  `call(routing_input=...)` keeps routing values out of replay identity), plus:
   - `requires_approval` (bool or runtime predicate) — pauses the workflow until an operator runs
     `flux execution approve|reject` (or POSTs the equivalent). Rejection raises `ApprovalRejected` and
     **bypasses retry/fallback/rollback**, since the body never ran. `approve --always` records a
@@ -240,9 +243,11 @@ Higher-level managers:
   `service_proxy.py` provides standalone MCP endpoints with lazy discovery.
 - `flux/schedule_manager.py` — runs in the server process. Under the cross-replica dispatch lock, the
   scheduler tick polls due schedules, runs the overlap-skip check, sweeps the park-TTL (failing
-  executions unclaimed past `executions.park_deadline`), and resumes executions whose
+  executions unclaimed past `executions.park_deadline`), resumes executions whose
   `wake_at`/`wake_on_complete` fired — wake columns are stamped atomically with the PAUSED state write
-  in `context_managers.py::_sync_wake_columns`.
+  in `context_managers.py::_sync_wake_columns` — resolves orphaned CANCELLING executions whose
+  delivery target is gone (`resolve_orphaned_cancellations`, issue #225), and reaps dead worker
+  join tokens hourly (`Server._purge_join_tokens`).
 - `flux/observability/` — OpenTelemetry tracing/metrics + a Prometheus `/metrics` endpoint, gated by
   `[flux.observability] enabled` and the `observability` extra.
 

--- a/docs/advanced-features/worker-affinity.md
+++ b/docs/advanced-features/worker-affinity.md
@@ -161,6 +161,12 @@ affinity=require(label("maintenance") != "true")
   against a constant or `input("path")` (dotted paths descend nested dicts).
   Only `==` and `!=`; ordered comparisons belong to
   [Dynamic Routing](dynamic-routing.md).
+- `routing_input("key")` — a drop-in alternative to `input(...)` anywhere a
+  term takes one: reads per-execution routing values that are matched at
+  dispatch but never delivered to the worker (set via the run header, a
+  schedule's `routing_input` field, `call(routing_input=...)`, or the CLI's
+  `--routing-input`). Same resolution and fail-closed semantics as `input`.
+  See [Dynamic Routing](dynamic-routing.md#routing-on-values-the-worker-cannot-see).
 - `label_for(prefix, input("path"))` — dynamic label key: the author
   declares the namespace (`prefix` is mandatory), input only completes it.
   The resolved key must be a valid label key; inputs never create labels,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.81.6"
+version = "0.81.7"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"


### PR DESCRIPTION
Documentation-only. Three leftovers noted in earlier reviews:

- **`routing_input()` in `worker-affinity.md`** — usable anywhere `input()` is accepted since #220, but only `dynamic-routing.md` documented it. The affinity vocabulary now lists it with its sources (run header, schedule field, `call()` kwarg, CLI flag) and points at the full treatment.
- **`digest_exclude` in CLAUDE.md's task-option inventory** — the option existed and carries real semantics (task_id doubles as cache key and approval call_id) but was absent from the inventory.
- **CLAUDE.md's scheduler-tick description** — now names the two passes added this cycle: orphaned-CANCELLING resolution (#225 / #228) and the hourly join-token reap (#229).

No code changes. Version bump only for the CI gate.

**Merge order:** after #228 and #229 — the scheduler-tick description references the passes those PRs add.