### PR TITLE
refactor(api): one routing-input ingress adapter instead of per-route copies

### DIFF
--- a/flux/api/schedule_routes.py
+++ b/flux/api/schedule_routes.py
@@ -19,7 +19,6 @@ from flux.errors import WorkflowNotFoundError
 from flux.schedule_manager import create_schedule_manager
 from flux.security.dependencies import get_identity, require_permission
 from flux.security.identity import FluxIdentity
-from flux.routing_input import RoutingInputError, validate_routing_input
 from flux.utils import get_logger
 from flux.api.schemas import (
     ScheduleRequest,
@@ -27,6 +26,7 @@ from flux.api.schemas import (
     ScheduleUpdateRequest,
     ScheduleHistoryEntry,
     ScheduleHistoryResponse,
+    routing_input_or_400,
 )
 
 logger = get_logger(__name__)
@@ -197,12 +197,7 @@ class ScheduleRoutesMixin:
                 # Create schedule from configuration
                 schedule = schedule_factory(request.schedule_config)
 
-                try:
-                    checked_routing_input = validate_routing_input(request.routing_input)
-                    if request.routing_input == {}:
-                        checked_routing_input = {}  # explicit clear
-                except RoutingInputError as e:
-                    raise HTTPException(status_code=400, detail=str(e))
+                checked_routing_input = routing_input_or_400(request.routing_input)
 
                 # Create schedule via manager
                 schedule_manager = create_schedule_manager()
@@ -417,12 +412,7 @@ class ScheduleRoutesMixin:
                             },
                         )
 
-                try:
-                    checked_routing_input = validate_routing_input(request.routing_input)
-                    if request.routing_input == {}:
-                        checked_routing_input = {}  # explicit clear
-                except RoutingInputError as e:
-                    raise HTTPException(status_code=400, detail=str(e))
+                checked_routing_input = routing_input_or_400(request.routing_input)
 
                 # Build update parameters
                 schedule_param = None

--- a/flux/api/schemas.py
+++ b/flux/api/schemas.py
@@ -10,14 +10,43 @@ from __future__ import annotations
 import re
 from typing import Any
 
+from fastapi import HTTPException
 from fastapi import Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 from slowapi.errors import RateLimitExceeded
 
+from flux.routing_input import (
+    RoutingInputError,
+    parse_routing_input_header,
+    validate_routing_input,
+)
+
 
 MAX_WORKFLOW_UPLOAD_BYTES = 1_048_576  # 1 MiB — workflow sources should be small
 SERVICE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+
+# The routing-input ingress adapters: every HTTP entry point validates the
+# same way, so the mapping to 400 (rejected, never dropped — a dropped
+# directive routes the execution somewhere the caller did not intend, #211)
+# and the explicit-clear quirk live in one place instead of being repeated
+# at each route.
+def routing_input_or_400(value: Any) -> dict[str, Any] | None:
+    try:
+        checked = validate_routing_input(value)
+    except RoutingInputError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    # {} is the explicit clear at the API surface (schedule updates); the
+    # validator normalises it to None, so restore the distinction.
+    return {} if value == {} else checked
+
+
+def routing_input_header_or_400(raw: str | list[str] | None) -> dict[str, Any] | None:
+    try:
+        return parse_routing_input_header(raw)
+    except RoutingInputError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 def _rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:

--- a/flux/api/workflow_routes.py
+++ b/flux/api/workflow_routes.py
@@ -27,7 +27,6 @@ from flux.errors import (
     WorkerNotFoundError,
     WorkflowNotFoundError,
 )
-from flux.routing_input import RoutingInputError, parse_routing_input_header
 from flux.security.dependencies import get_identity
 from flux.security.identity import ANONYMOUS, FluxIdentity
 from flux.servers.models import ExecutionContext as ExecutionContextDTO
@@ -37,6 +36,7 @@ from flux.utils import to_json
 from flux.api.schemas import (
     MAX_WORKFLOW_UPLOAD_BYTES,
     WorkflowVersionResponse,
+    routing_input_header_or_400,
 )
 
 logger = get_logger(__name__)
@@ -304,13 +304,8 @@ class WorkflowRoutesMixin:
                     )
 
                 # Routing-only values (issue #211): matched at dispatch, never
-                # delivered. Rejected rather than dropped — a discarded routing
-                # directive routes the execution somewhere the caller did not
-                # intend, and that is invisible from outside.
-                try:
-                    parsed_routing_input = parse_routing_input_header(routing_input)
-                except RoutingInputError as e:
-                    raise HTTPException(status_code=400, detail=str(e))
+                # delivered.
+                parsed_routing_input = routing_input_header_or_400(routing_input)
 
                 ctx = self._create_execution(
                     namespace,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.81.7"
+version = "0.81.8"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_routing_input.py
+++ b/tests/flux/test_routing_input.py
@@ -500,3 +500,40 @@ class TestCallIngress:
         from flux.tasks.call import call
 
         assert "routing_input" in call.digest_exclude
+
+
+class TestIngressAdapters:
+    """One adapter per wire shape, shared by every HTTP ingress — the #220
+    defect lived in an ingress diverging from the validator, so the mapping
+    to 400 and the explicit-clear quirk live in exactly one place."""
+
+    def test_error_maps_to_400_with_the_diagnostic(self):
+        from fastapi import HTTPException
+
+        from flux.api.schemas import routing_input_or_400
+
+        with pytest.raises(HTTPException) as excinfo:
+            routing_input_or_400({"a.b": 1})
+
+        assert excinfo.value.status_code == 400
+        assert "a.b" in str(excinfo.value.detail)
+
+    def test_header_error_maps_to_400(self):
+        from fastapi import HTTPException
+
+        from flux.api.schemas import routing_input_header_or_400
+
+        with pytest.raises(HTTPException) as excinfo:
+            routing_input_header_or_400("{oops")
+
+        assert excinfo.value.status_code == 400
+
+    def test_explicit_clear_survives_normalisation(self):
+        """{} means 'clear the stored value' on schedule updates; the
+        validator normalises it to None, which would read as 'leave it
+        alone' — the adapter must preserve the distinction."""
+        from flux.api.schemas import routing_input_or_400
+
+        assert routing_input_or_400({}) == {}
+        assert routing_input_or_400(None) is None
+        assert routing_input_or_400({"cohort": "canary"}) == {"cohort": "canary"}


### PR DESCRIPTION
Follow-up to #220's review: the routing-input validate-or-400 adaptation was copied at each HTTP ingress.

## Change

- `flux/api/schemas.py` gains two adapters, one per wire shape: `routing_input_or_400` (body mappings — schedule create/update) and `routing_input_header_or_400` (the `X-Flux-Routing-Input` header — run route). The `RoutingInputError → 400` mapping and the explicit-clear quirk (`{}` means *clear the stored value*; the validator normalises it to `None`, which reads as *leave it alone*) now exist in exactly one place.
- The three route sites collapse to one-line calls. `call()` is deliberately unchanged: no HTTP context, and its callers handle `RoutingInputError`.

The #220 defect class was an ingress diverging from the validator — this makes the next ingress reuse the adapter instead of re-implementing it.

## Verification

- New adapter tests: 400 mapping for both shapes (diagnostic preserved), and the explicit-clear distinction (`{} → {}`, `None → None`).
- Routing-input unit suites: 53 passed. CLI + schedule suites: 90 passed.
- Five-ingress E2E (`tests/e2e/test_routing_input.py`) against a real server/worker: 5 passed.
- No behavior change intended; pre-commit clean.