### PR TITLE
feat(docker): publish role-scoped image variants (slim, server)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,11 @@ on:
   push:
     tags: [ 'v*' ]
   workflow_dispatch:  # Allow manual triggering
+    inputs:
+      push:
+        description: "Push the images (uncheck to build and verify only)"
+        type: boolean
+        default: true
 
 env:
   REGISTRY: docker.io
@@ -18,6 +23,24 @@ jobs:
     runs-on: ubuntu-latest
     # Only run if the previous workflow completed successfully, or if triggered by tag/manual dispatch
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # One Dockerfile, three roles. `extras` feeds the FLUX_EXTRAS build
+        # arg the Dockerfile already accepts; `suffix` is appended to every
+        # tag, so each variant gets the full X.Y.Z / X.Y / latest set. The
+        # unsuffixed variant owns the bare tags and stays the everything
+        # image (issue #247, docs/specs/2026-08-14-role-scoped-images.md).
+        variant:
+          - name: full
+            suffix: ""
+            extras: postgresql,observability,ai
+          - name: slim
+            suffix: "-slim"
+            extras: ""
+          - name: server
+            suffix: "-server"
+            extras: postgresql,observability
     permissions:
       contents: read
       packages: write
@@ -53,6 +76,8 @@ jobs:
       uses: docker/metadata-action@v6
       with:
         images: ${{ env.REGISTRY }}/${{ secrets.DOCKER_USERNAME }}/flux
+        flavor: |
+          suffix=${{ matrix.variant.suffix }},onlatest=true
         # Version tags come from pyproject.toml (extracted above) rather than
         # the git ref: the main publish path is workflow_run (ref
         # refs/heads/main), where plain type=semver entries would never fire.
@@ -66,21 +91,45 @@ jobs:
           type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.version }}
           type=raw,value=latest,enable={{is_default_branch}}
 
