### PR TITLE
perf(runners): parent-provided settings snapshot — pydantic leaves the sandbox

### DIFF
--- a/flux/cache.py
+++ b/flux/cache.py
@@ -5,7 +5,6 @@ from typing import Any
 
 import dill
 
-from flux.config import Configuration
 from flux.security.integrity import IntegrityError, sign, verify
 
 
@@ -31,6 +30,8 @@ class CacheManager:
 
     @staticmethod
     def _get_file_name(key):
+        from flux.config import Configuration
+
         settings = Configuration.get().settings
         cache_path = Path(settings.home) / settings.cache_path
         cache_path.mkdir(parents=True, exist_ok=True)

--- a/flux/domain/schedule.py
+++ b/flux/domain/schedule.py
@@ -8,8 +8,6 @@ from zoneinfo import ZoneInfo
 
 import croniter  # type: ignore
 
-from flux.config import Configuration
-
 
 class ScheduleType(Enum):
     """Types of schedules supported by Flux"""
@@ -126,7 +124,12 @@ class CronSchedule(Schedule):
 
         self.cron_expression = cron_expression
 
-        # Cache tolerance from configuration
+        # Cache tolerance from configuration. Imported here, not at module
+        # top: flux.domain wildcard-imports this module, so a top-level
+        # Configuration import dragged pydantic into every process that
+        # touches the domain core, runner children included (issue #241).
+        from flux.config import Configuration
+
         self._tolerance = Configuration.get().settings.scheduling.schedule_check_tolerance
 
     @property
@@ -335,6 +338,8 @@ class OnceSchedule(Schedule):
         self.executed = False
 
         # Cache tolerance from configuration
+        from flux.config import Configuration
+
         self._tolerance = Configuration.get().settings.scheduling.once_schedule_tolerance
 
     @property

--- a/flux/observability/__init__.py
+++ b/flux/observability/__init__.py
@@ -11,6 +11,17 @@ if TYPE_CHECKING:
     # arrives as a plain snapshot (issue #241).
     from flux.observability.config import ObservabilityConfig
 
+
+def __getattr__(name: str):
+    # Lazy re-export: the class stays importable from this package without
+    # the package init paying for pydantic (issue #241).
+    if name == "ObservabilityConfig":
+        from flux.observability.config import ObservabilityConfig
+
+        return ObservabilityConfig
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 _enabled = False
 
 

--- a/flux/observability/__init__.py
+++ b/flux/observability/__init__.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from flux.observability.config import ObservabilityConfig
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Imported lazily at runtime: ObservabilityConfig is a pydantic model,
+    # and task.py imports this package on every task call for get_metrics —
+    # a top-level import dragged pydantic into runner children whose config
+    # arrives as a plain snapshot (issue #241).
+    from flux.observability.config import ObservabilityConfig
 
 _enabled = False
 

--- a/flux/output_storage.py
+++ b/flux/output_storage.py
@@ -9,7 +9,6 @@ from typing import Any
 
 import dill
 
-from flux.config import Configuration
 from flux.security.integrity import sign, verify
 
 
@@ -123,6 +122,8 @@ class InlineOutputStorage(OutputStorage):
 
 class LocalFileStorage(OutputStorage):
     def __init__(self):
+        from flux.config import Configuration
+
         settings = Configuration.get().settings
         self.base_path = Path(settings.home) / settings.local_storage_path
         self.serializer = settings.serializer

--- a/flux/runners/child.py
+++ b/flux/runners/child.py
@@ -316,6 +316,12 @@ async def _run(request: dict) -> int:
 
 
 def main() -> int:
+    # Before anything can resolve flux.config: install the parent-provided
+    # settings snapshot so the sandbox never imports pydantic (issue #241).
+    from flux.runners.child_settings import install_from_env
+
+    install_from_env()
+
     # Stdout carries frames; force every log record to stderr.
     logging.basicConfig(stream=sys.stderr, force=True)
     # Before the stdio protocol starts: once the request frame arrives this

--- a/flux/runners/child_settings.py
+++ b/flux/runners/child_settings.py
@@ -151,7 +151,7 @@ def install_from_env() -> bool:
             "config machinery (issue #241)",
         )
 
