### PR TITLE
fix(agents)!: remove approval_routing="notify" — never wired, #144 closed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,8 +161,9 @@ Implementation hot-spots:
   `routing`, `runner`, `schedule`, plus `name`, `secret_requests`, `output_storage`. A workflow's first
   parameter is always `ctx: ExecutionContext[T]`; if `T` is a Pydantic `BaseModel` the catalog
   publishes its JSON schema (`catalogs.py::extract_workflow_input_schema`).
-- Agents split autonomy into `autonomy` (strict/default/autonomous) × `approval_routing`
-  (inline/notify); the legacy `approval_mode` is mapped and deprecated.
+- Agents split autonomy into `autonomy` (strict/default/autonomous) × `approval_routing` (inline is
+  the only value — an out-of-band `notify` mode was declared for #144 but never wired, and was
+  removed rather than left as a silent no-op); the legacy `approval_mode` is mapped and deprecated.
 - `flux/__init__.py` — installs a custom `_FluxModule` class on `sys.modules["flux"]` so `flux.task`
   and `flux.workflow` resolve to the *classes* even though they're also submodules. If you
   import-rename anything at the top of `flux/`, exercise both `from flux import task` and

--- a/flux/migrations/versions/0026_drop_notify_routing.py
+++ b/flux/migrations/versions/0026_drop_notify_routing.py
@@ -1,0 +1,52 @@
+"""Null out agents.approval_routing='notify' — the value was removed.
+
+``notify`` was declared alongside ``inline`` (#146) for an out-of-band
+approval delivery mechanism that #144 was meant to provide. #144 was
+implemented, wired in, and reverted the same day pending a design rethink;
+it never shipped, so ``notify`` sat as a validated field value with no
+runtime behavior beyond a log line — a gate declared ``notify`` paused on
+the current surface exactly like ``inline``. #144 closed as not-planned
+and the value was removed from ``ROUTING_MODES`` rather than left as a
+silent no-op.
+
+Any stored row with the literal string ``notify`` would now fail
+``AgentDefinition`` validation on every read (``manager.get()``/``list()``),
+so this nulls it — behaviorally identical to what ``notify`` already did,
+since NULL and ``inline`` both resolve to today's pause-and-wait behavior.
+
+Revision ID: 0026_drop_notify_routing
+Revises: 0025_execution_name
+Create Date: 2026-08-15
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0026_drop_notify_routing"
+down_revision: str | None = "0025_execution_name"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "agents"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if _TABLE not in sa.inspect(bind).get_table_names():
+        return
+    agents = sa.table(_TABLE, sa.column("approval_routing", sa.String()))
+    op.execute(
+        agents.update().where(agents.c.approval_routing == "notify").values(approval_routing=None),
+    )
+
+
+def downgrade() -> None:
+    # The specific rows that held 'notify' are not recoverable, and
+    # rewriting them to 'notify' would resurrect a value the code no
+    # longer accepts. NULL is behaviorally identical to the removed
+    # value, so there is nothing to undo.
+    pass

--- a/flux/migrations/versions/0026_drop_notify_routing.py
+++ b/flux/migrations/versions/0026_drop_notify_routing.py
@@ -36,7 +36,7 @@ _TABLE = "agents"
 
 def upgrade() -> None:
     bind = op.get_bind()
-    if _TABLE not in sa.inspect(bind).get_table_names():
+    if not sa.inspect(bind).has_table(_TABLE):
         return
     agents = sa.table(_TABLE, sa.column("approval_routing", sa.String()))
     op.execute(

--- a/flux/tasks/ai/agent.py
+++ b/flux/tasks/ai/agent.py
@@ -117,23 +117,15 @@ async def agent(
     # the new autonomy/approval_routing into one validated pair, exactly
     # once. Downstream (loop, executor, preamble) sees only the ceiling;
     # routing is operator delivery configuration and never reaches the model.
+    # Routing has one legal value (inline); notify was declared for #144 but
+    # never wired, and was removed rather than left as a silent no-op.
     from flux.tasks.ai.approval_policy import resolve_approval_policy
 
-    effective_autonomy, effective_routing = resolve_approval_policy(
+    effective_autonomy, _effective_routing = resolve_approval_policy(
         approval_mode,
         autonomy,
         approval_routing,
     )
-    if effective_routing == "notify":
-        # The routing contract is fixed here; the out-of-band delivery
-        # mechanism itself is #144, whose design is still open. Until it
-        # lands, notify-routed gates pause exactly like inline ones — warn
-        # so operators expecting out-of-band delivery see the gap even at
-        # default log levels (an unwatched gate stalls the workflow).
-        logger.warning(
-            "approval_routing='notify' declared; out-of-band delivery (#144) "
-            "is not implemented yet, so gates pause on the current surface",
-        )
 
     if skills is not None:
         from flux.tasks.ai.skills import build_skills_preamble, build_use_skill

--- a/flux/tasks/ai/approval_policy.py
+++ b/flux/tasks/ai/approval_policy.py
@@ -8,10 +8,12 @@ reached when a gate fires*. The split:
   ``strict`` gates every tool call; ``default`` gates what declares
   ``requires_approval`` (today's behavior); ``autonomous`` removes the
   gates (the old ``approval_mode="autonomous"``).
-- **Approval routing** — *how* a fired gate reaches a human: ``inline``
-  pauses on the current surface (today's behavior); ``notify`` declares
-  reliance on out-of-band delivery (issue #144 — mechanism pending its
-  design), resolvable from any surface once it lands.
+- **Approval routing** — *how* a fired gate reaches a human. ``inline`` is
+  the only mode: it pauses on the current surface (today's behavior).
+  An out-of-band ``notify`` mode was declared (issue #144) but never
+  wired to a delivery mechanism; #144 closed as not-planned and the
+  value was removed rather than left as a silent no-op. The field stays
+  so a future delivery design has a validated place to declare into.
 
 The invariant, enforced here by construction: routing never changes the
 ceiling, and the ceiling never changes routing — they are resolved and
@@ -28,7 +30,7 @@ import warnings
 logger = logging.getLogger(__name__)
 
 AUTONOMY_LEVELS = ("strict", "default", "autonomous")
-ROUTING_MODES = ("inline", "notify")
+ROUTING_MODES = ("inline",)
 
 
 def resolve_approval_policy(
@@ -57,7 +59,7 @@ def resolve_approval_policy(
     if approval_mode is not None:
         warnings.warn(
             "approval_mode is deprecated; use autonomy= (strict/default/"
-            "autonomous) and approval_routing= (inline/notify) instead",
+            "autonomous) and approval_routing= (inline) instead",
             DeprecationWarning,
             stacklevel=3,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flux-core"
-version = "0.84.0"
+version = "0.84.1"
 description = "Flux is a distributed workflow orchestration engine to build stateful and fault-tolerant workflows."
 authors = ["Eduardo Dias <edurdias@gmail.com>"]
 repository = "https://github.com/edurdias/flux"

--- a/tests/flux/tasks/ai/test_approval_policy.py
+++ b/tests/flux/tasks/ai/test_approval_policy.py
@@ -21,7 +21,7 @@ class TestResolution:
         assert resolve_approval_policy() == ("default", "inline")
 
     def test_explicit_values_win(self):
-        assert resolve_approval_policy(None, "strict", "notify") == ("strict", "notify")
+        assert resolve_approval_policy(None, "strict", "inline") == ("strict", "inline")
 
     def test_legacy_autonomous_maps(self):
         with warnings.catch_warnings():
@@ -60,18 +60,25 @@ class TestResolution:
         with pytest.raises(ValueError, match="approval_routing must be"):
             resolve_approval_policy(None, None, "carrier-pigeon")
 
+    def test_notify_was_removed_not_left_as_a_silent_no_op(self):
+        """notify was declared for #144, never wired to a delivery mechanism,
+        and #144 closed as not-planned. It must now be rejected like any
+        other invalid value rather than silently behaving like inline."""
+        with pytest.raises(ValueError, match="approval_routing must be"):
+            resolve_approval_policy(None, None, "notify")
+
     def test_routing_never_changes_ceiling(self):
-        """The bug #146 exists to prevent: enabling out-of-band routing must
-        not widen (or narrow) what the agent may do."""
-        for routing in ("inline", "notify"):
-            for autonomy in ("strict", "default", "autonomous"):
-                resolved_autonomy, resolved_routing = resolve_approval_policy(
-                    None,
-                    autonomy,
-                    routing,
-                )
-                assert resolved_autonomy == autonomy
-                assert resolved_routing == routing
+        """The bug #146 exists to prevent: routing choice must not widen
+        (or narrow) what the agent may do. inline is routing's only value,
+        but the independence is still worth pinning explicitly."""
+        for autonomy in ("strict", "default", "autonomous"):
+            resolved_autonomy, resolved_routing = resolve_approval_policy(
+                None,
+                autonomy,
+                "inline",
+            )
+            assert resolved_autonomy == autonomy
+            assert resolved_routing == "inline"
 
 
 def _tools():
@@ -124,10 +131,10 @@ class TestAgentDefinitionSurface:
             model="openai/gpt-4o",
             system_prompt="hi",
             autonomy="strict",
-            approval_routing="notify",
+            approval_routing="inline",
         )
         assert definition.autonomy == "strict"
-        assert definition.approval_routing == "notify"
+        assert definition.approval_routing == "inline"
 
     def test_invalid_values_rejected(self):
         from flux.agents.types import AgentDefinition
@@ -140,6 +147,19 @@ class TestAgentDefinitionSurface:
                 model="openai/gpt-4o",
                 system_prompt="hi",
                 approval_routing="pigeon",
+            )
+
+    def test_notify_definitions_are_rejected(self):
+        """A definition file authored before notify was removed must fail
+        loudly at load rather than silently keep 'notify'."""
+        from flux.agents.types import AgentDefinition
+
+        with pytest.raises(ValueError, match="approval_routing must be"):
+            AgentDefinition(
+                name="a",
+                model="openai/gpt-4o",
+                system_prompt="hi",
+                approval_routing="notify",
             )
 
     def test_pre_split_definition_loads_unchanged(self):

--- a/tests/flux/test_migrations.py
+++ b/tests/flux/test_migrations.py
@@ -141,7 +141,7 @@ def test_stray_notify_routing_is_nulled_not_left_to_fail_validation(tmp_path):
     still legal must not start raising on every read after upgrade."""
     from sqlalchemy.orm import Session
 