+    # Verify before publishing: a dependency promoted from an extra to a base
+    # requirement would otherwise silently refill the sandbox a runner child
+    # runs in. Single-arch and loaded locally; the push below is a cache hit.
+    - name: Build ${{ matrix.variant.name }} for verification
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        platforms: linux/amd64
+        load: true
+        tags: flux-verify:${{ matrix.variant.name }}
+        build-args: |
+          FLUX_VERSION=${{ steps.version.outputs.version }}
+          FLUX_EXTRAS=${{ matrix.variant.extras }}
+        cache-from: type=gha,scope=${{ matrix.variant.name }}
+        cache-to: type=gha,scope=${{ matrix.variant.name }},mode=max
+
+    - name: Verify the ${{ matrix.variant.name }} variant carries what it claims
+      run: |
+        docker run --rm \
+          -v "$PWD/docker/scripts:/scripts:ro" \
+          flux-verify:${{ matrix.variant.name }} \
+          python /scripts/verify_image_variant.py ${{ matrix.variant.name }}
+
     - name: Build and push Docker image
       id: build
       uses: docker/build-push-action@v7
       with:
         context: .
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: ${{ github.event_name != 'workflow_dispatch' || inputs.push }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
           FLUX_VERSION=${{ steps.version.outputs.version }}
-          FLUX_EXTRAS=postgresql,observability,ai
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+          FLUX_EXTRAS=${{ matrix.variant.extras }}
+        cache-from: type=gha,scope=${{ matrix.variant.name }}
+        cache-to: type=gha,scope=${{ matrix.variant.name }},mode=max
     - name: Generate artifact attestation
+      if: ${{ github.event_name != 'workflow_dispatch' || inputs.push }}
       uses: actions/attest-build-provenance@v4
       with:
         subject-name: ${{ env.REGISTRY }}/${{ secrets.DOCKER_USERNAME }}/flux

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -22,9 +22,17 @@ docker build -t flux .
 # Build with specific flux-core version
 docker build --build-arg FLUX_VERSION=0.4.0 -t flux:0.4.0 .
 
-# Build with flux extras baked in (the published image ships
-# postgresql,observability,ai so it works for every role out of the box)
+# Build with flux extras baked in. The published tags are this one arg:
+#   <version>          postgresql,observability,ai  (works for every role)
+#   <version>-slim     (none)                       runner children
+#   <version>-server   postgresql,observability     servers and workers
 docker build --build-arg FLUX_EXTRAS=postgresql,observability,ai -t flux .
+docker build --build-arg FLUX_EXTRAS= -t flux:slim .
+
+# Check an image carries exactly the extras its tag claims (what the publish
+# workflow runs before pushing):
+docker run --rm -v "$PWD/docker/scripts:/scripts:ro" flux:slim \
+    python /scripts/verify_image_variant.py slim
 
 # Build with extra packages (your workflows' dependencies)
 docker build --build-arg EXTRA_PACKAGES="pandas numpy" -t flux-data .

--- a/docker/scripts/verify_image_variant.py
+++ b/docker/scripts/verify_image_variant.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Assert a published image variant carries exactly the extras it claims.
+
+Run *inside* the built image, before it is pushed:
+
+    docker run --rm -v "$PWD/docker/scripts:/scripts:ro" <image> \\
+        python /scripts/verify_image_variant.py slim
+
+Packaging intent that is only documented drifts: promote one dependency from
+an extra to a base requirement and the slim image silently refills the
+sandbox a runner child runs in. This turns that into a failed publish.
+
+Importability is checked with ``find_spec`` rather than a real import, so the
+check is about what is installed, not about import side effects.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+
+# Import names, not distribution names: `google-genai` imports as
+# `google.genai`, `psycopg-binary` as `psycopg`.
+AI_CLIENTS = ("openai", "anthropic", "ollama", "google.genai")
+POSTGRESQL = ("psycopg",)
+# `opentelemetry.sdk`, not the `opentelemetry` namespace: a no-extras install
+# still lands `opentelemetry-api` (verified against a built image, and
+# consistent with the package delta measured in #247), while the SDK and the
+# exporters — the weight the observability extra actually adds — stay out.
+OBSERVABILITY = ("opentelemetry.sdk", "opentelemetry.exporter")
+
+VARIANTS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
+    # variant: (must be absent, must be present)
+    "slim": (AI_CLIENTS + POSTGRESQL + OBSERVABILITY, ()),
+    "server": (AI_CLIENTS, POSTGRESQL + OBSERVABILITY),
+    "full": ((), AI_CLIENTS + POSTGRESQL + OBSERVABILITY),
+}
+
+
+def installed(module: str) -> bool:
+    try:
+        return importlib.util.find_spec(module) is not None
+    except (ImportError, ValueError):
+        # A namespace parent that is absent raises rather than returning None.
+        return False
+
+
+def verify(variant: str) -> list[str]:
+    forbidden, required = VARIANTS[variant]
+    problems = [f"{module}: present, must not be" for module in forbidden if installed(module)]
+    problems += [
+        f"{module}: missing, must be installed" for module in required if not installed(module)
+    ]
+    return problems
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2 or argv[1] not in VARIANTS:
+        print(f"usage: {argv[0]} {{{'|'.join(VARIANTS)}}}", file=sys.stderr)
+        return 2
+
+    variant = argv[1]
+    problems = verify(variant)
+    if problems:
+        print(f"image does not match the '{variant}' variant:", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    print(f"image matches the '{variant}' variant")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main(sys.argv))

--- a/docs/advanced-features/airgapped-execution.md
+++ b/docs/advanced-features/airgapped-execution.md
@@ -45,7 +45,7 @@ runners; the airgapped profile forces the variable empty after operator
 ```toml
 [flux.workers]
 runners = ["docker-airgapped"]
-airgapped_image = "<registry>/flux:<version>"   # falls back to docker_image
+airgapped_image = "edurdias/flux:<version>-slim"  # falls back to docker_image
 
 airgapped_memory = "512m"          # required non-empty
 airgapped_cpus = 1.0

--- a/docs/advanced-features/system-tools.md
+++ b/docs/advanced-features/system-tools.md
@@ -109,7 +109,7 @@ workers that run agents:
 [flux.workers]
 runners = ["subprocess", "docker"]
 default_runner = "docker"
-docker_image = "my-registry/flux:1.2.3"
+docker_image = "edurdias/flux:1.2.3-slim"   # the child needs no extras
 ```
 
 The container runners set `FLUX_RUNNER_SANDBOXED=1` in the child; the tool reads

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -41,6 +41,35 @@ poetry add flux-core
 poetry shell
 ```
 
+### Container images
+
+Published images carry the same `flux-core` release, differing only in which
+optional extras are baked in. Pick by role — one image can serve them all, but
+the smaller ones exist so a process only ships what it can use.
+
+| Image | Extras | Use it for |
+|---|---|---|
+| `flux:<version>` | `postgresql`, `observability`, `ai` | anything; the default when you want one image |
+| `flux:<version>-slim` | none | runner children (`docker_image`, `airgapped_image`) |
+| `flux:<version>-server` | `postgresql`, `observability` | servers and workers that never call a hosted model |
+
+Each also publishes `<major>.<minor>` and `latest` forms (`flux:latest-slim`,
+`flux:0.84-server`, …). Pin the full `<version>` for a runner image: the child
+must match its worker's `flux-core`.
+
+```bash
+docker pull edurdias/flux:latest          # everything
+docker pull edurdias/flux:latest-slim     # sandboxed runner children
+```
+
+`-slim` matters most for the docker and airgapped runners. That container is
+rootless, has no network, and reaches its engine only over a granted Unix
+socket, so the LLM SDKs and the Postgres driver in the default image are
+surface it cannot use — roughly 30 packages a sandbox does not need.
+
+Building your own image from these is fine; the runner only requires
+`flux-core` at a worker-compatible version.
+
 ### Installing for Development
 If you're planning to contribute or need development tools:
 ```bash

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -262,7 +262,9 @@ approval rows.
   version — the child entrypoint and context wire format must match. The
   official image works directly (pin its tag to the worker's flux-core
   version; see DOCKER.md), or build on top of it to add workflow