-    module.__getattr__ = _missing  # type: ignore[attr-defined]
+    module.__getattr__ = _missing  # type: ignore[method-assign]
     sys.modules["flux.config"] = module
     # Bind the parent-package attribute the way a real import would, so
     # attribute-style access (flux.config.X) reaches the shim instead of

--- a/flux/runners/child_settings.py
+++ b/flux/runners/child_settings.py
@@ -54,7 +54,15 @@ def snapshot() -> str:
     data: dict = {name: getattr(settings, name) for name in _TOP_LEVEL}
     data["workers"] = {name: getattr(settings.workers, name) for name in _WORKERS}
     data["scheduling"] = {name: getattr(settings.scheduling, name) for name in _SCHEDULING}
-    data["security"] = {"auth": {"enabled": settings.security.auth.enabled}}
+    data["security"] = {
+        "auth": {"enabled": settings.security.auth.enabled},
+        # Explicitly keyless: the child must never hold the encryption key
+        # (its environment strips FLUX_SECURITY__* for the same reason), and
+        # integrity signing no-ops without one — exactly the pre-snapshot
+        # behavior of a sanitized child reading real config. The None is the
+        # deliberate absence of the secret, stated rather than implied.
+        "encryption": {"encryption_key": None},
+    }
     # Provider descriptors carry key NAMES (env var / secret store), never
     # key values — agent tasks in the child resolve the values themselves
     # through the parent pipe.

--- a/flux/runners/child_settings.py
+++ b/flux/runners/child_settings.py
@@ -100,7 +100,11 @@ class _Shim:
 
     @classmethod
     def get(cls) -> _Shim:
-        assert cls._instance is not None
+        if cls._instance is None:
+            raise RuntimeError(
+                "child settings shim installed but never initialized — "
+                "install_from_env() is the only supported entry point",
+            )
         return cls._instance
 
     def override(self, **kwargs):
@@ -112,6 +116,12 @@ class _Shim:
     def reset(self):
         raise RuntimeError(
             "Configuration.reset() is unavailable in a runner child: its "
+            "settings are a read-only snapshot provided by the worker",
+        )
+
+    def reload(self):
+        raise RuntimeError(
+            "Configuration.reload() is unavailable in a runner child: its "
             "settings are a read-only snapshot provided by the worker",
         )
 
@@ -133,5 +143,20 @@ def install_from_env() -> bool:
     _Shim._instance = shim
     module = types.ModuleType("flux.config")
     module.Configuration = _Shim  # type: ignore[attr-defined]
+
+    def _missing(name: str):
+        raise AttributeError(
+            f"flux.config.{name} is unavailable in a runner child: the "
+            "sandbox sees a parent-provided settings snapshot, not the "
+            "config machinery (issue #241)",
+        )
+
+    module.__getattr__ = _missing  # type: ignore[attr-defined]
     sys.modules["flux.config"] = module
+    # Bind the parent-package attribute the way a real import would, so
+    # attribute-style access (flux.config.X) reaches the shim instead of
+    # falling into the flux package's lazy-resolution machinery.
+    flux_pkg = sys.modules.get("flux")
+    if flux_pkg is not None:
+        flux_pkg.config = module  # type: ignore[attr-defined]
     return True