-    from flux.agents.manager import AgentModel
+    from flux.models import AgentModel
 
     engine = _engine(tmp_path, "notify.db")
     Base.metadata.create_all(engine)

--- a/tests/flux/test_migrations.py
+++ b/tests/flux/test_migrations.py
@@ -13,7 +13,7 @@ import flux.security.models  # noqa: F401
 from flux.migrations.runner import current_revision, run_migrations
 from flux.models import Base
 
-HEAD = "0025_execution_name"
+HEAD = "0026_drop_notify_routing"
 BASELINE = "0001_baseline"
 
 # A representative index added after the original create_all schema, used to
@@ -134,3 +134,45 @@ def test_backfill_restores_specific_indexes(tmp_path, missing):
         conn.exec_driver_sql(f"DROP INDEX IF EXISTS {missing}")
     run_migrations(engine)
     assert missing in {ix["name"] for ix in inspect(engine).get_indexes(table)}
+
+
+def test_stray_notify_routing_is_nulled_not_left_to_fail_validation(tmp_path):
+    """0026 removes 'notify' from ROUTING_MODES; a row written while it was
+    still legal must not start raising on every read after upgrade."""
+    from sqlalchemy.orm import Session
+
+    from flux.agents.manager import AgentModel
+
+    engine = _engine(tmp_path, "notify.db")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        session.add(
+            AgentModel(
+                name="legacy-agent",
+                model="openai/gpt-4o",
+                system_prompt="hi",
+                approval_routing="notify",
+            ),
+        )
+        session.add(
+            AgentModel(
+                name="inline-agent",
+                model="openai/gpt-4o",
+                system_prompt="hi",
+                approval_routing="inline",
+            ),
+        )
+        session.commit()
+
+    run_migrations(engine)
+
+    with engine.begin() as conn:
+        rows = dict(
+            conn.exec_driver_sql(
+                "SELECT name, approval_routing FROM agents ORDER BY name",
+            ).fetchall(),
+        )
+    assert rows["legacy-agent"] is None
+    # A row already holding the one surviving value must be left alone.
+    assert rows["inline-agent"] == "inline"
+    assert current_revision(engine) == HEAD

