### PR TITLE
fix(dispatch): arm the poll-mode wait before checking for work

### DIFF
--- a/flux/api/worker_routes.py
+++ b/flux/api/worker_routes.py
@@ -731,6 +731,19 @@ class WorkerRoutesMixin:
                                     await asyncio.sleep(fallback_interval)
                                     continue
 
+                                # Arm the wait BEFORE checking for work: a
+                                # submission landing mid-check re-sets the
+                                # events and the wait below returns at once.
+                                # Clearing after the checks discarded exactly
+                                # those signals, and the affected requests
+                                # slept the whole fallback interval — a flat
+                                # ~500 ms tax visible as a bimodal dispatch
+                                # latency with nothing between the modes
+                                # (issue #234). The worst this ordering does
+                                # is one spurious extra poll.
+                                worker_event.clear()
+                                self._work_available.clear()
+
                                 ctx = await asyncio.to_thread(
                                     context_manager.next_execution,
                                     worker,
@@ -801,9 +814,11 @@ class WorkerRoutesMixin:
                                     )
                                     continue
 
-                                # No work found — wait for per-worker signal or fallback
-                                worker_event.clear()
-                                self._work_available.clear()
+                                # No work found — wait for the per-worker
+                                # signal or fallback. The events were armed
+                                # before the checks above, so a signal that
+                                # raced them is still set here and the wait
+                                # returns immediately.
                                 try:
                                     worker_task = asyncio.ensure_future(worker_event.wait())
                                     broadcast_task = asyncio.ensure_future(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.81.8"
+version = "0.81.9"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"


### PR DESCRIPTION
Closes #234.

## Problem

The poll-mode SSE loop ran its three work checks (execution, cancellation, resume — each a DB read on a thread), **then** cleared `worker_event` and `_work_available`, then waited with `timeout=fallback_interval`. A submission landing anywhere inside that multi-read window set the events only to have them cleared — the waiter then slept the full fallback interval and found the work by poll. That's the reported bimodal distribution: a fast mode in the tens of ms, a slow mode at ~500 ms, and zero samples between — the empty band is the discarded-signal population paying the fixed timeout.

## Change

The events are armed at the top of the iteration, before the checks. An arrival concurrent with a check either re-sets an armed event (the subsequent wait returns immediately) or is seen by the check itself — never neither. All `continue` paths re-arm on the next iteration before re-checking, so no signal is lost there either. Worst case of the new ordering: one spurious extra poll after a wake.

## Verification

- Route-adjacent unit suites (heartbeat, pause routes): 44 passed.
- Poll-mode E2E (`test_pause.py`, `test_core.py` — dispatch, pause/resume, cancellation through this exact loop): 13 passed.
- Deliberately **no latency-distribution test**: a timing assertion on shared CI runners is flaky by construction. Delivery correctness is covered by the poll-mode E2E suite (the session default); the reporter's bucketing methodology is the right validation for the latency claim, and I'd welcome their before/after numbers on this branch.

**Merge order:** after #228–#232 (version bumps are stepped; this carries 0.81.9).