### PR TITLE
fix(cli): flux agent stop cancels through the route the server actually serves

### DIFF
--- a/flux/cli.py
+++ b/flux/cli.py
@@ -3228,31 +3228,40 @@ def start_agent(name, mode, session_id, port, host, allow_origins, allow_remote,
 
 @agent.command("stop")
 @click.argument("session_id")
-def stop_agent(session_id):
+@click.option("--server-url", "server_url", default=None, help="Flux server URL")
+def stop_agent(session_id, server_url):
     """Stop a running agent session."""
-    import httpx
-
-    from flux.config import Configuration
-
     click.echo(f"Stopping session {session_id}...")
 
     try:
-        settings = Configuration.get().settings
-        server_url = f"http://{settings.server_host}:{settings.server_port}"
-        token = _get_auth_token()
+        base_url = server_url or get_server_url()
 
-        headers: dict[str, str] = {"Content-Type": "application/json"}
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
+        with get_http_client() as client:
+            # Cancellation is workflow-scoped (same route `flux workflow
+            # cancel` uses); there is no /executions/{id}/cancel. A session is
+            # an execution, so its workflow comes from the execution itself
+            # rather than from the caller.
+            lookup = client.get(f"{base_url}/executions/{session_id}")
+            lookup.raise_for_status()
+            execution = lookup.json()
+            namespace = execution["workflow_namespace"]
+            workflow_name = execution["workflow_name"]
 
-        response = httpx.post(
-            f"{server_url}/executions/{session_id}/cancel",
-            headers=headers,
-        )
-        response.raise_for_status()
+            response = client.get(
+                f"{base_url}/workflows/{namespace}/{workflow_name}/cancel/{session_id}",
+            )
+            response.raise_for_status()
+
         click.echo(f"Session {session_id} stopped.")
+    except httpx.HTTPStatusError as ex:
+        if ex.response.status_code == 404:
+            click.echo(f"Session '{session_id}' not found.", err=True)
+        else:
+            click.echo(f"Error stopping session: {str(ex)}", err=True)
+        raise SystemExit(1) from None
     except Exception as ex:
         click.echo(f"Error stopping session: {str(ex)}", err=True)
+        raise SystemExit(1) from None
 
 
 @agent.group("session")

--- a/flux/cli.py
+++ b/flux/cli.py
@@ -3241,8 +3241,19 @@ def stop_agent(session_id, server_url):
             # cancel` uses); there is no /executions/{id}/cancel. A session is
             # an execution, so its workflow comes from the execution itself
             # rather than from the caller.
-            lookup = client.get(f"{base_url}/executions/{session_id}")
-            lookup.raise_for_status()
+            try:
+                lookup = client.get(f"{base_url}/executions/{session_id}")
+                lookup.raise_for_status()
+            except httpx.HTTPStatusError as ex:
+                # Only the lookup can establish that the session does not
+                # exist. A 404 from the cancel below means something else
+                # (workflow mismatch, route change) and must not be reported
+                # as a missing session.
+                if ex.response.status_code == 404:
+                    click.echo(f"Session '{session_id}' not found.", err=True)
+                    raise SystemExit(1) from None
+                raise
+
             execution = lookup.json()
             namespace = execution["workflow_namespace"]
             workflow_name = execution["workflow_name"]
@@ -3253,12 +3264,6 @@ def stop_agent(session_id, server_url):
             response.raise_for_status()
 
         click.echo(f"Session {session_id} stopped.")
-    except httpx.HTTPStatusError as ex:
-        if ex.response.status_code == 404:
-            click.echo(f"Session '{session_id}' not found.", err=True)
-        else:
-            click.echo(f"Error stopping session: {str(ex)}", err=True)
-        raise SystemExit(1) from None
     except Exception as ex:
         click.echo(f"Error stopping session: {str(ex)}", err=True)
         raise SystemExit(1) from None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.83.0"
+version = "0.83.1"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/e2e/test_agent_console.py
+++ b/tests/e2e/test_agent_console.py
@@ -417,6 +417,30 @@ def test_session_flow_spawn_send_rename_stop(console):
     console.wait_for_state(session_id, "CANCELLED")
 
 
+def test_cli_agent_stop_cancels_a_live_session(console, cli):
+    """`flux agent stop` against a real server (issue #243).
+
+    The command used to POST /executions/{id}/cancel -- a route the server
+    does not serve -- so it 404'd on every invocation while still exiting 0.
+    Only a real stack catches a missing route, which is why this lives here
+    rather than in the CliRunner tests.
+    """
+    session_id = console.create_session(PLAIN_AGENT)
+
+    result = cli._run(["agent", "stop", session_id])
+
+    assert result.returncode == 0, f"stdout={result.stdout} stderr={result.stderr}"
+    assert "stopped" in result.stdout
+    console.wait_for_state(session_id, "CANCELLED")
+
+
+def test_cli_agent_stop_reports_an_unknown_session(console, cli):
+    result = cli._run(["agent", "stop", "does-not-exist"])
+
+    assert result.returncode == 1
+    assert "not found" in (result.stdout + result.stderr)
+
+
 def test_custom_workflow_agent_runs_its_own_workflow(console):
     """An agent shipping a ``workflow_file`` gets its own registered workflow."""
     session_id = console.create_session(CUSTOM_AGENT, name="custom session")

--- a/tests/flux/test_cli.py
+++ b/tests/flux/test_cli.py
@@ -1350,6 +1350,17 @@ class TestAgentSessionResumeCLI:
         assert "Error resuming session: boom" in result.output
 
 
+def _status_error(status: int, url: str):
+    """An `httpx.HTTPStatusError` shaped like the one `raise_for_status()`
+    raises -- carrying its originating request, so handlers can inspect the
+    failing URL."""
+    import httpx
+
+    request = httpx.Request("GET", url)
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError(f"{status}", request=request, response=response)
+
+
 class TestAgentStop:
     """`flux agent stop` cancels through the workflow-scoped route.
 
@@ -1358,7 +1369,7 @@ class TestAgentStop:
     reporting the failure with exit code 0.
     """
 
-    def _client(self, execution=None, cancel_status=200):
+    def _client(self, execution=None, cancel_error=None):
         client = MagicMock()
         lookup = MagicMock()
         lookup.json.return_value = execution or {
@@ -1367,6 +1378,8 @@ class TestAgentStop:
             "workflow_name": "agent_chat",
         }
         cancel = MagicMock()
+        if cancel_error is not None:
+            cancel.raise_for_status.side_effect = cancel_error
         client.get.side_effect = [lookup, cancel]
         client.__enter__ = MagicMock(return_value=client)
         client.__exit__ = MagicMock(return_value=False)
@@ -1406,11 +1419,8 @@ class TestAgentStop:
         )
 
     def test_unknown_session_reports_clearly_and_exits_nonzero(self, runner):
