### PR TITLE
fix(config): warn on unknown keys, support [flux.workers.labels]

### DIFF
--- a/docs/advanced-features/worker-affinity.md
+++ b/docs/advanced-features/worker-affinity.md
@@ -22,6 +22,18 @@ flux start worker --label role=harness --label env=sandbox --label browser=true
 
 Multiple `--label` flags declare multiple labels. Label keys and values are strings.
 
+Labels can equally come from configuration — `[flux.workers.labels]` in
+`flux.toml`, or the `FLUX_WORKERS__LABELS` environment variable as JSON —
+which suits fleets whose config files are the deployment artifact:
+
+```toml
+[flux.workers.labels]
+role = "harness"
+env = "sandbox"
+```
+
+`--label` flags are applied on top and win on key conflicts.
+
 View a worker's labels:
 
 ```bash

--- a/flux.toml
+++ b/flux.toml
@@ -48,6 +48,13 @@ eviction_grace_period = 30                                  # Seconds to wait af
 cancellation_orphan_grace = 300                             # Seconds before the scheduler resolves a CANCELLING execution whose worker never returned (0 = wait forever); parked cancels resolve immediately
 join_token_retention = 86400                                # Seconds past expiry a join-token row is kept as audit trail before the hourly purge (0 = keep forever)
 
+# Capability labels, equivalent to repeated --label flags (--label wins per
+# key). A sub-table, so it must stay at the end of [flux.workers]: any key
+# after the header would belong to it.
+# [flux.workers.labels]
+# node = "node-a"
+# gpu = "true"
+
 [flux.security.encryption]
 # encryption_key = "<generate with: openssl rand -hex 32>"
 # Required for the secrets store. Set via FLUX_SECURITY__ENCRYPTION__ENCRYPTION_KEY

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -1497,8 +1497,21 @@ def start_worker(name: str | None, server_url: str | None = None, label: tuple[s
 
     # Config-file labels first, --label on top (per-key precedence for the
     # flag): [flux.workers] labels went silently ignored before it was a
-    # real field (issue #235).
-    labels = {str(k): str(v) for k, v in (settings.labels or {}).items()}
+    # real field (issue #235). Same normalization and fail-fast as the flag
+    # path — a whitespace-only key from config would otherwise register a
+    # label nothing can match.
+    labels = {}
+    for k, v in (settings.labels or {}).items():
+        key = str(k).strip()
+        value = str(v).strip()
+        if not key or not value:
+            click.echo(
+                f"Invalid label in [flux.workers] labels: {k!r} = {v!r}. "
+                "Label keys and values must be non-empty.",
+                err=True,
+            )
+            raise SystemExit(1)
+        labels[key] = value
     for item in label:
         if "=" not in item:
             click.echo(f"Invalid label format: '{item}'. Expected key=value.", err=True)

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -1495,7 +1495,10 @@ def start_worker(name: str | None, server_url: str | None = None, label: tuple[s
     settings = Configuration.get().settings.workers
     server_url = server_url or settings.server_url
 
-    labels = {}
+    # Config-file labels first, --label on top (per-key precedence for the
+    # flag): [flux.workers] labels went silently ignored before it was a
+    # real field (issue #235).
+    labels = {str(k): str(v) for k, v in (settings.labels or {}).items()}
     for item in label:
         if "=" not in item:
             click.echo(f"Invalid label format: '{item}'. Expected key=value.", err=True)

--- a/flux/config.py
+++ b/flux/config.py
@@ -136,6 +136,14 @@ class WorkersConfig(BaseConfig):
             "(0 = unbounded, the legacy behavior)"
         ),
     )
+    labels: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Capability labels this worker advertises at registration — the "
+            "config-file equivalent of repeated --label flags, which win on "
+            "key conflicts. The flux. prefix is reserved."
+        ),
+    )
     runners: list[str] = Field(
         default=["inprocess", "subprocess"],
         description=(
@@ -717,8 +725,38 @@ class FluxConfig(BaseSettings):
 
         filtered_config = drop_env_overrides(config)
 
+        # A key pydantic does not know is silently dropped, which reads as
+        # configured while doing nothing — and when the misconfiguration
+        # only parks work (a label that never matches), nothing ever
+        # surfaces it (issue #235). Warn on the pre-filter dict so keys
+        # shadowed by env vars are still checked.
+        cls._warn_unknown_keys(config, cls, "flux")
+
         # Create instance with toml values as fallback; env vars are applied by pydantic-settings
         return cls(**filtered_config)
+
+    @classmethod
+    def _warn_unknown_keys(cls, raw: dict, model: type[BaseModel], path: str) -> None:
+        import logging
+
+        fields = model.model_fields
+        for key, value in raw.items():
+            if key not in fields:
+                logging.getLogger("flux.config").warning(
+                    f"Unknown configuration key '{key}' in [{path}] — ignored. "
+                    f"Check for a typo; the shipped flux.toml documents the "
+                    f"full surface.",
+                )
+                continue
+            annotation = fields[key].annotation
+            # Descend only into typed sections; dict-valued fields (labels,
+            # AI provider descriptors) take arbitrary keys by design.
+            if (
+                isinstance(value, dict)
+                and isinstance(annotation, type)
+                and issubclass(annotation, BaseModel)
+            ):
+                cls._warn_unknown_keys(value, annotation, f"{path}.{key}")
 
     @staticmethod
     def _load_from_pyproject() -> dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.81.10"
+version = "0.81.11"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/e2e/test_require_affinity.py
+++ b/tests/e2e/test_require_affinity.py
@@ -80,3 +80,20 @@ def test_require_when_gate_waits_for_capable_worker(cli):
             cli.stop_worker(dedicated)
     finally:
         cli.stop_worker(plain)
+
+
+def test_config_sourced_labels_register_and_route(cli):
+    """[flux.workers] labels registers like --label (issue #235: it used to
+    be silently dropped). Env delivery here is the same pydantic-settings
+    path a flux.toml section takes."""
+    worker = cli.start_worker(
+        "cfg-label-worker",
+        env={"FLUX_WORKERS__LABELS": '{"region": "cfg-zone"}'},
+    )
+    try:
+        cli.register(str(FIXTURES / "require_workflow.py"))
+        r = cli.run("require_task", '{"region": "cfg-zone"}')
+        assert r["state"] == "COMPLETED"
+        assert r.get("current_worker") == "cfg-label-worker"
+    finally:
+        cli.stop_worker(worker)

--- a/tests/flux/test_cli.py
+++ b/tests/flux/test_cli.py
@@ -943,3 +943,20 @@ class TestWorkerLabelSources:
             {"node": "node-a", "region": "eu"},
         )
         assert labels == {"node": "node-b", "region": "eu", "gpu": "true"}
+
+    def test_config_labels_are_normalized_like_flags(self, runner):
+        labels = self._start(runner, [], {"  node  ": "  node-a  "})
+        assert labels == {"node": "node-a"}
+
+    def test_whitespace_only_config_label_fails_fast(self, runner):
+        from flux.config import Configuration
+
+        Configuration.get().override(workers={"labels": {"   ": "x"}})
+        try:
+            with patch("flux.worker.Worker") as worker_cls:
+                result = runner.invoke(cli, ["start", "worker", "w1"])
+            assert result.exit_code == 1
+            assert "Invalid label in [flux.workers] labels" in result.output
+            worker_cls.assert_not_called()
+        finally:
+            Configuration.get().override(workers={"labels": {}})

--- a/tests/flux/test_cli.py
+++ b/tests/flux/test_cli.py
@@ -913,3 +913,33 @@ class TestWorkflowCommandsNamespaceRouting:
         # pending approvals for the execution. Inspect the first call.
         first_call = mock_client.get.call_args_list[0]
         assert "/workflows/billing/invoice/status/exec-1" in first_call[0][0]
+
+
+class TestWorkerLabelSources:
+    """--label and [flux.workers] labels compose; the flag wins per key
+    (issue #235: config labels used to be silently dropped)."""
+
+    def _start(self, runner, args, config_labels):
+        from flux.config import Configuration
+
+        Configuration.get().override(workers={"labels": config_labels})
+        try:
+            with patch("flux.worker.Worker") as worker_cls:
+                worker_cls.return_value.start = MagicMock()
+                result = runner.invoke(cli, ["start", "worker", "w1", *args])
+                assert result.exit_code == 0, result.output
+                return worker_cls.call_args.kwargs["labels"]
+        finally:
+            Configuration.get().override(workers={"labels": {}})
+
+    def test_config_labels_reach_the_worker(self, runner):
+        labels = self._start(runner, [], {"node": "node-a"})
+        assert labels == {"node": "node-a"}
+
+    def test_flag_wins_on_key_conflict(self, runner):
+        labels = self._start(
+            runner,
+            ["--label", "node=node-b", "--label", "gpu=true"],
+            {"node": "node-a", "region": "eu"},
+        )
+        assert labels == {"node": "node-b", "region": "eu", "gpu": "true"}

--- a/tests/flux/test_config.py
+++ b/tests/flux/test_config.py
@@ -410,3 +410,67 @@ def test_configuration_update_nested_dict(reset_configuration):
     u = {"b": {"y": 3, "z": 4}}
     config._update_nested_dict(d, u)
     assert d == {"a": 1, "b": {"x": 1, "y": 3, "z": 4}}
+
+
+class TestUnknownKeyWarnings:
+    """Silent misconfiguration surface (issue #235): a key pydantic does not
+    know used to be dropped without a trace, reading as configured while
+    doing nothing."""
+
+    def _load_with(self, caplog, config: dict):
+        import logging
+
+        with (
+            patch.object(FluxConfig, "_load_from_config") as mock_config,
+            patch.object(FluxConfig, "_load_from_pyproject") as mock_pyproject,
+        ):
+            mock_config.return_value = config
+            mock_pyproject.return_value = {}
+            with caplog.at_level(logging.WARNING, logger="flux.config"):
+                return FluxConfig.load()
+
+    def test_unknown_top_level_key_warns_then_fails(self, caplog):
+        """Top-level unknowns already fail loudly (pydantic-settings forbids
+        extras at the root); the warning names the key first. Nested sections
+        are the ones that were silent."""
+        import pydantic
+
+        with pytest.raises(pydantic.ValidationError):
+            self._load_with(caplog, {"log_levl": "INFO"})
+        assert "Unknown configuration key 'log_levl' in [flux]" in caplog.text
+
+    def test_unknown_nested_key_names_its_section(self, caplog):
+        self._load_with(caplog, {"workers": {"hertbeat_interval": 5}})
+        assert "'hertbeat_interval' in [flux.workers]" in caplog.text
+
+    def test_known_keys_do_not_warn(self, caplog):
+        self._load_with(caplog, {"workers": {"heartbeat_interval": 5}})
+        assert "Unknown configuration key" not in caplog.text
+
+    def test_dict_valued_fields_take_arbitrary_keys_silently(self, caplog):
+        """labels and provider descriptors are open mappings by design."""
+        self._load_with(caplog, {"workers": {"labels": {"node": "node-a"}}})
+        assert "Unknown configuration key" not in caplog.text
+
+    def test_env_shadowed_keys_are_still_checked(self, caplog, monkeypatch):
+        """The warning walks the pre-filter dict, so a typo'd key is reported
+        even when an env var would have shadowed a sibling."""
+        monkeypatch.setenv("FLUX_WORKERS__HEARTBEAT_INTERVAL", "7")
+        self._load_with(
+            caplog,
+            {"workers": {"heartbeat_interval": 5, "hearbeat_timeout": 1}},
+        )
+        assert "'hearbeat_timeout' in [flux.workers]" in caplog.text
+
+
+class TestWorkerLabelsFromConfig:
+    def test_labels_field_parses(self):
+        with (
+            patch.object(FluxConfig, "_load_from_config") as mock_config,
+            patch.object(FluxConfig, "_load_from_pyproject") as mock_pyproject,
+        ):
+            mock_config.return_value = {"workers": {"labels": {"node": "node-a"}}}
+            mock_pyproject.return_value = {}
+            config = FluxConfig.load()
+
+        assert config.workers.labels == {"node": "node-a"}


### PR DESCRIPTION
Closes #235. Both asks, independently.

## 1. Unknown config keys warn

A key pydantic doesn't recognize was silently dropped — it *reads* as configured while doing nothing, and when the misconfiguration only parks work (a label that never matches), nothing ever surfaces it. The loader now walks the merged TOML dict against the config model tree before construction and logs a warning per unknown key, naming its section:

```
Unknown configuration key 'hertbeat_interval' in [flux.workers] — ignored. Check for a typo; ...
```

Notes on scope:
- **Top-level** unknowns already fail loudly (pydantic-settings forbids extras at the settings root) — the nested sections were the silent ones. The warning fires before the failure there too, so the key gets named either way.
- Dict-valued fields (`labels`, AI provider descriptors under `[flux.ai.providers.<name>]`) take arbitrary keys by design and are not descended into.
- The walk runs on the **pre-env-filter** dict, so a typo'd key is reported even when env vars shadow its siblings.
- Warn rather than reject for nested keys: rejection would break configs that carry keys from newer/older versions across up/downgrades. The loud path already exists at the root.

## 2. `[flux.workers.labels]` is real

The config-file equivalent of repeated `--label` flags; the CLI merges flags on top, winning per key. The `flux.toml` example is placed at the **end** of the `[flux.workers]` section with a comment saying why — a sub-table header mid-section would capture every key after it, which is exactly the class of trap this issue is about.

## Verification

- Config tests: unknown nested key warns with its section; known keys silent; dict-valued fields silent; env-shadowed typos still reported; top-level warns-then-fails; `labels` parses.
- CLI tests: config labels reach the worker; `--label` wins per key while non-conflicting config labels survive.
- E2E: a worker whose labels arrive via `FLUX_WORKERS__LABELS` (the same pydantic-settings path a `flux.toml` section takes) serves a `require(label("region") == input("region"))` workflow — 4 passed including the existing affinity scenarios.
- Docs: worker-affinity.md gains the config-file variant; flux.toml documents the sub-table.

**Merge order:** after #237 (version bumps are stepped; this carries 0.81.11).