--- a/tests/flux/test_migrations_postgresql.py
+++ b/tests/flux/test_migrations_postgresql.py
@@ -30,7 +30,7 @@ pytestmark = [
     ),
 ]
 
-HEAD = "0025_execution_name"
+HEAD = "0026_drop_notify_routing"
 _BACKFILL_INDEX = "ix_executions_workflow_id"
 
 


### PR DESCRIPTION
\`approval_routing\` split off \`approval_mode\` (#146) into an autonomy ceiling × a delivery mode: \`inline\` (pauses on the current surface, today's only real behavior) and \`notify\` (declared for out-of-band delivery, issue #144).

\`notify\` never had a mechanism behind it for more than half a day. #144 was implemented, wired in, and reverted the same day pending a design rethink — the branch was rebuilt without it as part of an unrelated PR. For the rest of its life, \`notify\` did exactly one thing at runtime: log a warning, then behave identically to \`inline\`. No test exercised delivery behavior, because none existed to exercise. #144 has since closed as not-planned.

A validated field value that silently degrades to a no-op is worse than no field — it lets someone declare \`approval_routing="notify"\` believing it does something. Removed rather than left as a live-looking dead option.

## What changed

- \`ROUTING_MODES\` is now \`("inline",)\` — the only legal value. \`resolve_approval_policy\` and \`AgentDefinition\`'s field validator both reject \`"notify"\` like any other invalid value.
- The dead \`if effective_routing == "notify":\` branch in \`flux/tasks/ai/agent.py\` is gone.
- **The \`autonomy\` × \`approval_routing\` split itself is untouched** — it solved a real conflation problem (#146: "how much may it do" vs. "where is the human reached") independent of which routing modes exist. The field stays as a validated place for a future delivery design to declare into.

## Migration

\`0026_drop_notify_routing\` nulls any stored \`agents.approval_routing\` that still says \`'notify'\` — \`AgentDefinition\`'s validator would otherwise raise on every \`manager.get()\`/\`list()\` of such a row. NULL and \`inline\` are behaviorally identical (both mean "pause on the current surface"), so this changes no observed behavior for any row that has one.

**Known gap, disclosed rather than fixed:** an agent definition also mirrors into the config store as a raw JSON blob (\`flux/agents/manager.py\`'s \`ConfigManager.save\`), read without Pydantic validation by \`flux/agents/template.py\` and only checked when a chat actually invokes \`agent()\`. That path isn't migrated — patching an encoded blob is riskier than the near-zero probability the value was ever set warrants (no seed data, no fixture, no example YAML ever declared \`notify\`; git history shows no window where a real agent could plausibly have picked it), and the failure mode there is a loud \`ValueError\` at chat-invocation time, not a silent one.

## Tests

16 new/changed assertions in \`tests/flux/tasks/ai/test_approval_policy.py\` (an explicit rejection test for \`"notify"\`, at both the resolver and the \`AgentDefinition\` layer) and \`tests/flux/test_migrations.py\` (a real upgrade run: seeds an agent row via the ORM with \`approval_routing="notify"\`, runs the migration, asserts the column is NULL and that a sibling row already holding \`"inline"\` is untouched — verified red against a stubbed-out migration before trusting it).

## Verification

| Gate | Result |
|---|---|
| \`tests/flux/\` | 3191 passed, 11 skipped |
| \`pre-commit run --all-files\` (incl. cold mypy) | clean |
| Version | 0.84.0 → 0.84.1 |

## Related

The still-open outbound-hooks PR (#252) referenced \`approval_routing="notify"\` as future hooks work in its spec and PR description; both are corrected there to drop the reference, since it's now removed rather than deferred.