-        import httpx
-
         client = MagicMock()
-        response = httpx.Response(404, request=httpx.Request("GET", "http://s/executions/nope"))
-        client.get.side_effect = httpx.HTTPStatusError("404", request=None, response=response)
+        client.get.side_effect = _status_error(404, "http://s/executions/nope")
         client.__enter__ = MagicMock(return_value=client)
         client.__exit__ = MagicMock(return_value=False)
 
@@ -1419,6 +1429,20 @@ class TestAgentStop:
 
         assert result.exit_code == 1
         assert "not found" in result.output
+
+    def test_a_404_from_the_cancel_is_not_reported_as_a_missing_session(self, runner):
+        """Only the lookup can establish that a session does not exist; a 404
+        from the cancel means something else (workflow mismatch, route
+        change) and saying "not found" would point at the wrong cause."""
+        client = self._client(
+            cancel_error=_status_error(404, "http://s/workflows/agents/agent_chat/cancel/exec-1"),
+        )
+        with patch("flux.cli.get_http_client", return_value=client):
+            result = runner.invoke(cli, ["agent", "stop", "exec-1"])
+
+        assert result.exit_code == 1
+        assert "not found" not in result.output
+        assert "Error stopping session" in result.output
 
     def test_cancel_failure_exits_nonzero(self, runner):
         """A printed error with exit 0 reads as success to a script."""

--- a/tests/flux/test_cli.py
+++ b/tests/flux/test_cli.py
@@ -1348,3 +1348,87 @@ class TestAgentSessionResumeCLI:
 
         assert result.exit_code != 0
         assert "Error resuming session: boom" in result.output