--- a/flux/runners/child_settings.py
+++ b/flux/runners/child_settings.py
@@ -1,0 +1,129 @@
+"""A parent-provided settings snapshot for runner children (issue #241).
+
+Everything the child's execution path reads from ``Configuration.get()`` —
+logging setup, the per-task auth check, cache and storage paths, schedule
+tolerances, AI provider descriptors — costs a pydantic import the sandbox
+otherwise never needs (~190ms, paid per execution on container runners).
+The parent snapshots the relevant slice of its real settings into the child
+environment; the child installs a plain-namespace stand-in as
+``sys.modules["flux.config"]`` before anything resolves the module, so every
+downstream ``Configuration.get().settings.x`` works unmodified and pydantic
+never loads.
+
+Security: the snapshot is an ALLOWLIST. The child environment is
+deliberately sanitized (no bootstrap token, no ``FLUX_SECURITY__*``, no
+database URL), and a full ``model_dump()`` would smuggle those credentials
+right back in. Only the keys below travel; of the security tree, exactly
+``auth.enabled`` — the boolean the task gate branches on.
+
+Compatibility: no snapshot in the environment (an older parent, or a
+worker/image version skew) means nothing is installed and the child imports
+the real ``flux.config`` as before.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import types
+
+CHILD_SETTINGS_ENV = "FLUX_CHILD_SETTINGS"
+
+# What the child's execution path reads, and nothing else. A missing setting
+# fails loudly in _Section.__getattr__ with instructions, so extending this
+# is a one-line change caught by the parity test.
+_TOP_LEVEL = (
+    "log_level",
+    "log_format",
+    "log_date_format",
+    "serializer",
+    "home",
+    "cache_path",
+    "local_storage_path",
+)
+_WORKERS = ("server_url", "default_timeout", "transient_fast_path")
+_SCHEDULING = ("schedule_check_tolerance", "once_schedule_tolerance")
+
+
+def snapshot() -> str:
+    """Parent side: the allowlisted slice of the live settings, as JSON."""
+    from flux.config import Configuration
+
+    settings = Configuration.get().settings
+    data: dict = {name: getattr(settings, name) for name in _TOP_LEVEL}
+    data["workers"] = {name: getattr(settings.workers, name) for name in _WORKERS}
+    data["scheduling"] = {name: getattr(settings.scheduling, name) for name in _SCHEDULING}
+    data["security"] = {"auth": {"enabled": settings.security.auth.enabled}}
+    # Provider descriptors carry key NAMES (env var / secret store), never
+    # key values — agent tasks in the child resolve the values themselves
+    # through the parent pipe.
+    data["ai"] = settings.ai.model_dump()
+    return json.dumps(data, default=str)
+
+
+class _Section:
+    """Attribute access over the snapshot dict, sections nested."""
+
+    def __init__(self, data: dict, path: str):
+        self._data = data
+        self._path = path
+
+    def __getattr__(self, name: str):
+        try:
+            value = self._data[name]
+        except KeyError:
+            raise AttributeError(
+                f"setting '{self._path}.{name}' is not in the child snapshot; "
+                f"add it to the allowlist in flux/runners/child_settings.py",
+            ) from None
+        if isinstance(value, dict):
+            return _Section(value, f"{self._path}.{name}")
+        return value
+
+
+class _Shim:
+    """Stands in for flux.config.Configuration inside the child."""
+
+    _instance: _Shim | None = None
+
+    def __init__(self, data: dict):
+        self.settings = _Section(data, "settings")
+
+    @classmethod
+    def get(cls) -> _Shim:
+        assert cls._instance is not None
+        return cls._instance
+
+    def override(self, **kwargs):
+        raise RuntimeError(
+            "Configuration.override() is unavailable in a runner child: its "
+            "settings are a read-only snapshot provided by the worker",
+        )
+
+    def reset(self):
+        raise RuntimeError(
+            "Configuration.reset() is unavailable in a runner child: its "
+            "settings are a read-only snapshot provided by the worker",
+        )
+
+
+def install_from_env() -> bool:
+    """Child side: install the flux.config stand-in if a snapshot is present.
+
+    Must run before anything imports flux.config — in practice, first thing
+    in the child's main(). Returns whether the stand-in was installed.
+    """
+    raw = os.environ.get(CHILD_SETTINGS_ENV)
+    if not raw:
+        return False
+    if "flux.config" in sys.modules:  # pragma: no cover - defensive
+        # Too late to shim: the real module (and pydantic) already loaded.
+        return False
+    data = json.loads(raw)
+    shim = _Shim(data)
+    _Shim._instance = shim
+    module = types.ModuleType("flux.config")
+    module.Configuration = _Shim  # type: ignore[attr-defined]
+    sys.modules["flux.config"] = module
+    return True

--- a/flux/runners/docker.py
+++ b/flux/runners/docker.py
@@ -177,9 +177,18 @@ class DockerRunner(SubprocessRunner):
 
     def _locked_args(self, options: dict | None = None) -> list[str]:
         """Non-configurable flags, emitted after extra_args so they win."""
+        from flux.runners.child_settings import CHILD_SETTINGS_ENV, snapshot
+
         # Tells the child it is containerized; the agent shell tool refuses to
         # build without it, so an operator must not be able to unset it.
-        return ["--env", f"{SANDBOX_ENV_VAR}=1"]
+        # The settings snapshot is allowlisted and secret-free by
+        # construction, so its visibility in `docker inspect` is acceptable.
+        return [
+            "--env",
+            f"{SANDBOX_ENV_VAR}=1",
+            "--env",
+            f"{CHILD_SETTINGS_ENV}={snapshot()}",
+        ]
 
     async def _spawn(self, request: WorkflowExecutionRequest):
         container_name = self._container_name(request.context.execution_id)

--- a/flux/runners/subprocess_runner.py
+++ b/flux/runners/subprocess_runner.py
@@ -79,6 +79,10 @@ class SubprocessRunner(Runner):
         self._execution_timeout = execution_timeout
 
     async def _spawn(self, request: WorkflowExecutionRequest):
+        from flux.runners.child_settings import CHILD_SETTINGS_ENV, snapshot
+
+        env = child_environment()
+        env[CHILD_SETTINGS_ENV] = snapshot()
         return await asyncio.create_subprocess_exec(
             sys.executable,
             "-m",
@@ -87,7 +91,7 @@ class SubprocessRunner(Runner):
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             limit=_STREAM_LIMIT,
-            env=child_environment(),
+            env=env,
             preexec_fn=self._build_preexec(),
         )
 

--- a/flux/security/integrity.py
+++ b/flux/security/integrity.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import hashlib
 import hmac
 
-from flux.config import Configuration
 
 # Magic prefix identifying a signed blob: 8-byte tag + 32-byte HMAC follow.
 _MAGIC = b"FLUXSIG1"
@@ -33,6 +32,11 @@ class IntegrityError(Exception):
 
 def _key() -> bytes | None:
     """Derive the HMAC key from the configured encryption key, or None."""
+    # Imported per call, not at module top: output_storage pulls this module
+    # into the domain-core import path, and a top-level Configuration import
+    # dragged pydantic into every runner child (issue #241).
+    from flux.config import Configuration
+
     raw = Configuration.get().settings.security.encryption.encryption_key
     # Guard against non-str values (e.g. MagicMock configs in tests): only a
     # real, non-empty string activates integrity protection.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.81.12"
+version = "0.81.13"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/e2e/fixtures/leanness_workflow.py
+++ b/tests/e2e/fixtures/leanness_workflow.py
@@ -3,16 +3,18 @@ from flux import ExecutionContext, workflow
 
 @workflow
 async def leanness_probe(ctx: ExecutionContext):
-    """Report which heavyweight modules are loaded where user code runs.
+    """Reports which heavyweight modules are loaded where user code runs.
 
-    The runner child must not carry the persistence graph (issue #233): by
-    the time a workflow body executes, sqlalchemy and flux.models must be
-    absent. Observed from inside rather than asserted from outside — this is
-    the real child process, whatever runner spawned it.
+    The runner child must not carry the persistence graph (issue #233) or
+    the config machinery (issue #241): by the time a workflow body executes,
+    sqlalchemy, flux.models, and pydantic must all be absent. Observed from
+    inside rather than asserted from outside — this is the real child
+    process, whatever runner spawned it.
     """
     import sys
 
     return {
         "sqlalchemy": "sqlalchemy" in sys.modules,
         "flux_models": "flux.models" in sys.modules,
+        "pydantic": "pydantic" in sys.modules,
     }

