### PR TITLE
fix(engine): record a task's start when it first runs in a resumed run

### DIFF
--- a/docs/advanced-features/agent-console.md
+++ b/docs/advanced-features/agent-console.md
@@ -119,14 +119,13 @@ overlay on top of it.
   appear on the open session. This is a deliberate v1 limit — no per-row
   detail fetches.
 
-Tool calls are ordinary Flux tasks, so the log carries their real names,
-outputs and durations. Two shapes are worth knowing about because the console
-handles them for you: executions logged before the engine recorded starts in
-resumed runs carry a completion with no matching start, and task outputs are
-stored as output-storage envelopes rather than bare values. The
-console reconstructs the call from its completion event and unwraps inline
-outputs; a value kept outside the log (e.g. `local_file` storage) is named
-rather than dumped.
+Tool calls are ordinary Flux tasks, so the log carries their real names, args
+and outputs, and a duration for every call whose start and terminal events are
+both present — which the engine records per call, including calls that begin
+in a resumed run. One shape is worth knowing about because the console handles
+it for you: task outputs are stored as output-storage envelopes rather than
+bare values, so the console unwraps inline outputs and names a value kept
+outside the log (e.g. `local_file` storage) rather than dumping it.
 
 ## Permissions
 

--- a/docs/advanced-features/agent-console.md
+++ b/docs/advanced-features/agent-console.md
@@ -121,9 +121,9 @@ overlay on top of it.
 
 Tool calls are ordinary Flux tasks, so the log carries their real names,
 outputs and durations. Two shapes are worth knowing about because the console