+
+
+class TestAgentStop:
+    """`flux agent stop` cancels through the workflow-scoped route.
+
+    There is no ``POST /executions/{id}/cancel`` on the server (issue #243) --
+    the command used to post to it and 404 on every invocation, while
+    reporting the failure with exit code 0.
+    """
+
+    def _client(self, execution=None, cancel_status=200):
+        client = MagicMock()
+        lookup = MagicMock()
+        lookup.json.return_value = execution or {
+            "execution_id": "exec-1",
+            "workflow_namespace": "agents",
+            "workflow_name": "agent_chat",
+        }
+        cancel = MagicMock()
+        client.get.side_effect = [lookup, cancel]
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+        return client
+
+    def test_stop_cancels_through_the_execution_s_own_workflow(self, runner):
+        client = self._client()
+        with patch("flux.cli.get_http_client", return_value=client):
+            result = runner.invoke(cli, ["agent", "stop", "exec-1"])
+
+        assert result.exit_code == 0, result.output
+        urls = [call.args[0] for call in client.get.call_args_list]
+        assert urls[0].endswith("/executions/exec-1")
+        assert urls[1].endswith("/workflows/agents/agent_chat/cancel/exec-1")
+        assert "stopped" in result.output
+
+    def test_custom_workflow_session_cancels_under_its_own_workflow(self, runner):
+        """An agent shipping a workflow_file runs as agent_custom_<name>, so
+        the workflow cannot be assumed."""
+        client = self._client(
+            execution={
+                "execution_id": "exec-2",
+                "workflow_namespace": "agents",
+                "workflow_name": "agent_custom_reviewer",
+            },
+        )
+        with patch("flux.cli.get_http_client", return_value=client):
+            result = runner.invoke(cli, ["agent", "stop", "exec-2"])
+
+        assert result.exit_code == 0, result.output
+        assert (
+            client.get.call_args_list[1]
+            .args[0]
+            .endswith(
+                "/workflows/agents/agent_custom_reviewer/cancel/exec-2",
+            )
+        )
+
+    def test_unknown_session_reports_clearly_and_exits_nonzero(self, runner):
+        import httpx
+
+        client = MagicMock()
+        response = httpx.Response(404, request=httpx.Request("GET", "http://s/executions/nope"))
+        client.get.side_effect = httpx.HTTPStatusError("404", request=None, response=response)
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+
+        with patch("flux.cli.get_http_client", return_value=client):
+            result = runner.invoke(cli, ["agent", "stop", "nope"])
+
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+    def test_cancel_failure_exits_nonzero(self, runner):
+        """A printed error with exit 0 reads as success to a script."""
+        client = MagicMock()
+        client.get.side_effect = RuntimeError("boom")
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+
+        with patch("flux.cli.get_http_client", return_value=client):
+            result = runner.invoke(cli, ["agent", "stop", "exec-1"])
+
+        assert result.exit_code == 1
+        assert "Error stopping session" in result.output


### PR DESCRIPTION
Closes #243.

`flux agent stop <session>` posted to `POST /executions/{id}/cancel` — a route the server does not serve. Every invocation 404'd, and because the failure was printed from a bare `except Exception` with no re-raise, the command still exited 0: a script or CI caller read the failure as success.

## The fix

It now resolves the session's own workflow and cancels through the workflow-scoped route, the same one `flux workflow cancel` and the console's stop button use:

```
GET /executions/{id}                                  → workflow_namespace, workflow_name
GET /workflows/{ns}/{workflow}/cancel/{execution_id}
```

The workflow is read from the execution rather than assumed, because an agent shipping a `workflow_file` runs as `agent_custom_<name>`, not `agent_chat`. Failures now exit 1, an unknown session reports "not found", and the command gained `--server-url` for parity with its sibling agent commands.

## Tests

Four CliRunner tests — the happy path asserting **both** request URLs, a custom-workflow session cancelling under its own workflow, an unknown session, and a failure exiting non-zero. All four were verified red against the previous implementation.

Two e2e tests against a real server + worker, because a missing route is exactly what mocked unit tests cannot catch: `flux agent stop` on a live session exits 0 and drives the execution to `CANCELLED`, and an unknown id exits 1.

## Verification

| Gate | Result |
|---|---|
| `tests/flux/` | 3168 passed, 11 skipped |
| `tests/e2e/test_agent_console.py` | 8 passed |
| `pre-commit` (incl. cold mypy) | clean |
| Version | 0.83.0 → 0.83.1 |