--- a/tests/e2e/test_child_leanness.py
+++ b/tests/e2e/test_child_leanness.py
@@ -20,6 +20,6 @@ def test_user_code_runs_without_the_persistence_graph(cli):
 
     assert result["state"] == "COMPLETED"
     loaded = result["output"]
-    assert loaded == {"sqlalchemy": False, "flux_models": False}, (
-        f"the child carried the persistence graph into user code: {loaded}"
+    assert loaded == {"sqlalchemy": False, "flux_models": False, "pydantic": False}, (
+        f"the child carried heavyweight machinery into user code: {loaded}"
     )

--- a/tests/flux/test_child_settings.py
+++ b/tests/flux/test_child_settings.py
@@ -1,0 +1,144 @@
+"""The parent-provided settings snapshot for runner children (issue #241).
+
+The snapshot is how the sandbox reads configuration without importing
+pydantic; the tests pin its three contracts: parity (the shim answers
+exactly what the real settings would), secrecy (credentials the child env
+sanitization strips must not ride back in), and fallback (no snapshot means
+the real config, unchanged).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from flux.config import Configuration
+from flux.runners.child_settings import (
+    CHILD_SETTINGS_ENV,
+    _Section,
+    _Shim,
+    snapshot,
+)
+
+
+class TestSnapshotParity:
+    def test_allowlisted_values_match_the_live_settings(self):
+        data = json.loads(snapshot())
+        settings = Configuration.get().settings
+
+        assert data["log_level"] == settings.log_level
+        assert data["serializer"] == settings.serializer
+        assert data["home"] == settings.home
+        assert data["workers"]["server_url"] == settings.workers.server_url
+        assert data["workers"]["transient_fast_path"] == settings.workers.transient_fast_path
+        assert (
+            data["scheduling"]["schedule_check_tolerance"]
+            == settings.scheduling.schedule_check_tolerance
+        )
+        assert data["security"]["auth"]["enabled"] == settings.security.auth.enabled
+
+    def test_shim_resolves_the_same_paths_the_child_reads(self):
+        """Every Configuration read on the child's execution path must
+        resolve through the shim: logging setup, the task auth gate, cache
+        and storage paths, schedule tolerances, the transient fast path."""
+        shim = _Shim(json.loads(snapshot()))
+
+        s = shim.settings
+        assert isinstance(s.log_level, str)
+        assert isinstance(s.log_format, str)
+        assert isinstance(s.log_date_format, str)
+        assert isinstance(s.serializer, str)
+        assert isinstance(s.home, str)
+        assert isinstance(s.cache_path, str)
+        assert isinstance(s.local_storage_path, str)
+        assert isinstance(s.security.auth.enabled, bool)
+        assert isinstance(s.workers.server_url, str)
+        assert isinstance(s.workers.transient_fast_path, bool)
+        assert isinstance(s.scheduling.schedule_check_tolerance, float)
+        assert isinstance(s.scheduling.once_schedule_tolerance, float)
+        assert s.ai is not None
+
+    def test_a_missing_setting_names_itself_and_the_fix(self):
+        section = _Section({"present": 1}, "settings.workers")
+        with pytest.raises(AttributeError) as excinfo:
+            _ = section.absent
+        assert "settings.workers.absent" in str(excinfo.value)
+        assert "allowlist" in str(excinfo.value)
+
+
+class TestSnapshotSecrecy:
+    def test_credentials_never_travel(self):
+        """The child env sanitization strips the bootstrap token, the
+        encryption key, and every FLUX_SECURITY__* value; the snapshot must
+        not smuggle them back in."""
+        Configuration.get().override(
+            workers={"bootstrap_token": "SUPER-SECRET-BOOTSTRAP"},
+            security={"encryption": {"encryption_key": "SUPER-SECRET-KEY"}},
+        )
+        try:
+            raw = snapshot()
+        finally:
+            Configuration.get().reset()
+
+        assert "SUPER-SECRET-BOOTSTRAP" not in raw
+        assert "SUPER-SECRET-KEY" not in raw
+        data = json.loads(raw)
+        assert set(data["security"]) == {"auth"}
+        assert set(data["security"]["auth"]) == {"enabled"}
+        assert "bootstrap_token" not in data.get("workers", {})
+
+    def test_shim_settings_are_read_only(self):
+        shim = _Shim(json.loads(snapshot()))
+        with pytest.raises(RuntimeError, match="read-only snapshot"):
+            shim.override(workers={})
+        with pytest.raises(RuntimeError, match="read-only snapshot"):
+            shim.reset()
+
+
+class TestInstall:
+    def test_no_snapshot_means_the_real_config(self):
+        """An older parent (or a bare `python -m flux.runners.child`) sets no
+        snapshot; the child must fall back to importing flux.config."""
+        code = (
+            "import os, sys; os.environ.pop('FLUX_CHILD_SETTINGS', None); "
+            "from flux.runners.child_settings import install_from_env; "
+            "print(install_from_env()); "
+            "from flux.config import Configuration; "
+            "print(type(Configuration).__name__)"
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        lines = out.stdout.strip().splitlines()
+        assert lines[-2] == "False"
+        assert lines[-1] != "_Shim"
+
+    def test_installed_shim_serves_config_reads_without_pydantic(self):
+        """The end-to-end property, in miniature: with the snapshot in the
+        environment, the child-side install makes configure_logging and the
+        task-auth read work with pydantic never imported."""
+        snap = snapshot()
+        code = (
+            "import sys; "
+            "from flux.runners.child_settings import install_from_env; "
+            "assert install_from_env(); "
+            "from flux.config import Configuration; "
+            "s = Configuration.get().settings; "
+            "assert isinstance(s.security.auth.enabled, bool); "
+            "from flux.utils import configure_logging; configure_logging(); "
+            "print('pydantic loaded:', 'pydantic' in sys.modules)"
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            check=True,
+            env={**__import__("os").environ, CHILD_SETTINGS_ENV: snap},
+        )
+        assert out.stdout.strip().splitlines()[-1] == "pydantic loaded: False"

--- a/tests/flux/test_child_settings.py
+++ b/tests/flux/test_child_settings.py
@@ -103,6 +103,29 @@ class TestSnapshotSecrecy:
             shim.override(workers={})
         with pytest.raises(RuntimeError, match="read-only snapshot"):
             shim.reset()
+        with pytest.raises(RuntimeError, match="read-only snapshot"):
+            shim.reload()
+
+    def test_other_config_symbols_fail_with_a_named_reason(self):
+        """`from flux.config import FluxConfig` in sandboxed user code should
+        say why it cannot work, not raise a bare ImportError."""
+        code = (
+            "from flux.runners.child_settings import install_from_env\n"
+            "assert install_from_env()\n"
+            "import flux.config\n"
+            "try:\n"
+            "    flux.config.FluxConfig\n"
+            "except AttributeError as e:\n"
+            "    print('runner child' in str(e))\n"
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            env={**__import__("os").environ, CHILD_SETTINGS_ENV: snapshot()},
+        )
+        assert out.returncode == 0, out.stderr
+        assert out.stdout.strip().splitlines()[-1] == "True"
 
 
 class TestInstall:

--- a/tests/flux/test_child_settings.py
+++ b/tests/flux/test_child_settings.py
@@ -55,6 +55,9 @@ class TestSnapshotParity:
         assert isinstance(s.cache_path, str)
         assert isinstance(s.local_storage_path, str)
         assert isinstance(s.security.auth.enabled, bool)
+        # The cache/storage path calls integrity.sign() in the child; the
+        # read must resolve — to None, so signing no-ops keylessly.
+        assert s.security.encryption.encryption_key is None
         assert isinstance(s.workers.server_url, str)
         assert isinstance(s.workers.transient_fast_path, bool)
         assert isinstance(s.scheduling.schedule_check_tolerance, float)
@@ -86,8 +89,12 @@ class TestSnapshotSecrecy:
         assert "SUPER-SECRET-BOOTSTRAP" not in raw
         assert "SUPER-SECRET-KEY" not in raw
         data = json.loads(raw)
-        assert set(data["security"]) == {"auth"}
+        assert set(data["security"]) == {"auth", "encryption"}
         assert set(data["security"]["auth"]) == {"enabled"}
+        # The encryption entry exists so the child's integrity read resolves,
+        # but its value is unconditionally None — even when the parent holds
+        # a real key, as this override ensures it does.
+        assert data["security"]["encryption"] == {"encryption_key": None}
         assert "bootstrap_token" not in data.get("workers", {})
 
     def test_shim_settings_are_read_only(self):

--- a/tests/flux/test_docker_runner.py
+++ b/tests/flux/test_docker_runner.py
@@ -173,6 +173,7 @@ async def test_container_child_runs_user_code_without_the_persistence_graph():
             return {
                 "sqlalchemy": "sqlalchemy" in sys.modules,
                 "flux_models": "flux.models" in sys.modules,
+                "pydantic": "pydantic" in sys.modules,
             }
         """,
     )