-handles them for you: a task that starts in a *resumed* run records no
-`TASK_STARTED` event (every tool call after a session's first turn), and task
-outputs are stored as output-storage envelopes rather than bare values. The
+handles them for you: executions logged before the engine recorded starts in
+resumed runs carry a completion with no matching start, and task outputs are
+stored as output-storage envelopes rather than bare values. The
 console reconstructs the call from its completion event and unwraps inline
 outputs; a value kept outside the log (e.g. `local_file` storage) is named
 rather than dumped.

--- a/flux/agents/ui/textual_app.py
+++ b/flux/agents/ui/textual_app.py
@@ -285,27 +285,13 @@ def derive_blocks(
             blocks.append(ChatBlock("tool", tool=tool, time=when))
 
         elif event_type in ("TASK_COMPLETED", "TASK_FAILED", "TASK_CANCELLED"):
+            # Every terminal event has a start: the engine records one per
+            # call, including calls that begin in a resumed run (#244). An
+            # unmatched terminal event is an internal task filtered above,
+            # or an engine bug -- not a shape to reconstruct from.
             started_tool = tools.get(str(event.get("source_id")))
             if started_tool is None:
-                # A completion with no start: every task begun in a resumed
-                # run looked like this until #244 (task.py suppressed
-                # TASK_STARTED for the whole resumed run), which is every
-                # tool call after a session's first turn. Executions logged
-                # before that fix still read back this way, so the recovery
-                # stays — dropping these would blank tool activity from an
-                # existing transcript at every turn boundary.
-                name = event.get("name") or ""
-                if INTERNAL_TASK.match(name):
-                    continue
-                started_tool = ToolCall(
-                    id=str(event.get("source_id") or name),
-                    name=name,
-                    # No start event means no start time; leave it unset so
-                    # the duration is omitted rather than invented.
-                    started=None,
-                )
-                tools[started_tool.id] = started_tool
-                blocks.append(ChatBlock("tool", tool=started_tool, time=when))
+                continue
             started_tool.status = {
                 "TASK_COMPLETED": "success",
                 "TASK_FAILED": "failed",

--- a/flux/agents/ui/textual_app.py
+++ b/flux/agents/ui/textual_app.py
@@ -287,15 +287,13 @@ def derive_blocks(
         elif event_type in ("TASK_COMPLETED", "TASK_FAILED", "TASK_CANCELLED"):
             started_tool = tools.get(str(event.get("source_id")))
             if started_tool is None:
-                # A completion with no start is the normal shape for every
-                # task that begins in a *resumed* run: task.py suppresses
-                # TASK_STARTED while `ctx.has_resumed`, and that stays true
-                # for the whole resumed run (it reads the last *workflow*
-                # event, which remains WORKFLOW_RESUMED until the next
-                # pause). Since an agent's tool calls all happen after the
-                # session's first resume, dropping these would blank tool
-                # activity from the transcript at every turn boundary.
-                # Verified end to end in tests/e2e/test_agent_console.py.
+                # A completion with no start: every task begun in a resumed
+                # run looked like this until #244 (task.py suppressed
+                # TASK_STARTED for the whole resumed run), which is every
+                # tool call after a session's first turn. Executions logged
+                # before that fix still read back this way, so the recovery
+                # stays — dropping these would blank tool activity from an
+                # existing transcript at every turn boundary.
                 name = event.get("name") or ""
                 if INTERNAL_TASK.match(name):
                     continue

--- a/flux/agents/web/console.js
+++ b/flux/agents/web/console.js
@@ -480,28 +480,12 @@ function applyDetail(detail) {
       case "TASK_COMPLETED":
       case "TASK_FAILED":
       case "TASK_CANCELLED": {
-        let tool = tools.get(event.source_id);
-        if (!tool) {
-          // A completion with no start: every task begun in a resumed run
-          // looked like this until #244 (the engine suppressed TASK_STARTED
-          // for the whole resumed run), which is every tool an agent called
-          // after its first turn. Executions logged before that fix still
-          // read back this way, so render from the completion alone.
-          if (INTERNAL_TASK.test(event.name || "")) break;
-          tool = {
-            id: event.source_id,
-            name: event.name,
-            args: undefined,
-            output: undefined,
-            status: "running",
-            // No start event means no start time; leave it null so the
-            // duration is omitted rather than invented.
-            started: null,
-            ended: null,
-          };
-          tools.set(event.source_id, tool);
-          blocks.push({ kind: "tool", tool });
-        }
+        // Every terminal event has a start: the engine records one per call,
+        // including calls that begin in a resumed run (#244). An unmatched
+        // terminal event is an internal task filtered above, or an engine
+        // bug -- not a shape to reconstruct from.
+        const tool = tools.get(event.source_id);
+        if (!tool) break;
         tool.status =
           event.type === "TASK_COMPLETED"
             ? "success"

--- a/flux/agents/web/console.js
+++ b/flux/agents/web/console.js
@@ -482,12 +482,11 @@ function applyDetail(detail) {
       case "TASK_CANCELLED": {
         let tool = tools.get(event.source_id);
         if (!tool) {
-          // A completion with no start is the normal shape for every task
-          // that begins in a *resumed* run: the engine suppresses
-          // TASK_STARTED while the execution counts as resumed (task.py),
-          // which covers every tool an agent calls after its first turn.
-          // Dropping these would blank tool activity from the transcript at
-          // every turn boundary, so render from the completion alone.
+          // A completion with no start: every task begun in a resumed run
+          // looked like this until #244 (the engine suppressed TASK_STARTED
+          // for the whole resumed run), which is every tool an agent called
+          // after its first turn. Executions logged before that fix still
+          // read back this way, so render from the completion alone.
           if (INTERNAL_TASK.test(event.name || "")) break;
           tool = {
             id: event.source_id,

--- a/flux/task.py
+++ b/flux/task.py
@@ -727,14 +727,11 @@ class task:
         full_name: str,
         args: tuple,
         kwargs: dict,
-    ) -> bool:
+    ) -> None:
         """Run the approval gate for one task attempt identified by ``call_id``.
 
-        Returns ``True`` when the gate consumed a resume transition for this
-        task (an approval decided while the execution was suspended), so the
-        caller knows to still emit ``TASK_STARTED`` for the gated task even
-        though ``ctx`` is no longer ``is_resuming``. Returns ``False`` when
-        approved without resuming or when no approval is required. Raises
+        Returns nothing: the gate either lets the call proceed or raises.
+        Raises
         ``ApprovalRejected`` on rejection, ``asyncio.CancelledError`` on
         cancellation, and ``PauseRequested`` (via ``ctx._await_approval``)
         while waiting for a decision. An unexpected gate failure — a
@@ -749,7 +746,7 @@ class task:
         every attempt is independently re-gated.
         """
         if self.requires_approval is False:
-            return False
+            return
 
         if ctx.is_transient:
             # The gate's verdict lives in a durable row another process
@@ -776,7 +773,7 @@ class task:
                 verdict_required = await self._evaluate_approval_predicate(args, kwargs)
 
             if not verdict_required:
-                return False
+                return
 
             if existing is None:
                 target_value = self._resolve_approval_target(args, kwargs)
@@ -836,12 +833,10 @@ class task:
 
         # Approved. If this gate is the point a paused workflow resumed from,
         # transition the context back to RUNNING — mirroring the pause()
-        # primitive — so subsequent task calls no longer see the execution as
-        # resuming and emit their TASK_STARTED events.
+        # primitive — so the rest of the run sees a running execution rather
+        # than a resuming one.
         if ctx.is_resuming:
             ctx.resume()
-            return True
-        return False
 
     async def _record_gate_failure(
         self,

--- a/flux/task.py
+++ b/flux/task.py
@@ -471,13 +471,23 @@ class task:
         # Approval gate — evaluated after auth and the replay short-circuit.
         # ``task_id`` doubles as the approval ``task_call_id`` for the
         # initial call; each retry attempt is gated under its own id.
-        gate_resumed = await self._approval_gate(ctx, task_id, full_name, args, kwargs)
+        await self._approval_gate(ctx, task_id, full_name, args, kwargs)
 
         from flux._task_context import _CURRENT_TASK
 
         task_token = _CURRENT_TASK.set((task_id, full_name))
         try:
-            if gate_resumed or (not ctx.is_resuming and not ctx.has_resumed):
+            # Per call, not per run (issue #244). Replay returns above for any
+            # call with a terminal event, so a call reaching here is running
+            # now and owes the log a start. The one exception is the call that
+            # was in flight when the execution parked — `pause` itself, or a
+            # task suspended at its approval gate: it already recorded a
+            # start, and the body re-running must not append a second.
+            already_started = any(
+                e.type == ExecutionEventType.TASK_STARTED and e.source_id == task_id
+                for e in ctx.events
+            )
+            if not already_started:
                 ctx.events.append(
                     ExecutionEvent(
                         type=ExecutionEventType.TASK_STARTED,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.83.1"
+version = "0.83.2"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/e2e/test_agent_console.py
+++ b/tests/e2e/test_agent_console.py
@@ -387,11 +387,10 @@ def test_session_flow_spawn_send_rename_stop(console):
     tool_start = next(f for f in frames if f["kind"] == "tool_start")
     assert tool_start["data"]["name"] == "search_docs"
 
-    # ...and durably, in the log the detail endpoint returns. Note the log
-    # carries only the *completion*: the engine suppresses TASK_STARTED for
-    # tasks that begin in a resumed run, which is every tool call an agent
-    # makes after its first turn, so both renderers rebuild the tool from
-    # this event alone (see derive_blocks / applyDetail).
+    # ...and durably, in the log the detail endpoint returns. Since #244 the
+    # log carries both halves for a tool called after a resume; renderers
+    # still rebuild from a lone completion for executions logged before that
+    # fix (see derive_blocks / applyDetail).
     detail = console.json(f"/console/sessions/{session_id}/detail")
     events = detail["events"]
     completed = [

--- a/tests/e2e/test_agent_console.py
+++ b/tests/e2e/test_agent_console.py
@@ -387,16 +387,21 @@ def test_session_flow_spawn_send_rename_stop(console):
     tool_start = next(f for f in frames if f["kind"] == "tool_start")
     assert tool_start["data"]["name"] == "search_docs"
 
-    # ...and durably, in the log the detail endpoint returns. Since #244 the
-    # log carries both halves for a tool called after a resume; renderers
-    # still rebuild from a lone completion for executions logged before that
-    # fix (see derive_blocks / applyDetail).
+    # ...and durably, in the log the detail endpoint returns. Both halves are
+    # there for a tool called after a resume (#244), which is what gives the
+    # activity panel a duration.
     detail = console.json(f"/console/sessions/{session_id}/detail")
     events = detail["events"]
     completed = [
         e for e in events if e["type"] == "TASK_COMPLETED" and e.get("name") == "search_docs"
     ]
     assert completed, f"search_docs missing from the log: {[e['type'] for e in events]}"
+    # The tool ran on a resumed run (every turn after the first is one), and
+    # its start is in the log paired to the same call -- the invariant #244
+    # restored, proven against a real stack rather than a fixture.
+    started = [e for e in events if e["type"] == "TASK_STARTED" and e.get("name") == "search_docs"]
+    assert started, f"search_docs start missing: {[e['type'] for e in events]}"
+    assert started[0]["source_id"] == completed[0]["source_id"]
     # Task outputs are logged as output-storage envelopes, never bare values;
     # both renderers unwrap them (unwrap_output / unwrapOutput) so the panel
     # shows the tool's result instead of storage bookkeeping.

--- a/tests/flux/agents/console/test_tui.py
+++ b/tests/flux/agents/console/test_tui.py
@@ -1008,11 +1008,10 @@ def test_derive_blocks_mirrors_the_web_log_semantics():
     assert tools["call-1"].status == "success"
 
 
-def test_derive_blocks_recovers_a_tool_that_only_logged_its_completion():
-    """The engine records no TASK_STARTED for a task that begins in a resumed
-    run — which is every tool an agent calls after the first turn — so a bare
-    completion has to render, or the transcript loses tool activity at each
-    turn boundary."""
+def test_derive_blocks_ignores_a_terminal_event_with_no_start():
+    """Since #244 the engine records a start for every call, including calls
+    that begin in a resumed run, so a terminal event with no start is an
+    engine bug rather than a shape to reconstruct a tool from."""
     detail = {
         "execution_id": "exec-1",
         "events": [
@@ -1024,9 +1023,6 @@ def test_derive_blocks_recovers_a_tool_that_only_logged_its_completion():
             },
             {
                 "type": "TASK_COMPLETED",
-                # The real log shape: an output-storage envelope, not the
-                # return value (verified against a live stack in
-                # tests/e2e/test_agent_console.py).
                 "value": {
                     "storage_type": "inline",
                     "reference_id": "search_docs_1",
@@ -1036,28 +1032,56 @@ def test_derive_blocks_recovers_a_tool_that_only_logged_its_completion():
                 "name": "search_docs",
                 "source_id": "call-9",
             },
+        ],
+    }
+
+    _blocks, tools, _title = derive_blocks(detail)
+
+    assert tools == {}
+
+
+def test_derive_blocks_pairs_a_start_with_its_completion_after_a_resume():
+    """The shape the engine actually produces now: both halves, joinable by
+    source_id, so the panel has a name, args, output and a duration."""
+    detail = {
+        "execution_id": "exec-1",
+        "events": [
+            {
+                "type": "WORKFLOW_RESUMED",
+                "value": {"message": "search the docs"},
+                "time": "2026-08-14T10:00:00",
+                "name": "w",
+            },
+            {
+                "type": "TASK_STARTED",
+                "value": {"query": "schedules"},
+                "time": "2026-08-14T10:00:02",
+                "name": "search_docs",
+                "source_id": "call-9",
+            },
             {
                 "type": "TASK_COMPLETED",
-                "value": None,
-                "time": "2026-08-14T10:00:05",
-                "name": "pause",
-                "source_id": "call-pause",
+                "value": {
+                    "storage_type": "inline",
+                    "reference_id": "search_docs_1",
+                    "metadata": {"value": "3 hits"},
+                },
+                "time": "2026-08-14T10:00:04",
+                "name": "search_docs",
+                "source_id": "call-9",
             },
         ],
     }
-    blocks, tools, _ = derive_blocks(detail)
 
-    assert [block.kind for block in blocks] == ["user", "tool"]
-    # Internal machinery stays filtered out on this path too.
+    _blocks, tools, _title = derive_blocks(detail)
+
     assert list(tools) == ["call-9"]
     tool = tools["call-9"]
     assert tool.name == "search_docs"
-    assert tool.status == "success"
-    # Unwrapped: operators see what the tool returned, not storage bookkeeping.
+    assert tool.args == {"query": "schedules"}
     assert tool.output == "3 hits"
-    # No start event means no duration to show, rather than a fabricated one.
-    assert tool.started is None
-    assert tool.ended is not None
+    assert tool.status == "success"
+    assert tool.started is not None and tool.ended is not None
 
 
 def test_unwrap_output_names_an_externally_stored_value():

--- a/tests/flux/agents/console/test_web_shell.py
+++ b/tests/flux/agents/console/test_web_shell.py
@@ -112,12 +112,11 @@ def test_failed_sessions_are_never_bucketed_with_done():
     assert "failed" not in row_class.group(0)
 
 
-def test_tool_activity_survives_a_missing_task_started():
-    """Another source-level guard: the engine logs no TASK_STARTED for a task
-    that begins in a resumed run (every tool call after an agent's first
-    turn), so `applyDetail` must build the tool from its completion event
-    instead of dropping it — the same recovery `derive_blocks` does for the
-    TUI."""
+def test_completions_are_paired_with_their_start_not_reconstructed():
+    """Source-level guard mirroring derive_blocks: since #244 the engine
+    records a start for every call, including calls that begin in a resumed
+    run, so `applyDetail` pairs a terminal event with its start instead of
+    inventing a tool from the completion alone."""
     script = (WEB_DIR / "console.js").read_text()
     branch = re.search(
         r'case "TASK_COMPLETED":.*?case "TASK_AWAITING_APPROVAL"',
@@ -126,12 +125,11 @@ def test_tool_activity_survives_a_missing_task_started():
     )
     assert branch, "applyDetail must handle task completion events"
     body = branch.group(0)
-    assert "tools.set(event.source_id" in body, "a completion with no start must create the tool"
-    assert "if (!tool) break;" not in body, "a completion with no start must not be dropped"
-    assert "INTERNAL_TASK.test" in body, "the recovery path must keep filtering internal tasks"
+    assert "if (!tool) break;" in body, "an unmatched terminal event must not invent a tool"
+    assert "tools.set(event.source_id" not in body, "the completion branch must not create tools"
     # The log stores outputs as OutputStorageReference envelopes; the panel
-    # must show what the tool returned, not the storage bookkeeping.
-    assert "unwrapOutput(value)" in body, "tool output must be unwrapped for display"
+    # shows the value, not the storage bookkeeping.
+    assert "unwrapOutput" in body
 
 
 def test_reducer_drops_frames_addressed_to_another_session():

--- a/tests/flux/test_task_started_on_resume.py
+++ b/tests/flux/test_task_started_on_resume.py
@@ -1,0 +1,167 @@
+"""TASK_STARTED for tasks that begin in a resumed run (issue #244).
+
+A resumed run replays the workflow body: tasks with a terminal event
+short-circuit, so anything that reaches the emission site is genuinely
+running now. Suppressing its ``TASK_STARTED`` because the *execution* had
+resumed left the log with completions that have no start — no duration, and
+nothing at all for a task that is still in flight.
+
+The suppression did protect one real case, which these tests pin too: the
+task that was mid-flight when the pause happened (``pause`` itself) has a
+``TASK_STARTED`` and no terminal event, so replaying the body must not
+append a second one for the same call.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from flux import ExecutionContext, task as task_decorator, workflow
+from flux.domain.events import ExecutionEventType
+
+
+def _events(ctx, event_type, name_part):
+    return [e for e in ctx.events if e.type == event_type and name_part in e.name]
+
+
+class TestTaskStartedAcrossResume:
+    def test_task_first_run_after_resume_records_its_start(self, isolated_db):
+        from flux.tasks import pause
+
+        @task_decorator
+        async def before() -> str:
+            return "before"
+
+        @task_decorator
+        async def after() -> str:
+            return "after"
+
+        @workflow
+        async def wf(ctx: ExecutionContext):
+            first = await before()
+            await pause("gate")
+            second = await after()
+            return [first, second]
+
+        ctx = wf.run()
+        assert ctx.is_paused
+
+        resumed = wf.run(execution_id=ctx.execution_id)
+        assert resumed.has_succeeded, resumed.output
+
+        started = _events(resumed, ExecutionEventType.TASK_STARTED, "after")
+        completed = _events(resumed, ExecutionEventType.TASK_COMPLETED, "after")
+        assert len(completed) == 1
+        assert len(started) == 1, "a task running for the first time must record its start"
+        # Same call, so the pair is joinable — this is what durations and
+        # in-flight views are rebuilt from.
+        assert started[0].source_id == completed[0].source_id
+
+    def test_replayed_task_records_nothing_new(self, isolated_db):
+        """The pre-pause task short-circuits on its stored output: no second
+        start, no second completion."""
+        from flux.tasks import pause
+
+        runs = [0]
+
+        @task_decorator
+        async def before() -> str:
+            runs[0] += 1
+            return "before"
+
+        @workflow
+        async def wf(ctx: ExecutionContext):
+            value = await before()
+            await pause("gate")
+            return value
+
+        ctx = wf.run()
+        resumed = wf.run(execution_id=ctx.execution_id)
+        assert resumed.has_succeeded
+
+        assert runs == [1], "replay must not re-execute a completed task"
+        assert len(_events(resumed, ExecutionEventType.TASK_STARTED, "before")) == 1
+        assert len(_events(resumed, ExecutionEventType.TASK_COMPLETED, "before")) == 1
+
+    def test_in_flight_task_at_pause_does_not_duplicate_its_start(self, isolated_db):
+        """``pause`` is itself a task: it has a start and no terminal event
+        when the execution parks, and the body re-runs it on resume. That is
+        the case the blanket suppression existed for."""
+        from flux.tasks import pause
+
+        @workflow
+        async def wf(ctx: ExecutionContext):
+            await pause("gate")
+            return "done"
+
+        ctx = wf.run()
+        assert ctx.is_paused
+        # The gate's name is the task's *argument*; the task itself is `pause`.
+        assert len(_events(ctx, ExecutionEventType.TASK_STARTED, "pause")) == 1
+
+        resumed = wf.run(execution_id=ctx.execution_id)
+        assert resumed.has_succeeded
+
+        assert len(_events(resumed, ExecutionEventType.TASK_STARTED, "pause")) == 1
+
+    def test_every_turn_of_a_multi_pause_workflow_records_its_own_starts(self, isolated_db):
+        """The agent-session shape: pause, work, pause, work. Each turn's
+        tasks are new, so each turn's starts must land."""
+        from flux.tasks import pause
+
+        @task_decorator
+        async def turn_one() -> str:
+            return "one"
+
+        @task_decorator
+        async def turn_two() -> str:
+            return "two"
+
+        @workflow
+        async def wf(ctx: ExecutionContext):
+            await pause("turn-1")
+            first = await turn_one()
+            await pause("turn-2")
+            second = await turn_two()
+            return [first, second]
+
+        ctx = wf.run()
+        ctx = wf.run(execution_id=ctx.execution_id)
+        assert ctx.is_paused, "second gate should park the execution again"
+        final = wf.run(execution_id=ctx.execution_id)
+        assert final.has_succeeded, final.output
+
+        for name in ("turn_one", "turn_two"):
+            assert len(_events(final, ExecutionEventType.TASK_STARTED, name)) == 1, name
+            assert len(_events(final, ExecutionEventType.TASK_COMPLETED, name)) == 1, name
+
+    @pytest.mark.parametrize("occurrences", [2, 3])
+    def test_repeated_calls_after_resume_each_record_their_own_start(
+        self,
+        isolated_db,
+        occurrences,
+    ):
+        """Repeated identical calls get distinct ids (``~1``, ``~2``), so each
+        one is a separate call with its own start."""
+        from flux.tasks import pause
+
+        @task_decorator
+        async def echo(value: str) -> str:
+            return value
+
+        @workflow
+        async def wf(ctx: ExecutionContext):
+            await pause("gate")
+            for _ in range(occurrences):
+                await echo("same")
+            return "ok"
+
+        ctx = wf.run()
+        resumed = wf.run(execution_id=ctx.execution_id)
+        assert resumed.has_succeeded
+
+        started = _events(resumed, ExecutionEventType.TASK_STARTED, "echo")
+        completed = _events(resumed, ExecutionEventType.TASK_COMPLETED, "echo")
+        assert len(started) == occurrences
+        assert len(completed) == occurrences
+        assert {e.source_id for e in started} == {e.source_id for e in completed}


### PR DESCRIPTION
Closes #244.

## Root cause

`TASK_STARTED` was gated on `not ctx.is_resuming and not ctx.has_resumed` — an *execution-scoped* question — when the property it needs is *per call*: has this call already recorded a start?

`has_resumed` reads the last `WORKFLOW_*` event, which stays `WORKFLOW_RESUMED` for the entire resumed run. So every task begun after a resume was silently denied its start event. For any pause/resume workflow that is every task after the first turn, and for an agent session it is every tool call the agent ever makes.

The replay short-circuit returns *before* the emission site for any call with a terminal event, so a call reaching it is genuinely running now and owes the log a start.

## What the old guard was actually protecting

One real case, which the fix now covers precisely instead of run-wide: the call that was in flight when the execution parked — `pause` itself, or a task suspended at its approval gate — already has a `TASK_STARTED` and no terminal event, so the body re-running must not append a second one.

```python
already_started = any(
    e.type == ExecutionEventType.TASK_STARTED and e.source_id == task_id
    for e in ctx.events
)
if not already_started:
    ...
```

The approval gate's compensating workaround (calling `ctx.resume()` mid-gate so *subsequent* tasks would emit their starts) was a symptom of the same defect. Its return value had no other consumer and is no longer read; the `ctx.resume()` transition itself is unchanged.

## Tests

`tests/flux/test_task_started_on_resume.py` — 6 tests, 4 red against the previous engine:

- a task running for the first time after a resume records a start, joinable to its completion by `source_id`
- a multi-pause workflow (the agent-session shape) records starts for every turn's tasks
- repeated identical calls after a resume each record their own start (distinct `~N` ids)
- **not** a regression: a replayed task re-runs nothing and logs nothing; and the in-flight-at-pause call does not duplicate its start — the property the old guard existed for, green before and after

## Downstream

Both console renderers keep rebuilding a tool from a lone completion, because executions logged before this fix still read that way. Their comments, the e2e note and the console docs now say that instead of describing it as current engine behavior.

## Verification

| Gate | Result |
|---|---|
| `tests/flux/` | 3175 passed, 11 skipped |
| approvals / pause / resume / replay / sensitive neighbours | 91 passed |
| `tests/flux/agents/` | 335 passed |
| `tests/e2e/test_agent_console.py` | 8 passed |
| `pre-commit` (incl. cold mypy) | clean |
| Version | 0.83.1 → 0.83.2 |