### PR TITLE
perf(runners): keep the persistence graph out of the child's import path

### DIFF
--- a/flux/config_manager.py
+++ b/flux/config_manager.py
@@ -5,10 +5,6 @@ import json
 from abc import ABC, abstractmethod
 from typing import Any
 
-from sqlalchemy import select
-
-from flux.models import ConfigModel, RepositoryFactory
-
 
 class ConfigManager(ABC):
     @abstractmethod
@@ -38,7 +34,12 @@ class ConfigManager(ABC):
 
 
 class DatabaseConfigManager(ConfigManager):
+    # The persistence graph is imported per method, worker_registry-style: a
+    # runner child imports this module for the ConfigManager ABC alone, and a
+    # top-level import would pull SQLAlchemy into every sandbox (issue #233).
     def __init__(self):
+        from flux.models import RepositoryFactory
+
         self._repository = RepositoryFactory.create_repository()
 
     def session(self):
@@ -50,6 +51,8 @@ class DatabaseConfigManager(ConfigManager):
 
         serialized = json.dumps(value)
 
+        from flux.models import ConfigModel
+
         with self.session() as session:
             config = session.get(ConfigModel, name)
             if config:
@@ -59,6 +62,8 @@ class DatabaseConfigManager(ConfigManager):
             session.commit()
 
     def remove(self, name: str) -> None:
+        from flux.models import ConfigModel
+
         with self.session() as session:
             config = session.get(ConfigModel, name)
             if config:
@@ -67,6 +72,10 @@ class DatabaseConfigManager(ConfigManager):
 
     async def get(self, config_requests: list[str]) -> dict[str, Any]:
         def _query() -> dict[str, Any]:
+            from sqlalchemy import select
+
+            from flux.models import ConfigModel
+
             with self.session() as session:
                 stmt = select(ConfigModel.name, ConfigModel.value).where(
                     ConfigModel.name.in_(config_requests),
@@ -79,6 +88,10 @@ class DatabaseConfigManager(ConfigManager):
         return result
 
     def all(self) -> list[str]:
+        from sqlalchemy import select
+
+        from flux.models import ConfigModel
+
         with self.session() as session:
             stmt = select(ConfigModel.name)
             return [row[0] for row in session.execute(stmt)]

--- a/flux/runners/__init__.py
+++ b/flux/runners/__init__.py
@@ -14,12 +14,38 @@ container-based runners (Docker, Kubernetes) fit behind it later.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+# Runner classes are imported inside create_runners, not here: this package
+# init runs in every runner child (python -m flux.runners.child imports the
+# package first), and the eager registry pulled the loader's whole dependency
+# graph into the sandbox before any user code (issue #233).
 from flux.runners.base import Runner, RunnerHooks
-from flux.runners.inprocess import InProcessRunner
-from flux.runners.loader import WorkflowModuleLoader
-from flux.runners.subprocess_runner import SubprocessRunner
+
+if TYPE_CHECKING:
+    from flux.runners.inprocess import InProcessRunner  # noqa: F401
+    from flux.runners.loader import WorkflowModuleLoader  # noqa: F401
+    from flux.runners.subprocess_runner import SubprocessRunner  # noqa: F401
 
 KNOWN_RUNNERS = ("inprocess", "subprocess", "docker", "docker-airgapped")
+
+
+def __getattr__(name: str):
+    # Preserve `from flux.runners import InProcessRunner` for existing
+    # imports without paying for the registry in the child.
+    if name == "InProcessRunner":
+        from flux.runners.inprocess import InProcessRunner
+
+        return InProcessRunner
+    if name == "SubprocessRunner":
+        from flux.runners.subprocess_runner import SubprocessRunner
+
+        return SubprocessRunner
+    if name == "WorkflowModuleLoader":
+        from flux.runners.loader import WorkflowModuleLoader
+
+        return WorkflowModuleLoader
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def create_runners(names: list[str], config) -> dict[str, Runner]:
@@ -31,6 +57,9 @@ def create_runners(names: list[str], config) -> dict[str, Runner]:
     runners: dict[str, Runner] = {}
     for name in names:
         if name == "inprocess":
+            from flux.runners.inprocess import InProcessRunner
+            from flux.runners.loader import WorkflowModuleLoader
+
             runners[name] = InProcessRunner(
                 loader=WorkflowModuleLoader(
                     ttl=config.module_cache_ttl,
@@ -38,6 +67,8 @@ def create_runners(names: list[str], config) -> dict[str, Runner]:
                 ),
             )
         elif name == "subprocess":
+            from flux.runners.subprocess_runner import SubprocessRunner
+
             runners[name] = SubprocessRunner(
                 term_grace=config.subprocess_term_grace,
                 memory_limit=config.subprocess_memory_limit,

--- a/flux/secret_managers.py
+++ b/flux/secret_managers.py
@@ -5,12 +5,6 @@ from abc import ABC
 from abc import abstractmethod
 from typing import Any
 
-from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
-
-from flux.models import RepositoryFactory
-from flux.models import SecretModel
-
 
 class SecretManager(ABC):
     @abstractmethod
@@ -43,7 +37,12 @@ class SecretManager(ABC):
 class DatabaseSecretManager(SecretManager):
     """Dialect-agnostic secret manager. Delegates to ``RepositoryFactory``."""
 
+    # Persistence imports are per-method, worker_registry-style: a runner
+    # child imports this module for the SecretManager ABC alone, and a
+    # top-level import pulled SQLAlchemy into every sandbox (issue #233).
     def __init__(self):
+        from flux.models import RepositoryFactory
+
         self._repository = RepositoryFactory.create_repository()
 
     def session(self):
@@ -52,6 +51,10 @@ class DatabaseSecretManager(SecretManager):
     def save(self, name: str, value: Any):
         if value is None:
             raise ValueError("Secret value cannot be None")
+
+        from sqlalchemy.exc import IntegrityError
+
+        from flux.models import SecretModel
 
         with self.session() as session:
             try:
@@ -66,6 +69,10 @@ class DatabaseSecretManager(SecretManager):
                 raise
 
     def remove(self, name: str):
+        from sqlalchemy.exc import IntegrityError
+
+        from flux.models import SecretModel
+
         with self.session() as session:
             try:
                 secret = session.get(SecretModel, name)
@@ -78,6 +85,10 @@ class DatabaseSecretManager(SecretManager):
 
     async def get(self, secret_requests: list[str]) -> dict[str, Any]:
         def _query() -> dict[str, Any]:
+            from sqlalchemy import select
+
+            from flux.models import SecretModel
+
             with self.session() as session:
                 stmt = select(SecretModel.name, SecretModel.value).where(
                     SecretModel.name.in_(secret_requests),
@@ -91,6 +102,10 @@ class DatabaseSecretManager(SecretManager):
 
     def all(self) -> list[str]:
         """Return a list of all secret names in the database."""
+        from sqlalchemy import select
+
+        from flux.models import SecretModel
+
         with self.session() as session:
             stmt = select(SecretModel.name)
             result = [row[0] for row in session.execute(stmt)]

--- a/flux/workflow.py
+++ b/flux/workflow.py
@@ -7,7 +7,6 @@ from collections.abc import Callable
 
 from flux._concurrency import CANCELLED_CHECKPOINT_TIMEOUT
 from flux._namespace import validate_namespace
-from flux.context_managers import ContextManager
 from flux.domain.events import ExecutionState
 from flux.domain.execution_context import ExecutionContext
 from flux.domain.resource_request import ResourceRequest
@@ -378,6 +377,8 @@ class workflow:
         Returns:
             ExecutionContext: The updated execution context after resuming the workflow.
         """
+        from flux.context_managers import ContextManager
+
         ctx = ContextManager.create().get(execution_id)
         if input is not None:
             ctx.start_resuming(input)
@@ -386,4 +387,11 @@ class workflow:
         return asyncio.run(self(ctx))
 
     def _save(self, ctx: ExecutionContext):
+        # Imported here, not at module top: the persistence graph (SQLAlchemy
+        # and friends) is inline-path only, and a module-level import would
+        # drag it into every runner child and workflow-module exec (issue
+        # #233 — 185 ms of SQLAlchemy into a network=none sandbox that
+        # cannot open a database connection).
+        from flux.context_managers import ContextManager
+
         ContextManager.create().save(ctx)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.81.9"
+version = "0.81.10"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/e2e/fixtures/leanness_workflow.py
+++ b/tests/e2e/fixtures/leanness_workflow.py
@@ -1,0 +1,18 @@
+from flux import ExecutionContext, workflow
+
+
+@workflow
+async def leanness_probe(ctx: ExecutionContext):
+    """Report which heavyweight modules are loaded where user code runs.
+
+    The runner child must not carry the persistence graph (issue #233): by
+    the time a workflow body executes, sqlalchemy and flux.models must be
+    absent. Observed from inside rather than asserted from outside — this is
+    the real child process, whatever runner spawned it.
+    """
+    import sys
+
+    return {
+        "sqlalchemy": "sqlalchemy" in sys.modules,
+        "flux_models": "flux.models" in sys.modules,
+    }

--- a/tests/e2e/test_child_leanness.py
+++ b/tests/e2e/test_child_leanness.py
@@ -1,0 +1,25 @@
+"""The runner child's import graph, asserted end-to-end (issue #233).
+
+The unit guards in tests/flux/test_child_import_graph.py prove the modules
+import lean in isolation; this proves the property where it matters — inside
+the real child a live worker spawns, with the full dispatch/claim/checkpoint
+machinery in front of it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_user_code_runs_without_the_persistence_graph(cli):
+    cli.register(str(FIXTURES / "leanness_workflow.py"))
+
+    result = cli.run("leanness_probe", "null")
+
+    assert result["state"] == "COMPLETED"
+    loaded = result["output"]
+    assert loaded == {"sqlalchemy": False, "flux_models": False}, (
+        f"the child carried the persistence graph into user code: {loaded}"
+    )

--- a/tests/flux/test_child_import_graph.py
+++ b/tests/flux/test_child_import_graph.py
@@ -1,0 +1,76 @@
+"""The runner child's import graph stays lean (issue #233).
+
+The child is the per-execution entrypoint: for container runners its
+module-level imports are paid on every request, and profiling showed ~600ms
+before any user code — 185ms of it SQLAlchemy, imported into a network=none
+sandbox that cannot open a database connection. The persistence graph is
+server/inline-path only; a sandboxed child should not even be able to load
+it. These run a fresh interpreter per check so this file's own imports
+cannot mask a regression.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _imported_after(statement: str, module: str) -> bool:
+    code = f"import sys; {statement}; print({module!r} in sys.modules)"
+    out = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.strip() == "True"
+
+
+class TestChildStaysLean:
+    def test_child_does_not_import_sqlalchemy(self):
+        assert not _imported_after("import flux.runners.child", "sqlalchemy")
+
+    def test_child_does_not_import_flux_models(self):
+        assert not _imported_after("import flux.runners.child", "flux.models")
+
+    def test_runners_package_does_not_import_the_loader_graph(self):
+        """python -m flux.runners.child imports the package init first, so
+        an eager registry there would defeat every deferral below it."""
+        assert not _imported_after("import flux.runners", "flux.runners.loader")
+
+    def test_manager_abcs_do_not_pull_the_persistence_graph(self):
+        assert not _imported_after("import flux.config_manager", "sqlalchemy")
+        assert not _imported_after("import flux.secret_managers", "sqlalchemy")
+
+
+class TestLazySurfacesStillResolve:
+    def test_runner_registry_attributes(self):
+        from flux.runners import (  # noqa: F401
+            InProcessRunner,
+            Runner,
+            RunnerHooks,
+            SubprocessRunner,
+            WorkflowModuleLoader,
+        )
+
+    def test_database_managers_still_work(self, tmp_path):
+        from flux.config import Configuration
+
+        Configuration.get().override(database_url=f"sqlite:///{tmp_path / 'lean.db'}")
+        from flux.models import DatabaseRepository
+
+        DatabaseRepository._engines.clear()
+        try:
+            from flux.config_manager import DatabaseConfigManager
+
+            manager = DatabaseConfigManager()
+            manager.save("k", {"v": 1})
+            assert manager.all() == ["k"]
+
+            from flux.secret_managers import DatabaseSecretManager
+
+            secrets = DatabaseSecretManager()
+            secrets.save("s", "value")
+            assert secrets.all() == ["s"]
+        finally:
+            DatabaseRepository._engines.clear()

--- a/tests/flux/test_docker_runner.py
+++ b/tests/flux/test_docker_runner.py
@@ -147,3 +147,67 @@ async def test_docker_runner_executes_workflow_in_container():
     # 16 * 2 + len("0123456789") — the secret resolved through the parent pipe.
     assert result.output == 42
     assert checkpoints and checkpoints[-1].has_finished
+
+
+@pytest.mark.skipif(
+    not DOCKER_TEST_IMAGE,
+    reason="FLUX_TEST_DOCKER_IMAGE not set (needs an image with flux-core installed)",
+)
+@pytest.mark.asyncio
+async def test_container_child_runs_user_code_without_the_persistence_graph():
+    """Issue #233, asserted inside the real container: by the time the
+    workflow body runs, sqlalchemy and flux.models must be absent. For
+    container runners the import graph is paid per execution, and a sandboxed
+    child has no database to reach either way."""
+    from flux.domain.execution_context import ExecutionContext
+    from flux.runners.base import RunnerHooks
+    from flux.worker import WorkflowDefinition, WorkflowExecutionRequest
+
+    source = textwrap.dedent(
+        """
+        from flux import ExecutionContext, workflow
+
+        @workflow
+        async def lean_wf(ctx: ExecutionContext):
+            import sys
+            return {
+                "sqlalchemy": "sqlalchemy" in sys.modules,
+                "flux_models": "flux.models" in sys.modules,
+            }
+        """,
+    )
+
+    async def checkpoint(ctx):
+        pass
+
+    async def get_secrets(names):
+        return {}
+
+    async def get_configs(names):
+        return {}
+
+    request = WorkflowExecutionRequest(
+        workflow=WorkflowDefinition(
+            id="default/lean_wf",
+            namespace="default",
+            name="lean_wf",
+            version=1,
+            source=base64.b64encode(source.encode()).decode(),
+        ),
+        context=ExecutionContext(
+            workflow_id="default/lean_wf",
+            workflow_namespace="default",
+            workflow_name="lean_wf",
+            input=None,
+        ),
+    )
+    runner = DockerRunner(image=DOCKER_TEST_IMAGE, term_grace=10)
+    result = await runner.execute(
+        request,
+        RunnerHooks(checkpoint=checkpoint, get_secrets=get_secrets, get_configs=get_configs),
+    )
+
+    assert result.has_finished and not result.has_failed
+    assert result.output == {"sqlalchemy": False, "flux_models": False}, (
+        f"the container child carried the persistence graph into user code: {result.output}"
+    )


### PR DESCRIPTION
Closes #233.

## Problem

The runner child ran ~600ms of module-level imports before any user code — 185ms of it SQLAlchemy, into a `--network=none` sandbox with no database connection to make. Startup cost for a long-lived worker; **per-request cost for container runners**, where it measured as two-thirds of end-to-end latency. The reporter is right that it's a layering problem: removing the child's own imports changes nothing because the graph arrives transitively.

## The four edges, all cut

| Edge | Fix |
|---|---|
| `flux/runners/__init__.py` eagerly imported the whole registry, and `python -m flux.runners.child` imports the package init first | Runner classes load inside `create_runners`; module `__getattr__` keeps `from flux.runners import InProcessRunner` working |
| `flux/workflow.py` imported `ContextManager` at module level for two inline-path methods | Deferred into the methods — this also removes the graph from every **workflow-module exec**, not just the child |
| `flux/config_manager.py` / `flux/secret_managers.py` imported `models`/`sqlalchemy` at top for their `Database*` subclasses | Per-method imports, the pattern `worker_registry` already uses — the child imports these modules for the ABCs alone |

## Measured (local, same method as the issue)

- child module-level: **594ms → 66ms**
- total import work incl. the loader graph deferred into `_run`: **~670ms → ~260ms**
- `sqlalchemy` / `flux.models`: **never imported** in the child
- The ~196ms residual is pydantic/`flux.config`, which the child genuinely uses at runtime — a config-light child protocol would be the follow-up if more is wanted.

The isolation argument lands too: a sandboxed child now cannot load the DB layer, because nothing in its path references it.

## Verification

- Guard tests (`tests/flux/test_child_import_graph.py`), each in a fresh interpreter so this file's own imports can't mask a regression: child and manager ABCs must not pull `sqlalchemy`/`flux.models`; the runners package init must not pull the loader graph; the lazy surfaces resolve; both `Database*` managers still function against a real SQLite.
- Full unit tree: **2903 passed**. The fragile `flux/__init__` surfaces (`from flux import task/workflow`, `import flux.task`) exercised explicitly.
- **Real container verification**: `make test-docker` — the full docker + airgapped child-protocol suites against an image built from this tree: **109 passed** (and ~2s faster than the same suite pre-diet).

**Merge order:** after #236 (version bumps are stepped; this carries 0.81.10).