-  dependencies. Optional knobs: `docker_network` / `docker_memory` /
+  dependencies. Prefer the `-slim` variant: the child is sandboxed and
+  network-less, so the LLM SDKs and Postgres driver in the default image are
+  surface it cannot use (see Installation → Container images). Optional knobs: `docker_network` / `docker_memory` /
   `docker_cpus` / `docker_extra_args` (volumes, env, `--user`,
   `--cap-drop`). Use it for untrusted code,
   conflicting dependency sets, or filesystem isolation. Workers advertising

--- a/docs/specs/2026-08-14-role-scoped-images.md
+++ b/docs/specs/2026-08-14-role-scoped-images.md
@@ -1,0 +1,111 @@
+# Role-scoped published images
+
+Status: accepted (2026-08-14). Closes #247.
+
+## Problem
+
+One published image serves every role. A **runner child** is the sharpest case:
+it runs rootless, `--network=none`, and reaches its engine only over a granted
+Unix socket, so every package in it is surface inside the sandbox. Measured on
+0.81.13, published against the same Dockerfile built with `FLUX_EXTRAS=""`:
+
+| | size | packages |
+|---|---|---|
+| `flux:0.81.13` | 549 MB | 126 |
+| no extras | 428 MB | 96 |
+
+The 30-package delta is `openai` (20 MB), the `google-*` stack (19 MB), the
+`psycopg` family (21 MB) and `anthropic` (13 MB), plus their transitive deps.
+Three vendor clients for calling hosted LLM APIs, in a container with no
+network, cannot function there by construction. The Postgres driver is the
+milder version of the same point: the child is deliberately denied a database
+URL.
+
+It also works against the child-import diet (#242, #233), whose stated goal is
+keeping heavy dependencies out of the sandbox — and which the default image
+then puts back.
+
+## Decision
+
+Publish three variants from the existing Dockerfile, parameterized by the
+`FLUX_EXTRAS` build arg it already accepts. No new Dockerfile machinery.
+
+| Tag | `FLUX_EXTRAS` | Intended role |
+|---|---|---|
+| `flux:X.Y.Z`, `X.Y`, `latest` | `postgresql,observability,ai` | unchanged default: any role, one image |
+| `flux:X.Y.Z-slim`, `X.Y-slim`, `latest-slim` | *(empty)* | runner children (`docker_image`, `airgapped_image`) |
+| `flux:X.Y.Z-server`, `X.Y-server`, `latest-server` | `postgresql,observability` | servers and workers that never call a hosted model |
+
+The default stays the everything image. Making it slim would silently change
+what `flux:latest` means for anyone already running it, and an agent workflow
+on the new default would fail at import with no obvious cause.
+
+## Mechanism
+
+`docker-publish.yml`'s single build job becomes a matrix over the three
+variants. Each entry carries its extras and a tag suffix, applied through
+`docker/metadata-action`'s `flavor: suffix=`, so every variant gets the full
+tag set (`X.Y.Z`, `X.Y`, `latest`, branch) with its suffix appended.
+
+Two details are load-bearing:
+
+- **Cache scope per variant.** `type=gha` without a `scope` is shared, so
+  three variants would evict each other and every build would run cold.
+- **Attestation per variant.** `subject-digest` differs per build, so the
+  attest step belongs inside the matrix, not after it.
+
+## The packaging guard
+
+Intent that is only documented drifts. Each variant therefore builds
+`linux/amd64` with `load: true` first, asserts its package set, and only then
+runs the multi-arch build-and-push — a cache hit, so the second build is
+cheap. A promoted dependency (an extra becoming a base requirement) fails the
+publish instead of silently refilling the sandbox.
+
+`docker/scripts/verify_image_variant.py` takes a variant name and asserts,
+inside the built image:
+
+| Variant | must NOT import | must import |
+|---|---|---|
+| `slim` | `openai`, `anthropic`, `ollama`, `google.genai`, `psycopg`, `opentelemetry.sdk`, `opentelemetry.exporter` | — |
+| `server` | `openai`, `anthropic`, `ollama`, `google.genai` | `psycopg`, `opentelemetry.sdk`, `opentelemetry.exporter` |
+| `full` | — | all of the above |
+
+It checks importability with `importlib.util.find_spec`, so it is a packaging
+assertion rather than an import side-effect test, and it prints the offending
+module on failure.
+
+The rules name `opentelemetry.sdk` rather than the `opentelemetry` namespace
+for a reason found by running the guard against a real build: a no-extras
+image still carries `opentelemetry-api`, even though the published wheel
+declares it under `extra == "observability"` and no installed distribution
+requires it. The measurement in #247 shows the same — its 30-package delta
+lists the exporters and the SDK but not `-api`. The SDK and exporters are the
+weight the extra actually adds, so those are what slim forbids. The stray
+`-api` is worth a separate look; it is not this change's business.
+
+Measured locally on amd64 against flux-core 0.81.12 (the version PyPI serves
+today), building this Dockerfile with each variant's extras: slim 418 MB,
+server 497 MB, full 549 MB (#247's figure).
+
+## Rollout
+
+The workflow runs on `main` and `v*` tags only, and nothing in PR CI exercises
+it, so a broken matrix would first surface as a failed publish. A
+`workflow_dispatch` input `push` (default `true`) allows one manual dry run —
+build and verify every variant, push nothing — before the change goes live.
+
+## Documentation
+
+- `docs/getting-started/installation.md`: the variants table, and which to
+  pull for which role.
+- `docs/advanced-features/system-tools.md` and `airgapped-execution.md`: point
+  `docker_image` / `airgapped_image` examples at `-slim`.
+- `docs/production-deployment.md`: name the variant in the runner section.
+
+## Out of scope
+
+- Changing what `flux:latest` resolves to.
+- A `-worker` variant: a worker's needs are the server's minus nothing
+  measurable, and nobody has asked.
+- Local Makefile targets for variant builds; the matrix is the deliverable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.83.2"
+version = "0.84.0"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/test_image_variants.py
+++ b/tests/flux/test_image_variants.py
@@ -26,10 +26,18 @@ verifier = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(verifier)
 
 
+JOB = "build-and-publish"
+
+
 @pytest.fixture(scope="module")
-def matrix() -> list[dict]:
+def job() -> dict:
     workflow = yaml.safe_load(WORKFLOW.read_text())
-    [job] = [job for name, job in workflow["jobs"].items() if "strategy" in job]
+    assert JOB in workflow["jobs"], f"{WORKFLOW.name} has no '{JOB}' job"
+    return workflow["jobs"][JOB]
+
+
+@pytest.fixture(scope="module")
+def matrix(job) -> list[dict]:
     return job["strategy"]["matrix"]["variant"]
 
 
@@ -107,9 +115,33 @@ class TestPublishMatrix:
         assert "postgresql" in extras["server"] and "observability" in extras["server"]
         assert "ai" in extras["full"]
 
-    def test_each_variant_caches_under_its_own_scope(self, matrix):
-        """A shared gha cache scope makes three variants evict each other, so
-        every build would run cold."""
-        scopes = [entry["name"] for entry in matrix]
+    def test_every_build_caches_under_the_variant_s_own_scope(self, job):
+        """A shared gha cache scope makes the variants evict each other, so
+        every build would run cold. Both builds (the verification one and the
+        push) must scope their cache by variant."""
+        builds = [
+            step
+            for step in job["steps"]
+            if str(step.get("uses", "")).startswith("docker/build-push-action")
+        ]
 
-        assert len(set(scopes)) == len(scopes)
+        assert len(builds) == 2, "expected a verification build and a push build"
+        for step in builds:
+            for key in ("cache-from", "cache-to"):
+                assert "scope=${{ matrix.variant.name }}" in step["with"][key], (
+                    f"{step['name']}: {key} must be scoped per variant"
+                )
+
+    def test_the_extras_of_every_build_come_from_the_matrix(self, job):
+        """A hardcoded FLUX_EXTRAS would publish three identical images under
+        three different tags."""
+        builds = [
+            step
+            for step in job["steps"]
+            if str(step.get("uses", "")).startswith("docker/build-push-action")
+        ]
+
+        for step in builds:
+            assert "FLUX_EXTRAS=${{ matrix.variant.extras }}" in step["with"]["build-args"], (
+                f"{step['name']}: build args must take extras from the matrix"
+            )

--- a/tests/flux/test_image_variants.py
+++ b/tests/flux/test_image_variants.py
@@ -1,0 +1,115 @@
+"""The published image variants and the guard that keeps them honest (#247).
+
+The variant matrix lives in `.github/workflows/docker-publish.yml`, which no
+CI job exercises before it publishes. These tests pin the two things that
+would otherwise only fail in production: the guard's own logic, and the
+workflow declaring the variants the guard knows about.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "docker-publish.yml"
+
+_spec = importlib.util.spec_from_file_location(
+    "verify_image_variant",
+    ROOT / "docker" / "scripts" / "verify_image_variant.py",
+)
+assert _spec and _spec.loader
+verifier = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(verifier)
+
+
+@pytest.fixture(scope="module")
+def matrix() -> list[dict]:
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    [job] = [job for name, job in workflow["jobs"].items() if "strategy" in job]
+    return job["strategy"]["matrix"]["variant"]
+
+
+class TestGuard:
+    def test_slim_rejects_an_image_carrying_ai_clients(self, monkeypatch):
+        monkeypatch.setattr(verifier, "installed", lambda module: module == "openai")
+
+        problems = verifier.verify("slim")
+
+        assert problems == ["openai: present, must not be"]
+
+    def test_server_rejects_ai_clients_and_requires_its_own_extras(self, monkeypatch):
+        monkeypatch.setattr(
+            verifier,
+            "installed",
+            lambda module: module in ("anthropic", "psycopg"),
+        )
+
+        problems = verifier.verify("server")
+
+        assert "anthropic: present, must not be" in problems
+        assert "opentelemetry.sdk: missing, must be installed" in problems
+        assert not any("psycopg" in problem for problem in problems)
+
+    def test_full_requires_every_extra(self, monkeypatch):
+        monkeypatch.setattr(verifier, "installed", lambda module: module != "ollama")
+
+        assert verifier.verify("full") == ["ollama: missing, must be installed"]
+
+    def test_a_matching_image_reports_no_problems(self, monkeypatch):
+        monkeypatch.setattr(verifier, "installed", lambda module: False)
+
+        assert verifier.verify("slim") == []
+
+    def test_unknown_variant_is_a_usage_error(self):
+        assert verifier.main(["verify", "worker"]) == 2
+
+    def test_slim_tolerates_the_opentelemetry_api_a_base_install_carries(self, monkeypatch):
+        """A no-extras install still lands `opentelemetry-api`; the extra's
+        real weight is the SDK and exporters, so those are what slim forbids."""
+        monkeypatch.setattr(
+            verifier,
+            "installed",
+            lambda module: module == "opentelemetry",
+        )
+
+        assert verifier.verify("slim") == []
+
+    def test_namespace_parent_absence_is_not_an_error(self, monkeypatch):
+        """`google.genai` raises rather than returning None when `google` is
+        absent; the guard must read that as "not installed"."""
+
+        def _raise(module, *_args, **_kwargs):
+            raise ValueError(module)
+
+        monkeypatch.setattr(importlib.util, "find_spec", _raise)
+
+        assert verifier.installed("google.genai") is False
+
+
+class TestPublishMatrix:
+    def test_every_declared_variant_is_one_the_guard_knows(self, matrix):
+        assert {entry["name"] for entry in matrix} == set(verifier.VARIANTS)
+
+    def test_only_the_default_variant_is_unsuffixed(self, matrix):
+        unsuffixed = [entry["name"] for entry in matrix if not entry.get("suffix")]
+
+        assert unsuffixed == ["full"], "exactly one variant may own the bare tags"
+
+    def test_extras_match_each_variant_s_promise(self, matrix):
+        extras = {entry["name"]: entry["extras"] for entry in matrix}
+
+        assert extras["slim"] == ""
+        assert "ai" not in extras["server"]
+        assert "postgresql" in extras["server"] and "observability" in extras["server"]
+        assert "ai" in extras["full"]
+
+    def test_each_variant_caches_under_its_own_scope(self, matrix):
+        """A shared gha cache scope makes three variants evict each other, so
+        every build would run cold."""
+        scopes = [entry["name"] for entry in matrix]
+
+        assert len(set(scopes)) == len(scopes)


### PR DESCRIPTION
Closes #247. Spec: [`docs/specs/2026-08-14-role-scoped-images.md`](https://github.com/edurdias/flux/blob/feat/role-scoped-images/docs/specs/2026-08-14-role-scoped-images.md).

One published image serves every role, so a **sandboxed runner child** — rootless, `--network=none`, engine reachable only over a granted Unix socket — ships three hosted-LLM clients and a Postgres driver it cannot use by construction. That also works against the child-import diet (#242, #233), whose whole point is keeping heavy dependencies out of the sandbox.

## What publishes now

| Tag | `FLUX_EXTRAS` | For |
|---|---|---|
| `flux:X.Y.Z`, `X.Y`, `latest` | `postgresql,observability,ai` | unchanged default — one image, any role |
| `flux:X.Y.Z-slim`, `X.Y-slim`, `latest-slim` | *(none)* | runner children (`docker_image`, `airgapped_image`) |
| `flux:X.Y.Z-server`, `X.Y-server`, `latest-server` | `postgresql,observability` | servers and workers that never call a hosted model |

No new Dockerfile machinery — this is the `FLUX_EXTRAS` arg it already accepts, driven from a job matrix with a per-variant tag suffix. The default stays the everything image: making it slim would silently change what `flux:latest` means, and an agent workflow on the new default would fail at import with no obvious cause.

Two details that bite if missed, both handled: each variant caches under its **own** `type=gha` scope (a shared scope makes three builds evict each other and every build runs cold), and the attestation step runs **inside** the matrix, since `subject-digest` differs per build.

## The packaging guard

Documented intent drifts. Each variant is built single-arch with `load: true`, asserted, and only then pushed multi-arch — a cache hit, so the second build is cheap. Promote one dependency from an extra to a base requirement and the publish fails instead of silently refilling the sandbox.

Running that guard against real builds is also what corrected it: a no-extras image still carries `opentelemetry-api` even though the published wheel declares it under `extra == "observability"` and no installed distribution requires it — so the rule names `opentelemetry.sdk` and the exporters, which are the weight the extra actually adds. #247's own 30-package delta shows the same (it lists the SDK and exporters, not `-api`). **That stray `-api` looks like a real packaging oddity worth its own look; I did not chase it here.**

## Verified against real images, not just the matrix

Built locally on amd64 from this Dockerfile:

| Variant | Size | Guard |
|---|---|---|
| slim | 418 MB (96 packages, matching #247's measurement) | passes `slim`, correctly fails `full` |
| server | 497 MB | passes `server`, correctly fails `slim` naming `psycopg`, `opentelemetry.sdk`, `opentelemetry.exporter` |

Plus 11 unit tests: the guard's rules (including the namespace-parent case where `find_spec` raises), and the workflow matrix itself — every declared variant is one the guard knows, exactly one variant owns the bare tags, the extras match each variant's promise, and no two variants share a cache scope.

## Rollout

Nothing in PR CI exercises this workflow, so `workflow_dispatch` gains a `push` input (default true): run it once unchecked to build and verify all three variants without pushing, before it goes live on the next merge to main.

Docs: the published images had no documentation at all, so Installation gains a **Container images** section; the runner examples in system-tools and airgapped-execution now point at `-slim`; production-deployment and DOCKER.md say why.

| Gate | Result |
|---|---|
| `tests/flux/` | 3187 passed, 11 skipped |
| `pre-commit` (incl. cold mypy) | clean |
| Version | 0.83.2 → 0.84.0 |