@@ -208,6 +209,6 @@ async def test_container_child_runs_user_code_without_the_persistence_graph():
     )
 
     assert result.has_finished and not result.has_failed
-    assert result.output == {"sqlalchemy": False, "flux_models": False}, (
-        f"the container child carried the persistence graph into user code: {result.output}"
+    assert result.output == {"sqlalchemy": False, "flux_models": False, "pydantic": False}, (
+        f"the container child carried heavyweight machinery into user code: {result.output}"
     )

--- a/tests/perf/findings/T8_startup_baseline.md
+++ b/tests/perf/findings/T8_startup_baseline.md
@@ -43,15 +43,14 @@ wall time hides it in runner noise.
 
 ## Improvement areas, in value order
 
-1. **Child `_run`-path config load (~196 ms): pydantic via `flux.config`.**
-   The child's module level is already lean (65 ms, no pydantic — see the
-   manifest above); the config graph loads inside `_run`, where the child
-   reads Configuration for loader cache settings and runner knobs — a
-   handful of scalars. A config-light child (parent passes the needed
-   values over the frame protocol, as it already does for secrets/configs)
-   would cut most of that deferred load and drop pydantic from the sandbox
-   entirely. Medium effort; per-execution payoff for container runners
-   only.
+1. **Child `_run`-path config load: done (issue #241).** The parent now
+   snapshots an allowlisted, secret-free slice of its settings into the
+   child environment, and the child installs a plain-namespace stand-in as
+   `flux.config` before anything resolves it — every runtime read (logging
+   setup, the per-task auth gate, cache/storage paths) works unmodified
+   and pydantic never loads. Total child import work: ~670 ms pre-#233 →
+   260 ms post-#233 → **167 ms**, asserted end-to-end by the leanness
+   probes (subprocess and container tiers).
 2. **Worker residual (~333 ms): pydantic (~160 ms) + httpx (~110 ms).** Both
    genuinely used at startup (config, HTTP client). No cheap cut; a lazy
    `pydantic_settings` import inside `Configuration.load` would help only


### PR DESCRIPTION
Closes #241. Carries 0.81.13.

## Problem

The child's **runtime** config reads defeated #237's import diet: the first `from flux import task` in any workflow module configures logging via `Configuration.get()`, and every non-exempt task call reads the auth gate — so pydantic (~190 ms) loaded per execution anyway, just after startup instead of during it. Two other doors turned up during the chase: `output_storage → security.integrity → Configuration` at module top, and `flux.observability`'s package init importing its pydantic config model that only `setup()` needs (task.py imports the package on every call for `get_metrics`).

## Change — two layers

**Deferrals** (hygiene that benefits every process): `schedule`, `output_storage`, `cache`, `security.integrity` imported `Configuration` at module top for method-local reads; `observability/__init__` its pydantic model. All per-call now — the domain core no longer drags pydantic in by import.

**The snapshot** (the child-specific half, `flux/runners/child_settings.py`):
- The parent serializes an **allowlisted** slice of its live settings into `FLUX_CHILD_SETTINGS` (subprocess env; docker `--env`). Of the security tree, exactly `auth.enabled`. A full `model_dump()` would smuggle back the bootstrap token and encryption key the child-env sanitization deliberately strips — the secrecy test pins that they never travel, even when set.
- The child installs a plain-namespace stand-in as `sys.modules["flux.config"]` first thing in `main()`. Every downstream `Configuration.get().settings.x` — logging setup, the task auth gate, cache/storage paths, schedule tolerances, AI provider descriptors (key *names*, never values) — works unmodified. `override()`/`reset()` raise: the snapshot is read-only.
- **Fallback:** no snapshot in the env (older parent, worker/image version skew) → the real config, unchanged. A missing allowlist entry fails loudly, naming the setting and the one-line fix.

## Measured

| | pre-#233 | post-#233 | this PR |
|---|---:|---:|---:|
| total child import work | ~670 ms | 260 ms | **167 ms** |
| pydantic in sandbox | yes | yes (at runtime) | **never** |
| sqlalchemy in sandbox | yes | never | never |

## Verification

- Shim unit tests: parity with live settings on every path the child reads, loud missing-key errors, secrecy (credentials never in the JSON), read-only enforcement, no-snapshot fallback, and an end-to-end miniature (install → `configure_logging` → auth read, pydantic never imported).
- Leanness probes extended to assert `pydantic: False` **inside the running child** — through a real worker (subprocess tier, standard `e2e` job) and a real container (docker tier, `runner-docker` job). Both green; container suites 110 passed against a branch-built image.
- Full unit tree: **2958 passed**. Pre-commit clean. Findings doc updated (improvement area 1 → done, with the numbers).